### PR TITLE
fix(nextcloud)!: Move all query parameters to body to fix many serialization problems

### DIFF
--- a/.cspell/nextcloud.txt
+++ b/.cspell/nextcloud.txt
@@ -15,6 +15,7 @@ displayname
 etag
 federatedfilesharing
 fediverse
+groupid
 heavyrain
 heavyrainshowers
 iscustomavatar
@@ -40,6 +41,7 @@ productname
 rainshowers
 replyable
 requesttoken
+reshares
 resharing
 rgdnvw
 roomid
@@ -54,6 +56,7 @@ stime
 stunservers
 stylesheet
 subadmin
+subfiles
 subline
 systemtags
 totalitems

--- a/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
+++ b/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
@@ -85,11 +85,11 @@ class $Client extends _i1.DynamiteClient {
     int? limit,
   }) {
     final _parameters = <String, Object?>{};
-    final $tags = _$jsonSerializers.serialize(tags, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    _parameters['tags'] = $tags;
+    final __tags = _$jsonSerializers.serialize(tags, specifiedType: const FullType(BuiltList, [FullType(String)]));
+    _parameters['tags'] = __tags;
 
-    final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = $limit;
+    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    _parameters['limit'] = __limit;
 
     final _path = _i4.UriTemplate('/pets{?tags*,limit*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -156,13 +156,13 @@ class $Client extends _i1.DynamiteClient {
   ///  * [addPet] for a method executing this request and parsing the response.
   ///  * [$addPet_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $addPet_Request({required NewPet newPet}) {
+  _i3.Request $addPet_Request({required NewPet $body}) {
     const _path = '/pets';
     final _uri = Uri.parse('$baseURL$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
     _request.headers['Content-Type'] = 'application/json';
-    _request.body = json.encode(_$jsonSerializers.serialize(newPet, specifiedType: const FullType(NewPet)));
+    _request.body = json.encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(NewPet)));
     return _request;
   }
 
@@ -178,9 +178,9 @@ class $Client extends _i1.DynamiteClient {
   /// See:
   ///  * [$addPet_Request] for the request send by this method.
   ///  * [$addPet_Serializer] for a converter to parse the `Response` from an executed request.
-  Future<_i1.DynamiteResponse<Pet, void>> addPet({required NewPet newPet}) async {
+  Future<_i1.DynamiteResponse<Pet, void>> addPet({required NewPet $body}) async {
     final _request = $addPet_Request(
-      newPet: newPet,
+      $body: $body,
     );
     final _streamedResponse = await httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -217,8 +217,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $findPetById_Request({required int id}) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path = _i4.UriTemplate('/pets/{id}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -281,8 +281,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $deletePet_Request({required int id}) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path = _i4.UriTemplate('/pets/{id}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');

--- a/packages/dynamite/dynamite/lib/src/builder/client.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/client.dart
@@ -231,7 +231,7 @@ Iterable<Method> buildTags(
         );
       }
 
-      ({String mimeType, TypeResult result})? bodyParameter;
+      ({String mimeType, TypeResult result, bool dartParameterNullable, String? $default})? bodyParameter;
       final requestBody = operation.requestBody;
       if (requestBody != null) {
         for (final content in requestBody.content.entries) {
@@ -261,7 +261,12 @@ Iterable<Method> buildTags(
             }),
           );
 
-          bodyParameter = (mimeType: mimeType, result: result);
+          bodyParameter = (
+            mimeType: mimeType,
+            result: result,
+            dartParameterNullable: dartParameterNullable,
+            $default: mediaType.schema?.$default,
+          );
 
           operationParameters.add(
             Parameter(
@@ -380,7 +385,13 @@ ${allocate(returnType)}(
             }
 
             if (bodyParameter != null) {
-              resolveMimeTypeEncode(bodyParameter.mimeType, bodyParameter.result, code);
+              resolveMimeTypeEncode(
+                bodyParameter.mimeType,
+                bodyParameter.result,
+                bodyParameter.dartParameterNullable,
+                bodyParameter.$default,
+                code,
+              );
             }
 
             code.writeln('return _request;');

--- a/packages/dynamite/dynamite/lib/src/builder/client.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/client.dart
@@ -263,11 +263,10 @@ Iterable<Method> buildTags(
 
           bodyParameter = (mimeType: mimeType, result: result);
 
-          final parameterName = toDartName(result.name);
           operationParameters.add(
             Parameter(
               (b) => b
-                ..name = parameterName
+                ..name = r'$body'
                 ..type = refer(result.nullableName)
                 ..named = true
                 ..required = dartParameterRequired,
@@ -555,7 +554,7 @@ String buildParameterSerialization(
   String Function(Reference) allocate,
 ) {
   final dartName = toDartName(parameter.name);
-  final serializedName = '\$$dartName';
+  final serializedName = '__$dartName';
   final buffer = StringBuffer();
 
   final $default = parameter.schema?.$default;

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_interface.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_interface.dart
@@ -185,7 +185,7 @@ void _generateProperties(
             propertyName,
             identifier: identifier,
           )
-          ..nullable = isDartParameterNullable(
+          ..nullable = isDartGetterNullable(
             schema.required.contains(propertyName),
             propertySchema,
           );

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_mime_type.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_mime_type.dart
@@ -48,18 +48,17 @@ void resolveMimeTypeEncode(
   StringSink output,
 ) {
   output.writeln("_request.headers['Content-Type'] = '$mimeType';");
-  final parameterName = toDartName(result.name);
 
   if (result.nullable) {
-    output.writeln('if ($parameterName != null) {');
+    output.writeln(r'if ($body != null) {');
   }
 
   switch (mimeType) {
     case 'application/json':
     case 'application/x-www-form-urlencoded':
-      output.writeln('_request.body = ${result.encode(parameterName, mimeType: mimeType)};');
+      output.writeln('_request.body = ${result.encode(r'$body', mimeType: mimeType)};');
     case 'application/octet-stream':
-      output.writeln('_request.bodyBytes = ${result.encode(parameterName, mimeType: mimeType)};');
+      output.writeln('_request.bodyBytes = ${result.encode(r'$body', mimeType: mimeType)};');
     case _:
       throw Exception('Can not parse any mime type of the Operation.');
   }

--- a/packages/dynamite/dynamite/lib/src/builder/resolve_mime_type.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/resolve_mime_type.dart
@@ -45,25 +45,32 @@ TypeResult? resolveMimeTypeDecode(
 void resolveMimeTypeEncode(
   String mimeType,
   TypeResult result,
+  // ignore: avoid_positional_boolean_parameters
+  bool dartParameterNullable,
+  String? $default,
   StringSink output,
 ) {
   output.writeln("_request.headers['Content-Type'] = '$mimeType';");
 
-  if (result.nullable) {
-    output.writeln(r'if ($body != null) {');
-  }
-
   switch (mimeType) {
     case 'application/json':
     case 'application/x-www-form-urlencoded':
-      output.writeln('_request.body = ${result.encode(r'$body', mimeType: mimeType)};');
+      if (dartParameterNullable) {
+        output.writeln(
+          '_request.body = \$body != null ? ${result.encode(result.serialize(r'$body'), mimeType: mimeType)} : ${$default != null ? result.encode($default, mimeType: mimeType) : result.encode(result.serialize('${result.name}()'), mimeType: mimeType)};',
+        );
+      } else {
+        output.writeln('_request.body = ${result.encode(result.serialize(r'$body'), mimeType: mimeType)};');
+      }
     case 'application/octet-stream':
-      output.writeln('_request.bodyBytes = ${result.encode(r'$body', mimeType: mimeType)};');
+      if (dartParameterNullable) {
+        output.writeln(
+          '_request.bodyBytes = \$body != null ? ${result.encode(r'$body', mimeType: mimeType)} : ${$default != null ? result.encode($default, mimeType: mimeType) : 'Uint8List(0)'};',
+        );
+      } else {
+        output.writeln('_request.bodyBytes = ${result.encode(r'$body', mimeType: mimeType)};');
+      }
     case _:
       throw Exception('Can not parse any mime type of the Operation.');
-  }
-
-  if (result.nullable) {
-    output.writeln('}');
   }
 }

--- a/packages/dynamite/dynamite/lib/src/helpers/dynamite.dart
+++ b/packages/dynamite/dynamite/lib/src/helpers/dynamite.dart
@@ -10,6 +10,12 @@ bool isDartParameterNullable(
   bool required,
   json_schema.JsonSchema? schema,
 ) =>
+    !required || (schema?.nullable ?? false);
+
+bool isDartGetterNullable(
+  bool required,
+  json_schema.JsonSchema? schema,
+) =>
     (!required && schema?.$default == null) || (schema?.nullable ?? false);
 
 bool isRequired(

--- a/packages/dynamite/dynamite/lib/src/models/type_result/type_result.dart
+++ b/packages/dynamite/dynamite/lib/src/models/type_result/type_result.dart
@@ -136,13 +136,11 @@ sealed class TypeResult {
     String object, {
     required String mimeType,
   }) {
-    final serialized = serialize(object);
-
     switch (mimeType) {
       case 'application/json':
-        return 'json.encode($serialized)';
+        return 'json.encode($object)';
       case 'application/x-www-form-urlencoded':
-        return 'Uri(queryParameters: $serialized! as Map<String, dynamic>).query';
+        return 'Uri(queryParameters: $object! as Map<String, dynamic>).query';
       case 'application/octet-stream':
         if (className != 'Uint8List') {
           throw Exception('octet-stream can only be applied to binary data. Expected Uint8List but got $className');

--- a/packages/dynamite/dynamite_end_to_end_test/lib/deprecation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/deprecation.openapi.dart
@@ -67,11 +67,11 @@ class $Client extends _i1.DynamiteClient {
     int? limit,
   }) {
     final _parameters = <String, Object?>{};
-    final $tags = _$jsonSerializers.serialize(tags, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    _parameters['tags'] = $tags;
+    final __tags = _$jsonSerializers.serialize(tags, specifiedType: const FullType(BuiltList, [FullType(String)]));
+    _parameters['tags'] = __tags;
 
-    final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = $limit;
+    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    _parameters['limit'] = __limit;
 
     final _path = _i4.UriTemplate('/{?tags*,limit*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');

--- a/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
@@ -89,11 +89,11 @@ class $Client extends _i1.DynamiteClient {
     int? limit,
   }) {
     final _parameters = <String, Object?>{};
-    final $tags = _$jsonSerializers.serialize(tags, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    _parameters['tags'] = $tags;
+    final __tags = _$jsonSerializers.serialize(tags, specifiedType: const FullType(BuiltList, [FullType(String)]));
+    _parameters['tags'] = __tags;
 
-    final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = $limit;
+    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    _parameters['limit'] = __limit;
 
     final _path = _i4.UriTemplate('/{?tags*,limit*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');

--- a/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
@@ -93,63 +93,64 @@ class $Client extends _i1.DynamiteClient {
     GetEnumPattern? enumPattern,
   }) {
     final _parameters = <String, Object?>{};
-    final $contentString = _$jsonSerializers.serialize(
+    final __contentString = _$jsonSerializers.serialize(
       contentString,
       specifiedType: const FullType(ContentString, [
         FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
       ]),
     );
-    _parameters['content_string'] = $contentString;
+    _parameters['content_string'] = __contentString;
 
-    final $contentParameter = _$jsonSerializers.serialize(
+    final __contentParameter = _$jsonSerializers.serialize(
       contentParameter,
       specifiedType: const FullType(ContentString, [
         FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
       ]),
     );
-    _parameters['content_parameter'] = $contentParameter;
+    _parameters['content_parameter'] = __contentParameter;
 
-    final $array = _$jsonSerializers.serialize(array, specifiedType: const FullType(BuiltList, [FullType(JsonObject)]));
-    _parameters['array'] = $array;
+    final __array =
+        _$jsonSerializers.serialize(array, specifiedType: const FullType(BuiltList, [FullType(JsonObject)]));
+    _parameters['array'] = __array;
 
-    final $arrayString =
+    final __arrayString =
         _$jsonSerializers.serialize(arrayString, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    _parameters['array_string'] = $arrayString;
+    _parameters['array_string'] = __arrayString;
 
-    final $$bool = _$jsonSerializers.serialize($bool, specifiedType: const FullType(bool));
-    _parameters['bool'] = $$bool;
+    final __$bool = _$jsonSerializers.serialize($bool, specifiedType: const FullType(bool));
+    _parameters['bool'] = __$bool;
 
-    final $string = _$jsonSerializers.serialize(string, specifiedType: const FullType(String));
-    _parameters['string'] = $string;
+    final __string = _$jsonSerializers.serialize(string, specifiedType: const FullType(String));
+    _parameters['string'] = __string;
 
-    final $stringBinary = _$jsonSerializers.serialize(stringBinary, specifiedType: const FullType(Uint8List));
-    _parameters['string_binary'] = $stringBinary;
+    final __stringBinary = _$jsonSerializers.serialize(stringBinary, specifiedType: const FullType(Uint8List));
+    _parameters['string_binary'] = __stringBinary;
 
-    final $$int = _$jsonSerializers.serialize($int, specifiedType: const FullType(int));
-    _parameters['int'] = $$int;
+    final __$int = _$jsonSerializers.serialize($int, specifiedType: const FullType(int));
+    _parameters['int'] = __$int;
 
-    final $$double = _$jsonSerializers.serialize($double, specifiedType: const FullType(double));
-    _parameters['double'] = $$double;
+    final __$double = _$jsonSerializers.serialize($double, specifiedType: const FullType(double));
+    _parameters['double'] = __$double;
 
-    final $$num = _$jsonSerializers.serialize($num, specifiedType: const FullType(num));
-    _parameters['num'] = $$num;
+    final __$num = _$jsonSerializers.serialize($num, specifiedType: const FullType(num));
+    _parameters['num'] = __$num;
 
-    final $object = _$jsonSerializers.serialize(object, specifiedType: const FullType(JsonObject));
-    _parameters['object'] = $object;
+    final __object = _$jsonSerializers.serialize(object, specifiedType: const FullType(JsonObject));
+    _parameters['object'] = __object;
 
-    final $oneOf = _$jsonSerializers.serialize(oneOf, specifiedType: const FullType(GetOneOf));
-    _parameters['oneOf'] = $oneOf;
+    final __oneOf = _$jsonSerializers.serialize(oneOf, specifiedType: const FullType(GetOneOf));
+    _parameters['oneOf'] = __oneOf;
 
-    final $anyOf = _$jsonSerializers.serialize(anyOf, specifiedType: const FullType(GetAnyOf));
-    _parameters['anyOf'] = $anyOf;
+    final __anyOf = _$jsonSerializers.serialize(anyOf, specifiedType: const FullType(GetAnyOf));
+    _parameters['anyOf'] = __anyOf;
 
-    final $enumPattern = _$jsonSerializers.serialize(enumPattern, specifiedType: const FullType(GetEnumPattern));
+    final __enumPattern = _$jsonSerializers.serialize(enumPattern, specifiedType: const FullType(GetEnumPattern));
     _i4.checkString(
-      $enumPattern,
+      __enumPattern,
       'enumPattern',
       pattern: RegExp('[a-z]'),
     );
-    _parameters['enum_pattern'] = $enumPattern;
+    _parameters['enum_pattern'] = __enumPattern;
 
     final _path = _i5.UriTemplate(
       '/{?content_string*,content_parameter*,array*,array_string*,bool*,string*,string_binary*,int*,double*,num*,object*,oneOf*,anyOf*,enum_pattern*}',
@@ -277,81 +278,81 @@ class $Client extends _i1.DynamiteClient {
     GetDefaultsEnumPattern? enumPattern,
   }) {
     final _parameters = <String, Object?>{};
-    var $contentString = _$jsonSerializers.serialize(
+    var __contentString = _$jsonSerializers.serialize(
       contentString,
       specifiedType: const FullType(ContentString, [
         FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
       ]),
     );
-    $contentString ??= '"{}"';
-    _parameters['content_string'] = $contentString;
+    __contentString ??= '"{}"';
+    _parameters['content_string'] = __contentString;
 
-    final $contentParameter = _$jsonSerializers.serialize(
+    final __contentParameter = _$jsonSerializers.serialize(
       contentParameter,
       specifiedType: const FullType(ContentString, [
         FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
       ]),
     );
-    _parameters['content_parameter'] = $contentParameter;
+    _parameters['content_parameter'] = __contentParameter;
 
-    var $array = _$jsonSerializers.serialize(array, specifiedType: const FullType(BuiltList, [FullType(JsonObject)]));
-    $array ??= const ['default-item', true, 1.0];
-    _parameters['array'] = $array;
+    var __array = _$jsonSerializers.serialize(array, specifiedType: const FullType(BuiltList, [FullType(JsonObject)]));
+    __array ??= const ['default-item', true, 1.0];
+    _parameters['array'] = __array;
 
-    var $arrayString =
+    var __arrayString =
         _$jsonSerializers.serialize(arrayString, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    $arrayString ??= const ['default-item', 'item'];
-    _parameters['array_string'] = $arrayString;
+    __arrayString ??= const ['default-item', 'item'];
+    _parameters['array_string'] = __arrayString;
 
-    var $$bool = _$jsonSerializers.serialize($bool, specifiedType: const FullType(bool));
-    $$bool ??= true;
-    _parameters['bool'] = $$bool;
+    var __$bool = _$jsonSerializers.serialize($bool, specifiedType: const FullType(bool));
+    __$bool ??= true;
+    _parameters['bool'] = __$bool;
 
-    var $string = _$jsonSerializers.serialize(string, specifiedType: const FullType(String));
-    $string ??= 'default';
-    _parameters['string'] = $string;
+    var __string = _$jsonSerializers.serialize(string, specifiedType: const FullType(String));
+    __string ??= 'default';
+    _parameters['string'] = __string;
 
-    var $stringBinary = _$jsonSerializers.serialize(stringBinary, specifiedType: const FullType(Uint8List));
-    $stringBinary ??= '';
-    _parameters['string_binary'] = $stringBinary;
+    var __stringBinary = _$jsonSerializers.serialize(stringBinary, specifiedType: const FullType(Uint8List));
+    __stringBinary ??= '';
+    _parameters['string_binary'] = __stringBinary;
 
-    var $$int = _$jsonSerializers.serialize($int, specifiedType: const FullType(int));
-    $$int ??= 1;
-    _parameters['int'] = $$int;
+    var __$int = _$jsonSerializers.serialize($int, specifiedType: const FullType(int));
+    __$int ??= 1;
+    _parameters['int'] = __$int;
 
-    var $$double = _$jsonSerializers.serialize($double, specifiedType: const FullType(double));
-    $$double ??= 1.0;
-    _parameters['double'] = $$double;
+    var __$double = _$jsonSerializers.serialize($double, specifiedType: const FullType(double));
+    __$double ??= 1.0;
+    _parameters['double'] = __$double;
 
-    var $$num = _$jsonSerializers.serialize($num, specifiedType: const FullType(num));
-    $$num ??= 0;
-    _parameters['num'] = $$num;
+    var __$num = _$jsonSerializers.serialize($num, specifiedType: const FullType(num));
+    __$num ??= 0;
+    _parameters['num'] = __$num;
 
-    var $object = _$jsonSerializers.serialize(object, specifiedType: const FullType(JsonObject));
-    $object ??= const {
+    var __object = _$jsonSerializers.serialize(object, specifiedType: const FullType(JsonObject));
+    __object ??= const {
       'list': ['list'],
       'string': 'default-item',
       'bool': true,
       'num': 1.0,
     };
-    _parameters['object'] = $object;
+    _parameters['object'] = __object;
 
-    var $oneOf = _$jsonSerializers.serialize(oneOf, specifiedType: const FullType(GetDefaultsOneOf));
-    $oneOf ??= false;
-    _parameters['oneOf'] = $oneOf;
+    var __oneOf = _$jsonSerializers.serialize(oneOf, specifiedType: const FullType(GetDefaultsOneOf));
+    __oneOf ??= false;
+    _parameters['oneOf'] = __oneOf;
 
-    var $anyOf = _$jsonSerializers.serialize(anyOf, specifiedType: const FullType(GetDefaultsAnyOf));
-    $anyOf ??= 'default-value';
-    _parameters['anyOf'] = $anyOf;
+    var __anyOf = _$jsonSerializers.serialize(anyOf, specifiedType: const FullType(GetDefaultsAnyOf));
+    __anyOf ??= 'default-value';
+    _parameters['anyOf'] = __anyOf;
 
-    var $enumPattern = _$jsonSerializers.serialize(enumPattern, specifiedType: const FullType(GetDefaultsEnumPattern));
-    $enumPattern ??= 'a';
+    var __enumPattern = _$jsonSerializers.serialize(enumPattern, specifiedType: const FullType(GetDefaultsEnumPattern));
+    __enumPattern ??= 'a';
     _i4.checkString(
-      $enumPattern,
+      __enumPattern,
       'enumPattern',
       pattern: RegExp('[a-z]'),
     );
-    _parameters['enum_pattern'] = $enumPattern;
+    _parameters['enum_pattern'] = __enumPattern;
 
     final _path = _i5.UriTemplate(
       '/defaults{?content_string*,content_parameter*,array*,array_string*,bool*,string*,string_binary*,int*,double*,num*,object*,oneOf*,anyOf*,enum_pattern*}',
@@ -482,90 +483,92 @@ class $Client extends _i1.DynamiteClient {
     final _uri = Uri.parse('$baseURL$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
-    final $contentString = _$jsonSerializers.serialize(
+    final __contentString = _$jsonSerializers.serialize(
       contentString,
       specifiedType: const FullType(ContentString, [
         FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
       ]),
     );
-    if ($contentString != null) {
-      _request.headers['content_string'] = const _i4.HeaderEncoder().convert($contentString);
+    if (__contentString != null) {
+      _request.headers['content_string'] = const _i4.HeaderEncoder().convert(__contentString);
     }
 
-    final $contentParameter = _$jsonSerializers.serialize(
+    final __contentParameter = _$jsonSerializers.serialize(
       contentParameter,
       specifiedType: const FullType(ContentString, [
         FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
       ]),
     );
-    if ($contentParameter != null) {
-      _request.headers['content_parameter'] = const _i4.HeaderEncoder().convert($contentParameter);
+    if (__contentParameter != null) {
+      _request.headers['content_parameter'] = const _i4.HeaderEncoder().convert(__contentParameter);
     }
 
-    final $array = _$jsonSerializers.serialize(array, specifiedType: const FullType(BuiltList, [FullType(JsonObject)]));
-    if ($array != null) {
-      _request.headers['array'] = const _i4.HeaderEncoder().convert($array);
+    final __array =
+        _$jsonSerializers.serialize(array, specifiedType: const FullType(BuiltList, [FullType(JsonObject)]));
+    if (__array != null) {
+      _request.headers['array'] = const _i4.HeaderEncoder().convert(__array);
     }
 
-    final $arrayString =
+    final __arrayString =
         _$jsonSerializers.serialize(arrayString, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    if ($arrayString != null) {
-      _request.headers['array_string'] = const _i4.HeaderEncoder().convert($arrayString);
+    if (__arrayString != null) {
+      _request.headers['array_string'] = const _i4.HeaderEncoder().convert(__arrayString);
     }
 
-    final $$bool = _$jsonSerializers.serialize($bool, specifiedType: const FullType(bool));
-    if ($$bool != null) {
-      _request.headers['bool'] = const _i4.HeaderEncoder().convert($$bool);
+    final __$bool = _$jsonSerializers.serialize($bool, specifiedType: const FullType(bool));
+    if (__$bool != null) {
+      _request.headers['bool'] = const _i4.HeaderEncoder().convert(__$bool);
     }
 
-    final $string = _$jsonSerializers.serialize(string, specifiedType: const FullType(String));
-    if ($string != null) {
-      _request.headers['string'] = const _i4.HeaderEncoder().convert($string);
+    final __string = _$jsonSerializers.serialize(string, specifiedType: const FullType(String));
+    if (__string != null) {
+      _request.headers['string'] = const _i4.HeaderEncoder().convert(__string);
     }
 
-    final $stringBinary = _$jsonSerializers.serialize(stringBinary, specifiedType: const FullType(Uint8List));
-    if ($stringBinary != null) {
-      _request.headers['string_binary'] = const _i4.HeaderEncoder().convert($stringBinary);
+    final __stringBinary = _$jsonSerializers.serialize(stringBinary, specifiedType: const FullType(Uint8List));
+    if (__stringBinary != null) {
+      _request.headers['string_binary'] = const _i4.HeaderEncoder().convert(__stringBinary);
     }
 
-    final $$int = _$jsonSerializers.serialize($int, specifiedType: const FullType(int));
-    if ($$int != null) {
-      _request.headers['int'] = const _i4.HeaderEncoder().convert($$int);
+    final __$int = _$jsonSerializers.serialize($int, specifiedType: const FullType(int));
+    if (__$int != null) {
+      _request.headers['int'] = const _i4.HeaderEncoder().convert(__$int);
     }
 
-    final $$double = _$jsonSerializers.serialize($double, specifiedType: const FullType(double));
-    if ($$double != null) {
-      _request.headers['double'] = const _i4.HeaderEncoder().convert($$double);
+    final __$double = _$jsonSerializers.serialize($double, specifiedType: const FullType(double));
+    if (__$double != null) {
+      _request.headers['double'] = const _i4.HeaderEncoder().convert(__$double);
     }
 
-    final $$num = _$jsonSerializers.serialize($num, specifiedType: const FullType(num));
-    if ($$num != null) {
-      _request.headers['num'] = const _i4.HeaderEncoder().convert($$num);
+    final __$num = _$jsonSerializers.serialize($num, specifiedType: const FullType(num));
+    if (__$num != null) {
+      _request.headers['num'] = const _i4.HeaderEncoder().convert(__$num);
     }
 
-    final $object = _$jsonSerializers.serialize(object, specifiedType: const FullType(JsonObject));
-    if ($object != null) {
-      _request.headers['object'] = const _i4.HeaderEncoder().convert($object);
+    final __object = _$jsonSerializers.serialize(object, specifiedType: const FullType(JsonObject));
+    if (__object != null) {
+      _request.headers['object'] = const _i4.HeaderEncoder().convert(__object);
     }
 
-    final $oneOf = _$jsonSerializers.serialize(oneOf, specifiedType: const FullType(GetHeadersOneOf));
-    if ($oneOf != null) {
-      _request.headers['oneOf'] = const _i4.HeaderEncoder().convert($oneOf);
+    final __oneOf = _$jsonSerializers.serialize(oneOf, specifiedType: const FullType(GetHeadersOneOf));
+    if (__oneOf != null) {
+      _request.headers['oneOf'] = const _i4.HeaderEncoder().convert(__oneOf);
     }
 
-    final $anyOf = _$jsonSerializers.serialize(anyOf, specifiedType: const FullType(GetHeadersAnyOf));
-    if ($anyOf != null) {
-      _request.headers['anyOf'] = const _i4.HeaderEncoder().convert($anyOf);
+    final __anyOf = _$jsonSerializers.serialize(anyOf, specifiedType: const FullType(GetHeadersAnyOf));
+    if (__anyOf != null) {
+      _request.headers['anyOf'] = const _i4.HeaderEncoder().convert(__anyOf);
     }
 
-    final $enumPattern = _$jsonSerializers.serialize(enumPattern, specifiedType: const FullType(GetHeadersEnumPattern));
+    final __enumPattern =
+        _$jsonSerializers.serialize(enumPattern, specifiedType: const FullType(GetHeadersEnumPattern));
     _i4.checkString(
-      $enumPattern,
+      __enumPattern,
       'enumPattern',
       pattern: RegExp('[a-z]'),
     );
-    if ($enumPattern != null) {
-      _request.headers['enum_pattern'] = const _i4.HeaderEncoder().convert($enumPattern);
+    if (__enumPattern != null) {
+      _request.headers['enum_pattern'] = const _i4.HeaderEncoder().convert(__enumPattern);
     }
 
     return _request;
@@ -657,8 +660,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $getPathParameter_Request({required String pathParameter}) {
     final _parameters = <String, Object?>{};
-    final $pathParameter = _$jsonSerializers.serialize(pathParameter, specifiedType: const FullType(String));
-    _parameters['path_parameter'] = $pathParameter;
+    final __pathParameter = _$jsonSerializers.serialize(pathParameter, specifiedType: const FullType(String));
+    _parameters['path_parameter'] = __pathParameter;
 
     final _path = _i5.UriTemplate('/{path_parameter}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -715,31 +718,31 @@ class $Client extends _i1.DynamiteClient {
     required String headers,
   }) {
     final _parameters = <String, Object?>{};
-    final $jsonSerializers = _$jsonSerializers.serialize(jsonSerializers, specifiedType: const FullType(String));
-    _parameters['%24jsonSerializers'] = $jsonSerializers;
+    final __jsonSerializers = _$jsonSerializers.serialize(jsonSerializers, specifiedType: const FullType(String));
+    _parameters['%24jsonSerializers'] = __jsonSerializers;
 
     final _path = _i5.UriTemplate('/naming_collisions{?%24jsonSerializers*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
-    final $serializers = _$jsonSerializers.serialize(serializers, specifiedType: const FullType(String));
-    if ($serializers != null) {
-      _request.headers['%24serializers'] = const _i4.HeaderEncoder().convert($serializers);
+    final __serializers = _$jsonSerializers.serialize(serializers, specifiedType: const FullType(String));
+    if (__serializers != null) {
+      _request.headers['%24serializers'] = const _i4.HeaderEncoder().convert(__serializers);
     }
 
-    final $body = _$jsonSerializers.serialize(body, specifiedType: const FullType(String));
-    if ($body != null) {
-      _request.headers['_body'] = const _i4.HeaderEncoder().convert($body);
+    final __body = _$jsonSerializers.serialize(body, specifiedType: const FullType(String));
+    if (__body != null) {
+      _request.headers['_body'] = const _i4.HeaderEncoder().convert(__body);
     }
 
-    final $parameters = _$jsonSerializers.serialize(parameters, specifiedType: const FullType(String));
-    if ($parameters != null) {
-      _request.headers['_parameters'] = const _i4.HeaderEncoder().convert($parameters);
+    final __parameters = _$jsonSerializers.serialize(parameters, specifiedType: const FullType(String));
+    if (__parameters != null) {
+      _request.headers['_parameters'] = const _i4.HeaderEncoder().convert(__parameters);
     }
 
-    final $headers = _$jsonSerializers.serialize(headers, specifiedType: const FullType(String));
-    if ($headers != null) {
-      _request.headers['_headers'] = const _i4.HeaderEncoder().convert($headers);
+    final __headers = _$jsonSerializers.serialize(headers, specifiedType: const FullType(String));
+    if (__headers != null) {
+      _request.headers['_headers'] = const _i4.HeaderEncoder().convert(__headers);
     }
 
     return _request;

--- a/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.dart
@@ -12,6 +12,7 @@ library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart' as _i6;
 import 'package:dynamite_runtime/built_value.dart' as _i5;
@@ -19,6 +20,8 @@ import 'package:dynamite_runtime/http_client.dart' as _i1;
 import 'package:http/http.dart' as _i3;
 import 'package:meta/meta.dart' as _i2;
 import 'package:uri/uri.dart' as _i4;
+
+part 'request_body.openapi.g.dart';
 
 class $Client extends _i1.DynamiteClient {
   /// Creates a new `DynamiteClient` for untagged requests.
@@ -34,56 +37,6 @@ class $Client extends _i1.DynamiteClient {
           httpClient: client.httpClient,
           authentications: client.authentications,
         );
-
-  /// Builds a serializer to parse the response of [$$get_Request].
-  @_i2.experimental
-  _i1.DynamiteSerializer<void, void> $$get_Serializer() => _i1.DynamiteSerializer(
-        bodyType: null,
-        headersType: null,
-        serializers: _$jsonSerializers,
-      );
-
-  /// Returns a `DynamiteRequest` backing the [$get] operation.
-  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
-  ///
-  /// Status codes:
-  ///   * default
-  ///
-  /// See:
-  ///  * [$get] for a method executing this request and parsing the response.
-  ///  * [$$get_Serializer] for a converter to parse the `Response` from an executed this request.
-  @_i2.experimental
-  _i3.Request $$get_Request({Uint8List? $body}) {
-    const _path = '/';
-    final _uri = Uri.parse('$baseURL$_path');
-    final _request = _i3.Request('get', _uri);
-    _request.headers['Content-Type'] = 'application/octet-stream';
-    if ($body != null) {
-      _request.bodyBytes = $body;
-    }
-    return _request;
-  }
-
-  /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
-  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
-  ///
-  /// Status codes:
-  ///   * default
-  ///
-  /// See:
-  ///  * [$$get_Request] for the request send by this method.
-  ///  * [$$get_Serializer] for a converter to parse the `Response` from an executed request.
-  Future<_i1.DynamiteResponse<void, void>> $get({Uint8List? $body}) async {
-    final _request = $$get_Request(
-      $body: $body,
-    );
-    final _streamedResponse = await httpClient.send(_request);
-    final _response = await _i3.Response.fromStream(_streamedResponse);
-
-    final _serializer = $$get_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
-  }
 
   /// Builds a serializer to parse the response of [$post_Request].
   @_i2.experimental
@@ -118,9 +71,7 @@ class $Client extends _i1.DynamiteClient {
     final _uri = Uri.parse('$baseURL$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Content-Type'] = 'application/octet-stream';
-    if ($body != null) {
-      _request.bodyBytes = utf8.encode($body);
-    }
+    _request.bodyBytes = $body != null ? utf8.encode($body) : Uint8List(0);
     return _request;
   }
 
@@ -151,6 +102,592 @@ class $Client extends _i1.DynamiteClient {
     final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
+
+  /// Builds a serializer to parse the response of [$getObject_Request].
+  @_i2.experimental
+  _i1.DynamiteSerializer<void, void> $getObject_Serializer() => _i1.DynamiteSerializer(
+        bodyType: null,
+        headersType: null,
+        serializers: _$jsonSerializers,
+      );
+
+  /// Returns a `DynamiteRequest` backing the [getObject] operation.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [getObject] for a method executing this request and parsing the response.
+  ///  * [$getObject_Serializer] for a converter to parse the `Response` from an executed this request.
+  @_i2.experimental
+  _i3.Request $getObject_Request({GetObjectRequestApplicationJson? $body}) {
+    const _path = '/object';
+    final _uri = Uri.parse('$baseURL$_path');
+    final _request = _i3.Request('get', _uri);
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json
+            .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(GetObjectRequestApplicationJson)))
+        : json.encode(
+            _$jsonSerializers.serialize(
+              GetObjectRequestApplicationJson(),
+              specifiedType: const FullType(GetObjectRequestApplicationJson),
+            ),
+          );
+    return _request;
+  }
+
+  /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [$getObject_Request] for the request send by this method.
+  ///  * [$getObject_Serializer] for a converter to parse the `Response` from an executed request.
+  Future<_i1.DynamiteResponse<void, void>> getObject({GetObjectRequestApplicationJson? $body}) async {
+    final _request = $getObject_Request(
+      $body: $body,
+    );
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
+
+    final _serializer = $getObject_Serializer();
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+  }
+
+  /// Builds a serializer to parse the response of [$putObject_Request].
+  @_i2.experimental
+  _i1.DynamiteSerializer<void, void> $putObject_Serializer() => _i1.DynamiteSerializer(
+        bodyType: null,
+        headersType: null,
+        serializers: _$jsonSerializers,
+      );
+
+  /// Returns a `DynamiteRequest` backing the [putObject] operation.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [putObject] for a method executing this request and parsing the response.
+  ///  * [$putObject_Serializer] for a converter to parse the `Response` from an executed this request.
+  @_i2.experimental
+  _i3.Request $putObject_Request({PutObjectRequestApplicationJson? $body}) {
+    const _path = '/object';
+    final _uri = Uri.parse('$baseURL$_path');
+    final _request = _i3.Request('put', _uri);
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json
+            .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(PutObjectRequestApplicationJson)))
+        : json.encode(
+            _$jsonSerializers.serialize(
+              PutObjectRequestApplicationJson(),
+              specifiedType: const FullType(PutObjectRequestApplicationJson),
+            ),
+          );
+    return _request;
+  }
+
+  /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [$putObject_Request] for the request send by this method.
+  ///  * [$putObject_Serializer] for a converter to parse the `Response` from an executed request.
+  Future<_i1.DynamiteResponse<void, void>> putObject({PutObjectRequestApplicationJson? $body}) async {
+    final _request = $putObject_Request(
+      $body: $body,
+    );
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
+
+    final _serializer = $putObject_Serializer();
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+  }
+
+  /// Builds a serializer to parse the response of [$postObject_Request].
+  @_i2.experimental
+  _i1.DynamiteSerializer<void, void> $postObject_Serializer() => _i1.DynamiteSerializer(
+        bodyType: null,
+        headersType: null,
+        serializers: _$jsonSerializers,
+      );
+
+  /// Returns a `DynamiteRequest` backing the [postObject] operation.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [postObject] for a method executing this request and parsing the response.
+  ///  * [$postObject_Serializer] for a converter to parse the `Response` from an executed this request.
+  @_i2.experimental
+  _i3.Request $postObject_Request({required PostObjectRequestApplicationJson $body}) {
+    const _path = '/object';
+    final _uri = Uri.parse('$baseURL$_path');
+    final _request = _i3.Request('post', _uri);
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json
+        .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(PostObjectRequestApplicationJson)));
+    return _request;
+  }
+
+  /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [$postObject_Request] for the request send by this method.
+  ///  * [$postObject_Serializer] for a converter to parse the `Response` from an executed request.
+  Future<_i1.DynamiteResponse<void, void>> postObject({required PostObjectRequestApplicationJson $body}) async {
+    final _request = $postObject_Request(
+      $body: $body,
+    );
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
+
+    final _serializer = $postObject_Serializer();
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+  }
+
+  /// Builds a serializer to parse the response of [$deleteObject_Request].
+  @_i2.experimental
+  _i1.DynamiteSerializer<void, void> $deleteObject_Serializer() => _i1.DynamiteSerializer(
+        bodyType: null,
+        headersType: null,
+        serializers: _$jsonSerializers,
+      );
+
+  /// Returns a `DynamiteRequest` backing the [deleteObject] operation.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [deleteObject] for a method executing this request and parsing the response.
+  ///  * [$deleteObject_Serializer] for a converter to parse the `Response` from an executed this request.
+  @_i2.experimental
+  _i3.Request $deleteObject_Request({DeleteObjectRequestApplicationJson? $body}) {
+    const _path = '/object';
+    final _uri = Uri.parse('$baseURL$_path');
+    final _request = _i3.Request('delete', _uri);
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(DeleteObjectRequestApplicationJson)),
+          )
+        : json.encode(const {'test': '123'});
+    return _request;
+  }
+
+  /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [$deleteObject_Request] for the request send by this method.
+  ///  * [$deleteObject_Serializer] for a converter to parse the `Response` from an executed request.
+  Future<_i1.DynamiteResponse<void, void>> deleteObject({DeleteObjectRequestApplicationJson? $body}) async {
+    final _request = $deleteObject_Request(
+      $body: $body,
+    );
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
+
+    final _serializer = $deleteObject_Serializer();
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+  }
+
+  /// Builds a serializer to parse the response of [$getBinary_Request].
+  @_i2.experimental
+  _i1.DynamiteSerializer<void, void> $getBinary_Serializer() => _i1.DynamiteSerializer(
+        bodyType: null,
+        headersType: null,
+        serializers: _$jsonSerializers,
+      );
+
+  /// Returns a `DynamiteRequest` backing the [getBinary] operation.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [getBinary] for a method executing this request and parsing the response.
+  ///  * [$getBinary_Serializer] for a converter to parse the `Response` from an executed this request.
+  @_i2.experimental
+  _i3.Request $getBinary_Request({Uint8List? $body}) {
+    const _path = '/binary';
+    final _uri = Uri.parse('$baseURL$_path');
+    final _request = _i3.Request('get', _uri);
+    _request.headers['Content-Type'] = 'application/octet-stream';
+    _request.bodyBytes = $body ?? Uint8List(0);
+    return _request;
+  }
+
+  /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [$getBinary_Request] for the request send by this method.
+  ///  * [$getBinary_Serializer] for a converter to parse the `Response` from an executed request.
+  Future<_i1.DynamiteResponse<void, void>> getBinary({Uint8List? $body}) async {
+    final _request = $getBinary_Request(
+      $body: $body,
+    );
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
+
+    final _serializer = $getBinary_Serializer();
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+  }
+
+  /// Builds a serializer to parse the response of [$putBinary_Request].
+  @_i2.experimental
+  _i1.DynamiteSerializer<void, void> $putBinary_Serializer() => _i1.DynamiteSerializer(
+        bodyType: null,
+        headersType: null,
+        serializers: _$jsonSerializers,
+      );
+
+  /// Returns a `DynamiteRequest` backing the [putBinary] operation.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [putBinary] for a method executing this request and parsing the response.
+  ///  * [$putBinary_Serializer] for a converter to parse the `Response` from an executed this request.
+  @_i2.experimental
+  _i3.Request $putBinary_Request({Uint8List? $body}) {
+    const _path = '/binary';
+    final _uri = Uri.parse('$baseURL$_path');
+    final _request = _i3.Request('put', _uri);
+    _request.headers['Content-Type'] = 'application/octet-stream';
+    _request.bodyBytes = $body ?? const [116, 101, 115, 116];
+    return _request;
+  }
+
+  /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [$putBinary_Request] for the request send by this method.
+  ///  * [$putBinary_Serializer] for a converter to parse the `Response` from an executed request.
+  Future<_i1.DynamiteResponse<void, void>> putBinary({Uint8List? $body}) async {
+    final _request = $putBinary_Request(
+      $body: $body,
+    );
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
+
+    final _serializer = $putBinary_Serializer();
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+  }
+
+  /// Builds a serializer to parse the response of [$postBinary_Request].
+  @_i2.experimental
+  _i1.DynamiteSerializer<void, void> $postBinary_Serializer() => _i1.DynamiteSerializer(
+        bodyType: null,
+        headersType: null,
+        serializers: _$jsonSerializers,
+      );
+
+  /// Returns a `DynamiteRequest` backing the [postBinary] operation.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [postBinary] for a method executing this request and parsing the response.
+  ///  * [$postBinary_Serializer] for a converter to parse the `Response` from an executed this request.
+  @_i2.experimental
+  _i3.Request $postBinary_Request({required Uint8List $body}) {
+    const _path = '/binary';
+    final _uri = Uri.parse('$baseURL$_path');
+    final _request = _i3.Request('post', _uri);
+    _request.headers['Content-Type'] = 'application/octet-stream';
+    _request.bodyBytes = $body;
+    return _request;
+  }
+
+  /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
+  /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
+  ///
+  /// Status codes:
+  ///   * default
+  ///
+  /// See:
+  ///  * [$postBinary_Request] for the request send by this method.
+  ///  * [$postBinary_Serializer] for a converter to parse the `Response` from an executed request.
+  Future<_i1.DynamiteResponse<void, void>> postBinary({required Uint8List $body}) async {
+    final _request = $postBinary_Request(
+      $body: $body,
+    );
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
+
+    final _serializer = $postBinary_Serializer();
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $GetObjectRequestApplicationJsonInterface {
+  String? get test;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GetObjectRequestApplicationJsonInterfaceBuilder].
+  $GetObjectRequestApplicationJsonInterface rebuild(
+    void Function($GetObjectRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GetObjectRequestApplicationJsonInterfaceBuilder].
+  $GetObjectRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GetObjectRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GetObjectRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class GetObjectRequestApplicationJson
+    implements
+        $GetObjectRequestApplicationJsonInterface,
+        Built<GetObjectRequestApplicationJson, GetObjectRequestApplicationJsonBuilder> {
+  /// Creates a new GetObjectRequestApplicationJson object using the builder pattern.
+  factory GetObjectRequestApplicationJson([void Function(GetObjectRequestApplicationJsonBuilder)? b]) =
+      _$GetObjectRequestApplicationJson;
+
+  const GetObjectRequestApplicationJson._();
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  factory GetObjectRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+
+  /// Serializer for GetObjectRequestApplicationJson.
+  static Serializer<GetObjectRequestApplicationJson> get serializer => _$getObjectRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GetObjectRequestApplicationJsonBuilder b) {
+    $GetObjectRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GetObjectRequestApplicationJsonBuilder b) {
+    $GetObjectRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $PutObjectRequestApplicationJsonInterface {
+  static final _$test = _$jsonSerializers.deserialize(
+    '123',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  String get test;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PutObjectRequestApplicationJsonInterfaceBuilder].
+  $PutObjectRequestApplicationJsonInterface rebuild(
+    void Function($PutObjectRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PutObjectRequestApplicationJsonInterfaceBuilder].
+  $PutObjectRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PutObjectRequestApplicationJsonInterfaceBuilder b) {
+    b.test = _$test;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PutObjectRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class PutObjectRequestApplicationJson
+    implements
+        $PutObjectRequestApplicationJsonInterface,
+        Built<PutObjectRequestApplicationJson, PutObjectRequestApplicationJsonBuilder> {
+  /// Creates a new PutObjectRequestApplicationJson object using the builder pattern.
+  factory PutObjectRequestApplicationJson([void Function(PutObjectRequestApplicationJsonBuilder)? b]) =
+      _$PutObjectRequestApplicationJson;
+
+  const PutObjectRequestApplicationJson._();
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  factory PutObjectRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+
+  /// Serializer for PutObjectRequestApplicationJson.
+  static Serializer<PutObjectRequestApplicationJson> get serializer => _$putObjectRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PutObjectRequestApplicationJsonBuilder b) {
+    $PutObjectRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PutObjectRequestApplicationJsonBuilder b) {
+    $PutObjectRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $PostObjectRequestApplicationJsonInterface {
+  String? get test;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PostObjectRequestApplicationJsonInterfaceBuilder].
+  $PostObjectRequestApplicationJsonInterface rebuild(
+    void Function($PostObjectRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PostObjectRequestApplicationJsonInterfaceBuilder].
+  $PostObjectRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PostObjectRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PostObjectRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class PostObjectRequestApplicationJson
+    implements
+        $PostObjectRequestApplicationJsonInterface,
+        Built<PostObjectRequestApplicationJson, PostObjectRequestApplicationJsonBuilder> {
+  /// Creates a new PostObjectRequestApplicationJson object using the builder pattern.
+  factory PostObjectRequestApplicationJson([void Function(PostObjectRequestApplicationJsonBuilder)? b]) =
+      _$PostObjectRequestApplicationJson;
+
+  const PostObjectRequestApplicationJson._();
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  factory PostObjectRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+
+  /// Serializer for PostObjectRequestApplicationJson.
+  static Serializer<PostObjectRequestApplicationJson> get serializer => _$postObjectRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PostObjectRequestApplicationJsonBuilder b) {
+    $PostObjectRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PostObjectRequestApplicationJsonBuilder b) {
+    $PostObjectRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $DeleteObjectRequestApplicationJsonInterface {
+  String? get test;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeleteObjectRequestApplicationJsonInterfaceBuilder].
+  $DeleteObjectRequestApplicationJsonInterface rebuild(
+    void Function($DeleteObjectRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeleteObjectRequestApplicationJsonInterfaceBuilder].
+  $DeleteObjectRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DeleteObjectRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DeleteObjectRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class DeleteObjectRequestApplicationJson
+    implements
+        $DeleteObjectRequestApplicationJsonInterface,
+        Built<DeleteObjectRequestApplicationJson, DeleteObjectRequestApplicationJsonBuilder> {
+  /// Creates a new DeleteObjectRequestApplicationJson object using the builder pattern.
+  factory DeleteObjectRequestApplicationJson([void Function(DeleteObjectRequestApplicationJsonBuilder)? b]) =
+      _$DeleteObjectRequestApplicationJson;
+
+  const DeleteObjectRequestApplicationJson._();
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  factory DeleteObjectRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+
+  /// Serializer for DeleteObjectRequestApplicationJson.
+  static Serializer<DeleteObjectRequestApplicationJson> get serializer =>
+      _$deleteObjectRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DeleteObjectRequestApplicationJsonBuilder b) {
+    $DeleteObjectRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DeleteObjectRequestApplicationJsonBuilder b) {
+    $DeleteObjectRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 // coverage:ignore-start
@@ -160,7 +697,19 @@ class $Client extends _i1.DynamiteClient {
 /// See: [$jsonSerializers] for serializing into json.
 @_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
-final Serializers _$serializers = Serializers();
+final Serializers _$serializers = (Serializers().toBuilder()
+      ..addBuilderFactory(const FullType(GetObjectRequestApplicationJson), GetObjectRequestApplicationJsonBuilder.new)
+      ..add(GetObjectRequestApplicationJson.serializer)
+      ..addBuilderFactory(const FullType(PutObjectRequestApplicationJson), PutObjectRequestApplicationJsonBuilder.new)
+      ..add(PutObjectRequestApplicationJson.serializer)
+      ..addBuilderFactory(const FullType(PostObjectRequestApplicationJson), PostObjectRequestApplicationJsonBuilder.new)
+      ..add(PostObjectRequestApplicationJson.serializer)
+      ..addBuilderFactory(
+        const FullType(DeleteObjectRequestApplicationJson),
+        DeleteObjectRequestApplicationJsonBuilder.new,
+      )
+      ..add(DeleteObjectRequestApplicationJson.serializer))
+    .build();
 
 /// Serializer for all values in this library.
 ///

--- a/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.dart
@@ -13,11 +13,12 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:built_value/serializer.dart';
-import 'package:built_value/standard_json_plugin.dart' as _i5;
-import 'package:dynamite_runtime/built_value.dart' as _i4;
+import 'package:built_value/standard_json_plugin.dart' as _i6;
+import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
 import 'package:http/http.dart' as _i3;
 import 'package:meta/meta.dart' as _i2;
+import 'package:uri/uri.dart' as _i4;
 
 class $Client extends _i1.DynamiteClient {
   /// Creates a new `DynamiteClient` for untagged requests.
@@ -52,13 +53,13 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$get] for a method executing this request and parsing the response.
   ///  * [$$get_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $$get_Request({Uint8List? uint8List}) {
+  _i3.Request $$get_Request({Uint8List? $body}) {
     const _path = '/';
     final _uri = Uri.parse('$baseURL$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Content-Type'] = 'application/octet-stream';
-    if (uint8List != null) {
-      _request.bodyBytes = uint8List;
+    if ($body != null) {
+      _request.bodyBytes = $body;
     }
     return _request;
   }
@@ -72,9 +73,9 @@ class $Client extends _i1.DynamiteClient {
   /// See:
   ///  * [$$get_Request] for the request send by this method.
   ///  * [$$get_Serializer] for a converter to parse the `Response` from an executed request.
-  Future<_i1.DynamiteResponse<void, void>> $get({Uint8List? uint8List}) async {
+  Future<_i1.DynamiteResponse<void, void>> $get({Uint8List? $body}) async {
     final _request = $$get_Request(
-      uint8List: uint8List,
+      $body: $body,
     );
     final _streamedResponse = await httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -95,6 +96,9 @@ class $Client extends _i1.DynamiteClient {
   /// Returns a `DynamiteRequest` backing the [post] operation.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
+  /// Parameters:
+  ///   * [body]
+  ///
   /// Status codes:
   ///   * default
   ///
@@ -102,13 +106,20 @@ class $Client extends _i1.DynamiteClient {
   ///  * [post] for a method executing this request and parsing the response.
   ///  * [$post_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $post_Request({String? string}) {
-    const _path = '/';
+  _i3.Request $post_Request({
+    int? body,
+    String? $body,
+  }) {
+    final _parameters = <String, Object?>{};
+    final __body = _$jsonSerializers.serialize(body, specifiedType: const FullType(int));
+    _parameters['body'] = __body;
+
+    final _path = _i4.UriTemplate('/{?body*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Content-Type'] = 'application/octet-stream';
-    if (string != null) {
-      _request.bodyBytes = utf8.encode(string);
+    if ($body != null) {
+      _request.bodyBytes = utf8.encode($body);
     }
     return _request;
   }
@@ -116,15 +127,22 @@ class $Client extends _i1.DynamiteClient {
   /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
+  /// Parameters:
+  ///   * [body]
+  ///
   /// Status codes:
   ///   * default
   ///
   /// See:
   ///  * [$post_Request] for the request send by this method.
   ///  * [$post_Serializer] for a converter to parse the `Response` from an executed request.
-  Future<_i1.DynamiteResponse<void, void>> post({String? string}) async {
+  Future<_i1.DynamiteResponse<void, void>> post({
+    int? body,
+    String? $body,
+  }) async {
     final _request = $post_Request(
-      string: string,
+      body: body,
+      $body: $body,
     );
     final _streamedResponse = await httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -151,9 +169,9 @@ final Serializers _$serializers = Serializers();
 @_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
-      ..add(_i4.DynamiteDoubleSerializer())
-      ..addPlugin(_i5.StandardJsonPlugin())
-      ..addPlugin(const _i4.HeaderPlugin())
-      ..addPlugin(const _i4.ContentStringPlugin()))
+      ..add(_i5.DynamiteDoubleSerializer())
+      ..addPlugin(_i6.StandardJsonPlugin())
+      ..addPlugin(const _i5.HeaderPlugin())
+      ..addPlugin(const _i5.ContentStringPlugin()))
     .build();
 // coverage:ignore-end

--- a/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.g.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.g.dart
@@ -1,0 +1,536 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'request_body.openapi.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<GetObjectRequestApplicationJson> _$getObjectRequestApplicationJsonSerializer =
+    _$GetObjectRequestApplicationJsonSerializer();
+Serializer<PutObjectRequestApplicationJson> _$putObjectRequestApplicationJsonSerializer =
+    _$PutObjectRequestApplicationJsonSerializer();
+Serializer<PostObjectRequestApplicationJson> _$postObjectRequestApplicationJsonSerializer =
+    _$PostObjectRequestApplicationJsonSerializer();
+Serializer<DeleteObjectRequestApplicationJson> _$deleteObjectRequestApplicationJsonSerializer =
+    _$DeleteObjectRequestApplicationJsonSerializer();
+
+class _$GetObjectRequestApplicationJsonSerializer implements StructuredSerializer<GetObjectRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [GetObjectRequestApplicationJson, _$GetObjectRequestApplicationJson];
+  @override
+  final String wireName = 'GetObjectRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GetObjectRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.test;
+    if (value != null) {
+      result
+        ..add('test')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  GetObjectRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GetObjectRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'test':
+          result.test = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$PutObjectRequestApplicationJsonSerializer implements StructuredSerializer<PutObjectRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [PutObjectRequestApplicationJson, _$PutObjectRequestApplicationJson];
+  @override
+  final String wireName = 'PutObjectRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PutObjectRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'test',
+      serializers.serialize(object.test, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  PutObjectRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PutObjectRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'test':
+          result.test = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$PostObjectRequestApplicationJsonSerializer implements StructuredSerializer<PostObjectRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [PostObjectRequestApplicationJson, _$PostObjectRequestApplicationJson];
+  @override
+  final String wireName = 'PostObjectRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PostObjectRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.test;
+    if (value != null) {
+      result
+        ..add('test')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  PostObjectRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PostObjectRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'test':
+          result.test = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$DeleteObjectRequestApplicationJsonSerializer
+    implements StructuredSerializer<DeleteObjectRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [DeleteObjectRequestApplicationJson, _$DeleteObjectRequestApplicationJson];
+  @override
+  final String wireName = 'DeleteObjectRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, DeleteObjectRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.test;
+    if (value != null) {
+      result
+        ..add('test')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  DeleteObjectRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = DeleteObjectRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'test':
+          result.test = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+abstract mixin class $GetObjectRequestApplicationJsonInterfaceBuilder {
+  void replace($GetObjectRequestApplicationJsonInterface other);
+  void update(void Function($GetObjectRequestApplicationJsonInterfaceBuilder) updates);
+  String? get test;
+  set test(String? test);
+}
+
+class _$GetObjectRequestApplicationJson extends GetObjectRequestApplicationJson {
+  @override
+  final String? test;
+
+  factory _$GetObjectRequestApplicationJson([void Function(GetObjectRequestApplicationJsonBuilder)? updates]) =>
+      (GetObjectRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$GetObjectRequestApplicationJson._({this.test}) : super._();
+
+  @override
+  GetObjectRequestApplicationJson rebuild(void Function(GetObjectRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GetObjectRequestApplicationJsonBuilder toBuilder() => GetObjectRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GetObjectRequestApplicationJson && test == other.test;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, test.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GetObjectRequestApplicationJson')..add('test', test)).toString();
+  }
+}
+
+class GetObjectRequestApplicationJsonBuilder
+    implements
+        Builder<GetObjectRequestApplicationJson, GetObjectRequestApplicationJsonBuilder>,
+        $GetObjectRequestApplicationJsonInterfaceBuilder {
+  _$GetObjectRequestApplicationJson? _$v;
+
+  String? _test;
+  String? get test => _$this._test;
+  set test(covariant String? test) => _$this._test = test;
+
+  GetObjectRequestApplicationJsonBuilder() {
+    GetObjectRequestApplicationJson._defaults(this);
+  }
+
+  GetObjectRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _test = $v.test;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant GetObjectRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GetObjectRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(GetObjectRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GetObjectRequestApplicationJson build() => _build();
+
+  _$GetObjectRequestApplicationJson _build() {
+    GetObjectRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$GetObjectRequestApplicationJson._(test: test);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $PutObjectRequestApplicationJsonInterfaceBuilder {
+  void replace($PutObjectRequestApplicationJsonInterface other);
+  void update(void Function($PutObjectRequestApplicationJsonInterfaceBuilder) updates);
+  String? get test;
+  set test(String? test);
+}
+
+class _$PutObjectRequestApplicationJson extends PutObjectRequestApplicationJson {
+  @override
+  final String test;
+
+  factory _$PutObjectRequestApplicationJson([void Function(PutObjectRequestApplicationJsonBuilder)? updates]) =>
+      (PutObjectRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PutObjectRequestApplicationJson._({required this.test}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(test, r'PutObjectRequestApplicationJson', 'test');
+  }
+
+  @override
+  PutObjectRequestApplicationJson rebuild(void Function(PutObjectRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PutObjectRequestApplicationJsonBuilder toBuilder() => PutObjectRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PutObjectRequestApplicationJson && test == other.test;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, test.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PutObjectRequestApplicationJson')..add('test', test)).toString();
+  }
+}
+
+class PutObjectRequestApplicationJsonBuilder
+    implements
+        Builder<PutObjectRequestApplicationJson, PutObjectRequestApplicationJsonBuilder>,
+        $PutObjectRequestApplicationJsonInterfaceBuilder {
+  _$PutObjectRequestApplicationJson? _$v;
+
+  String? _test;
+  String? get test => _$this._test;
+  set test(covariant String? test) => _$this._test = test;
+
+  PutObjectRequestApplicationJsonBuilder() {
+    PutObjectRequestApplicationJson._defaults(this);
+  }
+
+  PutObjectRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _test = $v.test;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PutObjectRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PutObjectRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PutObjectRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PutObjectRequestApplicationJson build() => _build();
+
+  _$PutObjectRequestApplicationJson _build() {
+    PutObjectRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$PutObjectRequestApplicationJson._(
+            test: BuiltValueNullFieldError.checkNotNull(test, r'PutObjectRequestApplicationJson', 'test'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $PostObjectRequestApplicationJsonInterfaceBuilder {
+  void replace($PostObjectRequestApplicationJsonInterface other);
+  void update(void Function($PostObjectRequestApplicationJsonInterfaceBuilder) updates);
+  String? get test;
+  set test(String? test);
+}
+
+class _$PostObjectRequestApplicationJson extends PostObjectRequestApplicationJson {
+  @override
+  final String? test;
+
+  factory _$PostObjectRequestApplicationJson([void Function(PostObjectRequestApplicationJsonBuilder)? updates]) =>
+      (PostObjectRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PostObjectRequestApplicationJson._({this.test}) : super._();
+
+  @override
+  PostObjectRequestApplicationJson rebuild(void Function(PostObjectRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PostObjectRequestApplicationJsonBuilder toBuilder() => PostObjectRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PostObjectRequestApplicationJson && test == other.test;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, test.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PostObjectRequestApplicationJson')..add('test', test)).toString();
+  }
+}
+
+class PostObjectRequestApplicationJsonBuilder
+    implements
+        Builder<PostObjectRequestApplicationJson, PostObjectRequestApplicationJsonBuilder>,
+        $PostObjectRequestApplicationJsonInterfaceBuilder {
+  _$PostObjectRequestApplicationJson? _$v;
+
+  String? _test;
+  String? get test => _$this._test;
+  set test(covariant String? test) => _$this._test = test;
+
+  PostObjectRequestApplicationJsonBuilder() {
+    PostObjectRequestApplicationJson._defaults(this);
+  }
+
+  PostObjectRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _test = $v.test;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PostObjectRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PostObjectRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PostObjectRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PostObjectRequestApplicationJson build() => _build();
+
+  _$PostObjectRequestApplicationJson _build() {
+    PostObjectRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$PostObjectRequestApplicationJson._(test: test);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $DeleteObjectRequestApplicationJsonInterfaceBuilder {
+  void replace($DeleteObjectRequestApplicationJsonInterface other);
+  void update(void Function($DeleteObjectRequestApplicationJsonInterfaceBuilder) updates);
+  String? get test;
+  set test(String? test);
+}
+
+class _$DeleteObjectRequestApplicationJson extends DeleteObjectRequestApplicationJson {
+  @override
+  final String? test;
+
+  factory _$DeleteObjectRequestApplicationJson([void Function(DeleteObjectRequestApplicationJsonBuilder)? updates]) =>
+      (DeleteObjectRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$DeleteObjectRequestApplicationJson._({this.test}) : super._();
+
+  @override
+  DeleteObjectRequestApplicationJson rebuild(void Function(DeleteObjectRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DeleteObjectRequestApplicationJsonBuilder toBuilder() => DeleteObjectRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DeleteObjectRequestApplicationJson && test == other.test;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, test.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'DeleteObjectRequestApplicationJson')..add('test', test)).toString();
+  }
+}
+
+class DeleteObjectRequestApplicationJsonBuilder
+    implements
+        Builder<DeleteObjectRequestApplicationJson, DeleteObjectRequestApplicationJsonBuilder>,
+        $DeleteObjectRequestApplicationJsonInterfaceBuilder {
+  _$DeleteObjectRequestApplicationJson? _$v;
+
+  String? _test;
+  String? get test => _$this._test;
+  set test(covariant String? test) => _$this._test = test;
+
+  DeleteObjectRequestApplicationJsonBuilder() {
+    DeleteObjectRequestApplicationJson._defaults(this);
+  }
+
+  DeleteObjectRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _test = $v.test;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant DeleteObjectRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$DeleteObjectRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(DeleteObjectRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DeleteObjectRequestApplicationJson build() => _build();
+
+  _$DeleteObjectRequestApplicationJson _build() {
+    DeleteObjectRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$DeleteObjectRequestApplicationJson._(test: test);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.json
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.json
@@ -33,6 +33,15 @@
                         }
                     }
                 },
+                "parameters": [
+                    {
+                        "name": "body",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
                 "responses": {
                     "default": {
                         "description": ""

--- a/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.json
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.json
@@ -6,23 +6,6 @@
     },
     "paths": {
         "/": {
-            "get": {
-                "requestBody": {
-                    "content": {
-                        "application/octet-stream": {
-                            "schema": {
-                                "type": "string",
-                                "format": "binary"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "default": {
-                        "description": ""
-                    }
-                }
-            },
             "post": {
                 "requestBody": {
                     "content": {
@@ -42,6 +25,150 @@
                         }
                     }
                 ],
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/object": {
+            "get": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "test": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "test": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "test": {
+                                        "type": "string",
+                                        "default": "123"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "default": {"test": "123"},
+                                "properties": {
+                                    "test": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/binary": {
+            "get": {
+                "requestBody": {
+                    "content": {
+                        "application/octet-stream": {
+                            "schema": {
+                                "type": "string",
+                                "format": "binary"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/octet-stream": {
+                            "schema": {
+                                "type": "string",
+                                "format": "binary"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "default": {
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "requestBody": {
+                    "content": {
+                        "application/octet-stream": {
+                            "schema": {
+                                "type": "string",
+                                "format": "binary",
+                                "default": [116, 101, 115, 116]
+                            }
+                        }
+                    }
+                },
                 "responses": {
                     "default": {
                         "description": ""

--- a/packages/dynamite/dynamite_end_to_end_test/test/request_body_test.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/test/request_body_test.dart
@@ -26,7 +26,7 @@ void main() async {
         return Response('{}', 200);
       }),
     );
-    await client.$get(uint8List: data);
+    await client.$get($body: data);
   });
 
   test('Request String body', () async {
@@ -48,6 +48,6 @@ void main() async {
         return Response('{}', 200);
       }),
     );
-    await client.post(string: 'value');
+    await client.post($body: 'value');
   });
 }

--- a/packages/dynamite/dynamite_end_to_end_test/test/request_body_test.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/test/request_body_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:dynamite_end_to_end_test/request_body.openapi.dart';
 import 'package:http/http.dart';
@@ -6,30 +7,7 @@ import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
 void main() async {
-  test('Request Uint8List body', () async {
-    // No body
-    var client = $Client(
-      Uri.parse('example.com'),
-      httpClient: MockClient((request) async {
-        expect(request.bodyBytes.length, 0);
-        return Response('{}', 200);
-      }),
-    );
-    await client.$get();
-
-    // with body
-    final data = utf8.encode('value');
-    client = $Client(
-      Uri.parse('example.com'),
-      httpClient: MockClient((request) async {
-        expect(request.bodyBytes, equals(data));
-        return Response('{}', 200);
-      }),
-    );
-    await client.$get($body: data);
-  });
-
-  test('Request String body', () async {
+  test('Request body parameter name conflict', () async {
     // No body
     var client = $Client(
       Uri.parse('example.com'),
@@ -49,5 +27,85 @@ void main() async {
       }),
     );
     await client.post($body: 'value');
+  });
+
+  test('Request Object body', () async {
+    // No body
+    var client = $Client(
+      Uri.parse('example.com'),
+      httpClient: MockClient((request) async {
+        expect(request.body, json.encode({}));
+        return Response('{}', 200);
+      }),
+    );
+    await client.getObject();
+
+    // with required body and field default
+    client = $Client(
+      Uri.parse('example.com'),
+      httpClient: MockClient((request) async {
+        expect(request.body, json.encode({'test': '123'}));
+        return Response('{}', 200);
+      }),
+    );
+    await client.postObject(
+      $body: PostObjectRequestApplicationJson(
+        (b) => b..test = '123',
+      ),
+    );
+
+    // with nullable body
+    client = $Client(
+      Uri.parse('example.com'),
+      httpClient: MockClient((request) async {
+        expect(request.body, json.encode({'test': '123'}));
+        return Response('{}', 200);
+      }),
+    );
+    await client.putObject();
+
+    // with body with default
+    client = $Client(
+      Uri.parse('example.com'),
+      httpClient: MockClient((request) async {
+        expect(request.body, json.encode({'test': '123'}));
+        return Response('{}', 200);
+      }),
+    );
+    await client.deleteObject();
+  });
+
+  test('Request Binary body', () async {
+    // No body
+    var client = $Client(
+      Uri.parse('example.com'),
+      httpClient: MockClient((request) async {
+        expect(request.bodyBytes, <int>[]);
+        return Response('{}', 200);
+      }),
+    );
+    await client.getBinary();
+
+    // with required body and field default
+    client = $Client(
+      Uri.parse('example.com'),
+      httpClient: MockClient((request) async {
+        expect(request.bodyBytes, utf8.encode('test'));
+        return Response('{}', 200);
+      }),
+    );
+    await client.postBinary(
+      $body: Uint8List.fromList([116, 101, 115, 116]),
+    );
+
+    // with body with default
+    client = $Client(
+      Uri.parse('example.com'),
+      httpClient: MockClient((request) async {
+        expect(request.bodyBytes, utf8.encode('test'));
+        return Response('{}', 200);
+      }),
+    );
+    await client.putBinary();
   });
 }

--- a/packages/neon/neon_dashboard/lib/src/blocs/dashboard.dart
+++ b/packages/neon/neon_dashboard/lib/src/blocs/dashboard.dart
@@ -102,8 +102,11 @@ class _DashboardBloc extends InteractiveBloc implements DashboardBloc {
           cacheKey: 'dashboard-widgets-v1',
           subject: itemsV1,
           getRequest: () => account.client.dashboard.dashboardApi.$getWidgetItems_Request(
-            widgets: v1WidgetIDs.build(),
-            limit: maxItems,
+            $body: dashboard.DashboardApiGetWidgetItemsRequestApplicationJson(
+              (b) => b
+                ..widgets.replace(v1WidgetIDs.build())
+                ..limit = maxItems,
+            ),
           ),
           serializer: account.client.dashboard.dashboardApi.$getWidgetItems_Serializer(),
           unwrap: (response) => response.body.ocs.data,
@@ -114,8 +117,11 @@ class _DashboardBloc extends InteractiveBloc implements DashboardBloc {
           cacheKey: 'dashboard-widgets-v2',
           subject: itemsV2,
           getRequest: () => account.client.dashboard.dashboardApi.$getWidgetItemsV2_Request(
-            widgets: v2WidgetIDs.build(),
-            limit: maxItems,
+            $body: dashboard.DashboardApiGetWidgetItemsV2RequestApplicationJson(
+              (b) => b
+                ..widgets.replace(v2WidgetIDs.build())
+                ..limit = maxItems,
+            ),
           ),
           serializer: account.client.dashboard.dashboardApi.$getWidgetItemsV2_Serializer(),
           unwrap: (response) => response.body.ocs.data,

--- a/packages/neon/neon_dashboard/test/bloc_test.dart
+++ b/packages/neon/neon_dashboard/test/bloc_test.dart
@@ -10,7 +10,7 @@ import 'package:neon_framework/testing.dart';
 
 Account mockDashboardAccount() => mockServer({
       RegExp(r'/ocs/v2\.php/apps/dashboard/api/v1/widgets'): {
-        'get': (match, queryParameters) => Response(
+        'get': (match, bodyBytes) => Response(
               json.encode({
                 'ocs': {
                   'meta': {'status': '', 'statuscode': 0},
@@ -38,13 +38,55 @@ Account mockDashboardAccount() => mockServer({
             ),
       },
       RegExp(r'/ocs/v2\.php/apps/dashboard/api/v1/widget-items'): {
-        'get': (match, queryParameters) => Response(
-              json.encode({
-                'ocs': {
-                  'meta': {'status': '', 'statuscode': 0},
-                  'data': {
-                    for (final key in queryParameters['widgets[]']!)
-                      key: [
+        'get': (match, bodyBytes) {
+          final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
+          return Response(
+            json.encode({
+              'ocs': {
+                'meta': {'status': '', 'statuscode': 0},
+                'data': {
+                  for (final key in (data['widgets'] as List).cast<String>())
+                    key: [
+                      {
+                        'subtitle': '',
+                        'title': key,
+                        'link': '',
+                        'iconUrl': '',
+                        'overlayIconUrl': '',
+                        'sinceId': '',
+                      },
+                    ],
+                  'tooMany1': [
+                    for (var i = 0; i < 8; i++)
+                      {
+                        'subtitle': '',
+                        'title': '$i',
+                        'link': '',
+                        'iconUrl': '',
+                        'overlayIconUrl': '',
+                        'sinceId': '',
+                      },
+                  ],
+                },
+              },
+            }),
+            200,
+          );
+        },
+      },
+      RegExp(r'/ocs/v2\.php/apps/dashboard/api/v2/widget-items'): {
+        'get': (match, bodyBytes) {
+          final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
+          return Response(
+            json.encode({
+              'ocs': {
+                'meta': {'status': '', 'statuscode': 0},
+                'data': {
+                  for (final key in (data['widgets'] as List).cast<String>())
+                    key: {
+                      'items': [
                         {
                           'subtitle': '',
                           'title': key,
@@ -54,7 +96,11 @@ Account mockDashboardAccount() => mockServer({
                           'sinceId': '',
                         },
                       ],
-                    'tooMany1': [
+                      'emptyContentMessage': '',
+                      'halfEmptyContentMessage': '',
+                    },
+                  'tooMany2': {
+                    'items': [
                       for (var i = 0; i < 8; i++)
                         {
                           'subtitle': '',
@@ -65,53 +111,15 @@ Account mockDashboardAccount() => mockServer({
                           'sinceId': '',
                         },
                     ],
+                    'emptyContentMessage': '',
+                    'halfEmptyContentMessage': '',
                   },
                 },
-              }),
-              200,
-            ),
-      },
-      RegExp(r'/ocs/v2\.php/apps/dashboard/api/v2/widget-items'): {
-        'get': (match, queryParameters) => Response(
-              json.encode({
-                'ocs': {
-                  'meta': {'status': '', 'statuscode': 0},
-                  'data': {
-                    for (final key in queryParameters['widgets[]']!)
-                      key: {
-                        'items': [
-                          {
-                            'subtitle': '',
-                            'title': key,
-                            'link': '',
-                            'iconUrl': '',
-                            'overlayIconUrl': '',
-                            'sinceId': '',
-                          },
-                        ],
-                        'emptyContentMessage': '',
-                        'halfEmptyContentMessage': '',
-                      },
-                    'tooMany2': {
-                      'items': [
-                        for (var i = 0; i < 8; i++)
-                          {
-                            'subtitle': '',
-                            'title': '$i',
-                            'link': '',
-                            'iconUrl': '',
-                            'overlayIconUrl': '',
-                            'sinceId': '',
-                          },
-                      ],
-                      'emptyContentMessage': '',
-                      'halfEmptyContentMessage': '',
-                    },
-                  },
-                },
-              }),
-              200,
-            ),
+              },
+            }),
+            200,
+          );
+        },
       },
     });
 

--- a/packages/neon/neon_files/lib/src/widgets/file_preview.dart
+++ b/packages/neon/neon_files/lib/src/widgets/file_preview.dart
@@ -107,9 +107,12 @@ class FilePreviewImage extends NeonApiImage {
     required super.account,
   }) : super(
           getRequest: (client) => client.core.preview.$getPreview_Request(
-            file: file.uri.path,
-            x: width,
-            y: height,
+            $body: PreviewGetPreviewRequestApplicationJson(
+              (b) => b
+                ..file = file.uri.path
+                ..x = width
+                ..y = height,
+            ),
           ),
           etag: file.etag,
           expires: null,

--- a/packages/neon/neon_notifications/test/bloc_test.dart
+++ b/packages/neon/neon_notifications/test/bloc_test.dart
@@ -26,7 +26,7 @@ Account mockNotificationsAccount() {
 
   return mockServer({
     RegExp(r'/ocs/v2\.php/apps/notifications/api/v2/notifications/([0-9]+)'): {
-      'delete': (match, queryParameters) {
+      'delete': (match, bodyBytes) {
         final id = int.parse(match.group(1)!);
         notifications.removeWhere((n) => n['notification_id'] == id);
 
@@ -42,7 +42,7 @@ Account mockNotificationsAccount() {
       },
     },
     RegExp(r'/ocs/v2\.php/apps/notifications/api/v2/notifications'): {
-      'get': (match, queryParameters) => Response(
+      'get': (match, bodyBytes) => Response(
             json.encode({
               'ocs': {
                 'meta': {'status': '', 'statuscode': 0},
@@ -51,7 +51,7 @@ Account mockNotificationsAccount() {
             }),
             200,
           ),
-      'delete': (match, queryParameters) {
+      'delete': (match, bodyBytes) {
         notifications.clear();
 
         return Response(

--- a/packages/neon/neon_talk/lib/src/blocs/room.dart
+++ b/packages/neon/neon_talk/lib/src/blocs/room.dart
@@ -123,11 +123,14 @@ class _TalkRoomBloc extends InteractiveBloc implements TalkRoomBloc {
 
         try {
           final response = await account.client.spreed.chat.receiveMessages(
-            lookIntoFuture: spreed.ChatReceiveMessagesLookIntoFuture.$1,
             token: token,
-            includeLastKnown: spreed.ChatReceiveMessagesIncludeLastKnown.$0,
-            lastKnownMessageId: lastKnownMessageId,
-            limit: 100,
+            $body: spreed.ChatReceiveMessagesRequestApplicationJson(
+              (b) => b
+                ..lookIntoFuture = spreed.ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.$1
+                ..includeLastKnown = spreed.ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown.$0
+                ..lastKnownMessageId = lastKnownMessageId
+                ..limit = 100,
+            ),
           );
 
           updateLastCommonRead(response.headers.xChatLastCommonRead);
@@ -208,9 +211,12 @@ class _TalkRoomBloc extends InteractiveBloc implements TalkRoomBloc {
         subject: messages,
         getRequest: () => account.client.spreed.chat.$receiveMessages_Request(
           token: token,
-          lookIntoFuture: spreed.ChatReceiveMessagesLookIntoFuture.$0,
-          includeLastKnown: spreed.ChatReceiveMessagesIncludeLastKnown.$0,
-          limit: 100,
+          $body: spreed.ChatReceiveMessagesRequestApplicationJson(
+            (b) => b
+              ..lookIntoFuture = spreed.ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.$0
+              ..includeLastKnown = spreed.ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown.$0
+              ..limit = 100,
+          ),
         ),
         serializer: account.client.spreed.chat.$receiveMessages_Serializer(),
         unwrap: (response) {
@@ -233,9 +239,15 @@ class _TalkRoomBloc extends InteractiveBloc implements TalkRoomBloc {
     await wrapAction(
       () async {
         final response = await account.client.spreed.chat.sendMessage(
-          message: message,
-          replyTo: replyToId,
           token: token,
+          $body: spreed.ChatSendMessageRequestApplicationJson(
+            (b) {
+              b.message = message;
+              if (replyToId != null) {
+                b.replyTo = replyToId;
+              }
+            },
+          ),
         );
 
         updateLastCommonRead(response.headers.xChatLastCommonRead);
@@ -256,9 +268,11 @@ class _TalkRoomBloc extends InteractiveBloc implements TalkRoomBloc {
     await wrapAction(
       () async {
         final response = await account.client.spreed.reaction.react(
-          reaction: reaction,
           token: token,
           messageId: message.id,
+          $body: spreed.ReactionReactRequestApplicationJson(
+            (b) => b..reaction = reaction,
+          ),
         );
 
         updateReactions(
@@ -275,9 +289,11 @@ class _TalkRoomBloc extends InteractiveBloc implements TalkRoomBloc {
     await wrapAction(
       () async {
         final response = await account.client.spreed.reaction.delete(
-          reaction: reaction,
           token: token,
           messageId: message.id,
+          $body: spreed.ReactionDeleteRequestApplicationJson(
+            (b) => b..reaction = reaction,
+          ),
         );
 
         updateReactions(

--- a/packages/neon/neon_talk/lib/src/blocs/talk.dart
+++ b/packages/neon/neon_talk/lib/src/blocs/talk.dart
@@ -94,10 +94,17 @@ class _TalkBloc extends InteractiveBloc implements TalkBloc {
   ) async {
     await wrapAction(() async {
       await account.client.spreed.room.createRoom(
-        roomType: type.value,
-        roomName: roomName,
-        invite: invite?.id,
-        source: invite?.source,
+        $body: spreed.RoomCreateRoomRequestApplicationJson(
+          (b) {
+            b
+              ..roomType = type.value
+              ..invite = invite?.id
+              ..source = invite?.source;
+            if (roomName != null) {
+              b.roomName = roomName;
+            }
+          },
+        ),
       );
     });
   }

--- a/packages/neon/neon_talk/lib/src/widgets/message_input.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/message_input.dart
@@ -150,7 +150,7 @@ class _TalkMessageInputState extends State<TalkMessageInput> {
           return [];
         }
 
-        String? matchingPart = controller.text.substring(0, cursor);
+        var matchingPart = controller.text.substring(0, cursor);
         final index = matchingPart.lastIndexOf(' ') + 1;
         matchingPart = matchingPart.substring(index);
         if (!matchingPart.startsWith('@') || matchingPart.isEmpty) {
@@ -159,15 +159,18 @@ class _TalkMessageInputState extends State<TalkMessageInput> {
 
         final account = NeonProvider.of<Account>(context);
         final response = await account.client.spreed.chat.mentions(
-          search: matchingPart.substring(1),
           token: bloc.room.value.requireData.token,
-          limit: 5,
+          $body: spreed.ChatMentionsRequestApplicationJson(
+            (b) => b
+              ..search = matchingPart.substring(1)
+              ..limit = 5,
+          ),
         );
 
         return response.body.ocs.data
             .map(
               (mention) => _Suggestion(
-                start: cursor - matchingPart!.length,
+                start: cursor - matchingPart.length,
                 end: cursor,
                 mention: mention,
               ),

--- a/packages/neon/neon_talk/lib/src/widgets/rich_object/file_preview.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/rich_object/file_preview.dart
@@ -63,9 +63,12 @@ class TalkRichObjectFilePreview extends StatelessWidget {
             etag: parameter.etag,
             expires: null,
             getRequest: (client) => client.core.preview.$getPreviewByFileId_Request(
-              fileId: int.parse(parameter.id),
-              x: deviceSize.width.toInt(),
-              y: deviceSize.height.toInt(),
+              $body: PreviewGetPreviewByFileIdRequestApplicationJson(
+                (b) => b
+                  ..fileId = int.parse(parameter.id)
+                  ..x = deviceSize.width.toInt()
+                  ..y = deviceSize.height.toInt(),
+              ),
             ),
           );
         }

--- a/packages/neon/neon_talk/test/bloc_test.dart
+++ b/packages/neon/neon_talk/test/bloc_test.dart
@@ -18,7 +18,7 @@ Account mockTalkAccount() {
 
   return mockServer({
     RegExp(r'/ocs/v2\.php/apps/spreed/api/v4/room'): {
-      'get': (match, queryParameters) => Response(
+      'get': (match, bodyBytes) => Response(
             json.encode({
               'ocs': {
                 'meta': {'status': '', 'statuscode': 0},
@@ -33,7 +33,7 @@ Account mockTalkAccount() {
             }),
             200,
           ),
-      'post': (match, queryParameters) {
+      'post': (match, bodyBytes) {
         roomCount++;
 
         return Response(

--- a/packages/neon/neon_talk/test/create_room_dialog_test.dart
+++ b/packages/neon/neon_talk/test/create_room_dialog_test.dart
@@ -23,8 +23,10 @@ import 'package:rxdart/subjects.dart';
 Account mockAutocompleteAccount() {
   return mockServer({
     RegExp(r'/ocs/v2\.php/core/autocomplete/get'): {
-      'get': (match, queryParameters) {
-        final source = queryParameters['shareTypes[]']![0] == '0' ? 'users' : 'groups';
+      'get': (match, bodyBytes) {
+        final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
+        final source = ((data['shareTypes'] as List)[0] as int) == 0 ? 'users' : 'groups';
         return Response(
           json.encode(
             {
@@ -49,7 +51,7 @@ Account mockAutocompleteAccount() {
       },
     },
     RegExp(r'/index\.php/avatar/.*'): {
-      'get': (match, queryParameters) => Response('', 404),
+      'get': (match, bodyBytes) => Response('', 404),
     },
   });
 }

--- a/packages/neon/neon_talk/test/room_bloc_test.dart
+++ b/packages/neon/neon_talk/test/room_bloc_test.dart
@@ -17,7 +17,7 @@ Account mockTalkAccount() {
 
   return mockServer({
     RegExp(r'/ocs/v2\.php/apps/spreed/api/v4/room/abcd/participants/active'): {
-      'post': (match, queryParameters) => Response(
+      'post': (match, bodyBytes) => Response(
             json.encode({
               'ocs': {
                 'meta': {'status': '', 'statuscode': 0},
@@ -28,7 +28,7 @@ Account mockTalkAccount() {
             }),
             200,
           ),
-      'delete': (match, queryParameters) => Response(
+      'delete': (match, bodyBytes) => Response(
             json.encode({
               'ocs': {
                 'meta': {'status': '', 'statuscode': 0},
@@ -39,8 +39,10 @@ Account mockTalkAccount() {
           ),
     },
     RegExp(r'/ocs/v2\.php/apps/spreed/api/v1/chat/abcd'): {
-      'get': (match, queryParameters) async {
-        final lookIntoFuture = queryParameters['lookIntoFuture']!.single == '1';
+      'get': (match, bodyBytes) async {
+        final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
+        final lookIntoFuture = (data['lookIntoFuture'] as int) == 1;
         if (lookIntoFuture) {
           // Simulate a new message received after some time
           await Future<void>.delayed(const Duration(milliseconds: 1));
@@ -97,8 +99,9 @@ Account mockTalkAccount() {
           );
         }
       },
-      'post': (match, queryParameters) {
-        final replyTo = queryParameters['replyTo']?.firstOrNull;
+      'post': (match, bodyBytes) {
+        final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+        final replyTo = data['replyTo'] as int?;
 
         return Response(
           json.encode({
@@ -108,7 +111,7 @@ Account mockTalkAccount() {
                 id: messageCount++,
                 parent: replyTo != null
                     ? getChatMessage(
-                        id: int.parse(replyTo),
+                        id: replyTo,
                       )
                     : null,
               ),
@@ -122,8 +125,10 @@ Account mockTalkAccount() {
       },
     },
     RegExp(r'/ocs/v2\.php/apps/spreed/api/v1/reaction/abcd/[0-9]+'): {
-      'post': (match, queryParameters) {
-        final reaction = queryParameters['reaction']!.single;
+      'post': (match, bodyBytes) {
+        final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
+        final reaction = data['reaction'] as String;
 
         return Response(
           json.encode({
@@ -153,8 +158,10 @@ Account mockTalkAccount() {
           },
         );
       },
-      'delete': (match, queryParameters) {
-        final reaction = queryParameters['reaction']!.single;
+      'delete': (match, bodyBytes) {
+        final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
+        final reaction = data['reaction'] as String;
 
         return Response(
           json.encode({
@@ -184,7 +191,7 @@ Account mockTalkAccount() {
           },
         );
       },
-      'get': (match, queryParameters) => Response(
+      'get': (match, bodyBytes) => Response(
             json.encode({
               'ocs': {
                 'meta': {'status': '', 'statuscode': 0},

--- a/packages/neon_framework/lib/src/blocs/login_flow.dart
+++ b/packages/neon_framework/lib/src/blocs/login_flow.dart
@@ -71,7 +71,11 @@ class _LoginFlowBloc extends InteractiveBloc implements LoginFlowBloc {
       cancelPollTimer();
       pollTimer = Timer.periodic(const Duration(seconds: 1), (_) async {
         try {
-          final resultResponse = await client.core.clientFlowLoginV2.poll(token: initResponse.body.poll.token);
+          final resultResponse = await client.core.clientFlowLoginV2.poll(
+            $body: core.ClientFlowLoginV2PollRequestApplicationJson(
+              (b) => b..token = initResponse.body.poll.token,
+            ),
+          );
           cancelPollTimer();
           resultController.add(resultResponse.body);
         } on DynamiteStatusCodeException catch (error) {

--- a/packages/neon_framework/lib/src/blocs/push_notifications.dart
+++ b/packages/neon_framework/lib/src/blocs/push_notifications.dart
@@ -86,9 +86,12 @@ class _PushNotificationsBloc extends Bloc implements PushNotificationsBloc {
         log.fine('Registering account $instance for push notifications on $endpoint');
 
         final subscription = await account.client.notifications.push.registerDevice(
-          pushTokenHash: notifications.generatePushTokenHash(endpoint),
-          devicePublicKey: keypair.publicKey.toFormattedPEM(),
-          proxyServer: '$endpoint#', // This is a hack to make the Nextcloud server directly push to the endpoint
+          $body: notifications.PushRegisterDeviceRequestApplicationJson(
+            (b) => b
+              ..pushTokenHash = notifications.generatePushTokenHash(endpoint)
+              ..devicePublicKey = keypair.publicKey.toFormattedPEM()
+              ..proxyServer = '$endpoint#', // This is a hack to make the Nextcloud server directly push to the endpoint
+          ),
         );
 
         await storage.setString(account.id, endpoint);

--- a/packages/neon_framework/lib/src/blocs/unified_search.dart
+++ b/packages/neon_framework/lib/src/blocs/unified_search.dart
@@ -143,7 +143,9 @@ class _UnifiedSearchBloc extends InteractiveBloc implements UnifiedSearchBloc {
         try {
           final response = await account.client.core.unifiedSearch.search(
             providerId: providerID,
-            term: term,
+            $body: core.UnifiedSearchSearchRequestApplicationJson(
+              (b) => b..term = term,
+            ),
           );
           updateResults(providerID, Result.success(response.body.ocs.data));
         } on http.ClientException catch (error, stackTrace) {

--- a/packages/neon_framework/lib/src/blocs/user_status.dart
+++ b/packages/neon_framework/lib/src/blocs/user_status.dart
@@ -135,7 +135,9 @@ class _UserStatusBloc extends InteractiveBloc implements UserStatusBloc {
 
         try {
           final response = await account.client.userStatus.heartbeat.heartbeat(
-            status: isAway ? 'away' : 'online',
+            $body: user_status.HeartbeatHeartbeatRequestApplicationJson(
+              (b) => b..status = isAway ? 'away' : 'online',
+            ),
           );
           data = response.body.ocs.data;
         } on DynamiteStatusCodeException catch (e) {
@@ -201,7 +203,11 @@ class _UserStatusBloc extends InteractiveBloc implements UserStatusBloc {
   Future<void> setStatusType(String statusType) async {
     await wrapAction(
       () async {
-        final response = await account.client.userStatus.userStatus.setStatus(statusType: statusType);
+        final response = await account.client.userStatus.userStatus.setStatus(
+          $body: user_status.UserStatusSetStatusRequestApplicationJson(
+            (b) => b..statusType = statusType,
+          ),
+        );
 
         updateStatus(account.username, Result.success(correctStatus(response.body.ocs.data)));
       },
@@ -217,8 +223,11 @@ class _UserStatusBloc extends InteractiveBloc implements UserStatusBloc {
     await wrapAction(
       () async {
         final response = await account.client.userStatus.userStatus.setPredefinedMessage(
-          messageId: id,
-          clearAt: clearAt?.secondsSinceEpoch,
+          $body: user_status.UserStatusSetPredefinedMessageRequestApplicationJson(
+            (b) => b
+              ..messageId = id
+              ..clearAt = clearAt?.secondsSinceEpoch,
+          ),
         );
 
         updateStatus(account.username, Result.success(correctStatus(response.body.ocs.data)));
@@ -236,9 +245,12 @@ class _UserStatusBloc extends InteractiveBloc implements UserStatusBloc {
     await wrapAction(
       () async {
         final response = await account.client.userStatus.userStatus.setCustomMessage(
-          statusIcon: icon,
-          message: message,
-          clearAt: clearAt?.secondsSinceEpoch,
+          $body: user_status.UserStatusSetCustomMessageRequestApplicationJson(
+            (b) => b
+              ..statusIcon = icon
+              ..message = message
+              ..clearAt = clearAt?.secondsSinceEpoch,
+          ),
         );
 
         updateStatus(account.username, Result.success(correctStatus(response.body.ocs.data)));

--- a/packages/neon_framework/lib/src/blocs/weather_status.dart
+++ b/packages/neon_framework/lib/src/blocs/weather_status.dart
@@ -127,7 +127,9 @@ class _WeatherStatusBloc extends InteractiveBloc implements WeatherStatusBloc {
     await wrapAction(
       () async {
         final response = await account.client.weatherStatus.weatherStatus.setLocation(
-          address: address,
+          $body: weather_status.WeatherStatusSetLocationRequestApplicationJson(
+            (b) => b..address = address,
+          ),
         );
         location.add(Result.success(response.body.ocs.data));
       },

--- a/packages/neon_framework/lib/src/testing/mock_server.dart
+++ b/packages/neon_framework/lib/src/testing/mock_server.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
@@ -8,8 +9,7 @@ import 'package:neon_framework/src/models/account.dart';
 ///
 /// To be used for end-to-end testing `Bloc`s.
 Account mockServer(
-  Map<RegExp, Map<String, FutureOr<Response> Function(RegExpMatch match, Map<String, List<String>> queryParameters)>>
-      requests,
+  Map<RegExp, Map<String, FutureOr<Response> Function(RegExpMatch match, Uint8List bodyBytes)>> requests,
 ) =>
     Account(
       (b) => b
@@ -22,7 +22,7 @@ Account mockServer(
             if (match != null) {
               final call = entry.value[request.method];
               if (call != null) {
-                return call(match, request.url.queryParametersAll);
+                return call(match, request.bodyBytes);
               }
             }
           }

--- a/packages/neon_framework/lib/src/widgets/autocomplete.dart
+++ b/packages/neon_framework/lib/src/widgets/autocomplete.dart
@@ -1,4 +1,3 @@
-import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:neon_framework/models.dart';
@@ -89,11 +88,18 @@ class _NeonAutocompleteState extends State<NeonAutocomplete> {
         }
 
         final response = await account.client.core.autoComplete.$get(
-          search: text.text,
-          itemType: widget.itemType,
-          itemId: widget.itemId,
-          shareTypes: BuiltList(widget.shareTypes.map((s) => s.index)),
-          limit: widget.limit,
+          $body: core.AutoCompleteGetRequestApplicationJson(
+            (b) {
+              b
+                ..search = text.text
+                ..itemType = widget.itemType
+                ..itemId = widget.itemId
+                ..shareTypes.replace(widget.shareTypes.map((s) => s.index));
+              if (widget.limit != null) {
+                b.limit = widget.limit;
+              }
+            },
+          ),
         );
         return response.body.ocs.data;
       },

--- a/packages/neon_framework/test/apps_bloc_test.dart
+++ b/packages/neon_framework/test/apps_bloc_test.dart
@@ -17,7 +17,7 @@ import 'package:version/version.dart';
 Account mockAppsAccount() {
   return mockServer({
     RegExp(r'/ocs/v2\.php/core/navigation/apps'): {
-      'get': (match, queryParameters) {
+      'get': (match, bodyBytes) {
         return Response(
           json.encode(
             {

--- a/packages/neon_framework/test/autocomplete_test.dart
+++ b/packages/neon_framework/test/autocomplete_test.dart
@@ -17,13 +17,7 @@ import 'package:provider/provider.dart';
 Account mockAutocompleteAccount() {
   return mockServer({
     RegExp(r'/ocs/v2\.php/core/autocomplete/get'): {
-      'get': (match, queryParameters) {
-        assert(queryParameters['itemType']!.single == 'itemType');
-        assert(queryParameters['itemId']!.single == 'itemId');
-        assert(queryParameters['shareTypes[]']![0] == '0');
-        assert(queryParameters['shareTypes[]']![1] == '1');
-        assert(queryParameters['limit']!.single == '10');
-
+      'get': (match, bodyBytes) {
         return Response(
           json.encode(
             {

--- a/packages/neon_framework/test/maintenance_mode_bloc_test.dart
+++ b/packages/neon_framework/test/maintenance_mode_bloc_test.dart
@@ -9,7 +9,7 @@ import 'package:neon_framework/testing.dart';
 Account mockMaintenanceModeAccount() {
   return mockServer({
     RegExp(r'/status\.php'): {
-      'get': (match, queryParameters) {
+      'get': (match, bodyBytes) {
         return Response(
           json.encode({
             'installed': false,

--- a/packages/neon_framework/test/unified_search_bloc_test.dart
+++ b/packages/neon_framework/test/unified_search_bloc_test.dart
@@ -17,8 +17,10 @@ import 'package:rxdart/rxdart.dart';
 
 Account mockUnifiedSearchAccount() => mockServer({
       RegExp(r'/ocs/v2\.php/search/providers/(.*)/search'): {
-        'get': (match, queryParameters) {
-          final term = queryParameters['term']!.single;
+        'get': (match, bodyBytes) {
+          final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
+          final term = data['term'] as String;
           if (term == 'error') {
             return Response('', 400);
           }
@@ -52,7 +54,7 @@ Account mockUnifiedSearchAccount() => mockServer({
         },
       },
       RegExp(r'/ocs/v2\.php/search/providers'): {
-        'get': (match, queryParameters) => Response(
+        'get': (match, bodyBytes) => Response(
               json.encode(
                 {
                   'ocs': {

--- a/packages/neon_framework/test/user_details_bloc_test.dart
+++ b/packages/neon_framework/test/user_details_bloc_test.dart
@@ -8,7 +8,7 @@ import 'package:neon_framework/testing.dart';
 
 Account mockUserDetailsAccount() => mockServer({
       RegExp(r'/ocs/v2\.php/cloud/user'): {
-        'get': (match, queryParameters) => Response(
+        'get': (match, bodyBytes) => Response(
               json.encode(
                 {
                   'ocs': {

--- a/packages/neon_framework/test/user_status_bloc_test.dart
+++ b/packages/neon_framework/test/user_status_bloc_test.dart
@@ -73,35 +73,41 @@ Account mockUserStatusAccount() {
 
   return mockServer({
     RegExp(r'/ocs/v2\.php/apps/user_status/api/v1/predefined_statuses'): {
-      'get': (match, queryParameters) => predefinedStatusesResponse(),
+      'get': (match, bodyBytes) => predefinedStatusesResponse(),
     },
     RegExp(r'/ocs/v2\.php/apps/user_status/api/v1/user_status/message/predefined'): {
-      'put': (match, queryParameters) {
-        messageId = queryParameters['messageId']!.single;
+      'put': (match, bodyBytes) {
+        final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
+        messageId = data['messageId'] as String;
         messageIsPredefined = true;
-        clearAt = int.parse(queryParameters['clearAt']!.single);
+        clearAt = data['clearAt'] as int;
         return statusResponse();
       },
     },
     RegExp(r'/ocs/v2\.php/apps/user_status/api/v1/user_status/message/custom'): {
-      'put': (match, queryParameters) {
+      'put': (match, bodyBytes) {
+        final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
         messageId = null;
-        message = queryParameters['message']!.single;
+        message = data['message'] as String;
         messageIsPredefined = false;
-        icon = queryParameters['statusIcon']!.single;
-        clearAt = int.parse(queryParameters['clearAt']!.single);
+        icon = data['statusIcon'] as String;
+        clearAt = data['clearAt'] as int;
         return statusResponse();
       },
     },
     RegExp(r'/ocs/v2\.php/apps/user_status/api/v1/user_status/status'): {
-      'put': (match, queryParameters) {
-        status = queryParameters['statusType']!.single;
+      'put': (match, bodyBytes) {
+        final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
+        status = data['statusType'] as String;
         statusIsUserDefined = true;
         return statusResponse();
       },
     },
     RegExp(r'/ocs/v2\.php/apps/user_status/api/v1/user_status/message'): {
-      'delete': (match, queryParameters) {
+      'delete': (match, bodyBytes) {
         messageId = null;
         messageIsPredefined = false;
         message = null;
@@ -111,10 +117,12 @@ Account mockUserStatusAccount() {
       },
     },
     RegExp(r'/ocs/v2\.php/apps/user_status/api/v1/statuses/(.*)'): {
-      'get': (match, queryParameters) => statusResponse(),
+      'get': (match, bodyBytes) => statusResponse(),
     },
     RegExp(r'/ocs/v2\.php/apps/user_status/api/v1/heartbeat'): {
-      'put': (match, queryParameters) {
+      'put': (match, bodyBytes) {
+        final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
         // Hardcoded behavior for testing
         if (status == 'offline') {
           return Response('', 204);
@@ -122,7 +130,7 @@ Account mockUserStatusAccount() {
           return Response('', 201);
         }
 
-        status = queryParameters['status']!.single;
+        status = data['status'] as String;
         statusIsUserDefined = false;
         return statusResponse();
       },

--- a/packages/neon_framework/test/weather_status_bloc_test.dart
+++ b/packages/neon_framework/test/weather_status_bloc_test.dart
@@ -31,16 +31,18 @@ Account mockWeatherStatusAccount() {
 
   return mockServer({
     RegExp(r'/ocs/v2\.php/apps/weather_status/api/v1/location'): {
-      'get': (match, queryParameters) => locationResponse(),
-      'put': (match, queryParameters) {
-        lat = queryParameters['lat']?.single;
-        lon = queryParameters['lon']?.single;
-        address = queryParameters['address']!.single;
+      'get': (match, bodyBytes) => locationResponse(),
+      'put': (match, bodyBytes) {
+        final data = json.decode(utf8.decode(bodyBytes)) as Map<String, dynamic>;
+
+        lat = data['lat'] as String?;
+        lon = data['lon'] as String?;
+        address = data['address'] as String;
         return locationResponse();
       },
     },
     RegExp(r'/ocs/v2\.php/apps/weather_status/api/v1/forecast'): {
-      'get': (match, queryParameters) => Response(
+      'get': (match, bodyBytes) => Response(
             json.encode({
               'ocs': {
                 'meta': {'status': '', 'statuscode': 0},

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -16,6 +16,7 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:built_collection/built_collection.dart';
@@ -425,7 +426,6 @@ class $AppPasswordClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [password] The password of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -437,14 +437,10 @@ class $AppPasswordClient {
   ///  * [$confirmUserPassword_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $confirmUserPassword_Request({
-    required String password,
+    required AppPasswordConfirmUserPasswordRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    _parameters['password'] = __password;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/core/apppassword/confirm{?password*}').expand(_parameters);
+    const _path = '/ocs/v2.php/core/apppassword/confirm';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -469,6 +465,13 @@ class $AppPasswordClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(AppPasswordConfirmUserPasswordRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -478,7 +481,6 @@ class $AppPasswordClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [password] The password of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -489,12 +491,12 @@ class $AppPasswordClient {
   ///  * [$confirmUserPassword_Request] for the request send by this method.
   ///  * [$confirmUserPassword_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<AppPasswordConfirmUserPasswordResponseApplicationJson, void>> confirmUserPassword({
-    required String password,
+    required AppPasswordConfirmUserPasswordRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $confirmUserPassword_Request(
-      password: password,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -527,12 +529,6 @@ class $AutoCompleteClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for.
-  ///   * [itemType] Type of the items to search for.
-  ///   * [itemId] ID of the items to search for.
-  ///   * [sorter] can be piped, top prio first, e.g.: "commenters|share-recipients".
-  ///   * [shareTypes] Types of shares to search for. Defaults to `[]`.
-  ///   * [limit] Maximum number of results to return. Defaults to `10`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -543,39 +539,10 @@ class $AutoCompleteClient {
   ///  * [$$get_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $$get_Request({
-    required String search,
-    String? itemType,
-    String? itemId,
-    String? sorter,
-    BuiltList<int>? shareTypes,
-    int? limit,
+    required AutoCompleteGetRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    _parameters['search'] = __search;
-
-    final __itemType = _$jsonSerializers.serialize(itemType, specifiedType: const FullType(String));
-    _parameters['itemType'] = __itemType;
-
-    final __itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(String));
-    _parameters['itemId'] = __itemId;
-
-    final __sorter = _$jsonSerializers.serialize(sorter, specifiedType: const FullType(String));
-    _parameters['sorter'] = __sorter;
-
-    var __shareTypes =
-        _$jsonSerializers.serialize(shareTypes, specifiedType: const FullType(BuiltList, [FullType(int)]));
-    __shareTypes ??= const [];
-    _parameters['shareTypes%5B%5D'] = __shareTypes;
-
-    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    __limit ??= 10;
-    _parameters['limit'] = __limit;
-
-    final _path = _i6.UriTemplate(
-      '/ocs/v2.php/core/autocomplete/get{?search*,itemType*,itemId*,sorter*,shareTypes%5B%5D*,limit*}',
-    ).expand(_parameters);
+    const _path = '/ocs/v2.php/core/autocomplete/get';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -600,6 +567,10 @@ class $AutoCompleteClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(AutoCompleteGetRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -609,12 +580,6 @@ class $AutoCompleteClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for.
-  ///   * [itemType] Type of the items to search for.
-  ///   * [itemId] ID of the items to search for.
-  ///   * [sorter] can be piped, top prio first, e.g.: "commenters|share-recipients".
-  ///   * [shareTypes] Types of shares to search for. Defaults to `[]`.
-  ///   * [limit] Maximum number of results to return. Defaults to `10`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -624,22 +589,12 @@ class $AutoCompleteClient {
   ///  * [$$get_Request] for the request send by this method.
   ///  * [$$get_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<AutoCompleteGetResponseApplicationJson, void>> $get({
-    required String search,
-    String? itemType,
-    String? itemId,
-    String? sorter,
-    BuiltList<int>? shareTypes,
-    int? limit,
+    required AutoCompleteGetRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $$get_Request(
-      search: search,
-      itemType: itemType,
-      itemId: itemId,
-      sorter: sorter,
-      shareTypes: shareTypes,
-      limit: limit,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -863,9 +818,6 @@ class $ClientFlowLoginV2Client {
   /// Returns a `DynamiteRequest` backing the [poll] operation.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [token] Token of the flow.
-  ///
   /// Status codes:
   ///   * 200: Login flow credentials returned
   ///   * 404: Login flow not found or completed
@@ -874,12 +826,8 @@ class $ClientFlowLoginV2Client {
   ///  * [poll] for a method executing this request and parsing the response.
   ///  * [$poll_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $poll_Request({required String token}) {
-    final _parameters = <String, Object?>{};
-    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _parameters['token'] = __token;
-
-    final _path = _i6.UriTemplate('/index.php/login/v2/poll{?token*}').expand(_parameters);
+  _i3.Request $poll_Request({required ClientFlowLoginV2PollRequestApplicationJson $body}) {
+    const _path = '/index.php/login/v2/poll';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -898,6 +846,10 @@ class $ClientFlowLoginV2Client {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(ClientFlowLoginV2PollRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -906,9 +858,6 @@ class $ClientFlowLoginV2Client {
   /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [token] Token of the flow.
-  ///
   /// Status codes:
   ///   * 200: Login flow credentials returned
   ///   * 404: Login flow not found or completed
@@ -916,9 +865,11 @@ class $ClientFlowLoginV2Client {
   /// See:
   ///  * [$poll_Request] for the request send by this method.
   ///  * [$poll_Serializer] for a converter to parse the `Response` from an executed request.
-  Future<_i1.DynamiteResponse<LoginFlowV2Credentials, void>> poll({required String token}) async {
+  Future<_i1.DynamiteResponse<LoginFlowV2Credentials, void>> poll({
+    required ClientFlowLoginV2PollRequestApplicationJson $body,
+  }) async {
     final _request = $poll_Request(
-      token: token,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1115,7 +1066,6 @@ class $CollaborationResourcesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [collectionName] New name.
   ///   * [collectionId] ID of the collection.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1129,19 +1079,15 @@ class $CollaborationResourcesClient {
   ///  * [$renameCollection_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $renameCollection_Request({
-    required String collectionName,
     required int collectionId,
+    required CollaborationResourcesRenameCollectionRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __collectionName = _$jsonSerializers.serialize(collectionName, specifiedType: const FullType(String));
-    _parameters['collectionName'] = __collectionName;
-
     final __collectionId = _$jsonSerializers.serialize(collectionId, specifiedType: const FullType(int));
     _parameters['collectionId'] = __collectionId;
 
-    final _path = _i6.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}{?collectionName*}')
-        .expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1166,6 +1112,13 @@ class $CollaborationResourcesClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(CollaborationResourcesRenameCollectionRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -1175,7 +1128,6 @@ class $CollaborationResourcesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [collectionName] New name.
   ///   * [collectionId] ID of the collection.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1188,14 +1140,14 @@ class $CollaborationResourcesClient {
   ///  * [$renameCollection_Request] for the request send by this method.
   ///  * [$renameCollection_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<CollaborationResourcesRenameCollectionResponseApplicationJson, void>> renameCollection({
-    required String collectionName,
     required int collectionId,
+    required CollaborationResourcesRenameCollectionRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $renameCollection_Request(
-      collectionName: collectionName,
       collectionId: collectionId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1223,8 +1175,6 @@ class $CollaborationResourcesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [resourceType] Name of the resource.
-  ///   * [resourceId] ID of the resource.
   ///   * [collectionId] ID of the collection.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1238,24 +1188,15 @@ class $CollaborationResourcesClient {
   ///  * [$addResource_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $addResource_Request({
-    required String resourceType,
-    required String resourceId,
     required int collectionId,
+    required CollaborationResourcesAddResourceRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __resourceType = _$jsonSerializers.serialize(resourceType, specifiedType: const FullType(String));
-    _parameters['resourceType'] = __resourceType;
-
-    final __resourceId = _$jsonSerializers.serialize(resourceId, specifiedType: const FullType(String));
-    _parameters['resourceId'] = __resourceId;
-
     final __collectionId = _$jsonSerializers.serialize(collectionId, specifiedType: const FullType(int));
     _parameters['collectionId'] = __collectionId;
 
-    final _path =
-        _i6.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}{?resourceType*,resourceId*}')
-            .expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1280,6 +1221,13 @@ class $CollaborationResourcesClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(CollaborationResourcesAddResourceRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -1289,8 +1237,6 @@ class $CollaborationResourcesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [resourceType] Name of the resource.
-  ///   * [resourceId] ID of the resource.
   ///   * [collectionId] ID of the collection.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1303,16 +1249,14 @@ class $CollaborationResourcesClient {
   ///  * [$addResource_Request] for the request send by this method.
   ///  * [$addResource_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<CollaborationResourcesAddResourceResponseApplicationJson, void>> addResource({
-    required String resourceType,
-    required String resourceId,
     required int collectionId,
+    required CollaborationResourcesAddResourceRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $addResource_Request(
-      resourceType: resourceType,
-      resourceId: resourceId,
       collectionId: collectionId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1340,8 +1284,6 @@ class $CollaborationResourcesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [resourceType] Name of the resource.
-  ///   * [resourceId] ID of the resource.
   ///   * [collectionId] ID of the collection.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1355,24 +1297,15 @@ class $CollaborationResourcesClient {
   ///  * [$removeResource_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $removeResource_Request({
-    required String resourceType,
-    required String resourceId,
     required int collectionId,
+    required CollaborationResourcesRemoveResourceRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __resourceType = _$jsonSerializers.serialize(resourceType, specifiedType: const FullType(String));
-    _parameters['resourceType'] = __resourceType;
-
-    final __resourceId = _$jsonSerializers.serialize(resourceId, specifiedType: const FullType(String));
-    _parameters['resourceId'] = __resourceId;
-
     final __collectionId = _$jsonSerializers.serialize(collectionId, specifiedType: const FullType(int));
     _parameters['collectionId'] = __collectionId;
 
-    final _path =
-        _i6.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}{?resourceType*,resourceId*}')
-            .expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1397,6 +1330,13 @@ class $CollaborationResourcesClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(CollaborationResourcesRemoveResourceRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -1406,8 +1346,6 @@ class $CollaborationResourcesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [resourceType] Name of the resource.
-  ///   * [resourceId] ID of the resource.
   ///   * [collectionId] ID of the collection.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1420,16 +1358,14 @@ class $CollaborationResourcesClient {
   ///  * [$removeResource_Request] for the request send by this method.
   ///  * [$removeResource_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<CollaborationResourcesRemoveResourceResponseApplicationJson, void>> removeResource({
-    required String resourceType,
-    required String resourceId,
     required int collectionId,
+    required CollaborationResourcesRemoveResourceRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $removeResource_Request(
-      resourceType: resourceType,
-      resourceId: resourceId,
       collectionId: collectionId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1663,7 +1599,6 @@ class $CollaborationResourcesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [name] Name of the collection.
   ///   * [baseResourceType] Type of the base resource.
   ///   * [baseResourceId] ID of the base resource.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -1679,23 +1614,20 @@ class $CollaborationResourcesClient {
   ///  * [$createCollectionOnResource_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $createCollectionOnResource_Request({
-    required String name,
     required String baseResourceType,
     required String baseResourceId,
+    required CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __name = _$jsonSerializers.serialize(name, specifiedType: const FullType(String));
-    _parameters['name'] = __name;
-
     final __baseResourceType = _$jsonSerializers.serialize(baseResourceType, specifiedType: const FullType(String));
     _parameters['baseResourceType'] = __baseResourceType;
 
     final __baseResourceId = _$jsonSerializers.serialize(baseResourceId, specifiedType: const FullType(String));
     _parameters['baseResourceId'] = __baseResourceId;
 
-    final _path = _i6.UriTemplate('/ocs/v2.php/collaboration/resources/{baseResourceType}/{baseResourceId}{?name*}')
-        .expand(_parameters);
+    final _path =
+        _i6.UriTemplate('/ocs/v2.php/collaboration/resources/{baseResourceType}/{baseResourceId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1720,6 +1652,13 @@ class $CollaborationResourcesClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -1729,7 +1668,6 @@ class $CollaborationResourcesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [name] Name of the collection.
   ///   * [baseResourceType] Type of the base resource.
   ///   * [baseResourceId] ID of the base resource.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -1745,16 +1683,16 @@ class $CollaborationResourcesClient {
   ///  * [$createCollectionOnResource_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson, void>>
       createCollectionOnResource({
-    required String name,
     required String baseResourceType,
     required String baseResourceId,
+    required CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $createCollectionOnResource_Request(
-      name: name,
       baseResourceType: baseResourceType,
       baseResourceId: baseResourceId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1790,7 +1728,6 @@ class $GuestAvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [darkTheme] Return dark avatar. Defaults to `0`.
   ///   * [guestName] The guest name, e.g. "Albert".
   ///   * [size] The desired avatar size, e.g. 64 for 64x64px.
   ///
@@ -1806,7 +1743,7 @@ class $GuestAvatarClient {
   _i3.Request $getAvatar_Request({
     required String guestName,
     required String size,
-    GuestAvatarGetAvatarDarkTheme? darkTheme,
+    GuestAvatarGetAvatarRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __guestName = _$jsonSerializers.serialize(guestName, specifiedType: const FullType(String));
@@ -1815,12 +1752,7 @@ class $GuestAvatarClient {
     final __size = _$jsonSerializers.serialize(size, specifiedType: const FullType(String));
     _parameters['size'] = __size;
 
-    var __darkTheme =
-        _$jsonSerializers.serialize(darkTheme, specifiedType: const FullType(GuestAvatarGetAvatarDarkTheme));
-    __darkTheme ??= 0;
-    _parameters['darkTheme'] = __darkTheme;
-
-    final _path = _i6.UriTemplate('/index.php/avatar/guest/{guestName}/{size}{?darkTheme*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/index.php/avatar/guest/{guestName}/{size}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = '*/*';
@@ -1839,6 +1771,20 @@ class $GuestAvatarClient {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(GuestAvatarGetAvatarRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              GuestAvatarGetAvatarRequestApplicationJson(),
+              specifiedType: const FullType(GuestAvatarGetAvatarRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -1848,7 +1794,6 @@ class $GuestAvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [darkTheme] Return dark avatar. Defaults to `0`.
   ///   * [guestName] The guest name, e.g. "Albert".
   ///   * [size] The desired avatar size, e.g. 64 for 64x64px.
   ///
@@ -1863,12 +1808,12 @@ class $GuestAvatarClient {
   Future<_i1.DynamiteResponse<Uint8List, void>> getAvatar({
     required String guestName,
     required String size,
-    GuestAvatarGetAvatarDarkTheme? darkTheme,
+    GuestAvatarGetAvatarRequestApplicationJson? $body,
   }) async {
     final _request = $getAvatar_Request(
       guestName: guestName,
       size: size,
-      darkTheme: darkTheme,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2095,9 +2040,6 @@ class $LoginClient {
   /// Returns a `DynamiteRequest` backing the [confirmPassword] operation.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [password] The password of the user.
-  ///
   /// Status codes:
   ///   * 200: Password confirmation succeeded
   ///   * 403: Password confirmation failed
@@ -2106,12 +2048,8 @@ class $LoginClient {
   ///  * [confirmPassword] for a method executing this request and parsing the response.
   ///  * [$confirmPassword_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $confirmPassword_Request({required String password}) {
-    final _parameters = <String, Object?>{};
-    final __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    _parameters['password'] = __password;
-
-    final _path = _i6.UriTemplate('/index.php/login/confirm{?password*}').expand(_parameters);
+  _i3.Request $confirmPassword_Request({required LoginConfirmPasswordRequestApplicationJson $body}) {
+    const _path = '/index.php/login/confirm';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2132,6 +2070,10 @@ class $LoginClient {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(LoginConfirmPasswordRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -2139,9 +2081,6 @@ class $LoginClient {
   ///
   /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
-  ///
-  /// Parameters:
-  ///   * [password] The password of the user.
   ///
   /// Status codes:
   ///   * 200: Password confirmation succeeded
@@ -2151,10 +2090,10 @@ class $LoginClient {
   ///  * [$confirmPassword_Request] for the request send by this method.
   ///  * [$confirmPassword_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<LoginConfirmPasswordResponseApplicationJson, void>> confirmPassword({
-    required String password,
+    required LoginConfirmPasswordRequestApplicationJson $body,
   }) async {
     final _request = $confirmPassword_Request(
-      password: password,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2188,7 +2127,6 @@ class $NavigationClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [absolute] Rewrite URLs to absolute ones. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2200,16 +2138,10 @@ class $NavigationClient {
   ///  * [$getAppsNavigation_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getAppsNavigation_Request({
-    NavigationGetAppsNavigationAbsolute? absolute,
     bool? oCSAPIRequest,
+    NavigationGetAppsNavigationRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    var __absolute =
-        _$jsonSerializers.serialize(absolute, specifiedType: const FullType(NavigationGetAppsNavigationAbsolute));
-    __absolute ??= 0;
-    _parameters['absolute'] = __absolute;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/core/navigation/apps{?absolute*}').expand(_parameters);
+    const _path = '/ocs/v2.php/core/navigation/apps';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2234,6 +2166,20 @@ class $NavigationClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(NavigationGetAppsNavigationRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              NavigationGetAppsNavigationRequestApplicationJson(),
+              specifiedType: const FullType(NavigationGetAppsNavigationRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -2243,7 +2189,6 @@ class $NavigationClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [absolute] Rewrite URLs to absolute ones. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2254,12 +2199,12 @@ class $NavigationClient {
   ///  * [$getAppsNavigation_Request] for the request send by this method.
   ///  * [$getAppsNavigation_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<NavigationGetAppsNavigationResponseApplicationJson, void>> getAppsNavigation({
-    NavigationGetAppsNavigationAbsolute? absolute,
     bool? oCSAPIRequest,
+    NavigationGetAppsNavigationRequestApplicationJson? $body,
   }) async {
     final _request = $getAppsNavigation_Request(
-      absolute: absolute,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2286,7 +2231,6 @@ class $NavigationClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [absolute] Rewrite URLs to absolute ones. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2298,16 +2242,10 @@ class $NavigationClient {
   ///  * [$getSettingsNavigation_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getSettingsNavigation_Request({
-    NavigationGetSettingsNavigationAbsolute? absolute,
     bool? oCSAPIRequest,
+    NavigationGetSettingsNavigationRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    var __absolute =
-        _$jsonSerializers.serialize(absolute, specifiedType: const FullType(NavigationGetSettingsNavigationAbsolute));
-    __absolute ??= 0;
-    _parameters['absolute'] = __absolute;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/core/navigation/settings{?absolute*}').expand(_parameters);
+    const _path = '/ocs/v2.php/core/navigation/settings';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2332,6 +2270,20 @@ class $NavigationClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(NavigationGetSettingsNavigationRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              NavigationGetSettingsNavigationRequestApplicationJson(),
+              specifiedType: const FullType(NavigationGetSettingsNavigationRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -2341,7 +2293,6 @@ class $NavigationClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [absolute] Rewrite URLs to absolute ones. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2352,12 +2303,12 @@ class $NavigationClient {
   ///  * [$getSettingsNavigation_Request] for the request send by this method.
   ///  * [$getSettingsNavigation_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<NavigationGetSettingsNavigationResponseApplicationJson, void>> getSettingsNavigation({
-    NavigationGetSettingsNavigationAbsolute? absolute,
     bool? oCSAPIRequest,
+    NavigationGetSettingsNavigationRequestApplicationJson? $body,
   }) async {
     final _request = $getSettingsNavigation_Request(
-      absolute: absolute,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2555,15 +2506,6 @@ class $PreviewClient {
   /// Returns a `DynamiteRequest` backing the [getPreview] operation.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [file] Path of the file. Defaults to `""`.
-  ///   * [x] Width of the preview. Defaults to `32`.
-  ///   * [y] Height of the preview. Defaults to `32`.
-  ///   * [a] Whether to not crop the preview. Defaults to `0`.
-  ///   * [forceIcon] Force returning an icon. Defaults to `1`.
-  ///   * [mode] How to crop the image. Defaults to `"fill"`.
-  ///   * [mimeFallback] Whether to fallback to the mime icon if no preview is available. Defaults to `0`.
-  ///
   /// Status codes:
   ///   * 200: Preview returned
   ///   * 400: Getting preview is not possible
@@ -2575,47 +2517,8 @@ class $PreviewClient {
   ///  * [getPreview] for a method executing this request and parsing the response.
   ///  * [$getPreview_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $getPreview_Request({
-    String? file,
-    int? x,
-    int? y,
-    PreviewGetPreviewA? a,
-    PreviewGetPreviewForceIcon? forceIcon,
-    String? mode,
-    PreviewGetPreviewMimeFallback? mimeFallback,
-  }) {
-    final _parameters = <String, Object?>{};
-    var __file = _$jsonSerializers.serialize(file, specifiedType: const FullType(String));
-    __file ??= '';
-    _parameters['file'] = __file;
-
-    var __x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
-    __x ??= 32;
-    _parameters['x'] = __x;
-
-    var __y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
-    __y ??= 32;
-    _parameters['y'] = __y;
-
-    var __a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PreviewGetPreviewA));
-    __a ??= 0;
-    _parameters['a'] = __a;
-
-    var __forceIcon = _$jsonSerializers.serialize(forceIcon, specifiedType: const FullType(PreviewGetPreviewForceIcon));
-    __forceIcon ??= 1;
-    _parameters['forceIcon'] = __forceIcon;
-
-    var __mode = _$jsonSerializers.serialize(mode, specifiedType: const FullType(String));
-    __mode ??= 'fill';
-    _parameters['mode'] = __mode;
-
-    var __mimeFallback =
-        _$jsonSerializers.serialize(mimeFallback, specifiedType: const FullType(PreviewGetPreviewMimeFallback));
-    __mimeFallback ??= 0;
-    _parameters['mimeFallback'] = __mimeFallback;
-
-    final _path = _i6.UriTemplate('/index.php/core/preview.png{?file*,x*,y*,a*,forceIcon*,mode*,mimeFallback*}')
-        .expand(_parameters);
+  _i3.Request $getPreview_Request({PreviewGetPreviewRequestApplicationJson? $body}) {
+    const _path = '/index.php/core/preview.png';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = '*/*';
@@ -2636,6 +2539,17 @@ class $PreviewClient {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(PreviewGetPreviewRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              PreviewGetPreviewRequestApplicationJson(),
+              specifiedType: const FullType(PreviewGetPreviewRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -2643,15 +2557,6 @@ class $PreviewClient {
   ///
   /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
-  ///
-  /// Parameters:
-  ///   * [file] Path of the file. Defaults to `""`.
-  ///   * [x] Width of the preview. Defaults to `32`.
-  ///   * [y] Height of the preview. Defaults to `32`.
-  ///   * [a] Whether to not crop the preview. Defaults to `0`.
-  ///   * [forceIcon] Force returning an icon. Defaults to `1`.
-  ///   * [mode] How to crop the image. Defaults to `"fill"`.
-  ///   * [mimeFallback] Whether to fallback to the mime icon if no preview is available. Defaults to `0`.
   ///
   /// Status codes:
   ///   * 200: Preview returned
@@ -2663,23 +2568,9 @@ class $PreviewClient {
   /// See:
   ///  * [$getPreview_Request] for the request send by this method.
   ///  * [$getPreview_Serializer] for a converter to parse the `Response` from an executed request.
-  Future<_i1.DynamiteResponse<Uint8List, void>> getPreview({
-    String? file,
-    int? x,
-    int? y,
-    PreviewGetPreviewA? a,
-    PreviewGetPreviewForceIcon? forceIcon,
-    String? mode,
-    PreviewGetPreviewMimeFallback? mimeFallback,
-  }) async {
+  Future<_i1.DynamiteResponse<Uint8List, void>> getPreview({PreviewGetPreviewRequestApplicationJson? $body}) async {
     final _request = $getPreview_Request(
-      file: file,
-      x: x,
-      y: y,
-      a: a,
-      forceIcon: forceIcon,
-      mode: mode,
-      mimeFallback: mimeFallback,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2703,15 +2594,6 @@ class $PreviewClient {
   /// Returns a `DynamiteRequest` backing the [getPreviewByFileId] operation.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [fileId] ID of the file. Defaults to `-1`.
-  ///   * [x] Width of the preview. Defaults to `32`.
-  ///   * [y] Height of the preview. Defaults to `32`.
-  ///   * [a] Whether to not crop the preview. Defaults to `0`.
-  ///   * [forceIcon] Force returning an icon. Defaults to `1`.
-  ///   * [mode] How to crop the image. Defaults to `"fill"`.
-  ///   * [mimeFallback] Whether to fallback to the mime icon if no preview is available. Defaults to `0`.
-  ///
   /// Status codes:
   ///   * 200: Preview returned
   ///   * 400: Getting preview is not possible
@@ -2723,48 +2605,8 @@ class $PreviewClient {
   ///  * [getPreviewByFileId] for a method executing this request and parsing the response.
   ///  * [$getPreviewByFileId_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $getPreviewByFileId_Request({
-    int? fileId,
-    int? x,
-    int? y,
-    PreviewGetPreviewByFileIdA? a,
-    PreviewGetPreviewByFileIdForceIcon? forceIcon,
-    String? mode,
-    PreviewGetPreviewByFileIdMimeFallback? mimeFallback,
-  }) {
-    final _parameters = <String, Object?>{};
-    var __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
-    __fileId ??= -1;
-    _parameters['fileId'] = __fileId;
-
-    var __x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
-    __x ??= 32;
-    _parameters['x'] = __x;
-
-    var __y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
-    __y ??= 32;
-    _parameters['y'] = __y;
-
-    var __a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PreviewGetPreviewByFileIdA));
-    __a ??= 0;
-    _parameters['a'] = __a;
-
-    var __forceIcon =
-        _$jsonSerializers.serialize(forceIcon, specifiedType: const FullType(PreviewGetPreviewByFileIdForceIcon));
-    __forceIcon ??= 1;
-    _parameters['forceIcon'] = __forceIcon;
-
-    var __mode = _$jsonSerializers.serialize(mode, specifiedType: const FullType(String));
-    __mode ??= 'fill';
-    _parameters['mode'] = __mode;
-
-    var __mimeFallback =
-        _$jsonSerializers.serialize(mimeFallback, specifiedType: const FullType(PreviewGetPreviewByFileIdMimeFallback));
-    __mimeFallback ??= 0;
-    _parameters['mimeFallback'] = __mimeFallback;
-
-    final _path = _i6.UriTemplate('/index.php/core/preview{?fileId*,x*,y*,a*,forceIcon*,mode*,mimeFallback*}')
-        .expand(_parameters);
+  _i3.Request $getPreviewByFileId_Request({PreviewGetPreviewByFileIdRequestApplicationJson? $body}) {
+    const _path = '/index.php/core/preview';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = '*/*';
@@ -2785,6 +2627,20 @@ class $PreviewClient {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(PreviewGetPreviewByFileIdRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              PreviewGetPreviewByFileIdRequestApplicationJson(),
+              specifiedType: const FullType(PreviewGetPreviewByFileIdRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -2792,15 +2648,6 @@ class $PreviewClient {
   ///
   /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
-  ///
-  /// Parameters:
-  ///   * [fileId] ID of the file. Defaults to `-1`.
-  ///   * [x] Width of the preview. Defaults to `32`.
-  ///   * [y] Height of the preview. Defaults to `32`.
-  ///   * [a] Whether to not crop the preview. Defaults to `0`.
-  ///   * [forceIcon] Force returning an icon. Defaults to `1`.
-  ///   * [mode] How to crop the image. Defaults to `"fill"`.
-  ///   * [mimeFallback] Whether to fallback to the mime icon if no preview is available. Defaults to `0`.
   ///
   /// Status codes:
   ///   * 200: Preview returned
@@ -2813,22 +2660,10 @@ class $PreviewClient {
   ///  * [$getPreviewByFileId_Request] for the request send by this method.
   ///  * [$getPreviewByFileId_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Uint8List, void>> getPreviewByFileId({
-    int? fileId,
-    int? x,
-    int? y,
-    PreviewGetPreviewByFileIdA? a,
-    PreviewGetPreviewByFileIdForceIcon? forceIcon,
-    String? mode,
-    PreviewGetPreviewByFileIdMimeFallback? mimeFallback,
+    PreviewGetPreviewByFileIdRequestApplicationJson? $body,
   }) async {
     final _request = $getPreviewByFileId_Request(
-      fileId: fileId,
-      x: x,
-      y: y,
-      a: a,
-      forceIcon: forceIcon,
-      mode: mode,
-      mimeFallback: mimeFallback,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2863,8 +2698,6 @@ class $ProfileApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [paramId] ID of the parameter.
-  ///   * [visibility] New visibility.
   ///   * [targetUserId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -2879,22 +2712,15 @@ class $ProfileApiClient {
   ///  * [$setVisibility_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setVisibility_Request({
-    required String paramId,
-    required String visibility,
     required String targetUserId,
+    required ProfileApiSetVisibilityRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __paramId = _$jsonSerializers.serialize(paramId, specifiedType: const FullType(String));
-    _parameters['paramId'] = __paramId;
-
-    final __visibility = _$jsonSerializers.serialize(visibility, specifiedType: const FullType(String));
-    _parameters['visibility'] = __visibility;
-
     final __targetUserId = _$jsonSerializers.serialize(targetUserId, specifiedType: const FullType(String));
     _parameters['targetUserId'] = __targetUserId;
 
-    final _path = _i6.UriTemplate('/ocs/v2.php/profile/{targetUserId}{?paramId*,visibility*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/profile/{targetUserId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2919,6 +2745,13 @@ class $ProfileApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(ProfileApiSetVisibilityRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -2930,8 +2763,6 @@ class $ProfileApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [paramId] ID of the parameter.
-  ///   * [visibility] New visibility.
   ///   * [targetUserId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -2945,16 +2776,14 @@ class $ProfileApiClient {
   ///  * [$setVisibility_Request] for the request send by this method.
   ///  * [$setVisibility_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ProfileApiSetVisibilityResponseApplicationJson, void>> setVisibility({
-    required String paramId,
-    required String visibility,
     required String targetUserId,
+    required ProfileApiSetVisibilityRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setVisibility_Request(
-      paramId: paramId,
-      visibility: visibility,
       targetUserId: targetUserId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -3074,9 +2903,6 @@ class $ReferenceApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [text] Text to extract from.
-  ///   * [resolve] Resolve the references. Defaults to `0`.
-  ///   * [limit] Maximum amount of references to extract. Defaults to `1`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -3087,24 +2913,10 @@ class $ReferenceApiClient {
   ///  * [$extract_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $extract_Request({
-    required String text,
-    ReferenceApiExtractResolve? resolve,
-    int? limit,
+    required ReferenceApiExtractRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __text = _$jsonSerializers.serialize(text, specifiedType: const FullType(String));
-    _parameters['text'] = __text;
-
-    var __resolve = _$jsonSerializers.serialize(resolve, specifiedType: const FullType(ReferenceApiExtractResolve));
-    __resolve ??= 0;
-    _parameters['resolve'] = __resolve;
-
-    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    __limit ??= 1;
-    _parameters['limit'] = __limit;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/references/extract{?text*,resolve*,limit*}').expand(_parameters);
+    const _path = '/ocs/v2.php/references/extract';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -3129,6 +2941,10 @@ class $ReferenceApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(ReferenceApiExtractRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -3138,9 +2954,6 @@ class $ReferenceApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [text] Text to extract from.
-  ///   * [resolve] Resolve the references. Defaults to `0`.
-  ///   * [limit] Maximum amount of references to extract. Defaults to `1`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -3150,16 +2963,12 @@ class $ReferenceApiClient {
   ///  * [$extract_Request] for the request send by this method.
   ///  * [$extract_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ReferenceApiExtractResponseApplicationJson, void>> extract({
-    required String text,
-    ReferenceApiExtractResolve? resolve,
-    int? limit,
+    required ReferenceApiExtractRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $extract_Request(
-      text: text,
-      resolve: resolve,
-      limit: limit,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -3186,7 +2995,6 @@ class $ReferenceApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [reference] Reference to resolve.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -3197,14 +3005,10 @@ class $ReferenceApiClient {
   ///  * [$resolveOne_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $resolveOne_Request({
-    required String reference,
+    required ReferenceApiResolveOneRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __reference = _$jsonSerializers.serialize(reference, specifiedType: const FullType(String));
-    _parameters['reference'] = __reference;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/references/resolve{?reference*}').expand(_parameters);
+    const _path = '/ocs/v2.php/references/resolve';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -3229,6 +3033,13 @@ class $ReferenceApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(ReferenceApiResolveOneRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -3238,7 +3049,6 @@ class $ReferenceApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [reference] Reference to resolve.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -3248,12 +3058,12 @@ class $ReferenceApiClient {
   ///  * [$resolveOne_Request] for the request send by this method.
   ///  * [$resolveOne_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ReferenceApiResolveOneResponseApplicationJson, void>> resolveOne({
-    required String reference,
+    required ReferenceApiResolveOneRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $resolveOne_Request(
-      reference: reference,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -3280,8 +3090,6 @@ class $ReferenceApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [references] References to resolve.
-  ///   * [limit] Maximum amount of references to resolve. Defaults to `1`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -3292,20 +3100,10 @@ class $ReferenceApiClient {
   ///  * [$resolve_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $resolve_Request({
-    required BuiltList<String> references,
-    int? limit,
+    required ReferenceApiResolveRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __references =
-        _$jsonSerializers.serialize(references, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    _parameters['references%5B%5D'] = __references;
-
-    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    __limit ??= 1;
-    _parameters['limit'] = __limit;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/references/resolve{?references%5B%5D*,limit*}').expand(_parameters);
+    const _path = '/ocs/v2.php/references/resolve';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -3330,6 +3128,10 @@ class $ReferenceApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(ReferenceApiResolveRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -3339,8 +3141,6 @@ class $ReferenceApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [references] References to resolve.
-  ///   * [limit] Maximum amount of references to resolve. Defaults to `1`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -3350,14 +3150,12 @@ class $ReferenceApiClient {
   ///  * [$resolve_Request] for the request send by this method.
   ///  * [$resolve_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ReferenceApiResolveResponseApplicationJson, void>> resolve({
-    required BuiltList<String> references,
-    int? limit,
+    required ReferenceApiResolveRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $resolve_Request(
-      references: references,
-      limit: limit,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -3467,7 +3265,6 @@ class $ReferenceApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [timestamp] Timestamp of the last usage.
   ///   * [providerId] ID of the provider.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -3480,17 +3277,14 @@ class $ReferenceApiClient {
   @_i2.experimental
   _i3.Request $touchProvider_Request({
     required String providerId,
-    int? timestamp,
     bool? oCSAPIRequest,
+    ReferenceApiTouchProviderRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __providerId = _$jsonSerializers.serialize(providerId, specifiedType: const FullType(String));
     _parameters['providerId'] = __providerId;
 
-    final __timestamp = _$jsonSerializers.serialize(timestamp, specifiedType: const FullType(int));
-    _parameters['timestamp'] = __timestamp;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/references/provider/{providerId}{?timestamp*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/references/provider/{providerId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -3515,6 +3309,20 @@ class $ReferenceApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(ReferenceApiTouchProviderRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ReferenceApiTouchProviderRequestApplicationJson(),
+              specifiedType: const FullType(ReferenceApiTouchProviderRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -3524,7 +3332,6 @@ class $ReferenceApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [timestamp] Timestamp of the last usage.
   ///   * [providerId] ID of the provider.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -3536,13 +3343,13 @@ class $ReferenceApiClient {
   ///  * [$touchProvider_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ReferenceApiTouchProviderResponseApplicationJson, void>> touchProvider({
     required String providerId,
-    int? timestamp,
     bool? oCSAPIRequest,
+    ReferenceApiTouchProviderRequestApplicationJson? $body,
   }) async {
     final _request = $touchProvider_Request(
       providerId: providerId,
-      timestamp: timestamp,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -3860,10 +3667,6 @@ class $TextProcessingApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [input] Input text.
-  ///   * [type] Type of the task.
-  ///   * [appId] ID of the app that will execute the task.
-  ///   * [identifier] An arbitrary identifier for the task. Defaults to `""`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -3877,28 +3680,10 @@ class $TextProcessingApiClient {
   ///  * [$schedule_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $schedule_Request({
-    required String input,
-    required String type,
-    required String appId,
-    String? identifier,
+    required TextProcessingApiScheduleRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __input = _$jsonSerializers.serialize(input, specifiedType: const FullType(String));
-    _parameters['input'] = __input;
-
-    final __type = _$jsonSerializers.serialize(type, specifiedType: const FullType(String));
-    _parameters['type'] = __type;
-
-    final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
-    _parameters['appId'] = __appId;
-
-    var __identifier = _$jsonSerializers.serialize(identifier, specifiedType: const FullType(String));
-    __identifier ??= '';
-    _parameters['identifier'] = __identifier;
-
-    final _path =
-        _i6.UriTemplate('/ocs/v2.php/textprocessing/schedule{?input*,type*,appId*,identifier*}').expand(_parameters);
+    const _path = '/ocs/v2.php/textprocessing/schedule';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -3921,6 +3706,13 @@ class $TextProcessingApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(TextProcessingApiScheduleRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -3930,10 +3722,6 @@ class $TextProcessingApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [input] Input text.
-  ///   * [type] Type of the task.
-  ///   * [appId] ID of the app that will execute the task.
-  ///   * [identifier] An arbitrary identifier for the task. Defaults to `""`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -3946,18 +3734,12 @@ class $TextProcessingApiClient {
   ///  * [$schedule_Request] for the request send by this method.
   ///  * [$schedule_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<TextProcessingApiScheduleResponseApplicationJson, void>> schedule({
-    required String input,
-    required String type,
-    required String appId,
-    String? identifier,
+    required TextProcessingApiScheduleRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $schedule_Request(
-      input: input,
-      type: type,
-      appId: appId,
-      identifier: identifier,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -4178,7 +3960,6 @@ class $TextProcessingApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [identifier] An arbitrary identifier for the task.
   ///   * [appId] ID of the app.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -4192,17 +3973,14 @@ class $TextProcessingApiClient {
   @_i2.experimental
   _i3.Request $listTasksByApp_Request({
     required String appId,
-    String? identifier,
     bool? oCSAPIRequest,
+    TextProcessingApiListTasksByAppRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
     _parameters['appId'] = __appId;
 
-    final __identifier = _$jsonSerializers.serialize(identifier, specifiedType: const FullType(String));
-    _parameters['identifier'] = __identifier;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/textprocessing/tasks/app/{appId}{?identifier*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/textprocessing/tasks/app/{appId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -4227,6 +4005,20 @@ class $TextProcessingApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(TextProcessingApiListTasksByAppRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              TextProcessingApiListTasksByAppRequestApplicationJson(),
+              specifiedType: const FullType(TextProcessingApiListTasksByAppRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -4236,7 +4028,6 @@ class $TextProcessingApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [identifier] An arbitrary identifier for the task.
   ///   * [appId] ID of the app.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -4249,13 +4040,13 @@ class $TextProcessingApiClient {
   ///  * [$listTasksByApp_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<TextProcessingApiListTasksByAppResponseApplicationJson, void>> listTasksByApp({
     required String appId,
-    String? identifier,
     bool? oCSAPIRequest,
+    TextProcessingApiListTasksByAppRequestApplicationJson? $body,
   }) async {
     final _request = $listTasksByApp_Request(
       appId: appId,
-      identifier: identifier,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -4371,10 +4162,6 @@ class $TextToImageApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [input] Input text.
-  ///   * [appId] ID of the app that will execute the task.
-  ///   * [identifier] An arbitrary identifier for the task. Defaults to `""`.
-  ///   * [numberOfImages] The number of images to generate. Defaults to `8`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -4387,29 +4174,10 @@ class $TextToImageApiClient {
   ///  * [$schedule_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $schedule_Request({
-    required String input,
-    required String appId,
-    String? identifier,
-    int? numberOfImages,
+    required TextToImageApiScheduleRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __input = _$jsonSerializers.serialize(input, specifiedType: const FullType(String));
-    _parameters['input'] = __input;
-
-    final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
-    _parameters['appId'] = __appId;
-
-    var __identifier = _$jsonSerializers.serialize(identifier, specifiedType: const FullType(String));
-    __identifier ??= '';
-    _parameters['identifier'] = __identifier;
-
-    var __numberOfImages = _$jsonSerializers.serialize(numberOfImages, specifiedType: const FullType(int));
-    __numberOfImages ??= 8;
-    _parameters['numberOfImages'] = __numberOfImages;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/text2image/schedule{?input*,appId*,identifier*,numberOfImages*}')
-        .expand(_parameters);
+    const _path = '/ocs/v2.php/text2image/schedule';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -4432,6 +4200,13 @@ class $TextToImageApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(TextToImageApiScheduleRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -4441,10 +4216,6 @@ class $TextToImageApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [input] Input text.
-  ///   * [appId] ID of the app that will execute the task.
-  ///   * [identifier] An arbitrary identifier for the task. Defaults to `""`.
-  ///   * [numberOfImages] The number of images to generate. Defaults to `8`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -4456,18 +4227,12 @@ class $TextToImageApiClient {
   ///  * [$schedule_Request] for the request send by this method.
   ///  * [$schedule_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<TextToImageApiScheduleResponseApplicationJson, void>> schedule({
-    required String input,
-    required String appId,
-    String? identifier,
-    int? numberOfImages,
+    required TextToImageApiScheduleRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $schedule_Request(
-      input: input,
-      appId: appId,
-      identifier: identifier,
-      numberOfImages: numberOfImages,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -4790,7 +4555,6 @@ class $TextToImageApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [identifier] An arbitrary identifier for the task.
   ///   * [appId] ID of the app.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -4804,17 +4568,14 @@ class $TextToImageApiClient {
   @_i2.experimental
   _i3.Request $listTasksByApp_Request({
     required String appId,
-    String? identifier,
     bool? oCSAPIRequest,
+    TextToImageApiListTasksByAppRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
     _parameters['appId'] = __appId;
 
-    final __identifier = _$jsonSerializers.serialize(identifier, specifiedType: const FullType(String));
-    _parameters['identifier'] = __identifier;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/text2image/tasks/app/{appId}{?identifier*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/text2image/tasks/app/{appId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -4839,6 +4600,20 @@ class $TextToImageApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(TextToImageApiListTasksByAppRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              TextToImageApiListTasksByAppRequestApplicationJson(),
+              specifiedType: const FullType(TextToImageApiListTasksByAppRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -4848,7 +4623,6 @@ class $TextToImageApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [identifier] An arbitrary identifier for the task.
   ///   * [appId] ID of the app.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -4861,13 +4635,13 @@ class $TextToImageApiClient {
   ///  * [$listTasksByApp_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<TextToImageApiListTasksByAppResponseApplicationJson, void>> listTasksByApp({
     required String appId,
-    String? identifier,
     bool? oCSAPIRequest,
+    TextToImageApiListTasksByAppRequestApplicationJson? $body,
   }) async {
     final _request = $listTasksByApp_Request(
       appId: appId,
-      identifier: identifier,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -4982,9 +4756,6 @@ class $TranslationApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [text] Text to be translated.
-  ///   * [fromLanguage] Language to translate from.
-  ///   * [toLanguage] Language to translate to.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -4998,23 +4769,10 @@ class $TranslationApiClient {
   ///  * [$translate_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $translate_Request({
-    required String text,
-    required String toLanguage,
-    String? fromLanguage,
+    required TranslationApiTranslateRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __text = _$jsonSerializers.serialize(text, specifiedType: const FullType(String));
-    _parameters['text'] = __text;
-
-    final __toLanguage = _$jsonSerializers.serialize(toLanguage, specifiedType: const FullType(String));
-    _parameters['toLanguage'] = __toLanguage;
-
-    final __fromLanguage = _$jsonSerializers.serialize(fromLanguage, specifiedType: const FullType(String));
-    _parameters['fromLanguage'] = __fromLanguage;
-
-    final _path =
-        _i6.UriTemplate('/ocs/v2.php/translation/translate{?text*,toLanguage*,fromLanguage*}').expand(_parameters);
+    const _path = '/ocs/v2.php/translation/translate';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -5037,6 +4795,13 @@ class $TranslationApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(TranslationApiTranslateRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -5046,9 +4811,6 @@ class $TranslationApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [text] Text to be translated.
-  ///   * [fromLanguage] Language to translate from.
-  ///   * [toLanguage] Language to translate to.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -5061,16 +4823,12 @@ class $TranslationApiClient {
   ///  * [$translate_Request] for the request send by this method.
   ///  * [$translate_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<TranslationApiTranslateResponseApplicationJson, void>> translate({
-    required String text,
-    required String toLanguage,
-    String? fromLanguage,
+    required TranslationApiTranslateRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $translate_Request(
-      text: text,
-      toLanguage: toLanguage,
-      fromLanguage: fromLanguage,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -5104,7 +4862,6 @@ class $UnifiedSearchClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [from] the url the user is currently at. Defaults to `""`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -5115,15 +4872,10 @@ class $UnifiedSearchClient {
   ///  * [$getProviders_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getProviders_Request({
-    String? from,
     bool? oCSAPIRequest,
+    UnifiedSearchGetProvidersRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    var __from = _$jsonSerializers.serialize(from, specifiedType: const FullType(String));
-    __from ??= '';
-    _parameters['from'] = __from;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/search/providers{?from*}').expand(_parameters);
+    const _path = '/ocs/v2.php/search/providers';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -5148,6 +4900,20 @@ class $UnifiedSearchClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(UnifiedSearchGetProvidersRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              UnifiedSearchGetProvidersRequestApplicationJson(),
+              specifiedType: const FullType(UnifiedSearchGetProvidersRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -5157,7 +4923,6 @@ class $UnifiedSearchClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [from] the url the user is currently at. Defaults to `""`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -5167,12 +4932,12 @@ class $UnifiedSearchClient {
   ///  * [$getProviders_Request] for the request send by this method.
   ///  * [$getProviders_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UnifiedSearchGetProvidersResponseApplicationJson, void>> getProviders({
-    String? from,
     bool? oCSAPIRequest,
+    UnifiedSearchGetProvidersRequestApplicationJson? $body,
   }) async {
     final _request = $getProviders_Request(
-      from: from,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -5201,11 +4966,6 @@ class $UnifiedSearchClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [term] Term to search. Defaults to `""`.
-  ///   * [sortOrder] Order of entries.
-  ///   * [limit] Maximum amount of entries.
-  ///   * [cursor] Offset for searching.
-  ///   * [from] The current user URL. Defaults to `""`.
   ///   * [providerId] ID of the provider.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -5219,37 +4979,14 @@ class $UnifiedSearchClient {
   @_i2.experimental
   _i3.Request $search_Request({
     required String providerId,
-    String? term,
-    int? sortOrder,
-    int? limit,
-    UnifiedSearchSearchCursor? cursor,
-    String? from,
     bool? oCSAPIRequest,
+    UnifiedSearchSearchRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __providerId = _$jsonSerializers.serialize(providerId, specifiedType: const FullType(String));
     _parameters['providerId'] = __providerId;
 
-    var __term = _$jsonSerializers.serialize(term, specifiedType: const FullType(String));
-    __term ??= '';
-    _parameters['term'] = __term;
-
-    final __sortOrder = _$jsonSerializers.serialize(sortOrder, specifiedType: const FullType(int));
-    _parameters['sortOrder'] = __sortOrder;
-
-    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = __limit;
-
-    final __cursor = _$jsonSerializers.serialize(cursor, specifiedType: const FullType(UnifiedSearchSearchCursor));
-    _parameters['cursor'] = __cursor;
-
-    var __from = _$jsonSerializers.serialize(from, specifiedType: const FullType(String));
-    __from ??= '';
-    _parameters['from'] = __from;
-
-    final _path =
-        _i6.UriTemplate('/ocs/v2.php/search/providers/{providerId}/search{?term*,sortOrder*,limit*,cursor*,from*}')
-            .expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/search/providers/{providerId}/search').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -5274,6 +5011,20 @@ class $UnifiedSearchClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(UnifiedSearchSearchRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              UnifiedSearchSearchRequestApplicationJson(),
+              specifiedType: const FullType(UnifiedSearchSearchRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -5285,11 +5036,6 @@ class $UnifiedSearchClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [term] Term to search. Defaults to `""`.
-  ///   * [sortOrder] Order of entries.
-  ///   * [limit] Maximum amount of entries.
-  ///   * [cursor] Offset for searching.
-  ///   * [from] The current user URL. Defaults to `""`.
   ///   * [providerId] ID of the provider.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -5302,21 +5048,13 @@ class $UnifiedSearchClient {
   ///  * [$search_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UnifiedSearchSearchResponseApplicationJson, void>> search({
     required String providerId,
-    String? term,
-    int? sortOrder,
-    int? limit,
-    UnifiedSearchSearchCursor? cursor,
-    String? from,
     bool? oCSAPIRequest,
+    UnifiedSearchSearchRequestApplicationJson? $body,
   }) async {
     final _request = $search_Request(
       providerId: providerId,
-      term: term,
-      sortOrder: sortOrder,
-      limit: limit,
-      cursor: cursor,
-      from: from,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -5431,7 +5169,6 @@ class $WhatsNewClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [version] Version to dismiss the changes for.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -5443,14 +5180,10 @@ class $WhatsNewClient {
   ///  * [$dismiss_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $dismiss_Request({
-    required String version,
+    required WhatsNewDismissRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
-    _parameters['version'] = __version;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/core/whatsnew{?version*}').expand(_parameters);
+    const _path = '/ocs/v2.php/core/whatsnew';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -5475,6 +5208,10 @@ class $WhatsNewClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(WhatsNewDismissRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -5484,7 +5221,6 @@ class $WhatsNewClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [version] Version to dismiss the changes for.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -5495,12 +5231,12 @@ class $WhatsNewClient {
   ///  * [$dismiss_Request] for the request send by this method.
   ///  * [$dismiss_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<WhatsNewDismissResponseApplicationJson, void>> dismiss({
-    required String version,
+    required WhatsNewDismissRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $dismiss_Request(
-      version: version,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -5532,9 +5268,6 @@ class $WipeClient {
   /// Returns a `DynamiteRequest` backing the [checkWipe] operation.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [token] App password.
-  ///
   /// Status codes:
   ///   * 200: Device should be wiped
   ///   * 404: Device should not be wiped
@@ -5543,12 +5276,8 @@ class $WipeClient {
   ///  * [checkWipe] for a method executing this request and parsing the response.
   ///  * [$checkWipe_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $checkWipe_Request({required String token}) {
-    final _parameters = <String, Object?>{};
-    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _parameters['token'] = __token;
-
-    final _path = _i6.UriTemplate('/index.php/core/wipe/check{?token*}').expand(_parameters);
+  _i3.Request $checkWipe_Request({required WipeCheckWipeRequestApplicationJson $body}) {
+    const _path = '/index.php/core/wipe/check';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -5567,6 +5296,9 @@ class $WipeClient {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json
+        .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(WipeCheckWipeRequestApplicationJson)));
     return _request;
   }
 
@@ -5575,9 +5307,6 @@ class $WipeClient {
   /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [token] App password.
-  ///
   /// Status codes:
   ///   * 200: Device should be wiped
   ///   * 404: Device should not be wiped
@@ -5585,9 +5314,11 @@ class $WipeClient {
   /// See:
   ///  * [$checkWipe_Request] for the request send by this method.
   ///  * [$checkWipe_Serializer] for a converter to parse the `Response` from an executed request.
-  Future<_i1.DynamiteResponse<WipeCheckWipeResponseApplicationJson, void>> checkWipe({required String token}) async {
+  Future<_i1.DynamiteResponse<WipeCheckWipeResponseApplicationJson, void>> checkWipe({
+    required WipeCheckWipeRequestApplicationJson $body,
+  }) async {
     final _request = $checkWipe_Request(
-      token: token,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -5612,9 +5343,6 @@ class $WipeClient {
   /// Returns a `DynamiteRequest` backing the [wipeDone] operation.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [token] App password.
-  ///
   /// Status codes:
   ///   * 200: Wipe finished successfully
   ///   * 404: Device should not be wiped
@@ -5623,12 +5351,8 @@ class $WipeClient {
   ///  * [wipeDone] for a method executing this request and parsing the response.
   ///  * [$wipeDone_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $wipeDone_Request({required String token}) {
-    final _parameters = <String, Object?>{};
-    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _parameters['token'] = __token;
-
-    final _path = _i6.UriTemplate('/index.php/core/wipe/success{?token*}').expand(_parameters);
+  _i3.Request $wipeDone_Request({required WipeWipeDoneRequestApplicationJson $body}) {
+    const _path = '/index.php/core/wipe/success';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -5647,6 +5371,9 @@ class $WipeClient {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json
+        .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(WipeWipeDoneRequestApplicationJson)));
     return _request;
   }
 
@@ -5655,9 +5382,6 @@ class $WipeClient {
   /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [token] App password.
-  ///
   /// Status codes:
   ///   * 200: Wipe finished successfully
   ///   * 404: Device should not be wiped
@@ -5665,9 +5389,9 @@ class $WipeClient {
   /// See:
   ///  * [$wipeDone_Request] for the request send by this method.
   ///  * [$wipeDone_Serializer] for a converter to parse the `Response` from an executed request.
-  Future<_i1.DynamiteResponse<JsonObject, void>> wipeDone({required String token}) async {
+  Future<_i1.DynamiteResponse<JsonObject, void>> wipeDone({required WipeWipeDoneRequestApplicationJson $body}) async {
     final _request = $wipeDone_Request(
-      token: token,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -6313,6 +6037,71 @@ abstract class AppPasswordRotateAppPasswordResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $AppPasswordConfirmUserPasswordRequestApplicationJsonInterface {
+  /// The password of the user.
+  String get password;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppPasswordConfirmUserPasswordRequestApplicationJsonInterfaceBuilder].
+  $AppPasswordConfirmUserPasswordRequestApplicationJsonInterface rebuild(
+    void Function($AppPasswordConfirmUserPasswordRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppPasswordConfirmUserPasswordRequestApplicationJsonInterfaceBuilder].
+  $AppPasswordConfirmUserPasswordRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppPasswordConfirmUserPasswordRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppPasswordConfirmUserPasswordRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class AppPasswordConfirmUserPasswordRequestApplicationJson
+    implements
+        $AppPasswordConfirmUserPasswordRequestApplicationJsonInterface,
+        Built<AppPasswordConfirmUserPasswordRequestApplicationJson,
+            AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder> {
+  /// Creates a new AppPasswordConfirmUserPasswordRequestApplicationJson object using the builder pattern.
+  factory AppPasswordConfirmUserPasswordRequestApplicationJson([
+    void Function(AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder)? b,
+  ]) = _$AppPasswordConfirmUserPasswordRequestApplicationJson;
+
+  // coverage:ignore-start
+  const AppPasswordConfirmUserPasswordRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory AppPasswordConfirmUserPasswordRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for AppPasswordConfirmUserPasswordRequestApplicationJson.
+  static Serializer<AppPasswordConfirmUserPasswordRequestApplicationJson> get serializer =>
+      _$appPasswordConfirmUserPasswordRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder b) {
+    $AppPasswordConfirmUserPasswordRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder b) {
+    $AppPasswordConfirmUserPasswordRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataInterface {
   int get lastLogin;
 
@@ -6502,6 +6291,98 @@ abstract class AppPasswordConfirmUserPasswordResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(AppPasswordConfirmUserPasswordResponseApplicationJsonBuilder b) {
     $AppPasswordConfirmUserPasswordResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $AutoCompleteGetRequestApplicationJsonInterface {
+  static final _$shareTypes = _$jsonSerializers.deserialize(
+    const [],
+    specifiedType: const FullType(BuiltList, [FullType(int)]),
+  )! as BuiltList<int>;
+
+  static final _$limit = _$jsonSerializers.deserialize(
+    10,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// Text to search for.
+  String get search;
+
+  /// Type of the items to search for.
+  String? get itemType;
+
+  /// ID of the items to search for.
+  String? get itemId;
+
+  /// can be piped, top prio first, e.g.: "commenters|share-recipients".
+  String? get sorter;
+
+  /// Types of shares to search for.
+  BuiltList<int> get shareTypes;
+
+  /// Maximum number of results to return.
+  int get limit;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AutoCompleteGetRequestApplicationJsonInterfaceBuilder].
+  $AutoCompleteGetRequestApplicationJsonInterface rebuild(
+    void Function($AutoCompleteGetRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AutoCompleteGetRequestApplicationJsonInterfaceBuilder].
+  $AutoCompleteGetRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AutoCompleteGetRequestApplicationJsonInterfaceBuilder b) {
+    b.shareTypes.replace(_$shareTypes);
+    b.limit = _$limit;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AutoCompleteGetRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class AutoCompleteGetRequestApplicationJson
+    implements
+        $AutoCompleteGetRequestApplicationJsonInterface,
+        Built<AutoCompleteGetRequestApplicationJson, AutoCompleteGetRequestApplicationJsonBuilder> {
+  /// Creates a new AutoCompleteGetRequestApplicationJson object using the builder pattern.
+  factory AutoCompleteGetRequestApplicationJson([void Function(AutoCompleteGetRequestApplicationJsonBuilder)? b]) =
+      _$AutoCompleteGetRequestApplicationJson;
+
+  // coverage:ignore-start
+  const AutoCompleteGetRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory AutoCompleteGetRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for AutoCompleteGetRequestApplicationJson.
+  static Serializer<AutoCompleteGetRequestApplicationJson> get serializer =>
+      _$autoCompleteGetRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AutoCompleteGetRequestApplicationJsonBuilder b) {
+    $AutoCompleteGetRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AutoCompleteGetRequestApplicationJsonBuilder b) {
+    $AutoCompleteGetRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -6878,6 +6759,70 @@ abstract class AvatarAvatarGetAvatarHeaders
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(AvatarAvatarGetAvatarHeadersBuilder b) {
     $AvatarAvatarGetAvatarHeadersInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ClientFlowLoginV2PollRequestApplicationJsonInterface {
+  /// Token of the flow.
+  String get token;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ClientFlowLoginV2PollRequestApplicationJsonInterfaceBuilder].
+  $ClientFlowLoginV2PollRequestApplicationJsonInterface rebuild(
+    void Function($ClientFlowLoginV2PollRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ClientFlowLoginV2PollRequestApplicationJsonInterfaceBuilder].
+  $ClientFlowLoginV2PollRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ClientFlowLoginV2PollRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ClientFlowLoginV2PollRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ClientFlowLoginV2PollRequestApplicationJson
+    implements
+        $ClientFlowLoginV2PollRequestApplicationJsonInterface,
+        Built<ClientFlowLoginV2PollRequestApplicationJson, ClientFlowLoginV2PollRequestApplicationJsonBuilder> {
+  /// Creates a new ClientFlowLoginV2PollRequestApplicationJson object using the builder pattern.
+  factory ClientFlowLoginV2PollRequestApplicationJson([
+    void Function(ClientFlowLoginV2PollRequestApplicationJsonBuilder)? b,
+  ]) = _$ClientFlowLoginV2PollRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ClientFlowLoginV2PollRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ClientFlowLoginV2PollRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ClientFlowLoginV2PollRequestApplicationJson.
+  static Serializer<ClientFlowLoginV2PollRequestApplicationJson> get serializer =>
+      _$clientFlowLoginV2PollRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ClientFlowLoginV2PollRequestApplicationJsonBuilder b) {
+    $ClientFlowLoginV2PollRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ClientFlowLoginV2PollRequestApplicationJsonBuilder b) {
+    $ClientFlowLoginV2PollRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -7351,6 +7296,71 @@ abstract class CollaborationResourcesListCollectionResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $CollaborationResourcesRenameCollectionRequestApplicationJsonInterface {
+  /// New name.
+  String get collectionName;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesRenameCollectionRequestApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesRenameCollectionRequestApplicationJsonInterface rebuild(
+    void Function($CollaborationResourcesRenameCollectionRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesRenameCollectionRequestApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesRenameCollectionRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesRenameCollectionRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesRenameCollectionRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class CollaborationResourcesRenameCollectionRequestApplicationJson
+    implements
+        $CollaborationResourcesRenameCollectionRequestApplicationJsonInterface,
+        Built<CollaborationResourcesRenameCollectionRequestApplicationJson,
+            CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder> {
+  /// Creates a new CollaborationResourcesRenameCollectionRequestApplicationJson object using the builder pattern.
+  factory CollaborationResourcesRenameCollectionRequestApplicationJson([
+    void Function(CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder)? b,
+  ]) = _$CollaborationResourcesRenameCollectionRequestApplicationJson;
+
+  // coverage:ignore-start
+  const CollaborationResourcesRenameCollectionRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory CollaborationResourcesRenameCollectionRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for CollaborationResourcesRenameCollectionRequestApplicationJson.
+  static Serializer<CollaborationResourcesRenameCollectionRequestApplicationJson> get serializer =>
+      _$collaborationResourcesRenameCollectionRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder b) {
+    $CollaborationResourcesRenameCollectionRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder b) {
+    $CollaborationResourcesRenameCollectionRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
@@ -7480,6 +7490,74 @@ abstract class CollaborationResourcesRenameCollectionResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $CollaborationResourcesAddResourceRequestApplicationJsonInterface {
+  /// Name of the resource.
+  String get resourceType;
+
+  /// ID of the resource.
+  String get resourceId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesAddResourceRequestApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesAddResourceRequestApplicationJsonInterface rebuild(
+    void Function($CollaborationResourcesAddResourceRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesAddResourceRequestApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesAddResourceRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesAddResourceRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesAddResourceRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class CollaborationResourcesAddResourceRequestApplicationJson
+    implements
+        $CollaborationResourcesAddResourceRequestApplicationJsonInterface,
+        Built<CollaborationResourcesAddResourceRequestApplicationJson,
+            CollaborationResourcesAddResourceRequestApplicationJsonBuilder> {
+  /// Creates a new CollaborationResourcesAddResourceRequestApplicationJson object using the builder pattern.
+  factory CollaborationResourcesAddResourceRequestApplicationJson([
+    void Function(CollaborationResourcesAddResourceRequestApplicationJsonBuilder)? b,
+  ]) = _$CollaborationResourcesAddResourceRequestApplicationJson;
+
+  // coverage:ignore-start
+  const CollaborationResourcesAddResourceRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory CollaborationResourcesAddResourceRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for CollaborationResourcesAddResourceRequestApplicationJson.
+  static Serializer<CollaborationResourcesAddResourceRequestApplicationJson> get serializer =>
+      _$collaborationResourcesAddResourceRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesAddResourceRequestApplicationJsonBuilder b) {
+    $CollaborationResourcesAddResourceRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesAddResourceRequestApplicationJsonBuilder b) {
+    $CollaborationResourcesAddResourceRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $CollaborationResourcesAddResourceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
@@ -7605,6 +7683,74 @@ abstract class CollaborationResourcesAddResourceResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(CollaborationResourcesAddResourceResponseApplicationJsonBuilder b) {
     $CollaborationResourcesAddResourceResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $CollaborationResourcesRemoveResourceRequestApplicationJsonInterface {
+  /// Name of the resource.
+  String get resourceType;
+
+  /// ID of the resource.
+  String get resourceId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesRemoveResourceRequestApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesRemoveResourceRequestApplicationJsonInterface rebuild(
+    void Function($CollaborationResourcesRemoveResourceRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesRemoveResourceRequestApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesRemoveResourceRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesRemoveResourceRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesRemoveResourceRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class CollaborationResourcesRemoveResourceRequestApplicationJson
+    implements
+        $CollaborationResourcesRemoveResourceRequestApplicationJsonInterface,
+        Built<CollaborationResourcesRemoveResourceRequestApplicationJson,
+            CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder> {
+  /// Creates a new CollaborationResourcesRemoveResourceRequestApplicationJson object using the builder pattern.
+  factory CollaborationResourcesRemoveResourceRequestApplicationJson([
+    void Function(CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder)? b,
+  ]) = _$CollaborationResourcesRemoveResourceRequestApplicationJson;
+
+  // coverage:ignore-start
+  const CollaborationResourcesRemoveResourceRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory CollaborationResourcesRemoveResourceRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for CollaborationResourcesRemoveResourceRequestApplicationJson.
+  static Serializer<CollaborationResourcesRemoveResourceRequestApplicationJson> get serializer =>
+      _$collaborationResourcesRemoveResourceRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder b) {
+    $CollaborationResourcesRemoveResourceRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder b) {
+    $CollaborationResourcesRemoveResourceRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -7998,6 +8144,71 @@ abstract class CollaborationResourcesGetCollectionsByResourceResponseApplication
 }
 
 @BuiltValue(instantiable: false)
+sealed class $CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterface {
+  /// Name of the collection.
+  String get name;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterface rebuild(
+    void Function($CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterfaceBuilder].
+  $CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson
+    implements
+        $CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterface,
+        Built<CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson,
+            CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder> {
+  /// Creates a new CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson object using the builder pattern.
+  factory CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson([
+    void Function(CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder)? b,
+  ]) = _$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson;
+
+  // coverage:ignore-start
+  const CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson.
+  static Serializer<CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson> get serializer =>
+      _$collaborationResourcesCreateCollectionOnResourceRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder b) {
+    $CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder b) {
+    $CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Collection get data;
@@ -8132,67 +8343,76 @@ abstract class CollaborationResourcesCreateCollectionOnResourceResponseApplicati
   }
 }
 
-class GuestAvatarGetAvatarDarkTheme extends EnumClass {
-  const GuestAvatarGetAvatarDarkTheme._(super.name);
+@BuiltValue(instantiable: false)
+sealed class $GuestAvatarGetAvatarRequestApplicationJsonInterface {
+  static final _$darkTheme = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const GuestAvatarGetAvatarDarkTheme $0 = _$guestAvatarGetAvatarDarkTheme$0;
+  /// Return dark avatar.
+  bool? get darkTheme;
 
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const GuestAvatarGetAvatarDarkTheme $1 = _$guestAvatarGetAvatarDarkTheme$1;
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GuestAvatarGetAvatarRequestApplicationJsonInterfaceBuilder].
+  $GuestAvatarGetAvatarRequestApplicationJsonInterface rebuild(
+    void Function($GuestAvatarGetAvatarRequestApplicationJsonInterfaceBuilder) updates,
+  );
 
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<GuestAvatarGetAvatarDarkTheme> get values => _$guestAvatarGetAvatarDarkThemeValues;
-  // coverage:ignore-end
+  /// Converts the instance to a builder [$GuestAvatarGetAvatarRequestApplicationJsonInterfaceBuilder].
+  $GuestAvatarGetAvatarRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GuestAvatarGetAvatarRequestApplicationJsonInterfaceBuilder b) {
+    b.darkTheme = _$darkTheme;
+  }
 
-  /// Returns the enum value associated to the [name].
-  static GuestAvatarGetAvatarDarkTheme valueOf(String name) => _$valueOfGuestAvatarGetAvatarDarkTheme(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for GuestAvatarGetAvatarDarkTheme.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<GuestAvatarGetAvatarDarkTheme> get serializer => const _$GuestAvatarGetAvatarDarkThemeSerializer();
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GuestAvatarGetAvatarRequestApplicationJsonInterfaceBuilder b) {}
 }
 
-class _$GuestAvatarGetAvatarDarkThemeSerializer implements PrimitiveSerializer<GuestAvatarGetAvatarDarkTheme> {
-  const _$GuestAvatarGetAvatarDarkThemeSerializer();
+abstract class GuestAvatarGetAvatarRequestApplicationJson
+    implements
+        $GuestAvatarGetAvatarRequestApplicationJsonInterface,
+        Built<GuestAvatarGetAvatarRequestApplicationJson, GuestAvatarGetAvatarRequestApplicationJsonBuilder> {
+  /// Creates a new GuestAvatarGetAvatarRequestApplicationJson object using the builder pattern.
+  factory GuestAvatarGetAvatarRequestApplicationJson([
+    void Function(GuestAvatarGetAvatarRequestApplicationJsonBuilder)? b,
+  ]) = _$GuestAvatarGetAvatarRequestApplicationJson;
 
-  static const Map<GuestAvatarGetAvatarDarkTheme, Object> _toWire = <GuestAvatarGetAvatarDarkTheme, Object>{
-    GuestAvatarGetAvatarDarkTheme.$0: 0,
-    GuestAvatarGetAvatarDarkTheme.$1: 1,
-  };
+  // coverage:ignore-start
+  const GuestAvatarGetAvatarRequestApplicationJson._();
+  // coverage:ignore-end
 
-  static const Map<Object, GuestAvatarGetAvatarDarkTheme> _fromWire = <Object, GuestAvatarGetAvatarDarkTheme>{
-    0: GuestAvatarGetAvatarDarkTheme.$0,
-    1: GuestAvatarGetAvatarDarkTheme.$1,
-  };
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory GuestAvatarGetAvatarRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
 
-  @override
-  Iterable<Type> get types => const [GuestAvatarGetAvatarDarkTheme];
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
 
-  @override
-  String get wireName => 'GuestAvatarGetAvatarDarkTheme';
+  /// Serializer for GuestAvatarGetAvatarRequestApplicationJson.
+  static Serializer<GuestAvatarGetAvatarRequestApplicationJson> get serializer =>
+      _$guestAvatarGetAvatarRequestApplicationJsonSerializer;
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    GuestAvatarGetAvatarDarkTheme object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GuestAvatarGetAvatarRequestApplicationJsonBuilder b) {
+    $GuestAvatarGetAvatarRequestApplicationJsonInterface._defaults(b);
+  }
 
-  @override
-  GuestAvatarGetAvatarDarkTheme deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GuestAvatarGetAvatarRequestApplicationJsonBuilder b) {
+    $GuestAvatarGetAvatarRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -8445,6 +8665,70 @@ abstract class HoverCardGetUserResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $LoginConfirmPasswordRequestApplicationJsonInterface {
+  /// The password of the user.
+  String get password;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$LoginConfirmPasswordRequestApplicationJsonInterfaceBuilder].
+  $LoginConfirmPasswordRequestApplicationJsonInterface rebuild(
+    void Function($LoginConfirmPasswordRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$LoginConfirmPasswordRequestApplicationJsonInterfaceBuilder].
+  $LoginConfirmPasswordRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($LoginConfirmPasswordRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($LoginConfirmPasswordRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class LoginConfirmPasswordRequestApplicationJson
+    implements
+        $LoginConfirmPasswordRequestApplicationJsonInterface,
+        Built<LoginConfirmPasswordRequestApplicationJson, LoginConfirmPasswordRequestApplicationJsonBuilder> {
+  /// Creates a new LoginConfirmPasswordRequestApplicationJson object using the builder pattern.
+  factory LoginConfirmPasswordRequestApplicationJson([
+    void Function(LoginConfirmPasswordRequestApplicationJsonBuilder)? b,
+  ]) = _$LoginConfirmPasswordRequestApplicationJson;
+
+  // coverage:ignore-start
+  const LoginConfirmPasswordRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory LoginConfirmPasswordRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for LoginConfirmPasswordRequestApplicationJson.
+  static Serializer<LoginConfirmPasswordRequestApplicationJson> get serializer =>
+      _$loginConfirmPasswordRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(LoginConfirmPasswordRequestApplicationJsonBuilder b) {
+    $LoginConfirmPasswordRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(LoginConfirmPasswordRequestApplicationJsonBuilder b) {
+    $LoginConfirmPasswordRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $LoginConfirmPasswordResponseApplicationJsonInterface {
   int get lastLogin;
 
@@ -8507,70 +8791,77 @@ abstract class LoginConfirmPasswordResponseApplicationJson
   }
 }
 
-class NavigationGetAppsNavigationAbsolute extends EnumClass {
-  const NavigationGetAppsNavigationAbsolute._(super.name);
+@BuiltValue(instantiable: false)
+sealed class $NavigationGetAppsNavigationRequestApplicationJsonInterface {
+  static final _$absolute = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const NavigationGetAppsNavigationAbsolute $0 = _$navigationGetAppsNavigationAbsolute$0;
+  /// Rewrite URLs to absolute ones.
+  bool get absolute;
 
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const NavigationGetAppsNavigationAbsolute $1 = _$navigationGetAppsNavigationAbsolute$1;
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NavigationGetAppsNavigationRequestApplicationJsonInterfaceBuilder].
+  $NavigationGetAppsNavigationRequestApplicationJsonInterface rebuild(
+    void Function($NavigationGetAppsNavigationRequestApplicationJsonInterfaceBuilder) updates,
+  );
 
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<NavigationGetAppsNavigationAbsolute> get values => _$navigationGetAppsNavigationAbsoluteValues;
-  // coverage:ignore-end
+  /// Converts the instance to a builder [$NavigationGetAppsNavigationRequestApplicationJsonInterfaceBuilder].
+  $NavigationGetAppsNavigationRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NavigationGetAppsNavigationRequestApplicationJsonInterfaceBuilder b) {
+    b.absolute = _$absolute;
+  }
 
-  /// Returns the enum value associated to the [name].
-  static NavigationGetAppsNavigationAbsolute valueOf(String name) => _$valueOfNavigationGetAppsNavigationAbsolute(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for NavigationGetAppsNavigationAbsolute.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<NavigationGetAppsNavigationAbsolute> get serializer =>
-      const _$NavigationGetAppsNavigationAbsoluteSerializer();
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NavigationGetAppsNavigationRequestApplicationJsonInterfaceBuilder b) {}
 }
 
-class _$NavigationGetAppsNavigationAbsoluteSerializer
-    implements PrimitiveSerializer<NavigationGetAppsNavigationAbsolute> {
-  const _$NavigationGetAppsNavigationAbsoluteSerializer();
+abstract class NavigationGetAppsNavigationRequestApplicationJson
+    implements
+        $NavigationGetAppsNavigationRequestApplicationJsonInterface,
+        Built<NavigationGetAppsNavigationRequestApplicationJson,
+            NavigationGetAppsNavigationRequestApplicationJsonBuilder> {
+  /// Creates a new NavigationGetAppsNavigationRequestApplicationJson object using the builder pattern.
+  factory NavigationGetAppsNavigationRequestApplicationJson([
+    void Function(NavigationGetAppsNavigationRequestApplicationJsonBuilder)? b,
+  ]) = _$NavigationGetAppsNavigationRequestApplicationJson;
 
-  static const Map<NavigationGetAppsNavigationAbsolute, Object> _toWire = <NavigationGetAppsNavigationAbsolute, Object>{
-    NavigationGetAppsNavigationAbsolute.$0: 0,
-    NavigationGetAppsNavigationAbsolute.$1: 1,
-  };
+  // coverage:ignore-start
+  const NavigationGetAppsNavigationRequestApplicationJson._();
+  // coverage:ignore-end
 
-  static const Map<Object, NavigationGetAppsNavigationAbsolute> _fromWire =
-      <Object, NavigationGetAppsNavigationAbsolute>{
-    0: NavigationGetAppsNavigationAbsolute.$0,
-    1: NavigationGetAppsNavigationAbsolute.$1,
-  };
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory NavigationGetAppsNavigationRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
 
-  @override
-  Iterable<Type> get types => const [NavigationGetAppsNavigationAbsolute];
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
 
-  @override
-  String get wireName => 'NavigationGetAppsNavigationAbsolute';
+  /// Serializer for NavigationGetAppsNavigationRequestApplicationJson.
+  static Serializer<NavigationGetAppsNavigationRequestApplicationJson> get serializer =>
+      _$navigationGetAppsNavigationRequestApplicationJsonSerializer;
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    NavigationGetAppsNavigationAbsolute object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NavigationGetAppsNavigationRequestApplicationJsonBuilder b) {
+    $NavigationGetAppsNavigationRequestApplicationJsonInterface._defaults(b);
+  }
 
-  @override
-  NavigationGetAppsNavigationAbsolute deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NavigationGetAppsNavigationRequestApplicationJsonBuilder b) {
+    $NavigationGetAppsNavigationRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 typedef NavigationEntry_Order = ({int? $int, String? string});
@@ -8768,73 +9059,77 @@ abstract class NavigationGetAppsNavigationResponseApplicationJson
   }
 }
 
-class NavigationGetSettingsNavigationAbsolute extends EnumClass {
-  const NavigationGetSettingsNavigationAbsolute._(super.name);
+@BuiltValue(instantiable: false)
+sealed class $NavigationGetSettingsNavigationRequestApplicationJsonInterface {
+  static final _$absolute = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const NavigationGetSettingsNavigationAbsolute $0 = _$navigationGetSettingsNavigationAbsolute$0;
+  /// Rewrite URLs to absolute ones.
+  bool get absolute;
 
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const NavigationGetSettingsNavigationAbsolute $1 = _$navigationGetSettingsNavigationAbsolute$1;
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$NavigationGetSettingsNavigationRequestApplicationJsonInterfaceBuilder].
+  $NavigationGetSettingsNavigationRequestApplicationJsonInterface rebuild(
+    void Function($NavigationGetSettingsNavigationRequestApplicationJsonInterfaceBuilder) updates,
+  );
 
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<NavigationGetSettingsNavigationAbsolute> get values =>
-      _$navigationGetSettingsNavigationAbsoluteValues;
-  // coverage:ignore-end
+  /// Converts the instance to a builder [$NavigationGetSettingsNavigationRequestApplicationJsonInterfaceBuilder].
+  $NavigationGetSettingsNavigationRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($NavigationGetSettingsNavigationRequestApplicationJsonInterfaceBuilder b) {
+    b.absolute = _$absolute;
+  }
 
-  /// Returns the enum value associated to the [name].
-  static NavigationGetSettingsNavigationAbsolute valueOf(String name) =>
-      _$valueOfNavigationGetSettingsNavigationAbsolute(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for NavigationGetSettingsNavigationAbsolute.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<NavigationGetSettingsNavigationAbsolute> get serializer =>
-      const _$NavigationGetSettingsNavigationAbsoluteSerializer();
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($NavigationGetSettingsNavigationRequestApplicationJsonInterfaceBuilder b) {}
 }
 
-class _$NavigationGetSettingsNavigationAbsoluteSerializer
-    implements PrimitiveSerializer<NavigationGetSettingsNavigationAbsolute> {
-  const _$NavigationGetSettingsNavigationAbsoluteSerializer();
+abstract class NavigationGetSettingsNavigationRequestApplicationJson
+    implements
+        $NavigationGetSettingsNavigationRequestApplicationJsonInterface,
+        Built<NavigationGetSettingsNavigationRequestApplicationJson,
+            NavigationGetSettingsNavigationRequestApplicationJsonBuilder> {
+  /// Creates a new NavigationGetSettingsNavigationRequestApplicationJson object using the builder pattern.
+  factory NavigationGetSettingsNavigationRequestApplicationJson([
+    void Function(NavigationGetSettingsNavigationRequestApplicationJsonBuilder)? b,
+  ]) = _$NavigationGetSettingsNavigationRequestApplicationJson;
 
-  static const Map<NavigationGetSettingsNavigationAbsolute, Object> _toWire =
-      <NavigationGetSettingsNavigationAbsolute, Object>{
-    NavigationGetSettingsNavigationAbsolute.$0: 0,
-    NavigationGetSettingsNavigationAbsolute.$1: 1,
-  };
+  // coverage:ignore-start
+  const NavigationGetSettingsNavigationRequestApplicationJson._();
+  // coverage:ignore-end
 
-  static const Map<Object, NavigationGetSettingsNavigationAbsolute> _fromWire =
-      <Object, NavigationGetSettingsNavigationAbsolute>{
-    0: NavigationGetSettingsNavigationAbsolute.$0,
-    1: NavigationGetSettingsNavigationAbsolute.$1,
-  };
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory NavigationGetSettingsNavigationRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
 
-  @override
-  Iterable<Type> get types => const [NavigationGetSettingsNavigationAbsolute];
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
 
-  @override
-  String get wireName => 'NavigationGetSettingsNavigationAbsolute';
+  /// Serializer for NavigationGetSettingsNavigationRequestApplicationJson.
+  static Serializer<NavigationGetSettingsNavigationRequestApplicationJson> get serializer =>
+      _$navigationGetSettingsNavigationRequestApplicationJsonSerializer;
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    NavigationGetSettingsNavigationAbsolute object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(NavigationGetSettingsNavigationRequestApplicationJsonBuilder b) {
+    $NavigationGetSettingsNavigationRequestApplicationJsonInterface._defaults(b);
+  }
 
-  @override
-  NavigationGetSettingsNavigationAbsolute deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(NavigationGetSettingsNavigationRequestApplicationJsonBuilder b) {
+    $NavigationGetSettingsNavigationRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -13585,389 +13880,322 @@ abstract class OcsGetCapabilitiesResponseApplicationJson
   }
 }
 
-class PreviewGetPreviewA extends EnumClass {
-  const PreviewGetPreviewA._(super.name);
+@BuiltValue(instantiable: false)
+sealed class $PreviewGetPreviewRequestApplicationJsonInterface {
+  static final _$file = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const PreviewGetPreviewA $0 = _$previewGetPreviewA$0;
+  static final _$x = _$jsonSerializers.deserialize(
+    32,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const PreviewGetPreviewA $1 = _$previewGetPreviewA$1;
+  static final _$y = _$jsonSerializers.deserialize(
+    32,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  /// Returns a set with all values this enum contains.
+  static final _$a = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  static final _$forceIcon = _$jsonSerializers.deserialize(
+    true,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  static final _$mode = _$jsonSerializers.deserialize(
+    'fill',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$mimeFallback = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// Path of the file.
+  String get file;
+
+  /// Width of the preview.
+  int get x;
+
+  /// Height of the preview.
+  int get y;
+
+  /// Whether to not crop the preview.
+  bool get a;
+
+  /// Force returning an icon.
+  bool get forceIcon;
+
+  /// How to crop the image.
+  String get mode;
+
+  /// Whether to fallback to the mime icon if no preview is available.
+  bool get mimeFallback;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreviewGetPreviewRequestApplicationJsonInterfaceBuilder].
+  $PreviewGetPreviewRequestApplicationJsonInterface rebuild(
+    void Function($PreviewGetPreviewRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreviewGetPreviewRequestApplicationJsonInterfaceBuilder].
+  $PreviewGetPreviewRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreviewGetPreviewRequestApplicationJsonInterfaceBuilder b) {
+    b.file = _$file;
+    b.x = _$x;
+    b.y = _$y;
+    b.a = _$a;
+    b.forceIcon = _$forceIcon;
+    b.mode = _$mode;
+    b.mimeFallback = _$mimeFallback;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreviewGetPreviewRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class PreviewGetPreviewRequestApplicationJson
+    implements
+        $PreviewGetPreviewRequestApplicationJsonInterface,
+        Built<PreviewGetPreviewRequestApplicationJson, PreviewGetPreviewRequestApplicationJsonBuilder> {
+  /// Creates a new PreviewGetPreviewRequestApplicationJson object using the builder pattern.
+  factory PreviewGetPreviewRequestApplicationJson([void Function(PreviewGetPreviewRequestApplicationJsonBuilder)? b]) =
+      _$PreviewGetPreviewRequestApplicationJson;
+
   // coverage:ignore-start
-  static BuiltSet<PreviewGetPreviewA> get values => _$previewGetPreviewAValues;
+  const PreviewGetPreviewRequestApplicationJson._();
   // coverage:ignore-end
 
-  /// Returns the enum value associated to the [name].
-  static PreviewGetPreviewA valueOf(String name) => _$valueOfPreviewGetPreviewA(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for PreviewGetPreviewA.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<PreviewGetPreviewA> get serializer => const _$PreviewGetPreviewASerializer();
-}
-
-class _$PreviewGetPreviewASerializer implements PrimitiveSerializer<PreviewGetPreviewA> {
-  const _$PreviewGetPreviewASerializer();
-
-  static const Map<PreviewGetPreviewA, Object> _toWire = <PreviewGetPreviewA, Object>{
-    PreviewGetPreviewA.$0: 0,
-    PreviewGetPreviewA.$1: 1,
-  };
-
-  static const Map<Object, PreviewGetPreviewA> _fromWire = <Object, PreviewGetPreviewA>{
-    0: PreviewGetPreviewA.$0,
-    1: PreviewGetPreviewA.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [PreviewGetPreviewA];
-
-  @override
-  String get wireName => 'PreviewGetPreviewA';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    PreviewGetPreviewA object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  PreviewGetPreviewA deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-class PreviewGetPreviewForceIcon extends EnumClass {
-  const PreviewGetPreviewForceIcon._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const PreviewGetPreviewForceIcon $0 = _$previewGetPreviewForceIcon$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const PreviewGetPreviewForceIcon $1 = _$previewGetPreviewForceIcon$1;
-
-  /// Returns a set with all values this enum contains.
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
   // coverage:ignore-start
-  static BuiltSet<PreviewGetPreviewForceIcon> get values => _$previewGetPreviewForceIconValues;
+  factory PreviewGetPreviewRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
-  /// Returns the enum value associated to the [name].
-  static PreviewGetPreviewForceIcon valueOf(String name) => _$valueOfPreviewGetPreviewForceIcon(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for PreviewGetPreviewForceIcon.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<PreviewGetPreviewForceIcon> get serializer => const _$PreviewGetPreviewForceIconSerializer();
-}
-
-class _$PreviewGetPreviewForceIconSerializer implements PrimitiveSerializer<PreviewGetPreviewForceIcon> {
-  const _$PreviewGetPreviewForceIconSerializer();
-
-  static const Map<PreviewGetPreviewForceIcon, Object> _toWire = <PreviewGetPreviewForceIcon, Object>{
-    PreviewGetPreviewForceIcon.$0: 0,
-    PreviewGetPreviewForceIcon.$1: 1,
-  };
-
-  static const Map<Object, PreviewGetPreviewForceIcon> _fromWire = <Object, PreviewGetPreviewForceIcon>{
-    0: PreviewGetPreviewForceIcon.$0,
-    1: PreviewGetPreviewForceIcon.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [PreviewGetPreviewForceIcon];
-
-  @override
-  String get wireName => 'PreviewGetPreviewForceIcon';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    PreviewGetPreviewForceIcon object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  PreviewGetPreviewForceIcon deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-class PreviewGetPreviewMimeFallback extends EnumClass {
-  const PreviewGetPreviewMimeFallback._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const PreviewGetPreviewMimeFallback $0 = _$previewGetPreviewMimeFallback$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const PreviewGetPreviewMimeFallback $1 = _$previewGetPreviewMimeFallback$1;
-
-  /// Returns a set with all values this enum contains.
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
   // coverage:ignore-start
-  static BuiltSet<PreviewGetPreviewMimeFallback> get values => _$previewGetPreviewMimeFallbackValues;
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
 
-  /// Returns the enum value associated to the [name].
-  static PreviewGetPreviewMimeFallback valueOf(String name) => _$valueOfPreviewGetPreviewMimeFallback(name);
+  /// Serializer for PreviewGetPreviewRequestApplicationJson.
+  static Serializer<PreviewGetPreviewRequestApplicationJson> get serializer =>
+      _$previewGetPreviewRequestApplicationJsonSerializer;
 
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreviewGetPreviewRequestApplicationJsonBuilder b) {
+    $PreviewGetPreviewRequestApplicationJsonInterface._defaults(b);
+  }
 
-  /// Serializer for PreviewGetPreviewMimeFallback.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<PreviewGetPreviewMimeFallback> get serializer => const _$PreviewGetPreviewMimeFallbackSerializer();
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreviewGetPreviewRequestApplicationJsonBuilder b) {
+    $PreviewGetPreviewRequestApplicationJsonInterface._validate(b);
+  }
 }
 
-class _$PreviewGetPreviewMimeFallbackSerializer implements PrimitiveSerializer<PreviewGetPreviewMimeFallback> {
-  const _$PreviewGetPreviewMimeFallbackSerializer();
+@BuiltValue(instantiable: false)
+sealed class $PreviewGetPreviewByFileIdRequestApplicationJsonInterface {
+  static final _$fileId = _$jsonSerializers.deserialize(
+    -1,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  static const Map<PreviewGetPreviewMimeFallback, Object> _toWire = <PreviewGetPreviewMimeFallback, Object>{
-    PreviewGetPreviewMimeFallback.$0: 0,
-    PreviewGetPreviewMimeFallback.$1: 1,
-  };
+  static final _$x = _$jsonSerializers.deserialize(
+    32,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  static const Map<Object, PreviewGetPreviewMimeFallback> _fromWire = <Object, PreviewGetPreviewMimeFallback>{
-    0: PreviewGetPreviewMimeFallback.$0,
-    1: PreviewGetPreviewMimeFallback.$1,
-  };
+  static final _$y = _$jsonSerializers.deserialize(
+    32,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  @override
-  Iterable<Type> get types => const [PreviewGetPreviewMimeFallback];
+  static final _$a = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  @override
-  String get wireName => 'PreviewGetPreviewMimeFallback';
+  static final _$forceIcon = _$jsonSerializers.deserialize(
+    true,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    PreviewGetPreviewMimeFallback object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+  static final _$mode = _$jsonSerializers.deserialize(
+    'fill',
+    specifiedType: const FullType(String),
+  )! as String;
 
-  @override
-  PreviewGetPreviewMimeFallback deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  static final _$mimeFallback = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// ID of the file.
+  int get fileId;
+
+  /// Width of the preview.
+  int get x;
+
+  /// Height of the preview.
+  int get y;
+
+  /// Whether to not crop the preview.
+  bool get a;
+
+  /// Force returning an icon.
+  bool get forceIcon;
+
+  /// How to crop the image.
+  String get mode;
+
+  /// Whether to fallback to the mime icon if no preview is available.
+  bool get mimeFallback;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreviewGetPreviewByFileIdRequestApplicationJsonInterfaceBuilder].
+  $PreviewGetPreviewByFileIdRequestApplicationJsonInterface rebuild(
+    void Function($PreviewGetPreviewByFileIdRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreviewGetPreviewByFileIdRequestApplicationJsonInterfaceBuilder].
+  $PreviewGetPreviewByFileIdRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreviewGetPreviewByFileIdRequestApplicationJsonInterfaceBuilder b) {
+    b.fileId = _$fileId;
+    b.x = _$x;
+    b.y = _$y;
+    b.a = _$a;
+    b.forceIcon = _$forceIcon;
+    b.mode = _$mode;
+    b.mimeFallback = _$mimeFallback;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreviewGetPreviewByFileIdRequestApplicationJsonInterfaceBuilder b) {}
 }
 
-class PreviewGetPreviewByFileIdA extends EnumClass {
-  const PreviewGetPreviewByFileIdA._(super.name);
+abstract class PreviewGetPreviewByFileIdRequestApplicationJson
+    implements
+        $PreviewGetPreviewByFileIdRequestApplicationJsonInterface,
+        Built<PreviewGetPreviewByFileIdRequestApplicationJson, PreviewGetPreviewByFileIdRequestApplicationJsonBuilder> {
+  /// Creates a new PreviewGetPreviewByFileIdRequestApplicationJson object using the builder pattern.
+  factory PreviewGetPreviewByFileIdRequestApplicationJson([
+    void Function(PreviewGetPreviewByFileIdRequestApplicationJsonBuilder)? b,
+  ]) = _$PreviewGetPreviewByFileIdRequestApplicationJson;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const PreviewGetPreviewByFileIdA $0 = _$previewGetPreviewByFileIdA$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const PreviewGetPreviewByFileIdA $1 = _$previewGetPreviewByFileIdA$1;
-
-  /// Returns a set with all values this enum contains.
   // coverage:ignore-start
-  static BuiltSet<PreviewGetPreviewByFileIdA> get values => _$previewGetPreviewByFileIdAValues;
+  const PreviewGetPreviewByFileIdRequestApplicationJson._();
   // coverage:ignore-end
 
-  /// Returns the enum value associated to the [name].
-  static PreviewGetPreviewByFileIdA valueOf(String name) => _$valueOfPreviewGetPreviewByFileIdA(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for PreviewGetPreviewByFileIdA.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<PreviewGetPreviewByFileIdA> get serializer => const _$PreviewGetPreviewByFileIdASerializer();
-}
-
-class _$PreviewGetPreviewByFileIdASerializer implements PrimitiveSerializer<PreviewGetPreviewByFileIdA> {
-  const _$PreviewGetPreviewByFileIdASerializer();
-
-  static const Map<PreviewGetPreviewByFileIdA, Object> _toWire = <PreviewGetPreviewByFileIdA, Object>{
-    PreviewGetPreviewByFileIdA.$0: 0,
-    PreviewGetPreviewByFileIdA.$1: 1,
-  };
-
-  static const Map<Object, PreviewGetPreviewByFileIdA> _fromWire = <Object, PreviewGetPreviewByFileIdA>{
-    0: PreviewGetPreviewByFileIdA.$0,
-    1: PreviewGetPreviewByFileIdA.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [PreviewGetPreviewByFileIdA];
-
-  @override
-  String get wireName => 'PreviewGetPreviewByFileIdA';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    PreviewGetPreviewByFileIdA object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  PreviewGetPreviewByFileIdA deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-class PreviewGetPreviewByFileIdForceIcon extends EnumClass {
-  const PreviewGetPreviewByFileIdForceIcon._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const PreviewGetPreviewByFileIdForceIcon $0 = _$previewGetPreviewByFileIdForceIcon$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const PreviewGetPreviewByFileIdForceIcon $1 = _$previewGetPreviewByFileIdForceIcon$1;
-
-  /// Returns a set with all values this enum contains.
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
   // coverage:ignore-start
-  static BuiltSet<PreviewGetPreviewByFileIdForceIcon> get values => _$previewGetPreviewByFileIdForceIconValues;
+  factory PreviewGetPreviewByFileIdRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
-  /// Returns the enum value associated to the [name].
-  static PreviewGetPreviewByFileIdForceIcon valueOf(String name) => _$valueOfPreviewGetPreviewByFileIdForceIcon(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for PreviewGetPreviewByFileIdForceIcon.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<PreviewGetPreviewByFileIdForceIcon> get serializer =>
-      const _$PreviewGetPreviewByFileIdForceIconSerializer();
-}
-
-class _$PreviewGetPreviewByFileIdForceIconSerializer
-    implements PrimitiveSerializer<PreviewGetPreviewByFileIdForceIcon> {
-  const _$PreviewGetPreviewByFileIdForceIconSerializer();
-
-  static const Map<PreviewGetPreviewByFileIdForceIcon, Object> _toWire = <PreviewGetPreviewByFileIdForceIcon, Object>{
-    PreviewGetPreviewByFileIdForceIcon.$0: 0,
-    PreviewGetPreviewByFileIdForceIcon.$1: 1,
-  };
-
-  static const Map<Object, PreviewGetPreviewByFileIdForceIcon> _fromWire = <Object, PreviewGetPreviewByFileIdForceIcon>{
-    0: PreviewGetPreviewByFileIdForceIcon.$0,
-    1: PreviewGetPreviewByFileIdForceIcon.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [PreviewGetPreviewByFileIdForceIcon];
-
-  @override
-  String get wireName => 'PreviewGetPreviewByFileIdForceIcon';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    PreviewGetPreviewByFileIdForceIcon object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  PreviewGetPreviewByFileIdForceIcon deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-class PreviewGetPreviewByFileIdMimeFallback extends EnumClass {
-  const PreviewGetPreviewByFileIdMimeFallback._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const PreviewGetPreviewByFileIdMimeFallback $0 = _$previewGetPreviewByFileIdMimeFallback$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const PreviewGetPreviewByFileIdMimeFallback $1 = _$previewGetPreviewByFileIdMimeFallback$1;
-
-  /// Returns a set with all values this enum contains.
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
   // coverage:ignore-start
-  static BuiltSet<PreviewGetPreviewByFileIdMimeFallback> get values => _$previewGetPreviewByFileIdMimeFallbackValues;
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
 
-  /// Returns the enum value associated to the [name].
-  static PreviewGetPreviewByFileIdMimeFallback valueOf(String name) =>
-      _$valueOfPreviewGetPreviewByFileIdMimeFallback(name);
+  /// Serializer for PreviewGetPreviewByFileIdRequestApplicationJson.
+  static Serializer<PreviewGetPreviewByFileIdRequestApplicationJson> get serializer =>
+      _$previewGetPreviewByFileIdRequestApplicationJsonSerializer;
 
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreviewGetPreviewByFileIdRequestApplicationJsonBuilder b) {
+    $PreviewGetPreviewByFileIdRequestApplicationJsonInterface._defaults(b);
+  }
 
-  /// Serializer for PreviewGetPreviewByFileIdMimeFallback.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<PreviewGetPreviewByFileIdMimeFallback> get serializer =>
-      const _$PreviewGetPreviewByFileIdMimeFallbackSerializer();
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreviewGetPreviewByFileIdRequestApplicationJsonBuilder b) {
+    $PreviewGetPreviewByFileIdRequestApplicationJsonInterface._validate(b);
+  }
 }
 
-class _$PreviewGetPreviewByFileIdMimeFallbackSerializer
-    implements PrimitiveSerializer<PreviewGetPreviewByFileIdMimeFallback> {
-  const _$PreviewGetPreviewByFileIdMimeFallbackSerializer();
+@BuiltValue(instantiable: false)
+sealed class $ProfileApiSetVisibilityRequestApplicationJsonInterface {
+  /// ID of the parameter.
+  String get paramId;
 
-  static const Map<PreviewGetPreviewByFileIdMimeFallback, Object> _toWire =
-      <PreviewGetPreviewByFileIdMimeFallback, Object>{
-    PreviewGetPreviewByFileIdMimeFallback.$0: 0,
-    PreviewGetPreviewByFileIdMimeFallback.$1: 1,
-  };
+  /// New visibility.
+  String get visibility;
 
-  static const Map<Object, PreviewGetPreviewByFileIdMimeFallback> _fromWire =
-      <Object, PreviewGetPreviewByFileIdMimeFallback>{
-    0: PreviewGetPreviewByFileIdMimeFallback.$0,
-    1: PreviewGetPreviewByFileIdMimeFallback.$1,
-  };
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ProfileApiSetVisibilityRequestApplicationJsonInterfaceBuilder].
+  $ProfileApiSetVisibilityRequestApplicationJsonInterface rebuild(
+    void Function($ProfileApiSetVisibilityRequestApplicationJsonInterfaceBuilder) updates,
+  );
 
-  @override
-  Iterable<Type> get types => const [PreviewGetPreviewByFileIdMimeFallback];
+  /// Converts the instance to a builder [$ProfileApiSetVisibilityRequestApplicationJsonInterfaceBuilder].
+  $ProfileApiSetVisibilityRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ProfileApiSetVisibilityRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ProfileApiSetVisibilityRequestApplicationJsonInterfaceBuilder b) {}
+}
 
-  @override
-  String get wireName => 'PreviewGetPreviewByFileIdMimeFallback';
+abstract class ProfileApiSetVisibilityRequestApplicationJson
+    implements
+        $ProfileApiSetVisibilityRequestApplicationJsonInterface,
+        Built<ProfileApiSetVisibilityRequestApplicationJson, ProfileApiSetVisibilityRequestApplicationJsonBuilder> {
+  /// Creates a new ProfileApiSetVisibilityRequestApplicationJson object using the builder pattern.
+  factory ProfileApiSetVisibilityRequestApplicationJson([
+    void Function(ProfileApiSetVisibilityRequestApplicationJsonBuilder)? b,
+  ]) = _$ProfileApiSetVisibilityRequestApplicationJson;
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    PreviewGetPreviewByFileIdMimeFallback object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+  // coverage:ignore-start
+  const ProfileApiSetVisibilityRequestApplicationJson._();
+  // coverage:ignore-end
 
-  @override
-  PreviewGetPreviewByFileIdMimeFallback deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ProfileApiSetVisibilityRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ProfileApiSetVisibilityRequestApplicationJson.
+  static Serializer<ProfileApiSetVisibilityRequestApplicationJson> get serializer =>
+      _$profileApiSetVisibilityRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ProfileApiSetVisibilityRequestApplicationJsonBuilder b) {
+    $ProfileApiSetVisibilityRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ProfileApiSetVisibilityRequestApplicationJsonBuilder b) {
+    $ProfileApiSetVisibilityRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -14098,67 +14326,88 @@ abstract class ProfileApiSetVisibilityResponseApplicationJson
   }
 }
 
-class ReferenceApiExtractResolve extends EnumClass {
-  const ReferenceApiExtractResolve._(super.name);
+@BuiltValue(instantiable: false)
+sealed class $ReferenceApiExtractRequestApplicationJsonInterface {
+  static final _$resolve = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ReferenceApiExtractResolve $0 = _$referenceApiExtractResolve$0;
+  static final _$limit = _$jsonSerializers.deserialize(
+    1,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ReferenceApiExtractResolve $1 = _$referenceApiExtractResolve$1;
+  /// Text to extract from.
+  String get text;
 
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<ReferenceApiExtractResolve> get values => _$referenceApiExtractResolveValues;
-  // coverage:ignore-end
+  /// Resolve the references.
+  bool get resolve;
 
-  /// Returns the enum value associated to the [name].
-  static ReferenceApiExtractResolve valueOf(String name) => _$valueOfReferenceApiExtractResolve(name);
+  /// Maximum amount of references to extract.
+  int get limit;
 
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiExtractRequestApplicationJsonInterfaceBuilder].
+  $ReferenceApiExtractRequestApplicationJsonInterface rebuild(
+    void Function($ReferenceApiExtractRequestApplicationJsonInterfaceBuilder) updates,
+  );
 
-  /// Serializer for ReferenceApiExtractResolve.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ReferenceApiExtractResolve> get serializer => const _$ReferenceApiExtractResolveSerializer();
+  /// Converts the instance to a builder [$ReferenceApiExtractRequestApplicationJsonInterfaceBuilder].
+  $ReferenceApiExtractRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiExtractRequestApplicationJsonInterfaceBuilder b) {
+    b.resolve = _$resolve;
+    b.limit = _$limit;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiExtractRequestApplicationJsonInterfaceBuilder b) {}
 }
 
-class _$ReferenceApiExtractResolveSerializer implements PrimitiveSerializer<ReferenceApiExtractResolve> {
-  const _$ReferenceApiExtractResolveSerializer();
+abstract class ReferenceApiExtractRequestApplicationJson
+    implements
+        $ReferenceApiExtractRequestApplicationJsonInterface,
+        Built<ReferenceApiExtractRequestApplicationJson, ReferenceApiExtractRequestApplicationJsonBuilder> {
+  /// Creates a new ReferenceApiExtractRequestApplicationJson object using the builder pattern.
+  factory ReferenceApiExtractRequestApplicationJson([
+    void Function(ReferenceApiExtractRequestApplicationJsonBuilder)? b,
+  ]) = _$ReferenceApiExtractRequestApplicationJson;
 
-  static const Map<ReferenceApiExtractResolve, Object> _toWire = <ReferenceApiExtractResolve, Object>{
-    ReferenceApiExtractResolve.$0: 0,
-    ReferenceApiExtractResolve.$1: 1,
-  };
+  // coverage:ignore-start
+  const ReferenceApiExtractRequestApplicationJson._();
+  // coverage:ignore-end
 
-  static const Map<Object, ReferenceApiExtractResolve> _fromWire = <Object, ReferenceApiExtractResolve>{
-    0: ReferenceApiExtractResolve.$0,
-    1: ReferenceApiExtractResolve.$1,
-  };
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ReferenceApiExtractRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
 
-  @override
-  Iterable<Type> get types => const [ReferenceApiExtractResolve];
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
 
-  @override
-  String get wireName => 'ReferenceApiExtractResolve';
+  /// Serializer for ReferenceApiExtractRequestApplicationJson.
+  static Serializer<ReferenceApiExtractRequestApplicationJson> get serializer =>
+      _$referenceApiExtractRequestApplicationJsonSerializer;
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    ReferenceApiExtractResolve object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiExtractRequestApplicationJsonBuilder b) {
+    $ReferenceApiExtractRequestApplicationJsonInterface._defaults(b);
+  }
 
-  @override
-  ReferenceApiExtractResolve deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiExtractRequestApplicationJsonBuilder b) {
+    $ReferenceApiExtractRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -14410,6 +14659,70 @@ abstract class ReferenceApiExtractResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ReferenceApiResolveOneRequestApplicationJsonInterface {
+  /// Reference to resolve.
+  String get reference;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiResolveOneRequestApplicationJsonInterfaceBuilder].
+  $ReferenceApiResolveOneRequestApplicationJsonInterface rebuild(
+    void Function($ReferenceApiResolveOneRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiResolveOneRequestApplicationJsonInterfaceBuilder].
+  $ReferenceApiResolveOneRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiResolveOneRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiResolveOneRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ReferenceApiResolveOneRequestApplicationJson
+    implements
+        $ReferenceApiResolveOneRequestApplicationJsonInterface,
+        Built<ReferenceApiResolveOneRequestApplicationJson, ReferenceApiResolveOneRequestApplicationJsonBuilder> {
+  /// Creates a new ReferenceApiResolveOneRequestApplicationJson object using the builder pattern.
+  factory ReferenceApiResolveOneRequestApplicationJson([
+    void Function(ReferenceApiResolveOneRequestApplicationJsonBuilder)? b,
+  ]) = _$ReferenceApiResolveOneRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ReferenceApiResolveOneRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ReferenceApiResolveOneRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ReferenceApiResolveOneRequestApplicationJson.
+  static Serializer<ReferenceApiResolveOneRequestApplicationJson> get serializer =>
+      _$referenceApiResolveOneRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiResolveOneRequestApplicationJsonBuilder b) {
+    $ReferenceApiResolveOneRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiResolveOneRequestApplicationJsonBuilder b) {
+    $ReferenceApiResolveOneRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterface {
   BuiltMap<String, Reference?> get references;
 
@@ -14598,6 +14911,81 @@ abstract class ReferenceApiResolveOneResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(ReferenceApiResolveOneResponseApplicationJsonBuilder b) {
     $ReferenceApiResolveOneResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ReferenceApiResolveRequestApplicationJsonInterface {
+  static final _$limit = _$jsonSerializers.deserialize(
+    1,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// References to resolve.
+  BuiltList<String> get references;
+
+  /// Maximum amount of references to resolve.
+  int get limit;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiResolveRequestApplicationJsonInterfaceBuilder].
+  $ReferenceApiResolveRequestApplicationJsonInterface rebuild(
+    void Function($ReferenceApiResolveRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiResolveRequestApplicationJsonInterfaceBuilder].
+  $ReferenceApiResolveRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiResolveRequestApplicationJsonInterfaceBuilder b) {
+    b.limit = _$limit;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiResolveRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ReferenceApiResolveRequestApplicationJson
+    implements
+        $ReferenceApiResolveRequestApplicationJsonInterface,
+        Built<ReferenceApiResolveRequestApplicationJson, ReferenceApiResolveRequestApplicationJsonBuilder> {
+  /// Creates a new ReferenceApiResolveRequestApplicationJson object using the builder pattern.
+  factory ReferenceApiResolveRequestApplicationJson([
+    void Function(ReferenceApiResolveRequestApplicationJsonBuilder)? b,
+  ]) = _$ReferenceApiResolveRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ReferenceApiResolveRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ReferenceApiResolveRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ReferenceApiResolveRequestApplicationJson.
+  static Serializer<ReferenceApiResolveRequestApplicationJson> get serializer =>
+      _$referenceApiResolveRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiResolveRequestApplicationJsonBuilder b) {
+    $ReferenceApiResolveRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiResolveRequestApplicationJsonBuilder b) {
+    $ReferenceApiResolveRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -14979,6 +15367,70 @@ abstract class ReferenceApiGetProvidersInfoResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(ReferenceApiGetProvidersInfoResponseApplicationJsonBuilder b) {
     $ReferenceApiGetProvidersInfoResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ReferenceApiTouchProviderRequestApplicationJsonInterface {
+  /// Timestamp of the last usage.
+  int? get timestamp;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReferenceApiTouchProviderRequestApplicationJsonInterfaceBuilder].
+  $ReferenceApiTouchProviderRequestApplicationJsonInterface rebuild(
+    void Function($ReferenceApiTouchProviderRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReferenceApiTouchProviderRequestApplicationJsonInterfaceBuilder].
+  $ReferenceApiTouchProviderRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReferenceApiTouchProviderRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReferenceApiTouchProviderRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ReferenceApiTouchProviderRequestApplicationJson
+    implements
+        $ReferenceApiTouchProviderRequestApplicationJsonInterface,
+        Built<ReferenceApiTouchProviderRequestApplicationJson, ReferenceApiTouchProviderRequestApplicationJsonBuilder> {
+  /// Creates a new ReferenceApiTouchProviderRequestApplicationJson object using the builder pattern.
+  factory ReferenceApiTouchProviderRequestApplicationJson([
+    void Function(ReferenceApiTouchProviderRequestApplicationJsonBuilder)? b,
+  ]) = _$ReferenceApiTouchProviderRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ReferenceApiTouchProviderRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ReferenceApiTouchProviderRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ReferenceApiTouchProviderRequestApplicationJson.
+  static Serializer<ReferenceApiTouchProviderRequestApplicationJson> get serializer =>
+      _$referenceApiTouchProviderRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReferenceApiTouchProviderRequestApplicationJsonBuilder b) {
+    $ReferenceApiTouchProviderRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReferenceApiTouchProviderRequestApplicationJsonBuilder b) {
+    $ReferenceApiTouchProviderRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -15931,6 +16383,87 @@ abstract class TextProcessingApiTaskTypesResponseApplicationJson
   }
 }
 
+@BuiltValue(instantiable: false)
+sealed class $TextProcessingApiScheduleRequestApplicationJsonInterface {
+  static final _$identifier = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// Input text.
+  String get input;
+
+  /// Type of the task.
+  String get type;
+
+  /// ID of the app that will execute the task.
+  String get appId;
+
+  /// An arbitrary identifier for the task.
+  String get identifier;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiScheduleRequestApplicationJsonInterfaceBuilder].
+  $TextProcessingApiScheduleRequestApplicationJsonInterface rebuild(
+    void Function($TextProcessingApiScheduleRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiScheduleRequestApplicationJsonInterfaceBuilder].
+  $TextProcessingApiScheduleRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiScheduleRequestApplicationJsonInterfaceBuilder b) {
+    b.identifier = _$identifier;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiScheduleRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class TextProcessingApiScheduleRequestApplicationJson
+    implements
+        $TextProcessingApiScheduleRequestApplicationJsonInterface,
+        Built<TextProcessingApiScheduleRequestApplicationJson, TextProcessingApiScheduleRequestApplicationJsonBuilder> {
+  /// Creates a new TextProcessingApiScheduleRequestApplicationJson object using the builder pattern.
+  factory TextProcessingApiScheduleRequestApplicationJson([
+    void Function(TextProcessingApiScheduleRequestApplicationJsonBuilder)? b,
+  ]) = _$TextProcessingApiScheduleRequestApplicationJson;
+
+  // coverage:ignore-start
+  const TextProcessingApiScheduleRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory TextProcessingApiScheduleRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for TextProcessingApiScheduleRequestApplicationJson.
+  static Serializer<TextProcessingApiScheduleRequestApplicationJson> get serializer =>
+      _$textProcessingApiScheduleRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiScheduleRequestApplicationJsonBuilder b) {
+    $TextProcessingApiScheduleRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiScheduleRequestApplicationJsonBuilder b) {
+    $TextProcessingApiScheduleRequestApplicationJsonInterface._validate(b);
+  }
+}
+
 class TextProcessingTask_Status extends EnumClass {
   const TextProcessingTask_Status._(super.name);
 
@@ -16655,6 +17188,71 @@ abstract class TextProcessingApiDeleteTaskResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $TextProcessingApiListTasksByAppRequestApplicationJsonInterface {
+  /// An arbitrary identifier for the task.
+  String? get identifier;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextProcessingApiListTasksByAppRequestApplicationJsonInterfaceBuilder].
+  $TextProcessingApiListTasksByAppRequestApplicationJsonInterface rebuild(
+    void Function($TextProcessingApiListTasksByAppRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextProcessingApiListTasksByAppRequestApplicationJsonInterfaceBuilder].
+  $TextProcessingApiListTasksByAppRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextProcessingApiListTasksByAppRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextProcessingApiListTasksByAppRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class TextProcessingApiListTasksByAppRequestApplicationJson
+    implements
+        $TextProcessingApiListTasksByAppRequestApplicationJsonInterface,
+        Built<TextProcessingApiListTasksByAppRequestApplicationJson,
+            TextProcessingApiListTasksByAppRequestApplicationJsonBuilder> {
+  /// Creates a new TextProcessingApiListTasksByAppRequestApplicationJson object using the builder pattern.
+  factory TextProcessingApiListTasksByAppRequestApplicationJson([
+    void Function(TextProcessingApiListTasksByAppRequestApplicationJsonBuilder)? b,
+  ]) = _$TextProcessingApiListTasksByAppRequestApplicationJson;
+
+  // coverage:ignore-start
+  const TextProcessingApiListTasksByAppRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory TextProcessingApiListTasksByAppRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for TextProcessingApiListTasksByAppRequestApplicationJson.
+  static Serializer<TextProcessingApiListTasksByAppRequestApplicationJson> get serializer =>
+      _$textProcessingApiListTasksByAppRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextProcessingApiListTasksByAppRequestApplicationJsonBuilder b) {
+    $TextProcessingApiListTasksByAppRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextProcessingApiListTasksByAppRequestApplicationJsonBuilder b) {
+    $TextProcessingApiListTasksByAppRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterface {
   BuiltList<TextProcessingTask> get tasks;
 
@@ -17037,6 +17635,93 @@ abstract class TextToImageApiIsAvailableResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(TextToImageApiIsAvailableResponseApplicationJsonBuilder b) {
     $TextToImageApiIsAvailableResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $TextToImageApiScheduleRequestApplicationJsonInterface {
+  static final _$identifier = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$numberOfImages = _$jsonSerializers.deserialize(
+    8,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// Input text.
+  String get input;
+
+  /// ID of the app that will execute the task.
+  String get appId;
+
+  /// An arbitrary identifier for the task.
+  String get identifier;
+
+  /// The number of images to generate.
+  int get numberOfImages;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiScheduleRequestApplicationJsonInterfaceBuilder].
+  $TextToImageApiScheduleRequestApplicationJsonInterface rebuild(
+    void Function($TextToImageApiScheduleRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiScheduleRequestApplicationJsonInterfaceBuilder].
+  $TextToImageApiScheduleRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiScheduleRequestApplicationJsonInterfaceBuilder b) {
+    b.identifier = _$identifier;
+    b.numberOfImages = _$numberOfImages;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiScheduleRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class TextToImageApiScheduleRequestApplicationJson
+    implements
+        $TextToImageApiScheduleRequestApplicationJsonInterface,
+        Built<TextToImageApiScheduleRequestApplicationJson, TextToImageApiScheduleRequestApplicationJsonBuilder> {
+  /// Creates a new TextToImageApiScheduleRequestApplicationJson object using the builder pattern.
+  factory TextToImageApiScheduleRequestApplicationJson([
+    void Function(TextToImageApiScheduleRequestApplicationJsonBuilder)? b,
+  ]) = _$TextToImageApiScheduleRequestApplicationJson;
+
+  // coverage:ignore-start
+  const TextToImageApiScheduleRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory TextToImageApiScheduleRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for TextToImageApiScheduleRequestApplicationJson.
+  static Serializer<TextToImageApiScheduleRequestApplicationJson> get serializer =>
+      _$textToImageApiScheduleRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiScheduleRequestApplicationJsonBuilder b) {
+    $TextToImageApiScheduleRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiScheduleRequestApplicationJsonBuilder b) {
+    $TextToImageApiScheduleRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -17759,6 +18444,71 @@ abstract class TextToImageApiDeleteTaskResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $TextToImageApiListTasksByAppRequestApplicationJsonInterface {
+  /// An arbitrary identifier for the task.
+  String? get identifier;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TextToImageApiListTasksByAppRequestApplicationJsonInterfaceBuilder].
+  $TextToImageApiListTasksByAppRequestApplicationJsonInterface rebuild(
+    void Function($TextToImageApiListTasksByAppRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TextToImageApiListTasksByAppRequestApplicationJsonInterfaceBuilder].
+  $TextToImageApiListTasksByAppRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TextToImageApiListTasksByAppRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TextToImageApiListTasksByAppRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class TextToImageApiListTasksByAppRequestApplicationJson
+    implements
+        $TextToImageApiListTasksByAppRequestApplicationJsonInterface,
+        Built<TextToImageApiListTasksByAppRequestApplicationJson,
+            TextToImageApiListTasksByAppRequestApplicationJsonBuilder> {
+  /// Creates a new TextToImageApiListTasksByAppRequestApplicationJson object using the builder pattern.
+  factory TextToImageApiListTasksByAppRequestApplicationJson([
+    void Function(TextToImageApiListTasksByAppRequestApplicationJsonBuilder)? b,
+  ]) = _$TextToImageApiListTasksByAppRequestApplicationJson;
+
+  // coverage:ignore-start
+  const TextToImageApiListTasksByAppRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory TextToImageApiListTasksByAppRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for TextToImageApiListTasksByAppRequestApplicationJson.
+  static Serializer<TextToImageApiListTasksByAppRequestApplicationJson> get serializer =>
+      _$textToImageApiListTasksByAppRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TextToImageApiListTasksByAppRequestApplicationJsonBuilder b) {
+    $TextToImageApiListTasksByAppRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TextToImageApiListTasksByAppRequestApplicationJsonBuilder b) {
+    $TextToImageApiListTasksByAppRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterface {
   BuiltList<TextToImageTask> get tasks;
 
@@ -18212,6 +18962,76 @@ abstract class TranslationApiLanguagesResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $TranslationApiTranslateRequestApplicationJsonInterface {
+  /// Text to be translated.
+  String get text;
+
+  /// Language to translate from.
+  String? get fromLanguage;
+
+  /// Language to translate to.
+  String get toLanguage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TranslationApiTranslateRequestApplicationJsonInterfaceBuilder].
+  $TranslationApiTranslateRequestApplicationJsonInterface rebuild(
+    void Function($TranslationApiTranslateRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TranslationApiTranslateRequestApplicationJsonInterfaceBuilder].
+  $TranslationApiTranslateRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TranslationApiTranslateRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TranslationApiTranslateRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class TranslationApiTranslateRequestApplicationJson
+    implements
+        $TranslationApiTranslateRequestApplicationJsonInterface,
+        Built<TranslationApiTranslateRequestApplicationJson, TranslationApiTranslateRequestApplicationJsonBuilder> {
+  /// Creates a new TranslationApiTranslateRequestApplicationJson object using the builder pattern.
+  factory TranslationApiTranslateRequestApplicationJson([
+    void Function(TranslationApiTranslateRequestApplicationJsonBuilder)? b,
+  ]) = _$TranslationApiTranslateRequestApplicationJson;
+
+  // coverage:ignore-start
+  const TranslationApiTranslateRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory TranslationApiTranslateRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for TranslationApiTranslateRequestApplicationJson.
+  static Serializer<TranslationApiTranslateRequestApplicationJson> get serializer =>
+      _$translationApiTranslateRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TranslationApiTranslateRequestApplicationJsonBuilder b) {
+    $TranslationApiTranslateRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TranslationApiTranslateRequestApplicationJsonBuilder b) {
+    $TranslationApiTranslateRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $TranslationApiTranslateResponseApplicationJson_Ocs_DataInterface {
   String get text;
   String? get from;
@@ -18401,6 +19221,78 @@ abstract class TranslationApiTranslateResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(TranslationApiTranslateResponseApplicationJsonBuilder b) {
     $TranslationApiTranslateResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $UnifiedSearchGetProvidersRequestApplicationJsonInterface {
+  static final _$from = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// the url the user is currently at.
+  String get from;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UnifiedSearchGetProvidersRequestApplicationJsonInterfaceBuilder].
+  $UnifiedSearchGetProvidersRequestApplicationJsonInterface rebuild(
+    void Function($UnifiedSearchGetProvidersRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UnifiedSearchGetProvidersRequestApplicationJsonInterfaceBuilder].
+  $UnifiedSearchGetProvidersRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UnifiedSearchGetProvidersRequestApplicationJsonInterfaceBuilder b) {
+    b.from = _$from;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UnifiedSearchGetProvidersRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UnifiedSearchGetProvidersRequestApplicationJson
+    implements
+        $UnifiedSearchGetProvidersRequestApplicationJsonInterface,
+        Built<UnifiedSearchGetProvidersRequestApplicationJson, UnifiedSearchGetProvidersRequestApplicationJsonBuilder> {
+  /// Creates a new UnifiedSearchGetProvidersRequestApplicationJson object using the builder pattern.
+  factory UnifiedSearchGetProvidersRequestApplicationJson([
+    void Function(UnifiedSearchGetProvidersRequestApplicationJsonBuilder)? b,
+  ]) = _$UnifiedSearchGetProvidersRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UnifiedSearchGetProvidersRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UnifiedSearchGetProvidersRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UnifiedSearchGetProvidersRequestApplicationJson.
+  static Serializer<UnifiedSearchGetProvidersRequestApplicationJson> get serializer =>
+      _$unifiedSearchGetProvidersRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UnifiedSearchGetProvidersRequestApplicationJsonBuilder b) {
+    $UnifiedSearchGetProvidersRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UnifiedSearchGetProvidersRequestApplicationJsonBuilder b) {
+    $UnifiedSearchGetProvidersRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -18596,7 +19488,100 @@ abstract class UnifiedSearchGetProvidersResponseApplicationJson
   }
 }
 
-typedef UnifiedSearchSearchCursor = ({int? $int, String? string});
+/// Offset for searching.
+typedef UnifiedSearchSearchRequestApplicationJson_Cursor = ({int? $int, String? string});
+
+@BuiltValue(instantiable: false)
+sealed class $UnifiedSearchSearchRequestApplicationJsonInterface {
+  static final _$term = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$from = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// Term to search.
+  String get term;
+
+  /// Order of entries.
+  int? get sortOrder;
+
+  /// Maximum amount of entries.
+  int? get limit;
+
+  /// Offset for searching.
+  UnifiedSearchSearchRequestApplicationJson_Cursor? get cursor;
+
+  /// The current user URL.
+  String get from;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UnifiedSearchSearchRequestApplicationJsonInterfaceBuilder].
+  $UnifiedSearchSearchRequestApplicationJsonInterface rebuild(
+    void Function($UnifiedSearchSearchRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UnifiedSearchSearchRequestApplicationJsonInterfaceBuilder].
+  $UnifiedSearchSearchRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UnifiedSearchSearchRequestApplicationJsonInterfaceBuilder b) {
+    b.term = _$term;
+    b.from = _$from;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UnifiedSearchSearchRequestApplicationJsonInterfaceBuilder b) {
+    b.cursor?.validateOneOf();
+  }
+}
+
+abstract class UnifiedSearchSearchRequestApplicationJson
+    implements
+        $UnifiedSearchSearchRequestApplicationJsonInterface,
+        Built<UnifiedSearchSearchRequestApplicationJson, UnifiedSearchSearchRequestApplicationJsonBuilder> {
+  /// Creates a new UnifiedSearchSearchRequestApplicationJson object using the builder pattern.
+  factory UnifiedSearchSearchRequestApplicationJson([
+    void Function(UnifiedSearchSearchRequestApplicationJsonBuilder)? b,
+  ]) = _$UnifiedSearchSearchRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UnifiedSearchSearchRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UnifiedSearchSearchRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UnifiedSearchSearchRequestApplicationJson.
+  static Serializer<UnifiedSearchSearchRequestApplicationJson> get serializer =>
+      _$unifiedSearchSearchRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UnifiedSearchSearchRequestApplicationJsonBuilder b) {
+    $UnifiedSearchSearchRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UnifiedSearchSearchRequestApplicationJsonBuilder b) {
+    $UnifiedSearchSearchRequestApplicationJsonInterface._validate(b);
+  }
+}
 
 @BuiltValue(instantiable: false)
 sealed class $UnifiedSearchResultEntryInterface {
@@ -19107,6 +20092,69 @@ abstract class WhatsNewGetResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $WhatsNewDismissRequestApplicationJsonInterface {
+  /// Version to dismiss the changes for.
+  String get version;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WhatsNewDismissRequestApplicationJsonInterfaceBuilder].
+  $WhatsNewDismissRequestApplicationJsonInterface rebuild(
+    void Function($WhatsNewDismissRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WhatsNewDismissRequestApplicationJsonInterfaceBuilder].
+  $WhatsNewDismissRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WhatsNewDismissRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WhatsNewDismissRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class WhatsNewDismissRequestApplicationJson
+    implements
+        $WhatsNewDismissRequestApplicationJsonInterface,
+        Built<WhatsNewDismissRequestApplicationJson, WhatsNewDismissRequestApplicationJsonBuilder> {
+  /// Creates a new WhatsNewDismissRequestApplicationJson object using the builder pattern.
+  factory WhatsNewDismissRequestApplicationJson([void Function(WhatsNewDismissRequestApplicationJsonBuilder)? b]) =
+      _$WhatsNewDismissRequestApplicationJson;
+
+  // coverage:ignore-start
+  const WhatsNewDismissRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory WhatsNewDismissRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for WhatsNewDismissRequestApplicationJson.
+  static Serializer<WhatsNewDismissRequestApplicationJson> get serializer =>
+      _$whatsNewDismissRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WhatsNewDismissRequestApplicationJsonBuilder b) {
+    $WhatsNewDismissRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WhatsNewDismissRequestApplicationJsonBuilder b) {
+    $WhatsNewDismissRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $WhatsNewDismissResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -19233,6 +20281,69 @@ abstract class WhatsNewDismissResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $WipeCheckWipeRequestApplicationJsonInterface {
+  /// App password.
+  String get token;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WipeCheckWipeRequestApplicationJsonInterfaceBuilder].
+  $WipeCheckWipeRequestApplicationJsonInterface rebuild(
+    void Function($WipeCheckWipeRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WipeCheckWipeRequestApplicationJsonInterfaceBuilder].
+  $WipeCheckWipeRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WipeCheckWipeRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WipeCheckWipeRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class WipeCheckWipeRequestApplicationJson
+    implements
+        $WipeCheckWipeRequestApplicationJsonInterface,
+        Built<WipeCheckWipeRequestApplicationJson, WipeCheckWipeRequestApplicationJsonBuilder> {
+  /// Creates a new WipeCheckWipeRequestApplicationJson object using the builder pattern.
+  factory WipeCheckWipeRequestApplicationJson([void Function(WipeCheckWipeRequestApplicationJsonBuilder)? b]) =
+      _$WipeCheckWipeRequestApplicationJson;
+
+  // coverage:ignore-start
+  const WipeCheckWipeRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory WipeCheckWipeRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for WipeCheckWipeRequestApplicationJson.
+  static Serializer<WipeCheckWipeRequestApplicationJson> get serializer =>
+      _$wipeCheckWipeRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WipeCheckWipeRequestApplicationJsonBuilder b) {
+    $WipeCheckWipeRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WipeCheckWipeRequestApplicationJsonBuilder b) {
+    $WipeCheckWipeRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $WipeCheckWipeResponseApplicationJsonInterface {
   bool get wipe;
 
@@ -19291,6 +20402,69 @@ abstract class WipeCheckWipeResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(WipeCheckWipeResponseApplicationJsonBuilder b) {
     $WipeCheckWipeResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $WipeWipeDoneRequestApplicationJsonInterface {
+  /// App password.
+  String get token;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WipeWipeDoneRequestApplicationJsonInterfaceBuilder].
+  $WipeWipeDoneRequestApplicationJsonInterface rebuild(
+    void Function($WipeWipeDoneRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WipeWipeDoneRequestApplicationJsonInterfaceBuilder].
+  $WipeWipeDoneRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WipeWipeDoneRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WipeWipeDoneRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class WipeWipeDoneRequestApplicationJson
+    implements
+        $WipeWipeDoneRequestApplicationJsonInterface,
+        Built<WipeWipeDoneRequestApplicationJson, WipeWipeDoneRequestApplicationJsonBuilder> {
+  /// Creates a new WipeWipeDoneRequestApplicationJson object using the builder pattern.
+  factory WipeWipeDoneRequestApplicationJson([void Function(WipeWipeDoneRequestApplicationJsonBuilder)? b]) =
+      _$WipeWipeDoneRequestApplicationJson;
+
+  // coverage:ignore-start
+  const WipeWipeDoneRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory WipeWipeDoneRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for WipeWipeDoneRequestApplicationJson.
+  static Serializer<WipeWipeDoneRequestApplicationJson> get serializer =>
+      _$wipeWipeDoneRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WipeWipeDoneRequestApplicationJsonBuilder b) {
+    $WipeWipeDoneRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WipeWipeDoneRequestApplicationJsonBuilder b) {
+    $WipeWipeDoneRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -19593,16 +20767,19 @@ extension $OcsGetCapabilitiesResponseApplicationJson_Ocs_Data_CapabilitiesExtens
       $f6f5edfce09cb06e8f14ce14ab1af117Extension._fromJson(json);
 }
 
-/// Serialization extension for `UnifiedSearchSearchCursor`.
-extension $UnifiedSearchSearchCursorExtension on UnifiedSearchSearchCursor {
-  /// Serializer for UnifiedSearchSearchCursor.
+/// Serialization extension for `UnifiedSearchSearchRequestApplicationJson_Cursor`.
+extension $UnifiedSearchSearchRequestApplicationJson_CursorExtension
+    on UnifiedSearchSearchRequestApplicationJson_Cursor {
+  /// Serializer for UnifiedSearchSearchRequestApplicationJson_Cursor.
   @BuiltValueSerializer(custom: true)
-  static Serializer<UnifiedSearchSearchCursor> get serializer => $b2c4857c0136baea42828d89c87c757dExtension._serializer;
+  static Serializer<UnifiedSearchSearchRequestApplicationJson_Cursor> get serializer =>
+      $b2c4857c0136baea42828d89c87c757dExtension._serializer;
 
   /// Creates a new object from the given [json] data.
   ///
   /// Use `toJson` to serialize it back into json.
-  static UnifiedSearchSearchCursor fromJson(Object? json) => $b2c4857c0136baea42828d89c87c757dExtension._fromJson(json);
+  static UnifiedSearchSearchRequestApplicationJson_Cursor fromJson(Object? json) =>
+      $b2c4857c0136baea42828d89c87c757dExtension._fromJson(json);
 }
 
 /// Serialization extension for `UnifiedSearchResult_Cursor`.
@@ -20357,6 +21534,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(AppPasswordRotateAppPasswordResponseApplicationJson_Ocs_Data.serializer)
       ..addBuilderFactory(
+        const FullType(AppPasswordConfirmUserPasswordRequestApplicationJson),
+        AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder.new,
+      )
+      ..add(AppPasswordConfirmUserPasswordRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(AppPasswordConfirmUserPasswordResponseApplicationJson),
         AppPasswordConfirmUserPasswordResponseApplicationJsonBuilder.new,
       )
@@ -20371,6 +21553,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_Data.serializer)
+      ..addBuilderFactory(
+        const FullType(AutoCompleteGetRequestApplicationJson),
+        AutoCompleteGetRequestApplicationJsonBuilder.new,
+      )
+      ..add(AutoCompleteGetRequestApplicationJson.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(int)]), ListBuilder<int>.new)
       ..addBuilderFactory(
         const FullType(AutoCompleteGetResponseApplicationJson),
@@ -20397,6 +21584,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(Header.serializer)
       ..addBuilderFactory(const FullType(AvatarAvatarGetAvatarHeaders), AvatarAvatarGetAvatarHeadersBuilder.new)
       ..add(AvatarAvatarGetAvatarHeaders.serializer)
+      ..addBuilderFactory(
+        const FullType(ClientFlowLoginV2PollRequestApplicationJson),
+        ClientFlowLoginV2PollRequestApplicationJsonBuilder.new,
+      )
+      ..add(ClientFlowLoginV2PollRequestApplicationJson.serializer)
       ..addBuilderFactory(const FullType(LoginFlowV2Credentials), LoginFlowV2CredentialsBuilder.new)
       ..add(LoginFlowV2Credentials.serializer)
       ..addBuilderFactory(const FullType(LoginFlowV2), LoginFlowV2Builder.new)
@@ -20425,6 +21617,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(OpenGraphObject.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(Resource)]), ListBuilder<Resource>.new)
       ..addBuilderFactory(
+        const FullType(CollaborationResourcesRenameCollectionRequestApplicationJson),
+        CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder.new,
+      )
+      ..add(CollaborationResourcesRenameCollectionRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(CollaborationResourcesRenameCollectionResponseApplicationJson),
         CollaborationResourcesRenameCollectionResponseApplicationJsonBuilder.new,
       )
@@ -20435,6 +21632,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(
+        const FullType(CollaborationResourcesAddResourceRequestApplicationJson),
+        CollaborationResourcesAddResourceRequestApplicationJsonBuilder.new,
+      )
+      ..add(CollaborationResourcesAddResourceRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(CollaborationResourcesAddResourceResponseApplicationJson),
         CollaborationResourcesAddResourceResponseApplicationJsonBuilder.new,
       )
@@ -20444,6 +21646,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         CollaborationResourcesAddResourceResponseApplicationJson_OcsBuilder.new,
       )
       ..add(CollaborationResourcesAddResourceResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(CollaborationResourcesRemoveResourceRequestApplicationJson),
+        CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder.new,
+      )
+      ..add(CollaborationResourcesRemoveResourceRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(CollaborationResourcesRemoveResourceResponseApplicationJson),
         CollaborationResourcesRemoveResourceResponseApplicationJsonBuilder.new,
@@ -20476,6 +21683,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(CollaborationResourcesGetCollectionsByResourceResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(
+        const FullType(CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson),
+        CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder.new,
+      )
+      ..add(CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson),
         CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonBuilder.new,
       )
@@ -20485,7 +21697,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsBuilder.new,
       )
       ..add(CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs.serializer)
-      ..add(GuestAvatarGetAvatarDarkTheme.serializer)
+      ..addBuilderFactory(
+        const FullType(GuestAvatarGetAvatarRequestApplicationJson),
+        GuestAvatarGetAvatarRequestApplicationJsonBuilder.new,
+      )
+      ..add(GuestAvatarGetAvatarRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(HoverCardGetUserResponseApplicationJson),
         HoverCardGetUserResponseApplicationJsonBuilder.new,
@@ -20505,11 +21721,20 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ContactsAction.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(ContactsAction)]), ListBuilder<ContactsAction>.new)
       ..addBuilderFactory(
+        const FullType(LoginConfirmPasswordRequestApplicationJson),
+        LoginConfirmPasswordRequestApplicationJsonBuilder.new,
+      )
+      ..add(LoginConfirmPasswordRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(LoginConfirmPasswordResponseApplicationJson),
         LoginConfirmPasswordResponseApplicationJsonBuilder.new,
       )
       ..add(LoginConfirmPasswordResponseApplicationJson.serializer)
-      ..add(NavigationGetAppsNavigationAbsolute.serializer)
+      ..addBuilderFactory(
+        const FullType(NavigationGetAppsNavigationRequestApplicationJson),
+        NavigationGetAppsNavigationRequestApplicationJsonBuilder.new,
+      )
+      ..add(NavigationGetAppsNavigationRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(NavigationGetAppsNavigationResponseApplicationJson),
         NavigationGetAppsNavigationResponseApplicationJsonBuilder.new,
@@ -20524,7 +21749,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(NavigationEntry.serializer)
       ..add($b2c4857c0136baea42828d89c87c757dExtension._serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(NavigationEntry)]), ListBuilder<NavigationEntry>.new)
-      ..add(NavigationGetSettingsNavigationAbsolute.serializer)
+      ..addBuilderFactory(
+        const FullType(NavigationGetSettingsNavigationRequestApplicationJson),
+        NavigationGetSettingsNavigationRequestApplicationJsonBuilder.new,
+      )
+      ..add(NavigationGetSettingsNavigationRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(NavigationGetSettingsNavigationResponseApplicationJson),
         NavigationGetSettingsNavigationResponseApplicationJsonBuilder.new,
@@ -20816,12 +22045,21 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(NotesCapabilities_Notes), NotesCapabilities_NotesBuilder.new)
       ..add(NotesCapabilities_Notes.serializer)
       ..add($f6f5edfce09cb06e8f14ce14ab1af117Extension._serializer)
-      ..add(PreviewGetPreviewA.serializer)
-      ..add(PreviewGetPreviewForceIcon.serializer)
-      ..add(PreviewGetPreviewMimeFallback.serializer)
-      ..add(PreviewGetPreviewByFileIdA.serializer)
-      ..add(PreviewGetPreviewByFileIdForceIcon.serializer)
-      ..add(PreviewGetPreviewByFileIdMimeFallback.serializer)
+      ..addBuilderFactory(
+        const FullType(PreviewGetPreviewRequestApplicationJson),
+        PreviewGetPreviewRequestApplicationJsonBuilder.new,
+      )
+      ..add(PreviewGetPreviewRequestApplicationJson.serializer)
+      ..addBuilderFactory(
+        const FullType(PreviewGetPreviewByFileIdRequestApplicationJson),
+        PreviewGetPreviewByFileIdRequestApplicationJsonBuilder.new,
+      )
+      ..add(PreviewGetPreviewByFileIdRequestApplicationJson.serializer)
+      ..addBuilderFactory(
+        const FullType(ProfileApiSetVisibilityRequestApplicationJson),
+        ProfileApiSetVisibilityRequestApplicationJsonBuilder.new,
+      )
+      ..add(ProfileApiSetVisibilityRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ProfileApiSetVisibilityResponseApplicationJson),
         ProfileApiSetVisibilityResponseApplicationJsonBuilder.new,
@@ -20832,7 +22070,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ProfileApiSetVisibilityResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ProfileApiSetVisibilityResponseApplicationJson_Ocs.serializer)
-      ..add(ReferenceApiExtractResolve.serializer)
+      ..addBuilderFactory(
+        const FullType(ReferenceApiExtractRequestApplicationJson),
+        ReferenceApiExtractRequestApplicationJsonBuilder.new,
+      )
+      ..add(ReferenceApiExtractRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ReferenceApiExtractResponseApplicationJson),
         ReferenceApiExtractResponseApplicationJsonBuilder.new,
@@ -20855,6 +22097,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         MapBuilder<String, Reference?>.new,
       )
       ..addBuilderFactory(
+        const FullType(ReferenceApiResolveOneRequestApplicationJson),
+        ReferenceApiResolveOneRequestApplicationJsonBuilder.new,
+      )
+      ..add(ReferenceApiResolveOneRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(ReferenceApiResolveOneResponseApplicationJson),
         ReferenceApiResolveOneResponseApplicationJsonBuilder.new,
       )
@@ -20869,6 +22116,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ReferenceApiResolveOneResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(ReferenceApiResolveOneResponseApplicationJson_Ocs_Data.serializer)
+      ..addBuilderFactory(
+        const FullType(ReferenceApiResolveRequestApplicationJson),
+        ReferenceApiResolveRequestApplicationJsonBuilder.new,
+      )
+      ..add(ReferenceApiResolveRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ReferenceApiResolveResponseApplicationJson),
         ReferenceApiResolveResponseApplicationJsonBuilder.new,
@@ -20897,6 +22149,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(ReferenceProvider), ReferenceProviderBuilder.new)
       ..add(ReferenceProvider.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(ReferenceProvider)]), ListBuilder<ReferenceProvider>.new)
+      ..addBuilderFactory(
+        const FullType(ReferenceApiTouchProviderRequestApplicationJson),
+        ReferenceApiTouchProviderRequestApplicationJsonBuilder.new,
+      )
+      ..add(ReferenceApiTouchProviderRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ReferenceApiTouchProviderResponseApplicationJson),
         ReferenceApiTouchProviderResponseApplicationJsonBuilder.new,
@@ -20973,6 +22230,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ListBuilder<TextProcessingApiTaskTypesResponseApplicationJson_Ocs_Data_Types>.new,
       )
       ..addBuilderFactory(
+        const FullType(TextProcessingApiScheduleRequestApplicationJson),
+        TextProcessingApiScheduleRequestApplicationJsonBuilder.new,
+      )
+      ..add(TextProcessingApiScheduleRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(TextProcessingApiScheduleResponseApplicationJson),
         TextProcessingApiScheduleResponseApplicationJsonBuilder.new,
       )
@@ -21021,6 +22283,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(TextProcessingApiDeleteTaskResponseApplicationJson_Ocs_Data.serializer)
       ..addBuilderFactory(
+        const FullType(TextProcessingApiListTasksByAppRequestApplicationJson),
+        TextProcessingApiListTasksByAppRequestApplicationJsonBuilder.new,
+      )
+      ..add(TextProcessingApiListTasksByAppRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(TextProcessingApiListTasksByAppResponseApplicationJson),
         TextProcessingApiListTasksByAppResponseApplicationJsonBuilder.new,
       )
@@ -21054,6 +22321,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         TextToImageApiIsAvailableResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(TextToImageApiIsAvailableResponseApplicationJson_Ocs_Data.serializer)
+      ..addBuilderFactory(
+        const FullType(TextToImageApiScheduleRequestApplicationJson),
+        TextToImageApiScheduleRequestApplicationJsonBuilder.new,
+      )
+      ..add(TextToImageApiScheduleRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(TextToImageApiScheduleResponseApplicationJson),
         TextToImageApiScheduleResponseApplicationJsonBuilder.new,
@@ -21103,6 +22375,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(TextToImageApiDeleteTaskResponseApplicationJson_Ocs_Data.serializer)
       ..addBuilderFactory(
+        const FullType(TextToImageApiListTasksByAppRequestApplicationJson),
+        TextToImageApiListTasksByAppRequestApplicationJsonBuilder.new,
+      )
+      ..add(TextToImageApiListTasksByAppRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(TextToImageApiListTasksByAppResponseApplicationJson),
         TextToImageApiListTasksByAppResponseApplicationJsonBuilder.new,
       )
@@ -21143,6 +22420,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ListBuilder<TranslationApiLanguagesResponseApplicationJson_Ocs_Data_Languages>.new,
       )
       ..addBuilderFactory(
+        const FullType(TranslationApiTranslateRequestApplicationJson),
+        TranslationApiTranslateRequestApplicationJsonBuilder.new,
+      )
+      ..add(TranslationApiTranslateRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(TranslationApiTranslateResponseApplicationJson),
         TranslationApiTranslateResponseApplicationJsonBuilder.new,
       )
@@ -21157,6 +22439,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         TranslationApiTranslateResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(TranslationApiTranslateResponseApplicationJson_Ocs_Data.serializer)
+      ..addBuilderFactory(
+        const FullType(UnifiedSearchGetProvidersRequestApplicationJson),
+        UnifiedSearchGetProvidersRequestApplicationJsonBuilder.new,
+      )
+      ..add(UnifiedSearchGetProvidersRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(UnifiedSearchGetProvidersResponseApplicationJson),
         UnifiedSearchGetProvidersResponseApplicationJsonBuilder.new,
@@ -21177,6 +22464,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         const FullType(BuiltList, [FullType(UnifiedSearchProvider)]),
         ListBuilder<UnifiedSearchProvider>.new,
       )
+      ..addBuilderFactory(
+        const FullType(UnifiedSearchSearchRequestApplicationJson),
+        UnifiedSearchSearchRequestApplicationJsonBuilder.new,
+      )
+      ..add(UnifiedSearchSearchRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(UnifiedSearchSearchResponseApplicationJson),
         UnifiedSearchSearchResponseApplicationJsonBuilder.new,
@@ -21216,6 +22508,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(WhatsNewGetResponseApplicationJson_Ocs_Data_WhatsNew.serializer)
       ..addBuilderFactory(
+        const FullType(WhatsNewDismissRequestApplicationJson),
+        WhatsNewDismissRequestApplicationJsonBuilder.new,
+      )
+      ..add(WhatsNewDismissRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(WhatsNewDismissResponseApplicationJson),
         WhatsNewDismissResponseApplicationJsonBuilder.new,
       )
@@ -21226,10 +22523,20 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(WhatsNewDismissResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(
+        const FullType(WipeCheckWipeRequestApplicationJson),
+        WipeCheckWipeRequestApplicationJsonBuilder.new,
+      )
+      ..add(WipeCheckWipeRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(WipeCheckWipeResponseApplicationJson),
         WipeCheckWipeResponseApplicationJsonBuilder.new,
       )
       ..add(WipeCheckWipeResponseApplicationJson.serializer)
+      ..addBuilderFactory(
+        const FullType(WipeWipeDoneRequestApplicationJson),
+        WipeWipeDoneRequestApplicationJsonBuilder.new,
+      )
+      ..add(WipeWipeDoneRequestApplicationJson.serializer)
       ..addBuilderFactory(const FullType(Capabilities), CapabilitiesBuilder.new)
       ..add(Capabilities.serializer)
       ..addBuilderFactory(const FullType(Capabilities_Core), Capabilities_CoreBuilder.new)

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -200,9 +200,9 @@ class $AppPasswordClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -287,9 +287,9 @@ class $AppPasswordClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -372,9 +372,9 @@ class $AppPasswordClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -441,8 +441,8 @@ class $AppPasswordClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    _parameters['password'] = $password;
+    final __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
+    _parameters['password'] = __password;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/core/apppassword/confirm{?password*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -465,9 +465,9 @@ class $AppPasswordClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -552,26 +552,26 @@ class $AutoCompleteClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    _parameters['search'] = $search;
+    final __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
+    _parameters['search'] = __search;
 
-    final $itemType = _$jsonSerializers.serialize(itemType, specifiedType: const FullType(String));
-    _parameters['itemType'] = $itemType;
+    final __itemType = _$jsonSerializers.serialize(itemType, specifiedType: const FullType(String));
+    _parameters['itemType'] = __itemType;
 
-    final $itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(String));
-    _parameters['itemId'] = $itemId;
+    final __itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(String));
+    _parameters['itemId'] = __itemId;
 
-    final $sorter = _$jsonSerializers.serialize(sorter, specifiedType: const FullType(String));
-    _parameters['sorter'] = $sorter;
+    final __sorter = _$jsonSerializers.serialize(sorter, specifiedType: const FullType(String));
+    _parameters['sorter'] = __sorter;
 
-    var $shareTypes =
+    var __shareTypes =
         _$jsonSerializers.serialize(shareTypes, specifiedType: const FullType(BuiltList, [FullType(int)]));
-    $shareTypes ??= const [];
-    _parameters['shareTypes%5B%5D'] = $shareTypes;
+    __shareTypes ??= const [];
+    _parameters['shareTypes%5B%5D'] = __shareTypes;
 
-    var $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    $limit ??= 10;
-    _parameters['limit'] = $limit;
+    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    __limit ??= 10;
+    _parameters['limit'] = __limit;
 
     final _path = _i6.UriTemplate(
       '/ocs/v2.php/core/autocomplete/get{?search*,itemType*,itemId*,sorter*,shareTypes%5B%5D*,limit*}',
@@ -596,9 +596,9 @@ class $AutoCompleteClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -690,11 +690,11 @@ class $AvatarClient {
     required int size,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
-    final $size = _$jsonSerializers.serialize(size, specifiedType: const FullType(int));
-    _parameters['size'] = $size;
+    final __size = _$jsonSerializers.serialize(size, specifiedType: const FullType(int));
+    _parameters['size'] = __size;
 
     final _path = _i6.UriTemplate('/index.php/avatar/{userId}/{size}/dark').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -782,11 +782,11 @@ class $AvatarClient {
     required int size,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
-    final $size = _$jsonSerializers.serialize(size, specifiedType: const FullType(int));
-    _parameters['size'] = $size;
+    final __size = _$jsonSerializers.serialize(size, specifiedType: const FullType(int));
+    _parameters['size'] = __size;
 
     final _path = _i6.UriTemplate('/index.php/avatar/{userId}/{size}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -876,8 +876,8 @@ class $ClientFlowLoginV2Client {
   @_i2.experimental
   _i3.Request $poll_Request({required String token}) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _parameters['token'] = $token;
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    _parameters['token'] = __token;
 
     final _path = _i6.UriTemplate('/index.php/login/v2/poll{?token*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1033,8 +1033,8 @@ class $CollaborationResourcesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $collectionId = _$jsonSerializers.serialize(collectionId, specifiedType: const FullType(int));
-    _parameters['collectionId'] = $collectionId;
+    final __collectionId = _$jsonSerializers.serialize(collectionId, specifiedType: const FullType(int));
+    _parameters['collectionId'] = __collectionId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1057,9 +1057,9 @@ class $CollaborationResourcesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1134,11 +1134,11 @@ class $CollaborationResourcesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $collectionName = _$jsonSerializers.serialize(collectionName, specifiedType: const FullType(String));
-    _parameters['collectionName'] = $collectionName;
+    final __collectionName = _$jsonSerializers.serialize(collectionName, specifiedType: const FullType(String));
+    _parameters['collectionName'] = __collectionName;
 
-    final $collectionId = _$jsonSerializers.serialize(collectionId, specifiedType: const FullType(int));
-    _parameters['collectionId'] = $collectionId;
+    final __collectionId = _$jsonSerializers.serialize(collectionId, specifiedType: const FullType(int));
+    _parameters['collectionId'] = __collectionId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}{?collectionName*}')
         .expand(_parameters);
@@ -1162,9 +1162,9 @@ class $CollaborationResourcesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1244,14 +1244,14 @@ class $CollaborationResourcesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $resourceType = _$jsonSerializers.serialize(resourceType, specifiedType: const FullType(String));
-    _parameters['resourceType'] = $resourceType;
+    final __resourceType = _$jsonSerializers.serialize(resourceType, specifiedType: const FullType(String));
+    _parameters['resourceType'] = __resourceType;
 
-    final $resourceId = _$jsonSerializers.serialize(resourceId, specifiedType: const FullType(String));
-    _parameters['resourceId'] = $resourceId;
+    final __resourceId = _$jsonSerializers.serialize(resourceId, specifiedType: const FullType(String));
+    _parameters['resourceId'] = __resourceId;
 
-    final $collectionId = _$jsonSerializers.serialize(collectionId, specifiedType: const FullType(int));
-    _parameters['collectionId'] = $collectionId;
+    final __collectionId = _$jsonSerializers.serialize(collectionId, specifiedType: const FullType(int));
+    _parameters['collectionId'] = __collectionId;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}{?resourceType*,resourceId*}')
@@ -1276,9 +1276,9 @@ class $CollaborationResourcesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1361,14 +1361,14 @@ class $CollaborationResourcesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $resourceType = _$jsonSerializers.serialize(resourceType, specifiedType: const FullType(String));
-    _parameters['resourceType'] = $resourceType;
+    final __resourceType = _$jsonSerializers.serialize(resourceType, specifiedType: const FullType(String));
+    _parameters['resourceType'] = __resourceType;
 
-    final $resourceId = _$jsonSerializers.serialize(resourceId, specifiedType: const FullType(String));
-    _parameters['resourceId'] = $resourceId;
+    final __resourceId = _$jsonSerializers.serialize(resourceId, specifiedType: const FullType(String));
+    _parameters['resourceId'] = __resourceId;
 
-    final $collectionId = _$jsonSerializers.serialize(collectionId, specifiedType: const FullType(int));
-    _parameters['collectionId'] = $collectionId;
+    final __collectionId = _$jsonSerializers.serialize(collectionId, specifiedType: const FullType(int));
+    _parameters['collectionId'] = __collectionId;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/collaboration/resources/collections/{collectionId}{?resourceType*,resourceId*}')
@@ -1393,9 +1393,9 @@ class $CollaborationResourcesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1473,8 +1473,8 @@ class $CollaborationResourcesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $filter = _$jsonSerializers.serialize(filter, specifiedType: const FullType(String));
-    _parameters['filter'] = $filter;
+    final __filter = _$jsonSerializers.serialize(filter, specifiedType: const FullType(String));
+    _parameters['filter'] = __filter;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/collaboration/resources/collections/search/{filter}').expand(_parameters);
@@ -1498,9 +1498,9 @@ class $CollaborationResourcesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1573,11 +1573,11 @@ class $CollaborationResourcesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $resourceType = _$jsonSerializers.serialize(resourceType, specifiedType: const FullType(String));
-    _parameters['resourceType'] = $resourceType;
+    final __resourceType = _$jsonSerializers.serialize(resourceType, specifiedType: const FullType(String));
+    _parameters['resourceType'] = __resourceType;
 
-    final $resourceId = _$jsonSerializers.serialize(resourceId, specifiedType: const FullType(String));
-    _parameters['resourceId'] = $resourceId;
+    final __resourceId = _$jsonSerializers.serialize(resourceId, specifiedType: const FullType(String));
+    _parameters['resourceId'] = __resourceId;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/collaboration/resources/{resourceType}/{resourceId}').expand(_parameters);
@@ -1601,9 +1601,9 @@ class $CollaborationResourcesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1685,14 +1685,14 @@ class $CollaborationResourcesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $name = _$jsonSerializers.serialize(name, specifiedType: const FullType(String));
-    _parameters['name'] = $name;
+    final __name = _$jsonSerializers.serialize(name, specifiedType: const FullType(String));
+    _parameters['name'] = __name;
 
-    final $baseResourceType = _$jsonSerializers.serialize(baseResourceType, specifiedType: const FullType(String));
-    _parameters['baseResourceType'] = $baseResourceType;
+    final __baseResourceType = _$jsonSerializers.serialize(baseResourceType, specifiedType: const FullType(String));
+    _parameters['baseResourceType'] = __baseResourceType;
 
-    final $baseResourceId = _$jsonSerializers.serialize(baseResourceId, specifiedType: const FullType(String));
-    _parameters['baseResourceId'] = $baseResourceId;
+    final __baseResourceId = _$jsonSerializers.serialize(baseResourceId, specifiedType: const FullType(String));
+    _parameters['baseResourceId'] = __baseResourceId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/collaboration/resources/{baseResourceType}/{baseResourceId}{?name*}')
         .expand(_parameters);
@@ -1716,9 +1716,9 @@ class $CollaborationResourcesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1809,16 +1809,16 @@ class $GuestAvatarClient {
     GuestAvatarGetAvatarDarkTheme? darkTheme,
   }) {
     final _parameters = <String, Object?>{};
-    final $guestName = _$jsonSerializers.serialize(guestName, specifiedType: const FullType(String));
-    _parameters['guestName'] = $guestName;
+    final __guestName = _$jsonSerializers.serialize(guestName, specifiedType: const FullType(String));
+    _parameters['guestName'] = __guestName;
 
-    final $size = _$jsonSerializers.serialize(size, specifiedType: const FullType(String));
-    _parameters['size'] = $size;
+    final __size = _$jsonSerializers.serialize(size, specifiedType: const FullType(String));
+    _parameters['size'] = __size;
 
-    var $darkTheme =
+    var __darkTheme =
         _$jsonSerializers.serialize(darkTheme, specifiedType: const FullType(GuestAvatarGetAvatarDarkTheme));
-    $darkTheme ??= 0;
-    _parameters['darkTheme'] = $darkTheme;
+    __darkTheme ??= 0;
+    _parameters['darkTheme'] = __darkTheme;
 
     final _path = _i6.UriTemplate('/index.php/avatar/guest/{guestName}/{size}{?darkTheme*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1910,11 +1910,11 @@ class $GuestAvatarClient {
     required String size,
   }) {
     final _parameters = <String, Object?>{};
-    final $guestName = _$jsonSerializers.serialize(guestName, specifiedType: const FullType(String));
-    _parameters['guestName'] = $guestName;
+    final __guestName = _$jsonSerializers.serialize(guestName, specifiedType: const FullType(String));
+    _parameters['guestName'] = __guestName;
 
-    final $size = _$jsonSerializers.serialize(size, specifiedType: const FullType(String));
-    _parameters['size'] = $size;
+    final __size = _$jsonSerializers.serialize(size, specifiedType: const FullType(String));
+    _parameters['size'] = __size;
 
     final _path = _i6.UriTemplate('/index.php/avatar/guest/{guestName}/{size}/dark').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2009,8 +2009,8 @@ class $HoverCardClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/hovercard/v1/{userId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2033,9 +2033,9 @@ class $HoverCardClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2108,8 +2108,8 @@ class $LoginClient {
   @_i2.experimental
   _i3.Request $confirmPassword_Request({required String password}) {
     final _parameters = <String, Object?>{};
-    final $password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    _parameters['password'] = $password;
+    final __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
+    _parameters['password'] = __password;
 
     final _path = _i6.UriTemplate('/index.php/login/confirm{?password*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2204,10 +2204,10 @@ class $NavigationClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $absolute =
+    var __absolute =
         _$jsonSerializers.serialize(absolute, specifiedType: const FullType(NavigationGetAppsNavigationAbsolute));
-    $absolute ??= 0;
-    _parameters['absolute'] = $absolute;
+    __absolute ??= 0;
+    _parameters['absolute'] = __absolute;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/core/navigation/apps{?absolute*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2230,9 +2230,9 @@ class $NavigationClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2302,10 +2302,10 @@ class $NavigationClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $absolute =
+    var __absolute =
         _$jsonSerializers.serialize(absolute, specifiedType: const FullType(NavigationGetSettingsNavigationAbsolute));
-    $absolute ??= 0;
-    _parameters['absolute'] = $absolute;
+    __absolute ??= 0;
+    _parameters['absolute'] = __absolute;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/core/navigation/settings{?absolute*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2328,9 +2328,9 @@ class $NavigationClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2498,9 +2498,9 @@ class $OcsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2585,34 +2585,34 @@ class $PreviewClient {
     PreviewGetPreviewMimeFallback? mimeFallback,
   }) {
     final _parameters = <String, Object?>{};
-    var $file = _$jsonSerializers.serialize(file, specifiedType: const FullType(String));
-    $file ??= '';
-    _parameters['file'] = $file;
+    var __file = _$jsonSerializers.serialize(file, specifiedType: const FullType(String));
+    __file ??= '';
+    _parameters['file'] = __file;
 
-    var $x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
-    $x ??= 32;
-    _parameters['x'] = $x;
+    var __x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
+    __x ??= 32;
+    _parameters['x'] = __x;
 
-    var $y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
-    $y ??= 32;
-    _parameters['y'] = $y;
+    var __y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
+    __y ??= 32;
+    _parameters['y'] = __y;
 
-    var $a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PreviewGetPreviewA));
-    $a ??= 0;
-    _parameters['a'] = $a;
+    var __a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PreviewGetPreviewA));
+    __a ??= 0;
+    _parameters['a'] = __a;
 
-    var $forceIcon = _$jsonSerializers.serialize(forceIcon, specifiedType: const FullType(PreviewGetPreviewForceIcon));
-    $forceIcon ??= 1;
-    _parameters['forceIcon'] = $forceIcon;
+    var __forceIcon = _$jsonSerializers.serialize(forceIcon, specifiedType: const FullType(PreviewGetPreviewForceIcon));
+    __forceIcon ??= 1;
+    _parameters['forceIcon'] = __forceIcon;
 
-    var $mode = _$jsonSerializers.serialize(mode, specifiedType: const FullType(String));
-    $mode ??= 'fill';
-    _parameters['mode'] = $mode;
+    var __mode = _$jsonSerializers.serialize(mode, specifiedType: const FullType(String));
+    __mode ??= 'fill';
+    _parameters['mode'] = __mode;
 
-    var $mimeFallback =
+    var __mimeFallback =
         _$jsonSerializers.serialize(mimeFallback, specifiedType: const FullType(PreviewGetPreviewMimeFallback));
-    $mimeFallback ??= 0;
-    _parameters['mimeFallback'] = $mimeFallback;
+    __mimeFallback ??= 0;
+    _parameters['mimeFallback'] = __mimeFallback;
 
     final _path = _i6.UriTemplate('/index.php/core/preview.png{?file*,x*,y*,a*,forceIcon*,mode*,mimeFallback*}')
         .expand(_parameters);
@@ -2733,35 +2733,35 @@ class $PreviewClient {
     PreviewGetPreviewByFileIdMimeFallback? mimeFallback,
   }) {
     final _parameters = <String, Object?>{};
-    var $fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
-    $fileId ??= -1;
-    _parameters['fileId'] = $fileId;
+    var __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
+    __fileId ??= -1;
+    _parameters['fileId'] = __fileId;
 
-    var $x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
-    $x ??= 32;
-    _parameters['x'] = $x;
+    var __x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
+    __x ??= 32;
+    _parameters['x'] = __x;
 
-    var $y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
-    $y ??= 32;
-    _parameters['y'] = $y;
+    var __y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
+    __y ??= 32;
+    _parameters['y'] = __y;
 
-    var $a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PreviewGetPreviewByFileIdA));
-    $a ??= 0;
-    _parameters['a'] = $a;
+    var __a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PreviewGetPreviewByFileIdA));
+    __a ??= 0;
+    _parameters['a'] = __a;
 
-    var $forceIcon =
+    var __forceIcon =
         _$jsonSerializers.serialize(forceIcon, specifiedType: const FullType(PreviewGetPreviewByFileIdForceIcon));
-    $forceIcon ??= 1;
-    _parameters['forceIcon'] = $forceIcon;
+    __forceIcon ??= 1;
+    _parameters['forceIcon'] = __forceIcon;
 
-    var $mode = _$jsonSerializers.serialize(mode, specifiedType: const FullType(String));
-    $mode ??= 'fill';
-    _parameters['mode'] = $mode;
+    var __mode = _$jsonSerializers.serialize(mode, specifiedType: const FullType(String));
+    __mode ??= 'fill';
+    _parameters['mode'] = __mode;
 
-    var $mimeFallback =
+    var __mimeFallback =
         _$jsonSerializers.serialize(mimeFallback, specifiedType: const FullType(PreviewGetPreviewByFileIdMimeFallback));
-    $mimeFallback ??= 0;
-    _parameters['mimeFallback'] = $mimeFallback;
+    __mimeFallback ??= 0;
+    _parameters['mimeFallback'] = __mimeFallback;
 
     final _path = _i6.UriTemplate('/index.php/core/preview{?fileId*,x*,y*,a*,forceIcon*,mode*,mimeFallback*}')
         .expand(_parameters);
@@ -2885,14 +2885,14 @@ class $ProfileApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $paramId = _$jsonSerializers.serialize(paramId, specifiedType: const FullType(String));
-    _parameters['paramId'] = $paramId;
+    final __paramId = _$jsonSerializers.serialize(paramId, specifiedType: const FullType(String));
+    _parameters['paramId'] = __paramId;
 
-    final $visibility = _$jsonSerializers.serialize(visibility, specifiedType: const FullType(String));
-    _parameters['visibility'] = $visibility;
+    final __visibility = _$jsonSerializers.serialize(visibility, specifiedType: const FullType(String));
+    _parameters['visibility'] = __visibility;
 
-    final $targetUserId = _$jsonSerializers.serialize(targetUserId, specifiedType: const FullType(String));
-    _parameters['targetUserId'] = $targetUserId;
+    final __targetUserId = _$jsonSerializers.serialize(targetUserId, specifiedType: const FullType(String));
+    _parameters['targetUserId'] = __targetUserId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/profile/{targetUserId}{?paramId*,visibility*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2915,9 +2915,9 @@ class $ProfileApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2999,8 +2999,8 @@ class $ReferenceClient {
   @_i2.experimental
   _i3.Request $preview_Request({required String referenceId}) {
     final _parameters = <String, Object?>{};
-    final $referenceId = _$jsonSerializers.serialize(referenceId, specifiedType: const FullType(String));
-    _parameters['referenceId'] = $referenceId;
+    final __referenceId = _$jsonSerializers.serialize(referenceId, specifiedType: const FullType(String));
+    _parameters['referenceId'] = __referenceId;
 
     final _path = _i6.UriTemplate('/index.php/core/references/preview/{referenceId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3093,16 +3093,16 @@ class $ReferenceApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $text = _$jsonSerializers.serialize(text, specifiedType: const FullType(String));
-    _parameters['text'] = $text;
+    final __text = _$jsonSerializers.serialize(text, specifiedType: const FullType(String));
+    _parameters['text'] = __text;
 
-    var $resolve = _$jsonSerializers.serialize(resolve, specifiedType: const FullType(ReferenceApiExtractResolve));
-    $resolve ??= 0;
-    _parameters['resolve'] = $resolve;
+    var __resolve = _$jsonSerializers.serialize(resolve, specifiedType: const FullType(ReferenceApiExtractResolve));
+    __resolve ??= 0;
+    _parameters['resolve'] = __resolve;
 
-    var $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    $limit ??= 1;
-    _parameters['limit'] = $limit;
+    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    __limit ??= 1;
+    _parameters['limit'] = __limit;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/references/extract{?text*,resolve*,limit*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3125,9 +3125,9 @@ class $ReferenceApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3201,8 +3201,8 @@ class $ReferenceApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $reference = _$jsonSerializers.serialize(reference, specifiedType: const FullType(String));
-    _parameters['reference'] = $reference;
+    final __reference = _$jsonSerializers.serialize(reference, specifiedType: const FullType(String));
+    _parameters['reference'] = __reference;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/references/resolve{?reference*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3225,9 +3225,9 @@ class $ReferenceApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3297,13 +3297,13 @@ class $ReferenceApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $references =
+    final __references =
         _$jsonSerializers.serialize(references, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    _parameters['references%5B%5D'] = $references;
+    _parameters['references%5B%5D'] = __references;
 
-    var $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    $limit ??= 1;
-    _parameters['limit'] = $limit;
+    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    __limit ??= 1;
+    _parameters['limit'] = __limit;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/references/resolve{?references%5B%5D*,limit*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3326,9 +3326,9 @@ class $ReferenceApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3415,9 +3415,9 @@ class $ReferenceApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3484,11 +3484,11 @@ class $ReferenceApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $providerId = _$jsonSerializers.serialize(providerId, specifiedType: const FullType(String));
-    _parameters['providerId'] = $providerId;
+    final __providerId = _$jsonSerializers.serialize(providerId, specifiedType: const FullType(String));
+    _parameters['providerId'] = __providerId;
 
-    final $timestamp = _$jsonSerializers.serialize(timestamp, specifiedType: const FullType(int));
-    _parameters['timestamp'] = $timestamp;
+    final __timestamp = _$jsonSerializers.serialize(timestamp, specifiedType: const FullType(int));
+    _parameters['timestamp'] = __timestamp;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/references/provider/{providerId}{?timestamp*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3511,9 +3511,9 @@ class $ReferenceApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3591,8 +3591,8 @@ class $TeamsApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $teamId = _$jsonSerializers.serialize(teamId, specifiedType: const FullType(String));
-    _parameters['teamId'] = $teamId;
+    final __teamId = _$jsonSerializers.serialize(teamId, specifiedType: const FullType(String));
+    _parameters['teamId'] = __teamId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/teams/{teamId}/resources').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3615,9 +3615,9 @@ class $TeamsApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3687,11 +3687,11 @@ class $TeamsApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $providerId = _$jsonSerializers.serialize(providerId, specifiedType: const FullType(String));
-    _parameters['providerId'] = $providerId;
+    final __providerId = _$jsonSerializers.serialize(providerId, specifiedType: const FullType(String));
+    _parameters['providerId'] = __providerId;
 
-    final $resourceId = _$jsonSerializers.serialize(resourceId, specifiedType: const FullType(String));
-    _parameters['resourceId'] = $resourceId;
+    final __resourceId = _$jsonSerializers.serialize(resourceId, specifiedType: const FullType(String));
+    _parameters['resourceId'] = __resourceId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/teams/resources/{providerId}/{resourceId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3714,9 +3714,9 @@ class $TeamsApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3808,9 +3808,9 @@ class $TextProcessingApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3884,18 +3884,18 @@ class $TextProcessingApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $input = _$jsonSerializers.serialize(input, specifiedType: const FullType(String));
-    _parameters['input'] = $input;
+    final __input = _$jsonSerializers.serialize(input, specifiedType: const FullType(String));
+    _parameters['input'] = __input;
 
-    final $type = _$jsonSerializers.serialize(type, specifiedType: const FullType(String));
-    _parameters['type'] = $type;
+    final __type = _$jsonSerializers.serialize(type, specifiedType: const FullType(String));
+    _parameters['type'] = __type;
 
-    final $appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
-    _parameters['appId'] = $appId;
+    final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
+    _parameters['appId'] = __appId;
 
-    var $identifier = _$jsonSerializers.serialize(identifier, specifiedType: const FullType(String));
-    $identifier ??= '';
-    _parameters['identifier'] = $identifier;
+    var __identifier = _$jsonSerializers.serialize(identifier, specifiedType: const FullType(String));
+    __identifier ??= '';
+    _parameters['identifier'] = __identifier;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/textprocessing/schedule{?input*,type*,appId*,identifier*}').expand(_parameters);
@@ -3917,9 +3917,9 @@ class $TextProcessingApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4001,8 +4001,8 @@ class $TextProcessingApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/textprocessing/task/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -4023,9 +4023,9 @@ class $TextProcessingApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4097,8 +4097,8 @@ class $TextProcessingApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/textprocessing/task/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -4121,9 +4121,9 @@ class $TextProcessingApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4196,11 +4196,11 @@ class $TextProcessingApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
-    _parameters['appId'] = $appId;
+    final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
+    _parameters['appId'] = __appId;
 
-    final $identifier = _$jsonSerializers.serialize(identifier, specifiedType: const FullType(String));
-    _parameters['identifier'] = $identifier;
+    final __identifier = _$jsonSerializers.serialize(identifier, specifiedType: const FullType(String));
+    _parameters['identifier'] = __identifier;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/textprocessing/tasks/app/{appId}{?identifier*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -4223,9 +4223,9 @@ class $TextProcessingApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4319,9 +4319,9 @@ class $TextToImageApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4394,19 +4394,19 @@ class $TextToImageApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $input = _$jsonSerializers.serialize(input, specifiedType: const FullType(String));
-    _parameters['input'] = $input;
+    final __input = _$jsonSerializers.serialize(input, specifiedType: const FullType(String));
+    _parameters['input'] = __input;
 
-    final $appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
-    _parameters['appId'] = $appId;
+    final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
+    _parameters['appId'] = __appId;
 
-    var $identifier = _$jsonSerializers.serialize(identifier, specifiedType: const FullType(String));
-    $identifier ??= '';
-    _parameters['identifier'] = $identifier;
+    var __identifier = _$jsonSerializers.serialize(identifier, specifiedType: const FullType(String));
+    __identifier ??= '';
+    _parameters['identifier'] = __identifier;
 
-    var $numberOfImages = _$jsonSerializers.serialize(numberOfImages, specifiedType: const FullType(int));
-    $numberOfImages ??= 8;
-    _parameters['numberOfImages'] = $numberOfImages;
+    var __numberOfImages = _$jsonSerializers.serialize(numberOfImages, specifiedType: const FullType(int));
+    __numberOfImages ??= 8;
+    _parameters['numberOfImages'] = __numberOfImages;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/text2image/schedule{?input*,appId*,identifier*,numberOfImages*}')
         .expand(_parameters);
@@ -4428,9 +4428,9 @@ class $TextToImageApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4511,8 +4511,8 @@ class $TextToImageApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/text2image/task/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -4533,9 +4533,9 @@ class $TextToImageApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4607,8 +4607,8 @@ class $TextToImageApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/text2image/task/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -4631,9 +4631,9 @@ class $TextToImageApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4706,11 +4706,11 @@ class $TextToImageApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
-    final $index = _$jsonSerializers.serialize(index, specifiedType: const FullType(int));
-    _parameters['index'] = $index;
+    final __index = _$jsonSerializers.serialize(index, specifiedType: const FullType(int));
+    _parameters['index'] = __index;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/text2image/task/{id}/image/{index}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -4731,9 +4731,9 @@ class $TextToImageApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4808,11 +4808,11 @@ class $TextToImageApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
-    _parameters['appId'] = $appId;
+    final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
+    _parameters['appId'] = __appId;
 
-    final $identifier = _$jsonSerializers.serialize(identifier, specifiedType: const FullType(String));
-    _parameters['identifier'] = $identifier;
+    final __identifier = _$jsonSerializers.serialize(identifier, specifiedType: const FullType(String));
+    _parameters['identifier'] = __identifier;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/text2image/tasks/app/{appId}{?identifier*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -4835,9 +4835,9 @@ class $TextToImageApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4930,9 +4930,9 @@ class $TranslationApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5004,14 +5004,14 @@ class $TranslationApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $text = _$jsonSerializers.serialize(text, specifiedType: const FullType(String));
-    _parameters['text'] = $text;
+    final __text = _$jsonSerializers.serialize(text, specifiedType: const FullType(String));
+    _parameters['text'] = __text;
 
-    final $toLanguage = _$jsonSerializers.serialize(toLanguage, specifiedType: const FullType(String));
-    _parameters['toLanguage'] = $toLanguage;
+    final __toLanguage = _$jsonSerializers.serialize(toLanguage, specifiedType: const FullType(String));
+    _parameters['toLanguage'] = __toLanguage;
 
-    final $fromLanguage = _$jsonSerializers.serialize(fromLanguage, specifiedType: const FullType(String));
-    _parameters['fromLanguage'] = $fromLanguage;
+    final __fromLanguage = _$jsonSerializers.serialize(fromLanguage, specifiedType: const FullType(String));
+    _parameters['fromLanguage'] = __fromLanguage;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/translation/translate{?text*,toLanguage*,fromLanguage*}').expand(_parameters);
@@ -5033,9 +5033,9 @@ class $TranslationApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5119,9 +5119,9 @@ class $UnifiedSearchClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $from = _$jsonSerializers.serialize(from, specifiedType: const FullType(String));
-    $from ??= '';
-    _parameters['from'] = $from;
+    var __from = _$jsonSerializers.serialize(from, specifiedType: const FullType(String));
+    __from ??= '';
+    _parameters['from'] = __from;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/search/providers{?from*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -5144,9 +5144,9 @@ class $UnifiedSearchClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5227,25 +5227,25 @@ class $UnifiedSearchClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $providerId = _$jsonSerializers.serialize(providerId, specifiedType: const FullType(String));
-    _parameters['providerId'] = $providerId;
+    final __providerId = _$jsonSerializers.serialize(providerId, specifiedType: const FullType(String));
+    _parameters['providerId'] = __providerId;
 
-    var $term = _$jsonSerializers.serialize(term, specifiedType: const FullType(String));
-    $term ??= '';
-    _parameters['term'] = $term;
+    var __term = _$jsonSerializers.serialize(term, specifiedType: const FullType(String));
+    __term ??= '';
+    _parameters['term'] = __term;
 
-    final $sortOrder = _$jsonSerializers.serialize(sortOrder, specifiedType: const FullType(int));
-    _parameters['sortOrder'] = $sortOrder;
+    final __sortOrder = _$jsonSerializers.serialize(sortOrder, specifiedType: const FullType(int));
+    _parameters['sortOrder'] = __sortOrder;
 
-    final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = $limit;
+    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    _parameters['limit'] = __limit;
 
-    final $cursor = _$jsonSerializers.serialize(cursor, specifiedType: const FullType(UnifiedSearchSearchCursor));
-    _parameters['cursor'] = $cursor;
+    final __cursor = _$jsonSerializers.serialize(cursor, specifiedType: const FullType(UnifiedSearchSearchCursor));
+    _parameters['cursor'] = __cursor;
 
-    var $from = _$jsonSerializers.serialize(from, specifiedType: const FullType(String));
-    $from ??= '';
-    _parameters['from'] = $from;
+    var __from = _$jsonSerializers.serialize(from, specifiedType: const FullType(String));
+    __from ??= '';
+    _parameters['from'] = __from;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/search/providers/{providerId}/search{?term*,sortOrder*,limit*,cursor*,from*}')
@@ -5270,9 +5270,9 @@ class $UnifiedSearchClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5381,9 +5381,9 @@ class $WhatsNewClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5447,8 +5447,8 @@ class $WhatsNewClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
-    _parameters['version'] = $version;
+    final __version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
+    _parameters['version'] = __version;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/core/whatsnew{?version*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -5471,9 +5471,9 @@ class $WhatsNewClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5545,8 +5545,8 @@ class $WipeClient {
   @_i2.experimental
   _i3.Request $checkWipe_Request({required String token}) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _parameters['token'] = $token;
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    _parameters['token'] = __token;
 
     final _path = _i6.UriTemplate('/index.php/core/wipe/check{?token*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -5625,8 +5625,8 @@ class $WipeClient {
   @_i2.experimental
   _i3.Request $wipeDone_Request({required String token}) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _parameters['token'] = $token;
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    _parameters['token'] = __token;
 
     final _path = _i6.UriTemplate('/index.php/core/wipe/success{?token*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');

--- a/packages/nextcloud/lib/src/api/core.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.g.dart
@@ -6,70 +6,6 @@ part of 'core.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-const GuestAvatarGetAvatarDarkTheme _$guestAvatarGetAvatarDarkTheme$0 = GuestAvatarGetAvatarDarkTheme._('\$0');
-const GuestAvatarGetAvatarDarkTheme _$guestAvatarGetAvatarDarkTheme$1 = GuestAvatarGetAvatarDarkTheme._('\$1');
-
-GuestAvatarGetAvatarDarkTheme _$valueOfGuestAvatarGetAvatarDarkTheme(String name) {
-  switch (name) {
-    case '\$0':
-      return _$guestAvatarGetAvatarDarkTheme$0;
-    case '\$1':
-      return _$guestAvatarGetAvatarDarkTheme$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<GuestAvatarGetAvatarDarkTheme> _$guestAvatarGetAvatarDarkThemeValues =
-    BuiltSet<GuestAvatarGetAvatarDarkTheme>(const <GuestAvatarGetAvatarDarkTheme>[
-  _$guestAvatarGetAvatarDarkTheme$0,
-  _$guestAvatarGetAvatarDarkTheme$1,
-]);
-
-const NavigationGetAppsNavigationAbsolute _$navigationGetAppsNavigationAbsolute$0 =
-    NavigationGetAppsNavigationAbsolute._('\$0');
-const NavigationGetAppsNavigationAbsolute _$navigationGetAppsNavigationAbsolute$1 =
-    NavigationGetAppsNavigationAbsolute._('\$1');
-
-NavigationGetAppsNavigationAbsolute _$valueOfNavigationGetAppsNavigationAbsolute(String name) {
-  switch (name) {
-    case '\$0':
-      return _$navigationGetAppsNavigationAbsolute$0;
-    case '\$1':
-      return _$navigationGetAppsNavigationAbsolute$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<NavigationGetAppsNavigationAbsolute> _$navigationGetAppsNavigationAbsoluteValues =
-    BuiltSet<NavigationGetAppsNavigationAbsolute>(const <NavigationGetAppsNavigationAbsolute>[
-  _$navigationGetAppsNavigationAbsolute$0,
-  _$navigationGetAppsNavigationAbsolute$1,
-]);
-
-const NavigationGetSettingsNavigationAbsolute _$navigationGetSettingsNavigationAbsolute$0 =
-    NavigationGetSettingsNavigationAbsolute._('\$0');
-const NavigationGetSettingsNavigationAbsolute _$navigationGetSettingsNavigationAbsolute$1 =
-    NavigationGetSettingsNavigationAbsolute._('\$1');
-
-NavigationGetSettingsNavigationAbsolute _$valueOfNavigationGetSettingsNavigationAbsolute(String name) {
-  switch (name) {
-    case '\$0':
-      return _$navigationGetSettingsNavigationAbsolute$0;
-    case '\$1':
-      return _$navigationGetSettingsNavigationAbsolute$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<NavigationGetSettingsNavigationAbsolute> _$navigationGetSettingsNavigationAbsoluteValues =
-    BuiltSet<NavigationGetSettingsNavigationAbsolute>(const <NavigationGetSettingsNavigationAbsolute>[
-  _$navigationGetSettingsNavigationAbsolute$0,
-  _$navigationGetSettingsNavigationAbsolute$1,
-]);
-
 const OcmOcmDiscoveryHeaders_XNextcloudOcmProviders _$ocmOcmDiscoveryHeadersXNextcloudOcmProviders$true =
     OcmOcmDiscoveryHeaders_XNextcloudOcmProviders._('\$true');
 
@@ -102,149 +38,6 @@ SystemtagsCapabilities_Systemtags_Enabled _$valueOfSystemtagsCapabilities_System
 final BuiltSet<SystemtagsCapabilities_Systemtags_Enabled> _$systemtagsCapabilitiesSystemtagsEnabledValues =
     BuiltSet<SystemtagsCapabilities_Systemtags_Enabled>(const <SystemtagsCapabilities_Systemtags_Enabled>[
   _$systemtagsCapabilitiesSystemtagsEnabled$true,
-]);
-
-const PreviewGetPreviewA _$previewGetPreviewA$0 = PreviewGetPreviewA._('\$0');
-const PreviewGetPreviewA _$previewGetPreviewA$1 = PreviewGetPreviewA._('\$1');
-
-PreviewGetPreviewA _$valueOfPreviewGetPreviewA(String name) {
-  switch (name) {
-    case '\$0':
-      return _$previewGetPreviewA$0;
-    case '\$1':
-      return _$previewGetPreviewA$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<PreviewGetPreviewA> _$previewGetPreviewAValues = BuiltSet<PreviewGetPreviewA>(const <PreviewGetPreviewA>[
-  _$previewGetPreviewA$0,
-  _$previewGetPreviewA$1,
-]);
-
-const PreviewGetPreviewForceIcon _$previewGetPreviewForceIcon$0 = PreviewGetPreviewForceIcon._('\$0');
-const PreviewGetPreviewForceIcon _$previewGetPreviewForceIcon$1 = PreviewGetPreviewForceIcon._('\$1');
-
-PreviewGetPreviewForceIcon _$valueOfPreviewGetPreviewForceIcon(String name) {
-  switch (name) {
-    case '\$0':
-      return _$previewGetPreviewForceIcon$0;
-    case '\$1':
-      return _$previewGetPreviewForceIcon$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<PreviewGetPreviewForceIcon> _$previewGetPreviewForceIconValues =
-    BuiltSet<PreviewGetPreviewForceIcon>(const <PreviewGetPreviewForceIcon>[
-  _$previewGetPreviewForceIcon$0,
-  _$previewGetPreviewForceIcon$1,
-]);
-
-const PreviewGetPreviewMimeFallback _$previewGetPreviewMimeFallback$0 = PreviewGetPreviewMimeFallback._('\$0');
-const PreviewGetPreviewMimeFallback _$previewGetPreviewMimeFallback$1 = PreviewGetPreviewMimeFallback._('\$1');
-
-PreviewGetPreviewMimeFallback _$valueOfPreviewGetPreviewMimeFallback(String name) {
-  switch (name) {
-    case '\$0':
-      return _$previewGetPreviewMimeFallback$0;
-    case '\$1':
-      return _$previewGetPreviewMimeFallback$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<PreviewGetPreviewMimeFallback> _$previewGetPreviewMimeFallbackValues =
-    BuiltSet<PreviewGetPreviewMimeFallback>(const <PreviewGetPreviewMimeFallback>[
-  _$previewGetPreviewMimeFallback$0,
-  _$previewGetPreviewMimeFallback$1,
-]);
-
-const PreviewGetPreviewByFileIdA _$previewGetPreviewByFileIdA$0 = PreviewGetPreviewByFileIdA._('\$0');
-const PreviewGetPreviewByFileIdA _$previewGetPreviewByFileIdA$1 = PreviewGetPreviewByFileIdA._('\$1');
-
-PreviewGetPreviewByFileIdA _$valueOfPreviewGetPreviewByFileIdA(String name) {
-  switch (name) {
-    case '\$0':
-      return _$previewGetPreviewByFileIdA$0;
-    case '\$1':
-      return _$previewGetPreviewByFileIdA$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<PreviewGetPreviewByFileIdA> _$previewGetPreviewByFileIdAValues =
-    BuiltSet<PreviewGetPreviewByFileIdA>(const <PreviewGetPreviewByFileIdA>[
-  _$previewGetPreviewByFileIdA$0,
-  _$previewGetPreviewByFileIdA$1,
-]);
-
-const PreviewGetPreviewByFileIdForceIcon _$previewGetPreviewByFileIdForceIcon$0 =
-    PreviewGetPreviewByFileIdForceIcon._('\$0');
-const PreviewGetPreviewByFileIdForceIcon _$previewGetPreviewByFileIdForceIcon$1 =
-    PreviewGetPreviewByFileIdForceIcon._('\$1');
-
-PreviewGetPreviewByFileIdForceIcon _$valueOfPreviewGetPreviewByFileIdForceIcon(String name) {
-  switch (name) {
-    case '\$0':
-      return _$previewGetPreviewByFileIdForceIcon$0;
-    case '\$1':
-      return _$previewGetPreviewByFileIdForceIcon$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<PreviewGetPreviewByFileIdForceIcon> _$previewGetPreviewByFileIdForceIconValues =
-    BuiltSet<PreviewGetPreviewByFileIdForceIcon>(const <PreviewGetPreviewByFileIdForceIcon>[
-  _$previewGetPreviewByFileIdForceIcon$0,
-  _$previewGetPreviewByFileIdForceIcon$1,
-]);
-
-const PreviewGetPreviewByFileIdMimeFallback _$previewGetPreviewByFileIdMimeFallback$0 =
-    PreviewGetPreviewByFileIdMimeFallback._('\$0');
-const PreviewGetPreviewByFileIdMimeFallback _$previewGetPreviewByFileIdMimeFallback$1 =
-    PreviewGetPreviewByFileIdMimeFallback._('\$1');
-
-PreviewGetPreviewByFileIdMimeFallback _$valueOfPreviewGetPreviewByFileIdMimeFallback(String name) {
-  switch (name) {
-    case '\$0':
-      return _$previewGetPreviewByFileIdMimeFallback$0;
-    case '\$1':
-      return _$previewGetPreviewByFileIdMimeFallback$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<PreviewGetPreviewByFileIdMimeFallback> _$previewGetPreviewByFileIdMimeFallbackValues =
-    BuiltSet<PreviewGetPreviewByFileIdMimeFallback>(const <PreviewGetPreviewByFileIdMimeFallback>[
-  _$previewGetPreviewByFileIdMimeFallback$0,
-  _$previewGetPreviewByFileIdMimeFallback$1,
-]);
-
-const ReferenceApiExtractResolve _$referenceApiExtractResolve$0 = ReferenceApiExtractResolve._('\$0');
-const ReferenceApiExtractResolve _$referenceApiExtractResolve$1 = ReferenceApiExtractResolve._('\$1');
-
-ReferenceApiExtractResolve _$valueOfReferenceApiExtractResolve(String name) {
-  switch (name) {
-    case '\$0':
-      return _$referenceApiExtractResolve$0;
-    case '\$1':
-      return _$referenceApiExtractResolve$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ReferenceApiExtractResolve> _$referenceApiExtractResolveValues =
-    BuiltSet<ReferenceApiExtractResolve>(const <ReferenceApiExtractResolve>[
-  _$referenceApiExtractResolve$0,
-  _$referenceApiExtractResolve$1,
 ]);
 
 const TextProcessingTask_Status _$textProcessingTaskStatus$0 = TextProcessingTask_Status._('\$0');
@@ -337,6 +130,9 @@ Serializer<AppPasswordRotateAppPasswordResponseApplicationJson_Ocs>
 Serializer<AppPasswordRotateAppPasswordResponseApplicationJson>
     _$appPasswordRotateAppPasswordResponseApplicationJsonSerializer =
     _$AppPasswordRotateAppPasswordResponseApplicationJsonSerializer();
+Serializer<AppPasswordConfirmUserPasswordRequestApplicationJson>
+    _$appPasswordConfirmUserPasswordRequestApplicationJsonSerializer =
+    _$AppPasswordConfirmUserPasswordRequestApplicationJsonSerializer();
 Serializer<AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_Data>
     _$appPasswordConfirmUserPasswordResponseApplicationJsonOcsDataSerializer =
     _$AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataSerializer();
@@ -346,6 +142,8 @@ Serializer<AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs>
 Serializer<AppPasswordConfirmUserPasswordResponseApplicationJson>
     _$appPasswordConfirmUserPasswordResponseApplicationJsonSerializer =
     _$AppPasswordConfirmUserPasswordResponseApplicationJsonSerializer();
+Serializer<AutoCompleteGetRequestApplicationJson> _$autoCompleteGetRequestApplicationJsonSerializer =
+    _$AutoCompleteGetRequestApplicationJsonSerializer();
 Serializer<AutocompleteResult_Status0> _$autocompleteResultStatus0Serializer = _$AutocompleteResult_Status0Serializer();
 Serializer<AutocompleteResult> _$autocompleteResultSerializer = _$AutocompleteResultSerializer();
 Serializer<AutoCompleteGetResponseApplicationJson_Ocs> _$autoCompleteGetResponseApplicationJsonOcsSerializer =
@@ -356,6 +154,8 @@ Serializer<AvatarAvatarGetAvatarDarkHeaders> _$avatarAvatarGetAvatarDarkHeadersS
     _$AvatarAvatarGetAvatarDarkHeadersSerializer();
 Serializer<AvatarAvatarGetAvatarHeaders> _$avatarAvatarGetAvatarHeadersSerializer =
     _$AvatarAvatarGetAvatarHeadersSerializer();
+Serializer<ClientFlowLoginV2PollRequestApplicationJson> _$clientFlowLoginV2PollRequestApplicationJsonSerializer =
+    _$ClientFlowLoginV2PollRequestApplicationJsonSerializer();
 Serializer<LoginFlowV2Credentials> _$loginFlowV2CredentialsSerializer = _$LoginFlowV2CredentialsSerializer();
 Serializer<LoginFlowV2_Poll> _$loginFlowV2PollSerializer = _$LoginFlowV2_PollSerializer();
 Serializer<LoginFlowV2> _$loginFlowV2Serializer = _$LoginFlowV2Serializer();
@@ -368,18 +168,27 @@ Serializer<CollaborationResourcesListCollectionResponseApplicationJson_Ocs>
 Serializer<CollaborationResourcesListCollectionResponseApplicationJson>
     _$collaborationResourcesListCollectionResponseApplicationJsonSerializer =
     _$CollaborationResourcesListCollectionResponseApplicationJsonSerializer();
+Serializer<CollaborationResourcesRenameCollectionRequestApplicationJson>
+    _$collaborationResourcesRenameCollectionRequestApplicationJsonSerializer =
+    _$CollaborationResourcesRenameCollectionRequestApplicationJsonSerializer();
 Serializer<CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs>
     _$collaborationResourcesRenameCollectionResponseApplicationJsonOcsSerializer =
     _$CollaborationResourcesRenameCollectionResponseApplicationJson_OcsSerializer();
 Serializer<CollaborationResourcesRenameCollectionResponseApplicationJson>
     _$collaborationResourcesRenameCollectionResponseApplicationJsonSerializer =
     _$CollaborationResourcesRenameCollectionResponseApplicationJsonSerializer();
+Serializer<CollaborationResourcesAddResourceRequestApplicationJson>
+    _$collaborationResourcesAddResourceRequestApplicationJsonSerializer =
+    _$CollaborationResourcesAddResourceRequestApplicationJsonSerializer();
 Serializer<CollaborationResourcesAddResourceResponseApplicationJson_Ocs>
     _$collaborationResourcesAddResourceResponseApplicationJsonOcsSerializer =
     _$CollaborationResourcesAddResourceResponseApplicationJson_OcsSerializer();
 Serializer<CollaborationResourcesAddResourceResponseApplicationJson>
     _$collaborationResourcesAddResourceResponseApplicationJsonSerializer =
     _$CollaborationResourcesAddResourceResponseApplicationJsonSerializer();
+Serializer<CollaborationResourcesRemoveResourceRequestApplicationJson>
+    _$collaborationResourcesRemoveResourceRequestApplicationJsonSerializer =
+    _$CollaborationResourcesRemoveResourceRequestApplicationJsonSerializer();
 Serializer<CollaborationResourcesRemoveResourceResponseApplicationJson_Ocs>
     _$collaborationResourcesRemoveResourceResponseApplicationJsonOcsSerializer =
     _$CollaborationResourcesRemoveResourceResponseApplicationJson_OcsSerializer();
@@ -398,12 +207,17 @@ Serializer<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson
 Serializer<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson>
     _$collaborationResourcesGetCollectionsByResourceResponseApplicationJsonSerializer =
     _$CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonSerializer();
+Serializer<CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson>
+    _$collaborationResourcesCreateCollectionOnResourceRequestApplicationJsonSerializer =
+    _$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonSerializer();
 Serializer<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs>
     _$collaborationResourcesCreateCollectionOnResourceResponseApplicationJsonOcsSerializer =
     _$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsSerializer();
 Serializer<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson>
     _$collaborationResourcesCreateCollectionOnResourceResponseApplicationJsonSerializer =
     _$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonSerializer();
+Serializer<GuestAvatarGetAvatarRequestApplicationJson> _$guestAvatarGetAvatarRequestApplicationJsonSerializer =
+    _$GuestAvatarGetAvatarRequestApplicationJsonSerializer();
 Serializer<ContactsAction> _$contactsActionSerializer = _$ContactsActionSerializer();
 Serializer<HoverCardGetUserResponseApplicationJson_Ocs_Data>
     _$hoverCardGetUserResponseApplicationJsonOcsDataSerializer =
@@ -412,8 +226,13 @@ Serializer<HoverCardGetUserResponseApplicationJson_Ocs> _$hoverCardGetUserRespon
     _$HoverCardGetUserResponseApplicationJson_OcsSerializer();
 Serializer<HoverCardGetUserResponseApplicationJson> _$hoverCardGetUserResponseApplicationJsonSerializer =
     _$HoverCardGetUserResponseApplicationJsonSerializer();
+Serializer<LoginConfirmPasswordRequestApplicationJson> _$loginConfirmPasswordRequestApplicationJsonSerializer =
+    _$LoginConfirmPasswordRequestApplicationJsonSerializer();
 Serializer<LoginConfirmPasswordResponseApplicationJson> _$loginConfirmPasswordResponseApplicationJsonSerializer =
     _$LoginConfirmPasswordResponseApplicationJsonSerializer();
+Serializer<NavigationGetAppsNavigationRequestApplicationJson>
+    _$navigationGetAppsNavigationRequestApplicationJsonSerializer =
+    _$NavigationGetAppsNavigationRequestApplicationJsonSerializer();
 Serializer<NavigationEntry> _$navigationEntrySerializer = _$NavigationEntrySerializer();
 Serializer<NavigationGetAppsNavigationResponseApplicationJson_Ocs>
     _$navigationGetAppsNavigationResponseApplicationJsonOcsSerializer =
@@ -421,6 +240,9 @@ Serializer<NavigationGetAppsNavigationResponseApplicationJson_Ocs>
 Serializer<NavigationGetAppsNavigationResponseApplicationJson>
     _$navigationGetAppsNavigationResponseApplicationJsonSerializer =
     _$NavigationGetAppsNavigationResponseApplicationJsonSerializer();
+Serializer<NavigationGetSettingsNavigationRequestApplicationJson>
+    _$navigationGetSettingsNavigationRequestApplicationJsonSerializer =
+    _$NavigationGetSettingsNavigationRequestApplicationJsonSerializer();
 Serializer<NavigationGetSettingsNavigationResponseApplicationJson_Ocs>
     _$navigationGetSettingsNavigationResponseApplicationJsonOcsSerializer =
     _$NavigationGetSettingsNavigationResponseApplicationJson_OcsSerializer();
@@ -561,11 +383,20 @@ Serializer<OcsGetCapabilitiesResponseApplicationJson_Ocs> _$ocsGetCapabilitiesRe
     _$OcsGetCapabilitiesResponseApplicationJson_OcsSerializer();
 Serializer<OcsGetCapabilitiesResponseApplicationJson> _$ocsGetCapabilitiesResponseApplicationJsonSerializer =
     _$OcsGetCapabilitiesResponseApplicationJsonSerializer();
+Serializer<PreviewGetPreviewRequestApplicationJson> _$previewGetPreviewRequestApplicationJsonSerializer =
+    _$PreviewGetPreviewRequestApplicationJsonSerializer();
+Serializer<PreviewGetPreviewByFileIdRequestApplicationJson>
+    _$previewGetPreviewByFileIdRequestApplicationJsonSerializer =
+    _$PreviewGetPreviewByFileIdRequestApplicationJsonSerializer();
+Serializer<ProfileApiSetVisibilityRequestApplicationJson> _$profileApiSetVisibilityRequestApplicationJsonSerializer =
+    _$ProfileApiSetVisibilityRequestApplicationJsonSerializer();
 Serializer<ProfileApiSetVisibilityResponseApplicationJson_Ocs>
     _$profileApiSetVisibilityResponseApplicationJsonOcsSerializer =
     _$ProfileApiSetVisibilityResponseApplicationJson_OcsSerializer();
 Serializer<ProfileApiSetVisibilityResponseApplicationJson> _$profileApiSetVisibilityResponseApplicationJsonSerializer =
     _$ProfileApiSetVisibilityResponseApplicationJsonSerializer();
+Serializer<ReferenceApiExtractRequestApplicationJson> _$referenceApiExtractRequestApplicationJsonSerializer =
+    _$ReferenceApiExtractRequestApplicationJsonSerializer();
 Serializer<Reference> _$referenceSerializer = _$ReferenceSerializer();
 Serializer<ReferenceApiExtractResponseApplicationJson_Ocs_Data>
     _$referenceApiExtractResponseApplicationJsonOcsDataSerializer =
@@ -574,6 +405,8 @@ Serializer<ReferenceApiExtractResponseApplicationJson_Ocs> _$referenceApiExtract
     _$ReferenceApiExtractResponseApplicationJson_OcsSerializer();
 Serializer<ReferenceApiExtractResponseApplicationJson> _$referenceApiExtractResponseApplicationJsonSerializer =
     _$ReferenceApiExtractResponseApplicationJsonSerializer();
+Serializer<ReferenceApiResolveOneRequestApplicationJson> _$referenceApiResolveOneRequestApplicationJsonSerializer =
+    _$ReferenceApiResolveOneRequestApplicationJsonSerializer();
 Serializer<ReferenceApiResolveOneResponseApplicationJson_Ocs_Data>
     _$referenceApiResolveOneResponseApplicationJsonOcsDataSerializer =
     _$ReferenceApiResolveOneResponseApplicationJson_Ocs_DataSerializer();
@@ -582,6 +415,8 @@ Serializer<ReferenceApiResolveOneResponseApplicationJson_Ocs>
     _$ReferenceApiResolveOneResponseApplicationJson_OcsSerializer();
 Serializer<ReferenceApiResolveOneResponseApplicationJson> _$referenceApiResolveOneResponseApplicationJsonSerializer =
     _$ReferenceApiResolveOneResponseApplicationJsonSerializer();
+Serializer<ReferenceApiResolveRequestApplicationJson> _$referenceApiResolveRequestApplicationJsonSerializer =
+    _$ReferenceApiResolveRequestApplicationJsonSerializer();
 Serializer<ReferenceApiResolveResponseApplicationJson_Ocs_Data>
     _$referenceApiResolveResponseApplicationJsonOcsDataSerializer =
     _$ReferenceApiResolveResponseApplicationJson_Ocs_DataSerializer();
@@ -596,6 +431,9 @@ Serializer<ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs>
 Serializer<ReferenceApiGetProvidersInfoResponseApplicationJson>
     _$referenceApiGetProvidersInfoResponseApplicationJsonSerializer =
     _$ReferenceApiGetProvidersInfoResponseApplicationJsonSerializer();
+Serializer<ReferenceApiTouchProviderRequestApplicationJson>
+    _$referenceApiTouchProviderRequestApplicationJsonSerializer =
+    _$ReferenceApiTouchProviderRequestApplicationJsonSerializer();
 Serializer<ReferenceApiTouchProviderResponseApplicationJson_Ocs_Data>
     _$referenceApiTouchProviderResponseApplicationJsonOcsDataSerializer =
     _$ReferenceApiTouchProviderResponseApplicationJson_Ocs_DataSerializer();
@@ -633,6 +471,9 @@ Serializer<TextProcessingApiTaskTypesResponseApplicationJson_Ocs>
 Serializer<TextProcessingApiTaskTypesResponseApplicationJson>
     _$textProcessingApiTaskTypesResponseApplicationJsonSerializer =
     _$TextProcessingApiTaskTypesResponseApplicationJsonSerializer();
+Serializer<TextProcessingApiScheduleRequestApplicationJson>
+    _$textProcessingApiScheduleRequestApplicationJsonSerializer =
+    _$TextProcessingApiScheduleRequestApplicationJsonSerializer();
 Serializer<TextProcessingTask> _$textProcessingTaskSerializer = _$TextProcessingTaskSerializer();
 Serializer<TextProcessingApiScheduleResponseApplicationJson_Ocs_Data>
     _$textProcessingApiScheduleResponseApplicationJsonOcsDataSerializer =
@@ -661,6 +502,9 @@ Serializer<TextProcessingApiDeleteTaskResponseApplicationJson_Ocs>
 Serializer<TextProcessingApiDeleteTaskResponseApplicationJson>
     _$textProcessingApiDeleteTaskResponseApplicationJsonSerializer =
     _$TextProcessingApiDeleteTaskResponseApplicationJsonSerializer();
+Serializer<TextProcessingApiListTasksByAppRequestApplicationJson>
+    _$textProcessingApiListTasksByAppRequestApplicationJsonSerializer =
+    _$TextProcessingApiListTasksByAppRequestApplicationJsonSerializer();
 Serializer<TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data>
     _$textProcessingApiListTasksByAppResponseApplicationJsonOcsDataSerializer =
     _$TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataSerializer();
@@ -679,6 +523,8 @@ Serializer<TextToImageApiIsAvailableResponseApplicationJson_Ocs>
 Serializer<TextToImageApiIsAvailableResponseApplicationJson>
     _$textToImageApiIsAvailableResponseApplicationJsonSerializer =
     _$TextToImageApiIsAvailableResponseApplicationJsonSerializer();
+Serializer<TextToImageApiScheduleRequestApplicationJson> _$textToImageApiScheduleRequestApplicationJsonSerializer =
+    _$TextToImageApiScheduleRequestApplicationJsonSerializer();
 Serializer<TextToImageTask> _$textToImageTaskSerializer = _$TextToImageTaskSerializer();
 Serializer<TextToImageApiScheduleResponseApplicationJson_Ocs_Data>
     _$textToImageApiScheduleResponseApplicationJsonOcsDataSerializer =
@@ -705,6 +551,9 @@ Serializer<TextToImageApiDeleteTaskResponseApplicationJson_Ocs>
 Serializer<TextToImageApiDeleteTaskResponseApplicationJson>
     _$textToImageApiDeleteTaskResponseApplicationJsonSerializer =
     _$TextToImageApiDeleteTaskResponseApplicationJsonSerializer();
+Serializer<TextToImageApiListTasksByAppRequestApplicationJson>
+    _$textToImageApiListTasksByAppRequestApplicationJsonSerializer =
+    _$TextToImageApiListTasksByAppRequestApplicationJsonSerializer();
 Serializer<TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data>
     _$textToImageApiListTasksByAppResponseApplicationJsonOcsDataSerializer =
     _$TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataSerializer();
@@ -725,6 +574,8 @@ Serializer<TranslationApiLanguagesResponseApplicationJson_Ocs>
     _$TranslationApiLanguagesResponseApplicationJson_OcsSerializer();
 Serializer<TranslationApiLanguagesResponseApplicationJson> _$translationApiLanguagesResponseApplicationJsonSerializer =
     _$TranslationApiLanguagesResponseApplicationJsonSerializer();
+Serializer<TranslationApiTranslateRequestApplicationJson> _$translationApiTranslateRequestApplicationJsonSerializer =
+    _$TranslationApiTranslateRequestApplicationJsonSerializer();
 Serializer<TranslationApiTranslateResponseApplicationJson_Ocs_Data>
     _$translationApiTranslateResponseApplicationJsonOcsDataSerializer =
     _$TranslationApiTranslateResponseApplicationJson_Ocs_DataSerializer();
@@ -733,6 +584,9 @@ Serializer<TranslationApiTranslateResponseApplicationJson_Ocs>
     _$TranslationApiTranslateResponseApplicationJson_OcsSerializer();
 Serializer<TranslationApiTranslateResponseApplicationJson> _$translationApiTranslateResponseApplicationJsonSerializer =
     _$TranslationApiTranslateResponseApplicationJsonSerializer();
+Serializer<UnifiedSearchGetProvidersRequestApplicationJson>
+    _$unifiedSearchGetProvidersRequestApplicationJsonSerializer =
+    _$UnifiedSearchGetProvidersRequestApplicationJsonSerializer();
 Serializer<UnifiedSearchProvider> _$unifiedSearchProviderSerializer = _$UnifiedSearchProviderSerializer();
 Serializer<UnifiedSearchGetProvidersResponseApplicationJson_Ocs>
     _$unifiedSearchGetProvidersResponseApplicationJsonOcsSerializer =
@@ -740,6 +594,8 @@ Serializer<UnifiedSearchGetProvidersResponseApplicationJson_Ocs>
 Serializer<UnifiedSearchGetProvidersResponseApplicationJson>
     _$unifiedSearchGetProvidersResponseApplicationJsonSerializer =
     _$UnifiedSearchGetProvidersResponseApplicationJsonSerializer();
+Serializer<UnifiedSearchSearchRequestApplicationJson> _$unifiedSearchSearchRequestApplicationJsonSerializer =
+    _$UnifiedSearchSearchRequestApplicationJsonSerializer();
 Serializer<UnifiedSearchResultEntry> _$unifiedSearchResultEntrySerializer = _$UnifiedSearchResultEntrySerializer();
 Serializer<UnifiedSearchResult> _$unifiedSearchResultSerializer = _$UnifiedSearchResultSerializer();
 Serializer<UnifiedSearchSearchResponseApplicationJson_Ocs> _$unifiedSearchSearchResponseApplicationJsonOcsSerializer =
@@ -755,12 +611,18 @@ Serializer<WhatsNewGetResponseApplicationJson_Ocs> _$whatsNewGetResponseApplicat
     _$WhatsNewGetResponseApplicationJson_OcsSerializer();
 Serializer<WhatsNewGetResponseApplicationJson> _$whatsNewGetResponseApplicationJsonSerializer =
     _$WhatsNewGetResponseApplicationJsonSerializer();
+Serializer<WhatsNewDismissRequestApplicationJson> _$whatsNewDismissRequestApplicationJsonSerializer =
+    _$WhatsNewDismissRequestApplicationJsonSerializer();
 Serializer<WhatsNewDismissResponseApplicationJson_Ocs> _$whatsNewDismissResponseApplicationJsonOcsSerializer =
     _$WhatsNewDismissResponseApplicationJson_OcsSerializer();
 Serializer<WhatsNewDismissResponseApplicationJson> _$whatsNewDismissResponseApplicationJsonSerializer =
     _$WhatsNewDismissResponseApplicationJsonSerializer();
+Serializer<WipeCheckWipeRequestApplicationJson> _$wipeCheckWipeRequestApplicationJsonSerializer =
+    _$WipeCheckWipeRequestApplicationJsonSerializer();
 Serializer<WipeCheckWipeResponseApplicationJson> _$wipeCheckWipeResponseApplicationJsonSerializer =
     _$WipeCheckWipeResponseApplicationJsonSerializer();
+Serializer<WipeWipeDoneRequestApplicationJson> _$wipeWipeDoneRequestApplicationJsonSerializer =
+    _$WipeWipeDoneRequestApplicationJsonSerializer();
 Serializer<Capabilities_Core> _$capabilitiesCoreSerializer = _$Capabilities_CoreSerializer();
 Serializer<Capabilities> _$capabilitiesSerializer = _$CapabilitiesSerializer();
 Serializer<PublicCapabilities_Bruteforce> _$publicCapabilitiesBruteforceSerializer =
@@ -1281,6 +1143,49 @@ class _$AppPasswordRotateAppPasswordResponseApplicationJsonSerializer
   }
 }
 
+class _$AppPasswordConfirmUserPasswordRequestApplicationJsonSerializer
+    implements StructuredSerializer<AppPasswordConfirmUserPasswordRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    AppPasswordConfirmUserPasswordRequestApplicationJson,
+    _$AppPasswordConfirmUserPasswordRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'AppPasswordConfirmUserPasswordRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, AppPasswordConfirmUserPasswordRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'password',
+      serializers.serialize(object.password, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  AppPasswordConfirmUserPasswordRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'password':
+          result.password = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataSerializer
     implements StructuredSerializer<AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_Data> {
   @override
@@ -1414,6 +1319,83 @@ class _$AppPasswordConfirmUserPasswordResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs))!
               as AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$AutoCompleteGetRequestApplicationJsonSerializer
+    implements StructuredSerializer<AutoCompleteGetRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [AutoCompleteGetRequestApplicationJson, _$AutoCompleteGetRequestApplicationJson];
+  @override
+  final String wireName = 'AutoCompleteGetRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, AutoCompleteGetRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'search',
+      serializers.serialize(object.search, specifiedType: const FullType(String)),
+      'shareTypes',
+      serializers.serialize(object.shareTypes, specifiedType: const FullType(BuiltList, [FullType(int)])),
+      'limit',
+      serializers.serialize(object.limit, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.itemType;
+    if (value != null) {
+      result
+        ..add('itemType')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.itemId;
+    if (value != null) {
+      result
+        ..add('itemId')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.sorter;
+    if (value != null) {
+      result
+        ..add('sorter')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  AutoCompleteGetRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = AutoCompleteGetRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'search':
+          result.search = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'itemType':
+          result.itemType = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'itemId':
+          result.itemId = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'sorter':
+          result.sorter = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'shareTypes':
+          result.shareTypes.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, [FullType(int)]))! as BuiltList<Object?>);
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -1722,6 +1704,48 @@ class _$AvatarAvatarGetAvatarHeadersSerializer implements StructuredSerializer<A
         case 'x-nc-iscustomavatar':
           result.xNcIscustomavatar.replace(serializers.deserialize(value,
               specifiedType: const FullType(Header, [FullType.nullable(int)]))! as Header<int?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ClientFlowLoginV2PollRequestApplicationJsonSerializer
+    implements StructuredSerializer<ClientFlowLoginV2PollRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ClientFlowLoginV2PollRequestApplicationJson,
+    _$ClientFlowLoginV2PollRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ClientFlowLoginV2PollRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ClientFlowLoginV2PollRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'token',
+      serializers.serialize(object.token, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ClientFlowLoginV2PollRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ClientFlowLoginV2PollRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'token':
+          result.token = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -2132,6 +2156,50 @@ class _$CollaborationResourcesListCollectionResponseApplicationJsonSerializer
   }
 }
 
+class _$CollaborationResourcesRenameCollectionRequestApplicationJsonSerializer
+    implements StructuredSerializer<CollaborationResourcesRenameCollectionRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    CollaborationResourcesRenameCollectionRequestApplicationJson,
+    _$CollaborationResourcesRenameCollectionRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'CollaborationResourcesRenameCollectionRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, CollaborationResourcesRenameCollectionRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'collectionName',
+      serializers.serialize(object.collectionName, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  CollaborationResourcesRenameCollectionRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'collectionName':
+          result.collectionName = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$CollaborationResourcesRenameCollectionResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<CollaborationResourcesRenameCollectionResponseApplicationJson_Ocs> {
   @override
@@ -2228,6 +2296,54 @@ class _$CollaborationResourcesRenameCollectionResponseApplicationJsonSerializer
   }
 }
 
+class _$CollaborationResourcesAddResourceRequestApplicationJsonSerializer
+    implements StructuredSerializer<CollaborationResourcesAddResourceRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    CollaborationResourcesAddResourceRequestApplicationJson,
+    _$CollaborationResourcesAddResourceRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'CollaborationResourcesAddResourceRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, CollaborationResourcesAddResourceRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'resourceType',
+      serializers.serialize(object.resourceType, specifiedType: const FullType(String)),
+      'resourceId',
+      serializers.serialize(object.resourceId, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  CollaborationResourcesAddResourceRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CollaborationResourcesAddResourceRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'resourceType':
+          result.resourceType = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'resourceId':
+          result.resourceId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$CollaborationResourcesAddResourceResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<CollaborationResourcesAddResourceResponseApplicationJson_Ocs> {
   @override
@@ -2315,6 +2431,55 @@ class _$CollaborationResourcesAddResourceResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(CollaborationResourcesAddResourceResponseApplicationJson_Ocs))!
               as CollaborationResourcesAddResourceResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CollaborationResourcesRemoveResourceRequestApplicationJsonSerializer
+    implements StructuredSerializer<CollaborationResourcesRemoveResourceRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    CollaborationResourcesRemoveResourceRequestApplicationJson,
+    _$CollaborationResourcesRemoveResourceRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'CollaborationResourcesRemoveResourceRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, CollaborationResourcesRemoveResourceRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'resourceType',
+      serializers.serialize(object.resourceType, specifiedType: const FullType(String)),
+      'resourceId',
+      serializers.serialize(object.resourceId, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  CollaborationResourcesRemoveResourceRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'resourceType':
+          result.resourceType = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'resourceId':
+          result.resourceId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -2614,6 +2779,50 @@ class _$CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonSer
   }
 }
 
+class _$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonSerializer
+    implements StructuredSerializer<CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson,
+    _$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'name':
+          result.name = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs> {
   @override
@@ -2703,6 +2912,51 @@ class _$CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonS
                   specifiedType:
                       const FullType(CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs))!
               as CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GuestAvatarGetAvatarRequestApplicationJsonSerializer
+    implements StructuredSerializer<GuestAvatarGetAvatarRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    GuestAvatarGetAvatarRequestApplicationJson,
+    _$GuestAvatarGetAvatarRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'GuestAvatarGetAvatarRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GuestAvatarGetAvatarRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.darkTheme;
+    if (value != null) {
+      result
+        ..add('darkTheme')
+        ..add(serializers.serialize(value, specifiedType: const FullType(bool)));
+    }
+    return result;
+  }
+
+  @override
+  GuestAvatarGetAvatarRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GuestAvatarGetAvatarRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'darkTheme':
+          result.darkTheme = serializers.deserialize(value, specifiedType: const FullType(bool)) as bool?;
           break;
       }
     }
@@ -2911,6 +3165,48 @@ class _$HoverCardGetUserResponseApplicationJsonSerializer
   }
 }
 
+class _$LoginConfirmPasswordRequestApplicationJsonSerializer
+    implements StructuredSerializer<LoginConfirmPasswordRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    LoginConfirmPasswordRequestApplicationJson,
+    _$LoginConfirmPasswordRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'LoginConfirmPasswordRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, LoginConfirmPasswordRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'password',
+      serializers.serialize(object.password, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  LoginConfirmPasswordRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = LoginConfirmPasswordRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'password':
+          result.password = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$LoginConfirmPasswordResponseApplicationJsonSerializer
     implements StructuredSerializer<LoginConfirmPasswordResponseApplicationJson> {
   @override
@@ -2945,6 +3241,48 @@ class _$LoginConfirmPasswordResponseApplicationJsonSerializer
       switch (key) {
         case 'lastLogin':
           result.lastLogin = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$NavigationGetAppsNavigationRequestApplicationJsonSerializer
+    implements StructuredSerializer<NavigationGetAppsNavigationRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    NavigationGetAppsNavigationRequestApplicationJson,
+    _$NavigationGetAppsNavigationRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'NavigationGetAppsNavigationRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, NavigationGetAppsNavigationRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'absolute',
+      serializers.serialize(object.absolute, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  NavigationGetAppsNavigationRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = NavigationGetAppsNavigationRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'absolute':
+          result.absolute = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -3118,6 +3456,49 @@ class _$NavigationGetAppsNavigationResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(NavigationGetAppsNavigationResponseApplicationJson_Ocs))!
               as NavigationGetAppsNavigationResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$NavigationGetSettingsNavigationRequestApplicationJsonSerializer
+    implements StructuredSerializer<NavigationGetSettingsNavigationRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    NavigationGetSettingsNavigationRequestApplicationJson,
+    _$NavigationGetSettingsNavigationRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'NavigationGetSettingsNavigationRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, NavigationGetSettingsNavigationRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'absolute',
+      serializers.serialize(object.absolute, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  NavigationGetSettingsNavigationRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = NavigationGetSettingsNavigationRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'absolute':
+          result.absolute = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -6853,6 +7234,197 @@ class _$OcsGetCapabilitiesResponseApplicationJsonSerializer
   }
 }
 
+class _$PreviewGetPreviewRequestApplicationJsonSerializer
+    implements StructuredSerializer<PreviewGetPreviewRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    PreviewGetPreviewRequestApplicationJson,
+    _$PreviewGetPreviewRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'PreviewGetPreviewRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PreviewGetPreviewRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'file',
+      serializers.serialize(object.file, specifiedType: const FullType(String)),
+      'x',
+      serializers.serialize(object.x, specifiedType: const FullType(int)),
+      'y',
+      serializers.serialize(object.y, specifiedType: const FullType(int)),
+      'a',
+      serializers.serialize(object.a, specifiedType: const FullType(bool)),
+      'forceIcon',
+      serializers.serialize(object.forceIcon, specifiedType: const FullType(bool)),
+      'mode',
+      serializers.serialize(object.mode, specifiedType: const FullType(String)),
+      'mimeFallback',
+      serializers.serialize(object.mimeFallback, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  PreviewGetPreviewRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PreviewGetPreviewRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'file':
+          result.file = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'x':
+          result.x = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'y':
+          result.y = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'a':
+          result.a = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'forceIcon':
+          result.forceIcon = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'mode':
+          result.mode = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'mimeFallback':
+          result.mimeFallback = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$PreviewGetPreviewByFileIdRequestApplicationJsonSerializer
+    implements StructuredSerializer<PreviewGetPreviewByFileIdRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    PreviewGetPreviewByFileIdRequestApplicationJson,
+    _$PreviewGetPreviewByFileIdRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'PreviewGetPreviewByFileIdRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PreviewGetPreviewByFileIdRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'fileId',
+      serializers.serialize(object.fileId, specifiedType: const FullType(int)),
+      'x',
+      serializers.serialize(object.x, specifiedType: const FullType(int)),
+      'y',
+      serializers.serialize(object.y, specifiedType: const FullType(int)),
+      'a',
+      serializers.serialize(object.a, specifiedType: const FullType(bool)),
+      'forceIcon',
+      serializers.serialize(object.forceIcon, specifiedType: const FullType(bool)),
+      'mode',
+      serializers.serialize(object.mode, specifiedType: const FullType(String)),
+      'mimeFallback',
+      serializers.serialize(object.mimeFallback, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  PreviewGetPreviewByFileIdRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PreviewGetPreviewByFileIdRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'fileId':
+          result.fileId = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'x':
+          result.x = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'y':
+          result.y = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'a':
+          result.a = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'forceIcon':
+          result.forceIcon = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'mode':
+          result.mode = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'mimeFallback':
+          result.mimeFallback = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ProfileApiSetVisibilityRequestApplicationJsonSerializer
+    implements StructuredSerializer<ProfileApiSetVisibilityRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ProfileApiSetVisibilityRequestApplicationJson,
+    _$ProfileApiSetVisibilityRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ProfileApiSetVisibilityRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ProfileApiSetVisibilityRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'paramId',
+      serializers.serialize(object.paramId, specifiedType: const FullType(String)),
+      'visibility',
+      serializers.serialize(object.visibility, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ProfileApiSetVisibilityRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ProfileApiSetVisibilityRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'paramId':
+          result.paramId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'visibility':
+          result.visibility = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ProfileApiSetVisibilityResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ProfileApiSetVisibilityResponseApplicationJson_Ocs> {
   @override
@@ -6937,6 +7509,58 @@ class _$ProfileApiSetVisibilityResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(ProfileApiSetVisibilityResponseApplicationJson_Ocs))!
               as ProfileApiSetVisibilityResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ReferenceApiExtractRequestApplicationJsonSerializer
+    implements StructuredSerializer<ReferenceApiExtractRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ReferenceApiExtractRequestApplicationJson,
+    _$ReferenceApiExtractRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ReferenceApiExtractRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ReferenceApiExtractRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'text',
+      serializers.serialize(object.text, specifiedType: const FullType(String)),
+      'resolve',
+      serializers.serialize(object.resolve, specifiedType: const FullType(bool)),
+      'limit',
+      serializers.serialize(object.limit, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ReferenceApiExtractRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ReferenceApiExtractRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'text':
+          result.text = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'resolve':
+          result.resolve = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -7139,6 +7763,48 @@ class _$ReferenceApiExtractResponseApplicationJsonSerializer
   }
 }
 
+class _$ReferenceApiResolveOneRequestApplicationJsonSerializer
+    implements StructuredSerializer<ReferenceApiResolveOneRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ReferenceApiResolveOneRequestApplicationJson,
+    _$ReferenceApiResolveOneRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ReferenceApiResolveOneRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ReferenceApiResolveOneRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'reference',
+      serializers.serialize(object.reference, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ReferenceApiResolveOneRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ReferenceApiResolveOneRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'reference':
+          result.reference = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ReferenceApiResolveOneResponseApplicationJson_Ocs_DataSerializer
     implements StructuredSerializer<ReferenceApiResolveOneResponseApplicationJson_Ocs_Data> {
   @override
@@ -7271,6 +7937,54 @@ class _$ReferenceApiResolveOneResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(ReferenceApiResolveOneResponseApplicationJson_Ocs))!
               as ReferenceApiResolveOneResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ReferenceApiResolveRequestApplicationJsonSerializer
+    implements StructuredSerializer<ReferenceApiResolveRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ReferenceApiResolveRequestApplicationJson,
+    _$ReferenceApiResolveRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ReferenceApiResolveRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ReferenceApiResolveRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'references',
+      serializers.serialize(object.references, specifiedType: const FullType(BuiltList, [FullType(String)])),
+      'limit',
+      serializers.serialize(object.limit, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ReferenceApiResolveRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ReferenceApiResolveRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'references':
+          result.references.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, [FullType(String)]))! as BuiltList<Object?>);
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -7566,6 +8280,51 @@ class _$ReferenceApiGetProvidersInfoResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs))!
               as ReferenceApiGetProvidersInfoResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ReferenceApiTouchProviderRequestApplicationJsonSerializer
+    implements StructuredSerializer<ReferenceApiTouchProviderRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ReferenceApiTouchProviderRequestApplicationJson,
+    _$ReferenceApiTouchProviderRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ReferenceApiTouchProviderRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ReferenceApiTouchProviderRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.timestamp;
+    if (value != null) {
+      result
+        ..add('timestamp')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  ReferenceApiTouchProviderRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ReferenceApiTouchProviderRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'timestamp':
+          result.timestamp = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
           break;
       }
     }
@@ -8308,6 +9067,63 @@ class _$TextProcessingApiTaskTypesResponseApplicationJsonSerializer
   }
 }
 
+class _$TextProcessingApiScheduleRequestApplicationJsonSerializer
+    implements StructuredSerializer<TextProcessingApiScheduleRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    TextProcessingApiScheduleRequestApplicationJson,
+    _$TextProcessingApiScheduleRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'TextProcessingApiScheduleRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, TextProcessingApiScheduleRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'input',
+      serializers.serialize(object.input, specifiedType: const FullType(String)),
+      'type',
+      serializers.serialize(object.type, specifiedType: const FullType(String)),
+      'appId',
+      serializers.serialize(object.appId, specifiedType: const FullType(String)),
+      'identifier',
+      serializers.serialize(object.identifier, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  TextProcessingApiScheduleRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = TextProcessingApiScheduleRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'input':
+          result.input = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'type':
+          result.type = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'appId':
+          result.appId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'identifier':
+          result.identifier = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$TextProcessingTaskSerializer implements StructuredSerializer<TextProcessingTask> {
   @override
   final Iterable<Type> types = const [TextProcessingTask, _$TextProcessingTask];
@@ -8823,6 +9639,52 @@ class _$TextProcessingApiDeleteTaskResponseApplicationJsonSerializer
   }
 }
 
+class _$TextProcessingApiListTasksByAppRequestApplicationJsonSerializer
+    implements StructuredSerializer<TextProcessingApiListTasksByAppRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    TextProcessingApiListTasksByAppRequestApplicationJson,
+    _$TextProcessingApiListTasksByAppRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'TextProcessingApiListTasksByAppRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, TextProcessingApiListTasksByAppRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.identifier;
+    if (value != null) {
+      result
+        ..add('identifier')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  TextProcessingApiListTasksByAppRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = TextProcessingApiListTasksByAppRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'identifier':
+          result.identifier = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataSerializer
     implements StructuredSerializer<TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_Data> {
   @override
@@ -9097,6 +9959,63 @@ class _$TextToImageApiIsAvailableResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(TextToImageApiIsAvailableResponseApplicationJson_Ocs))!
               as TextToImageApiIsAvailableResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$TextToImageApiScheduleRequestApplicationJsonSerializer
+    implements StructuredSerializer<TextToImageApiScheduleRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    TextToImageApiScheduleRequestApplicationJson,
+    _$TextToImageApiScheduleRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'TextToImageApiScheduleRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, TextToImageApiScheduleRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'input',
+      serializers.serialize(object.input, specifiedType: const FullType(String)),
+      'appId',
+      serializers.serialize(object.appId, specifiedType: const FullType(String)),
+      'identifier',
+      serializers.serialize(object.identifier, specifiedType: const FullType(String)),
+      'numberOfImages',
+      serializers.serialize(object.numberOfImages, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  TextToImageApiScheduleRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = TextToImageApiScheduleRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'input':
+          result.input = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'appId':
+          result.appId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'identifier':
+          result.identifier = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'numberOfImages':
+          result.numberOfImages = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -9612,6 +10531,51 @@ class _$TextToImageApiDeleteTaskResponseApplicationJsonSerializer
   }
 }
 
+class _$TextToImageApiListTasksByAppRequestApplicationJsonSerializer
+    implements StructuredSerializer<TextToImageApiListTasksByAppRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    TextToImageApiListTasksByAppRequestApplicationJson,
+    _$TextToImageApiListTasksByAppRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'TextToImageApiListTasksByAppRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, TextToImageApiListTasksByAppRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.identifier;
+    if (value != null) {
+      result
+        ..add('identifier')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  TextToImageApiListTasksByAppRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = TextToImageApiListTasksByAppRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'identifier':
+          result.identifier = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataSerializer
     implements StructuredSerializer<TextToImageApiListTasksByAppResponseApplicationJson_Ocs_Data> {
   @override
@@ -9960,6 +10924,62 @@ class _$TranslationApiLanguagesResponseApplicationJsonSerializer
   }
 }
 
+class _$TranslationApiTranslateRequestApplicationJsonSerializer
+    implements StructuredSerializer<TranslationApiTranslateRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    TranslationApiTranslateRequestApplicationJson,
+    _$TranslationApiTranslateRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'TranslationApiTranslateRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, TranslationApiTranslateRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'text',
+      serializers.serialize(object.text, specifiedType: const FullType(String)),
+      'toLanguage',
+      serializers.serialize(object.toLanguage, specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.fromLanguage;
+    if (value != null) {
+      result
+        ..add('fromLanguage')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  TranslationApiTranslateRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = TranslationApiTranslateRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'text':
+          result.text = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'fromLanguage':
+          result.fromLanguage = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'toLanguage':
+          result.toLanguage = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$TranslationApiTranslateResponseApplicationJson_Ocs_DataSerializer
     implements StructuredSerializer<TranslationApiTranslateResponseApplicationJson_Ocs_Data> {
   @override
@@ -10099,6 +11119,48 @@ class _$TranslationApiTranslateResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(TranslationApiTranslateResponseApplicationJson_Ocs))!
               as TranslationApiTranslateResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UnifiedSearchGetProvidersRequestApplicationJsonSerializer
+    implements StructuredSerializer<UnifiedSearchGetProvidersRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    UnifiedSearchGetProvidersRequestApplicationJson,
+    _$UnifiedSearchGetProvidersRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'UnifiedSearchGetProvidersRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UnifiedSearchGetProvidersRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'from',
+      serializers.serialize(object.from, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  UnifiedSearchGetProvidersRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UnifiedSearchGetProvidersRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'from':
+          result.from = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -10269,6 +11331,83 @@ class _$UnifiedSearchGetProvidersResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(UnifiedSearchGetProvidersResponseApplicationJson_Ocs))!
               as UnifiedSearchGetProvidersResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UnifiedSearchSearchRequestApplicationJsonSerializer
+    implements StructuredSerializer<UnifiedSearchSearchRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    UnifiedSearchSearchRequestApplicationJson,
+    _$UnifiedSearchSearchRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'UnifiedSearchSearchRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UnifiedSearchSearchRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'term',
+      serializers.serialize(object.term, specifiedType: const FullType(String)),
+      'from',
+      serializers.serialize(object.from, specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.sortOrder;
+    if (value != null) {
+      result
+        ..add('sortOrder')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.limit;
+    if (value != null) {
+      result
+        ..add('limit')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.cursor;
+    if (value != null) {
+      result
+        ..add('cursor')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(UnifiedSearchSearchRequestApplicationJson_Cursor)));
+    }
+    return result;
+  }
+
+  @override
+  UnifiedSearchSearchRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UnifiedSearchSearchRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'term':
+          result.term = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'sortOrder':
+          result.sortOrder = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'cursor':
+          result.cursor = serializers.deserialize(value,
+                  specifiedType: const FullType(UnifiedSearchSearchRequestApplicationJson_Cursor))
+              as UnifiedSearchSearchRequestApplicationJson_Cursor?;
+          break;
+        case 'from':
+          result.from = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -10699,6 +11838,45 @@ class _$WhatsNewGetResponseApplicationJsonSerializer
   }
 }
 
+class _$WhatsNewDismissRequestApplicationJsonSerializer
+    implements StructuredSerializer<WhatsNewDismissRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [WhatsNewDismissRequestApplicationJson, _$WhatsNewDismissRequestApplicationJson];
+  @override
+  final String wireName = 'WhatsNewDismissRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, WhatsNewDismissRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'version',
+      serializers.serialize(object.version, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  WhatsNewDismissRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = WhatsNewDismissRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'version':
+          result.version = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$WhatsNewDismissResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<WhatsNewDismissResponseApplicationJson_Ocs> {
   @override
@@ -10787,6 +11965,45 @@ class _$WhatsNewDismissResponseApplicationJsonSerializer
   }
 }
 
+class _$WipeCheckWipeRequestApplicationJsonSerializer
+    implements StructuredSerializer<WipeCheckWipeRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [WipeCheckWipeRequestApplicationJson, _$WipeCheckWipeRequestApplicationJson];
+  @override
+  final String wireName = 'WipeCheckWipeRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, WipeCheckWipeRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'token',
+      serializers.serialize(object.token, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  WipeCheckWipeRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = WipeCheckWipeRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'token':
+          result.token = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$WipeCheckWipeResponseApplicationJsonSerializer
     implements StructuredSerializer<WipeCheckWipeResponseApplicationJson> {
   @override
@@ -10818,6 +12035,45 @@ class _$WipeCheckWipeResponseApplicationJsonSerializer
       switch (key) {
         case 'wipe':
           result.wipe = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$WipeWipeDoneRequestApplicationJsonSerializer
+    implements StructuredSerializer<WipeWipeDoneRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [WipeWipeDoneRequestApplicationJson, _$WipeWipeDoneRequestApplicationJson];
+  @override
+  final String wireName = 'WipeWipeDoneRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, WipeWipeDoneRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'token',
+      serializers.serialize(object.token, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  WipeWipeDoneRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = WipeWipeDoneRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'token':
+          result.token = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -12269,6 +13525,107 @@ class AppPasswordRotateAppPasswordResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $AppPasswordConfirmUserPasswordRequestApplicationJsonInterfaceBuilder {
+  void replace($AppPasswordConfirmUserPasswordRequestApplicationJsonInterface other);
+  void update(void Function($AppPasswordConfirmUserPasswordRequestApplicationJsonInterfaceBuilder) updates);
+  String? get password;
+  set password(String? password);
+}
+
+class _$AppPasswordConfirmUserPasswordRequestApplicationJson
+    extends AppPasswordConfirmUserPasswordRequestApplicationJson {
+  @override
+  final String password;
+
+  factory _$AppPasswordConfirmUserPasswordRequestApplicationJson(
+          [void Function(AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder)? updates]) =>
+      (AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$AppPasswordConfirmUserPasswordRequestApplicationJson._({required this.password}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        password, r'AppPasswordConfirmUserPasswordRequestApplicationJson', 'password');
+  }
+
+  @override
+  AppPasswordConfirmUserPasswordRequestApplicationJson rebuild(
+          void Function(AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder toBuilder() =>
+      AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AppPasswordConfirmUserPasswordRequestApplicationJson && password == other.password;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, password.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'AppPasswordConfirmUserPasswordRequestApplicationJson')
+          ..add('password', password))
+        .toString();
+  }
+}
+
+class AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder
+    implements
+        Builder<AppPasswordConfirmUserPasswordRequestApplicationJson,
+            AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder>,
+        $AppPasswordConfirmUserPasswordRequestApplicationJsonInterfaceBuilder {
+  _$AppPasswordConfirmUserPasswordRequestApplicationJson? _$v;
+
+  String? _password;
+  String? get password => _$this._password;
+  set password(covariant String? password) => _$this._password = password;
+
+  AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder() {
+    AppPasswordConfirmUserPasswordRequestApplicationJson._defaults(this);
+  }
+
+  AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _password = $v.password;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant AppPasswordConfirmUserPasswordRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$AppPasswordConfirmUserPasswordRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(AppPasswordConfirmUserPasswordRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  AppPasswordConfirmUserPasswordRequestApplicationJson build() => _build();
+
+  _$AppPasswordConfirmUserPasswordRequestApplicationJson _build() {
+    AppPasswordConfirmUserPasswordRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$AppPasswordConfirmUserPasswordRequestApplicationJson._(
+            password: BuiltValueNullFieldError.checkNotNull(
+                password, r'AppPasswordConfirmUserPasswordRequestApplicationJson', 'password'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($AppPasswordConfirmUserPasswordResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
@@ -12602,6 +13959,189 @@ class AppPasswordConfirmUserPasswordResponseApplicationJsonBuilder
       } catch (e) {
         throw BuiltValueNestedFieldError(
             r'AppPasswordConfirmUserPasswordResponseApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $AutoCompleteGetRequestApplicationJsonInterfaceBuilder {
+  void replace($AutoCompleteGetRequestApplicationJsonInterface other);
+  void update(void Function($AutoCompleteGetRequestApplicationJsonInterfaceBuilder) updates);
+  String? get search;
+  set search(String? search);
+
+  String? get itemType;
+  set itemType(String? itemType);
+
+  String? get itemId;
+  set itemId(String? itemId);
+
+  String? get sorter;
+  set sorter(String? sorter);
+
+  ListBuilder<int> get shareTypes;
+  set shareTypes(ListBuilder<int>? shareTypes);
+
+  int? get limit;
+  set limit(int? limit);
+}
+
+class _$AutoCompleteGetRequestApplicationJson extends AutoCompleteGetRequestApplicationJson {
+  @override
+  final String search;
+  @override
+  final String? itemType;
+  @override
+  final String? itemId;
+  @override
+  final String? sorter;
+  @override
+  final BuiltList<int> shareTypes;
+  @override
+  final int limit;
+
+  factory _$AutoCompleteGetRequestApplicationJson(
+          [void Function(AutoCompleteGetRequestApplicationJsonBuilder)? updates]) =>
+      (AutoCompleteGetRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$AutoCompleteGetRequestApplicationJson._(
+      {required this.search, this.itemType, this.itemId, this.sorter, required this.shareTypes, required this.limit})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(search, r'AutoCompleteGetRequestApplicationJson', 'search');
+    BuiltValueNullFieldError.checkNotNull(shareTypes, r'AutoCompleteGetRequestApplicationJson', 'shareTypes');
+    BuiltValueNullFieldError.checkNotNull(limit, r'AutoCompleteGetRequestApplicationJson', 'limit');
+  }
+
+  @override
+  AutoCompleteGetRequestApplicationJson rebuild(void Function(AutoCompleteGetRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AutoCompleteGetRequestApplicationJsonBuilder toBuilder() =>
+      AutoCompleteGetRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AutoCompleteGetRequestApplicationJson &&
+        search == other.search &&
+        itemType == other.itemType &&
+        itemId == other.itemId &&
+        sorter == other.sorter &&
+        shareTypes == other.shareTypes &&
+        limit == other.limit;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, search.hashCode);
+    _$hash = $jc(_$hash, itemType.hashCode);
+    _$hash = $jc(_$hash, itemId.hashCode);
+    _$hash = $jc(_$hash, sorter.hashCode);
+    _$hash = $jc(_$hash, shareTypes.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'AutoCompleteGetRequestApplicationJson')
+          ..add('search', search)
+          ..add('itemType', itemType)
+          ..add('itemId', itemId)
+          ..add('sorter', sorter)
+          ..add('shareTypes', shareTypes)
+          ..add('limit', limit))
+        .toString();
+  }
+}
+
+class AutoCompleteGetRequestApplicationJsonBuilder
+    implements
+        Builder<AutoCompleteGetRequestApplicationJson, AutoCompleteGetRequestApplicationJsonBuilder>,
+        $AutoCompleteGetRequestApplicationJsonInterfaceBuilder {
+  _$AutoCompleteGetRequestApplicationJson? _$v;
+
+  String? _search;
+  String? get search => _$this._search;
+  set search(covariant String? search) => _$this._search = search;
+
+  String? _itemType;
+  String? get itemType => _$this._itemType;
+  set itemType(covariant String? itemType) => _$this._itemType = itemType;
+
+  String? _itemId;
+  String? get itemId => _$this._itemId;
+  set itemId(covariant String? itemId) => _$this._itemId = itemId;
+
+  String? _sorter;
+  String? get sorter => _$this._sorter;
+  set sorter(covariant String? sorter) => _$this._sorter = sorter;
+
+  ListBuilder<int>? _shareTypes;
+  ListBuilder<int> get shareTypes => _$this._shareTypes ??= ListBuilder<int>();
+  set shareTypes(covariant ListBuilder<int>? shareTypes) => _$this._shareTypes = shareTypes;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  AutoCompleteGetRequestApplicationJsonBuilder() {
+    AutoCompleteGetRequestApplicationJson._defaults(this);
+  }
+
+  AutoCompleteGetRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _search = $v.search;
+      _itemType = $v.itemType;
+      _itemId = $v.itemId;
+      _sorter = $v.sorter;
+      _shareTypes = $v.shareTypes.toBuilder();
+      _limit = $v.limit;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant AutoCompleteGetRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$AutoCompleteGetRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(AutoCompleteGetRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  AutoCompleteGetRequestApplicationJson build() => _build();
+
+  _$AutoCompleteGetRequestApplicationJson _build() {
+    AutoCompleteGetRequestApplicationJson._validate(this);
+    _$AutoCompleteGetRequestApplicationJson _$result;
+    try {
+      _$result = _$v ??
+          _$AutoCompleteGetRequestApplicationJson._(
+              search: BuiltValueNullFieldError.checkNotNull(search, r'AutoCompleteGetRequestApplicationJson', 'search'),
+              itemType: itemType,
+              itemId: itemId,
+              sorter: sorter,
+              shareTypes: shareTypes.build(),
+              limit: BuiltValueNullFieldError.checkNotNull(limit, r'AutoCompleteGetRequestApplicationJson', 'limit'));
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'shareTypes';
+        shareTypes.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'AutoCompleteGetRequestApplicationJson', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -13370,6 +14910,103 @@ class AvatarAvatarGetAvatarHeadersBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ClientFlowLoginV2PollRequestApplicationJsonInterfaceBuilder {
+  void replace($ClientFlowLoginV2PollRequestApplicationJsonInterface other);
+  void update(void Function($ClientFlowLoginV2PollRequestApplicationJsonInterfaceBuilder) updates);
+  String? get token;
+  set token(String? token);
+}
+
+class _$ClientFlowLoginV2PollRequestApplicationJson extends ClientFlowLoginV2PollRequestApplicationJson {
+  @override
+  final String token;
+
+  factory _$ClientFlowLoginV2PollRequestApplicationJson(
+          [void Function(ClientFlowLoginV2PollRequestApplicationJsonBuilder)? updates]) =>
+      (ClientFlowLoginV2PollRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ClientFlowLoginV2PollRequestApplicationJson._({required this.token}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(token, r'ClientFlowLoginV2PollRequestApplicationJson', 'token');
+  }
+
+  @override
+  ClientFlowLoginV2PollRequestApplicationJson rebuild(
+          void Function(ClientFlowLoginV2PollRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ClientFlowLoginV2PollRequestApplicationJsonBuilder toBuilder() =>
+      ClientFlowLoginV2PollRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ClientFlowLoginV2PollRequestApplicationJson && token == other.token;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, token.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ClientFlowLoginV2PollRequestApplicationJson')..add('token', token))
+        .toString();
+  }
+}
+
+class ClientFlowLoginV2PollRequestApplicationJsonBuilder
+    implements
+        Builder<ClientFlowLoginV2PollRequestApplicationJson, ClientFlowLoginV2PollRequestApplicationJsonBuilder>,
+        $ClientFlowLoginV2PollRequestApplicationJsonInterfaceBuilder {
+  _$ClientFlowLoginV2PollRequestApplicationJson? _$v;
+
+  String? _token;
+  String? get token => _$this._token;
+  set token(covariant String? token) => _$this._token = token;
+
+  ClientFlowLoginV2PollRequestApplicationJsonBuilder() {
+    ClientFlowLoginV2PollRequestApplicationJson._defaults(this);
+  }
+
+  ClientFlowLoginV2PollRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _token = $v.token;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ClientFlowLoginV2PollRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ClientFlowLoginV2PollRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ClientFlowLoginV2PollRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ClientFlowLoginV2PollRequestApplicationJson build() => _build();
+
+  _$ClientFlowLoginV2PollRequestApplicationJson _build() {
+    ClientFlowLoginV2PollRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ClientFlowLoginV2PollRequestApplicationJson._(
+            token:
+                BuiltValueNullFieldError.checkNotNull(token, r'ClientFlowLoginV2PollRequestApplicationJson', 'token'));
     replace(_$result);
     return _$result;
   }
@@ -14391,6 +16028,108 @@ class CollaborationResourcesListCollectionResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $CollaborationResourcesRenameCollectionRequestApplicationJsonInterfaceBuilder {
+  void replace($CollaborationResourcesRenameCollectionRequestApplicationJsonInterface other);
+  void update(void Function($CollaborationResourcesRenameCollectionRequestApplicationJsonInterfaceBuilder) updates);
+  String? get collectionName;
+  set collectionName(String? collectionName);
+}
+
+class _$CollaborationResourcesRenameCollectionRequestApplicationJson
+    extends CollaborationResourcesRenameCollectionRequestApplicationJson {
+  @override
+  final String collectionName;
+
+  factory _$CollaborationResourcesRenameCollectionRequestApplicationJson(
+          [void Function(CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder)? updates]) =>
+      (CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$CollaborationResourcesRenameCollectionRequestApplicationJson._({required this.collectionName}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        collectionName, r'CollaborationResourcesRenameCollectionRequestApplicationJson', 'collectionName');
+  }
+
+  @override
+  CollaborationResourcesRenameCollectionRequestApplicationJson rebuild(
+          void Function(CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder toBuilder() =>
+      CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CollaborationResourcesRenameCollectionRequestApplicationJson &&
+        collectionName == other.collectionName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, collectionName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CollaborationResourcesRenameCollectionRequestApplicationJson')
+          ..add('collectionName', collectionName))
+        .toString();
+  }
+}
+
+class CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder
+    implements
+        Builder<CollaborationResourcesRenameCollectionRequestApplicationJson,
+            CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder>,
+        $CollaborationResourcesRenameCollectionRequestApplicationJsonInterfaceBuilder {
+  _$CollaborationResourcesRenameCollectionRequestApplicationJson? _$v;
+
+  String? _collectionName;
+  String? get collectionName => _$this._collectionName;
+  set collectionName(covariant String? collectionName) => _$this._collectionName = collectionName;
+
+  CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder() {
+    CollaborationResourcesRenameCollectionRequestApplicationJson._defaults(this);
+  }
+
+  CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _collectionName = $v.collectionName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant CollaborationResourcesRenameCollectionRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CollaborationResourcesRenameCollectionRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(CollaborationResourcesRenameCollectionRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CollaborationResourcesRenameCollectionRequestApplicationJson build() => _build();
+
+  _$CollaborationResourcesRenameCollectionRequestApplicationJson _build() {
+    CollaborationResourcesRenameCollectionRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$CollaborationResourcesRenameCollectionRequestApplicationJson._(
+            collectionName: BuiltValueNullFieldError.checkNotNull(
+                collectionName, r'CollaborationResourcesRenameCollectionRequestApplicationJson', 'collectionName'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterfaceBuilder {
   void replace($CollaborationResourcesRenameCollectionResponseApplicationJson_OcsInterface other);
   void update(
@@ -14634,6 +16373,126 @@ class CollaborationResourcesRenameCollectionResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $CollaborationResourcesAddResourceRequestApplicationJsonInterfaceBuilder {
+  void replace($CollaborationResourcesAddResourceRequestApplicationJsonInterface other);
+  void update(void Function($CollaborationResourcesAddResourceRequestApplicationJsonInterfaceBuilder) updates);
+  String? get resourceType;
+  set resourceType(String? resourceType);
+
+  String? get resourceId;
+  set resourceId(String? resourceId);
+}
+
+class _$CollaborationResourcesAddResourceRequestApplicationJson
+    extends CollaborationResourcesAddResourceRequestApplicationJson {
+  @override
+  final String resourceType;
+  @override
+  final String resourceId;
+
+  factory _$CollaborationResourcesAddResourceRequestApplicationJson(
+          [void Function(CollaborationResourcesAddResourceRequestApplicationJsonBuilder)? updates]) =>
+      (CollaborationResourcesAddResourceRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$CollaborationResourcesAddResourceRequestApplicationJson._({required this.resourceType, required this.resourceId})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        resourceType, r'CollaborationResourcesAddResourceRequestApplicationJson', 'resourceType');
+    BuiltValueNullFieldError.checkNotNull(
+        resourceId, r'CollaborationResourcesAddResourceRequestApplicationJson', 'resourceId');
+  }
+
+  @override
+  CollaborationResourcesAddResourceRequestApplicationJson rebuild(
+          void Function(CollaborationResourcesAddResourceRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CollaborationResourcesAddResourceRequestApplicationJsonBuilder toBuilder() =>
+      CollaborationResourcesAddResourceRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CollaborationResourcesAddResourceRequestApplicationJson &&
+        resourceType == other.resourceType &&
+        resourceId == other.resourceId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, resourceType.hashCode);
+    _$hash = $jc(_$hash, resourceId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CollaborationResourcesAddResourceRequestApplicationJson')
+          ..add('resourceType', resourceType)
+          ..add('resourceId', resourceId))
+        .toString();
+  }
+}
+
+class CollaborationResourcesAddResourceRequestApplicationJsonBuilder
+    implements
+        Builder<CollaborationResourcesAddResourceRequestApplicationJson,
+            CollaborationResourcesAddResourceRequestApplicationJsonBuilder>,
+        $CollaborationResourcesAddResourceRequestApplicationJsonInterfaceBuilder {
+  _$CollaborationResourcesAddResourceRequestApplicationJson? _$v;
+
+  String? _resourceType;
+  String? get resourceType => _$this._resourceType;
+  set resourceType(covariant String? resourceType) => _$this._resourceType = resourceType;
+
+  String? _resourceId;
+  String? get resourceId => _$this._resourceId;
+  set resourceId(covariant String? resourceId) => _$this._resourceId = resourceId;
+
+  CollaborationResourcesAddResourceRequestApplicationJsonBuilder() {
+    CollaborationResourcesAddResourceRequestApplicationJson._defaults(this);
+  }
+
+  CollaborationResourcesAddResourceRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _resourceType = $v.resourceType;
+      _resourceId = $v.resourceId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant CollaborationResourcesAddResourceRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CollaborationResourcesAddResourceRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(CollaborationResourcesAddResourceRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CollaborationResourcesAddResourceRequestApplicationJson build() => _build();
+
+  _$CollaborationResourcesAddResourceRequestApplicationJson _build() {
+    CollaborationResourcesAddResourceRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$CollaborationResourcesAddResourceRequestApplicationJson._(
+            resourceType: BuiltValueNullFieldError.checkNotNull(
+                resourceType, r'CollaborationResourcesAddResourceRequestApplicationJson', 'resourceType'),
+            resourceId: BuiltValueNullFieldError.checkNotNull(
+                resourceId, r'CollaborationResourcesAddResourceRequestApplicationJson', 'resourceId'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $CollaborationResourcesAddResourceResponseApplicationJson_OcsInterfaceBuilder {
   void replace($CollaborationResourcesAddResourceResponseApplicationJson_OcsInterface other);
   void update(void Function($CollaborationResourcesAddResourceResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -14870,6 +16729,126 @@ class CollaborationResourcesAddResourceResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $CollaborationResourcesRemoveResourceRequestApplicationJsonInterfaceBuilder {
+  void replace($CollaborationResourcesRemoveResourceRequestApplicationJsonInterface other);
+  void update(void Function($CollaborationResourcesRemoveResourceRequestApplicationJsonInterfaceBuilder) updates);
+  String? get resourceType;
+  set resourceType(String? resourceType);
+
+  String? get resourceId;
+  set resourceId(String? resourceId);
+}
+
+class _$CollaborationResourcesRemoveResourceRequestApplicationJson
+    extends CollaborationResourcesRemoveResourceRequestApplicationJson {
+  @override
+  final String resourceType;
+  @override
+  final String resourceId;
+
+  factory _$CollaborationResourcesRemoveResourceRequestApplicationJson(
+          [void Function(CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder)? updates]) =>
+      (CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$CollaborationResourcesRemoveResourceRequestApplicationJson._({required this.resourceType, required this.resourceId})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        resourceType, r'CollaborationResourcesRemoveResourceRequestApplicationJson', 'resourceType');
+    BuiltValueNullFieldError.checkNotNull(
+        resourceId, r'CollaborationResourcesRemoveResourceRequestApplicationJson', 'resourceId');
+  }
+
+  @override
+  CollaborationResourcesRemoveResourceRequestApplicationJson rebuild(
+          void Function(CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder toBuilder() =>
+      CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CollaborationResourcesRemoveResourceRequestApplicationJson &&
+        resourceType == other.resourceType &&
+        resourceId == other.resourceId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, resourceType.hashCode);
+    _$hash = $jc(_$hash, resourceId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CollaborationResourcesRemoveResourceRequestApplicationJson')
+          ..add('resourceType', resourceType)
+          ..add('resourceId', resourceId))
+        .toString();
+  }
+}
+
+class CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder
+    implements
+        Builder<CollaborationResourcesRemoveResourceRequestApplicationJson,
+            CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder>,
+        $CollaborationResourcesRemoveResourceRequestApplicationJsonInterfaceBuilder {
+  _$CollaborationResourcesRemoveResourceRequestApplicationJson? _$v;
+
+  String? _resourceType;
+  String? get resourceType => _$this._resourceType;
+  set resourceType(covariant String? resourceType) => _$this._resourceType = resourceType;
+
+  String? _resourceId;
+  String? get resourceId => _$this._resourceId;
+  set resourceId(covariant String? resourceId) => _$this._resourceId = resourceId;
+
+  CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder() {
+    CollaborationResourcesRemoveResourceRequestApplicationJson._defaults(this);
+  }
+
+  CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _resourceType = $v.resourceType;
+      _resourceId = $v.resourceId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant CollaborationResourcesRemoveResourceRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CollaborationResourcesRemoveResourceRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(CollaborationResourcesRemoveResourceRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CollaborationResourcesRemoveResourceRequestApplicationJson build() => _build();
+
+  _$CollaborationResourcesRemoveResourceRequestApplicationJson _build() {
+    CollaborationResourcesRemoveResourceRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$CollaborationResourcesRemoveResourceRequestApplicationJson._(
+            resourceType: BuiltValueNullFieldError.checkNotNull(
+                resourceType, r'CollaborationResourcesRemoveResourceRequestApplicationJson', 'resourceType'),
+            resourceId: BuiltValueNullFieldError.checkNotNull(
+                resourceId, r'CollaborationResourcesRemoveResourceRequestApplicationJson', 'resourceId'));
     replace(_$result);
     return _$result;
   }
@@ -15613,6 +17592,108 @@ class CollaborationResourcesGetCollectionsByResourceResponseApplicationJsonBuild
   }
 }
 
+abstract mixin class $CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterfaceBuilder {
+  void replace($CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterface other);
+  void update(
+      void Function($CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterfaceBuilder) updates);
+  String? get name;
+  set name(String? name);
+}
+
+class _$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson
+    extends CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson {
+  @override
+  final String name;
+
+  factory _$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson(
+          [void Function(CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder)? updates]) =>
+      (CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson._({required this.name}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        name, r'CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson', 'name');
+  }
+
+  @override
+  CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson rebuild(
+          void Function(CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder toBuilder() =>
+      CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson && name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson')
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder
+    implements
+        Builder<CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson,
+            CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder>,
+        $CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonInterfaceBuilder {
+  _$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson? _$v;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(covariant String? name) => _$this._name = name;
+
+  CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder() {
+    CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson._defaults(this);
+  }
+
+  CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(CollaborationResourcesCreateCollectionOnResourceRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson build() => _build();
+
+  _$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson _build() {
+    CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson._(
+            name: BuiltValueNullFieldError.checkNotNull(
+                name, r'CollaborationResourcesCreateCollectionOnResourceRequestApplicationJson', 'name'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterfaceBuilder {
   void replace($CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson_OcsInterface other);
   void update(
@@ -15859,6 +17940,98 @@ class CollaborationResourcesCreateCollectionOnResourceResponseApplicationJsonBui
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $GuestAvatarGetAvatarRequestApplicationJsonInterfaceBuilder {
+  void replace($GuestAvatarGetAvatarRequestApplicationJsonInterface other);
+  void update(void Function($GuestAvatarGetAvatarRequestApplicationJsonInterfaceBuilder) updates);
+  bool? get darkTheme;
+  set darkTheme(bool? darkTheme);
+}
+
+class _$GuestAvatarGetAvatarRequestApplicationJson extends GuestAvatarGetAvatarRequestApplicationJson {
+  @override
+  final bool? darkTheme;
+
+  factory _$GuestAvatarGetAvatarRequestApplicationJson(
+          [void Function(GuestAvatarGetAvatarRequestApplicationJsonBuilder)? updates]) =>
+      (GuestAvatarGetAvatarRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$GuestAvatarGetAvatarRequestApplicationJson._({this.darkTheme}) : super._();
+
+  @override
+  GuestAvatarGetAvatarRequestApplicationJson rebuild(
+          void Function(GuestAvatarGetAvatarRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GuestAvatarGetAvatarRequestApplicationJsonBuilder toBuilder() =>
+      GuestAvatarGetAvatarRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GuestAvatarGetAvatarRequestApplicationJson && darkTheme == other.darkTheme;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, darkTheme.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GuestAvatarGetAvatarRequestApplicationJson')..add('darkTheme', darkTheme))
+        .toString();
+  }
+}
+
+class GuestAvatarGetAvatarRequestApplicationJsonBuilder
+    implements
+        Builder<GuestAvatarGetAvatarRequestApplicationJson, GuestAvatarGetAvatarRequestApplicationJsonBuilder>,
+        $GuestAvatarGetAvatarRequestApplicationJsonInterfaceBuilder {
+  _$GuestAvatarGetAvatarRequestApplicationJson? _$v;
+
+  bool? _darkTheme;
+  bool? get darkTheme => _$this._darkTheme;
+  set darkTheme(covariant bool? darkTheme) => _$this._darkTheme = darkTheme;
+
+  GuestAvatarGetAvatarRequestApplicationJsonBuilder() {
+    GuestAvatarGetAvatarRequestApplicationJson._defaults(this);
+  }
+
+  GuestAvatarGetAvatarRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _darkTheme = $v.darkTheme;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant GuestAvatarGetAvatarRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GuestAvatarGetAvatarRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(GuestAvatarGetAvatarRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GuestAvatarGetAvatarRequestApplicationJson build() => _build();
+
+  _$GuestAvatarGetAvatarRequestApplicationJson _build() {
+    GuestAvatarGetAvatarRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$GuestAvatarGetAvatarRequestApplicationJson._(darkTheme: darkTheme);
     replace(_$result);
     return _$result;
   }
@@ -16377,6 +18550,103 @@ class HoverCardGetUserResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $LoginConfirmPasswordRequestApplicationJsonInterfaceBuilder {
+  void replace($LoginConfirmPasswordRequestApplicationJsonInterface other);
+  void update(void Function($LoginConfirmPasswordRequestApplicationJsonInterfaceBuilder) updates);
+  String? get password;
+  set password(String? password);
+}
+
+class _$LoginConfirmPasswordRequestApplicationJson extends LoginConfirmPasswordRequestApplicationJson {
+  @override
+  final String password;
+
+  factory _$LoginConfirmPasswordRequestApplicationJson(
+          [void Function(LoginConfirmPasswordRequestApplicationJsonBuilder)? updates]) =>
+      (LoginConfirmPasswordRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$LoginConfirmPasswordRequestApplicationJson._({required this.password}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(password, r'LoginConfirmPasswordRequestApplicationJson', 'password');
+  }
+
+  @override
+  LoginConfirmPasswordRequestApplicationJson rebuild(
+          void Function(LoginConfirmPasswordRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  LoginConfirmPasswordRequestApplicationJsonBuilder toBuilder() =>
+      LoginConfirmPasswordRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is LoginConfirmPasswordRequestApplicationJson && password == other.password;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, password.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'LoginConfirmPasswordRequestApplicationJson')..add('password', password))
+        .toString();
+  }
+}
+
+class LoginConfirmPasswordRequestApplicationJsonBuilder
+    implements
+        Builder<LoginConfirmPasswordRequestApplicationJson, LoginConfirmPasswordRequestApplicationJsonBuilder>,
+        $LoginConfirmPasswordRequestApplicationJsonInterfaceBuilder {
+  _$LoginConfirmPasswordRequestApplicationJson? _$v;
+
+  String? _password;
+  String? get password => _$this._password;
+  set password(covariant String? password) => _$this._password = password;
+
+  LoginConfirmPasswordRequestApplicationJsonBuilder() {
+    LoginConfirmPasswordRequestApplicationJson._defaults(this);
+  }
+
+  LoginConfirmPasswordRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _password = $v.password;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant LoginConfirmPasswordRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$LoginConfirmPasswordRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(LoginConfirmPasswordRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  LoginConfirmPasswordRequestApplicationJson build() => _build();
+
+  _$LoginConfirmPasswordRequestApplicationJson _build() {
+    LoginConfirmPasswordRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$LoginConfirmPasswordRequestApplicationJson._(
+            password: BuiltValueNullFieldError.checkNotNull(
+                password, r'LoginConfirmPasswordRequestApplicationJson', 'password'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $LoginConfirmPasswordResponseApplicationJsonInterfaceBuilder {
   void replace($LoginConfirmPasswordResponseApplicationJsonInterface other);
   void update(void Function($LoginConfirmPasswordResponseApplicationJsonInterfaceBuilder) updates);
@@ -16469,6 +18739,105 @@ class LoginConfirmPasswordResponseApplicationJsonBuilder
         _$LoginConfirmPasswordResponseApplicationJson._(
             lastLogin: BuiltValueNullFieldError.checkNotNull(
                 lastLogin, r'LoginConfirmPasswordResponseApplicationJson', 'lastLogin'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $NavigationGetAppsNavigationRequestApplicationJsonInterfaceBuilder {
+  void replace($NavigationGetAppsNavigationRequestApplicationJsonInterface other);
+  void update(void Function($NavigationGetAppsNavigationRequestApplicationJsonInterfaceBuilder) updates);
+  bool? get absolute;
+  set absolute(bool? absolute);
+}
+
+class _$NavigationGetAppsNavigationRequestApplicationJson extends NavigationGetAppsNavigationRequestApplicationJson {
+  @override
+  final bool absolute;
+
+  factory _$NavigationGetAppsNavigationRequestApplicationJson(
+          [void Function(NavigationGetAppsNavigationRequestApplicationJsonBuilder)? updates]) =>
+      (NavigationGetAppsNavigationRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$NavigationGetAppsNavigationRequestApplicationJson._({required this.absolute}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(absolute, r'NavigationGetAppsNavigationRequestApplicationJson', 'absolute');
+  }
+
+  @override
+  NavigationGetAppsNavigationRequestApplicationJson rebuild(
+          void Function(NavigationGetAppsNavigationRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  NavigationGetAppsNavigationRequestApplicationJsonBuilder toBuilder() =>
+      NavigationGetAppsNavigationRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is NavigationGetAppsNavigationRequestApplicationJson && absolute == other.absolute;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, absolute.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'NavigationGetAppsNavigationRequestApplicationJson')
+          ..add('absolute', absolute))
+        .toString();
+  }
+}
+
+class NavigationGetAppsNavigationRequestApplicationJsonBuilder
+    implements
+        Builder<NavigationGetAppsNavigationRequestApplicationJson,
+            NavigationGetAppsNavigationRequestApplicationJsonBuilder>,
+        $NavigationGetAppsNavigationRequestApplicationJsonInterfaceBuilder {
+  _$NavigationGetAppsNavigationRequestApplicationJson? _$v;
+
+  bool? _absolute;
+  bool? get absolute => _$this._absolute;
+  set absolute(covariant bool? absolute) => _$this._absolute = absolute;
+
+  NavigationGetAppsNavigationRequestApplicationJsonBuilder() {
+    NavigationGetAppsNavigationRequestApplicationJson._defaults(this);
+  }
+
+  NavigationGetAppsNavigationRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _absolute = $v.absolute;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant NavigationGetAppsNavigationRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$NavigationGetAppsNavigationRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(NavigationGetAppsNavigationRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  NavigationGetAppsNavigationRequestApplicationJson build() => _build();
+
+  _$NavigationGetAppsNavigationRequestApplicationJson _build() {
+    NavigationGetAppsNavigationRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$NavigationGetAppsNavigationRequestApplicationJson._(
+            absolute: BuiltValueNullFieldError.checkNotNull(
+                absolute, r'NavigationGetAppsNavigationRequestApplicationJson', 'absolute'));
     replace(_$result);
     return _$result;
   }
@@ -16927,6 +19296,107 @@ class NavigationGetAppsNavigationResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $NavigationGetSettingsNavigationRequestApplicationJsonInterfaceBuilder {
+  void replace($NavigationGetSettingsNavigationRequestApplicationJsonInterface other);
+  void update(void Function($NavigationGetSettingsNavigationRequestApplicationJsonInterfaceBuilder) updates);
+  bool? get absolute;
+  set absolute(bool? absolute);
+}
+
+class _$NavigationGetSettingsNavigationRequestApplicationJson
+    extends NavigationGetSettingsNavigationRequestApplicationJson {
+  @override
+  final bool absolute;
+
+  factory _$NavigationGetSettingsNavigationRequestApplicationJson(
+          [void Function(NavigationGetSettingsNavigationRequestApplicationJsonBuilder)? updates]) =>
+      (NavigationGetSettingsNavigationRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$NavigationGetSettingsNavigationRequestApplicationJson._({required this.absolute}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        absolute, r'NavigationGetSettingsNavigationRequestApplicationJson', 'absolute');
+  }
+
+  @override
+  NavigationGetSettingsNavigationRequestApplicationJson rebuild(
+          void Function(NavigationGetSettingsNavigationRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  NavigationGetSettingsNavigationRequestApplicationJsonBuilder toBuilder() =>
+      NavigationGetSettingsNavigationRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is NavigationGetSettingsNavigationRequestApplicationJson && absolute == other.absolute;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, absolute.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'NavigationGetSettingsNavigationRequestApplicationJson')
+          ..add('absolute', absolute))
+        .toString();
+  }
+}
+
+class NavigationGetSettingsNavigationRequestApplicationJsonBuilder
+    implements
+        Builder<NavigationGetSettingsNavigationRequestApplicationJson,
+            NavigationGetSettingsNavigationRequestApplicationJsonBuilder>,
+        $NavigationGetSettingsNavigationRequestApplicationJsonInterfaceBuilder {
+  _$NavigationGetSettingsNavigationRequestApplicationJson? _$v;
+
+  bool? _absolute;
+  bool? get absolute => _$this._absolute;
+  set absolute(covariant bool? absolute) => _$this._absolute = absolute;
+
+  NavigationGetSettingsNavigationRequestApplicationJsonBuilder() {
+    NavigationGetSettingsNavigationRequestApplicationJson._defaults(this);
+  }
+
+  NavigationGetSettingsNavigationRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _absolute = $v.absolute;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant NavigationGetSettingsNavigationRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$NavigationGetSettingsNavigationRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(NavigationGetSettingsNavigationRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  NavigationGetSettingsNavigationRequestApplicationJson build() => _build();
+
+  _$NavigationGetSettingsNavigationRequestApplicationJson _build() {
+    NavigationGetSettingsNavigationRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$NavigationGetSettingsNavigationRequestApplicationJson._(
+            absolute: BuiltValueNullFieldError.checkNotNull(
+                absolute, r'NavigationGetSettingsNavigationRequestApplicationJson', 'absolute'));
     replace(_$result);
     return _$result;
   }
@@ -26323,6 +28793,521 @@ class OcsGetCapabilitiesResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $PreviewGetPreviewRequestApplicationJsonInterfaceBuilder {
+  void replace($PreviewGetPreviewRequestApplicationJsonInterface other);
+  void update(void Function($PreviewGetPreviewRequestApplicationJsonInterfaceBuilder) updates);
+  String? get file;
+  set file(String? file);
+
+  int? get x;
+  set x(int? x);
+
+  int? get y;
+  set y(int? y);
+
+  bool? get a;
+  set a(bool? a);
+
+  bool? get forceIcon;
+  set forceIcon(bool? forceIcon);
+
+  String? get mode;
+  set mode(String? mode);
+
+  bool? get mimeFallback;
+  set mimeFallback(bool? mimeFallback);
+}
+
+class _$PreviewGetPreviewRequestApplicationJson extends PreviewGetPreviewRequestApplicationJson {
+  @override
+  final String file;
+  @override
+  final int x;
+  @override
+  final int y;
+  @override
+  final bool a;
+  @override
+  final bool forceIcon;
+  @override
+  final String mode;
+  @override
+  final bool mimeFallback;
+
+  factory _$PreviewGetPreviewRequestApplicationJson(
+          [void Function(PreviewGetPreviewRequestApplicationJsonBuilder)? updates]) =>
+      (PreviewGetPreviewRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PreviewGetPreviewRequestApplicationJson._(
+      {required this.file,
+      required this.x,
+      required this.y,
+      required this.a,
+      required this.forceIcon,
+      required this.mode,
+      required this.mimeFallback})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(file, r'PreviewGetPreviewRequestApplicationJson', 'file');
+    BuiltValueNullFieldError.checkNotNull(x, r'PreviewGetPreviewRequestApplicationJson', 'x');
+    BuiltValueNullFieldError.checkNotNull(y, r'PreviewGetPreviewRequestApplicationJson', 'y');
+    BuiltValueNullFieldError.checkNotNull(a, r'PreviewGetPreviewRequestApplicationJson', 'a');
+    BuiltValueNullFieldError.checkNotNull(forceIcon, r'PreviewGetPreviewRequestApplicationJson', 'forceIcon');
+    BuiltValueNullFieldError.checkNotNull(mode, r'PreviewGetPreviewRequestApplicationJson', 'mode');
+    BuiltValueNullFieldError.checkNotNull(mimeFallback, r'PreviewGetPreviewRequestApplicationJson', 'mimeFallback');
+  }
+
+  @override
+  PreviewGetPreviewRequestApplicationJson rebuild(
+          void Function(PreviewGetPreviewRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PreviewGetPreviewRequestApplicationJsonBuilder toBuilder() =>
+      PreviewGetPreviewRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PreviewGetPreviewRequestApplicationJson &&
+        file == other.file &&
+        x == other.x &&
+        y == other.y &&
+        a == other.a &&
+        forceIcon == other.forceIcon &&
+        mode == other.mode &&
+        mimeFallback == other.mimeFallback;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, file.hashCode);
+    _$hash = $jc(_$hash, x.hashCode);
+    _$hash = $jc(_$hash, y.hashCode);
+    _$hash = $jc(_$hash, a.hashCode);
+    _$hash = $jc(_$hash, forceIcon.hashCode);
+    _$hash = $jc(_$hash, mode.hashCode);
+    _$hash = $jc(_$hash, mimeFallback.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PreviewGetPreviewRequestApplicationJson')
+          ..add('file', file)
+          ..add('x', x)
+          ..add('y', y)
+          ..add('a', a)
+          ..add('forceIcon', forceIcon)
+          ..add('mode', mode)
+          ..add('mimeFallback', mimeFallback))
+        .toString();
+  }
+}
+
+class PreviewGetPreviewRequestApplicationJsonBuilder
+    implements
+        Builder<PreviewGetPreviewRequestApplicationJson, PreviewGetPreviewRequestApplicationJsonBuilder>,
+        $PreviewGetPreviewRequestApplicationJsonInterfaceBuilder {
+  _$PreviewGetPreviewRequestApplicationJson? _$v;
+
+  String? _file;
+  String? get file => _$this._file;
+  set file(covariant String? file) => _$this._file = file;
+
+  int? _x;
+  int? get x => _$this._x;
+  set x(covariant int? x) => _$this._x = x;
+
+  int? _y;
+  int? get y => _$this._y;
+  set y(covariant int? y) => _$this._y = y;
+
+  bool? _a;
+  bool? get a => _$this._a;
+  set a(covariant bool? a) => _$this._a = a;
+
+  bool? _forceIcon;
+  bool? get forceIcon => _$this._forceIcon;
+  set forceIcon(covariant bool? forceIcon) => _$this._forceIcon = forceIcon;
+
+  String? _mode;
+  String? get mode => _$this._mode;
+  set mode(covariant String? mode) => _$this._mode = mode;
+
+  bool? _mimeFallback;
+  bool? get mimeFallback => _$this._mimeFallback;
+  set mimeFallback(covariant bool? mimeFallback) => _$this._mimeFallback = mimeFallback;
+
+  PreviewGetPreviewRequestApplicationJsonBuilder() {
+    PreviewGetPreviewRequestApplicationJson._defaults(this);
+  }
+
+  PreviewGetPreviewRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _file = $v.file;
+      _x = $v.x;
+      _y = $v.y;
+      _a = $v.a;
+      _forceIcon = $v.forceIcon;
+      _mode = $v.mode;
+      _mimeFallback = $v.mimeFallback;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PreviewGetPreviewRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PreviewGetPreviewRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PreviewGetPreviewRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PreviewGetPreviewRequestApplicationJson build() => _build();
+
+  _$PreviewGetPreviewRequestApplicationJson _build() {
+    PreviewGetPreviewRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$PreviewGetPreviewRequestApplicationJson._(
+            file: BuiltValueNullFieldError.checkNotNull(file, r'PreviewGetPreviewRequestApplicationJson', 'file'),
+            x: BuiltValueNullFieldError.checkNotNull(x, r'PreviewGetPreviewRequestApplicationJson', 'x'),
+            y: BuiltValueNullFieldError.checkNotNull(y, r'PreviewGetPreviewRequestApplicationJson', 'y'),
+            a: BuiltValueNullFieldError.checkNotNull(a, r'PreviewGetPreviewRequestApplicationJson', 'a'),
+            forceIcon: BuiltValueNullFieldError.checkNotNull(
+                forceIcon, r'PreviewGetPreviewRequestApplicationJson', 'forceIcon'),
+            mode: BuiltValueNullFieldError.checkNotNull(mode, r'PreviewGetPreviewRequestApplicationJson', 'mode'),
+            mimeFallback: BuiltValueNullFieldError.checkNotNull(
+                mimeFallback, r'PreviewGetPreviewRequestApplicationJson', 'mimeFallback'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $PreviewGetPreviewByFileIdRequestApplicationJsonInterfaceBuilder {
+  void replace($PreviewGetPreviewByFileIdRequestApplicationJsonInterface other);
+  void update(void Function($PreviewGetPreviewByFileIdRequestApplicationJsonInterfaceBuilder) updates);
+  int? get fileId;
+  set fileId(int? fileId);
+
+  int? get x;
+  set x(int? x);
+
+  int? get y;
+  set y(int? y);
+
+  bool? get a;
+  set a(bool? a);
+
+  bool? get forceIcon;
+  set forceIcon(bool? forceIcon);
+
+  String? get mode;
+  set mode(String? mode);
+
+  bool? get mimeFallback;
+  set mimeFallback(bool? mimeFallback);
+}
+
+class _$PreviewGetPreviewByFileIdRequestApplicationJson extends PreviewGetPreviewByFileIdRequestApplicationJson {
+  @override
+  final int fileId;
+  @override
+  final int x;
+  @override
+  final int y;
+  @override
+  final bool a;
+  @override
+  final bool forceIcon;
+  @override
+  final String mode;
+  @override
+  final bool mimeFallback;
+
+  factory _$PreviewGetPreviewByFileIdRequestApplicationJson(
+          [void Function(PreviewGetPreviewByFileIdRequestApplicationJsonBuilder)? updates]) =>
+      (PreviewGetPreviewByFileIdRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PreviewGetPreviewByFileIdRequestApplicationJson._(
+      {required this.fileId,
+      required this.x,
+      required this.y,
+      required this.a,
+      required this.forceIcon,
+      required this.mode,
+      required this.mimeFallback})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(fileId, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'fileId');
+    BuiltValueNullFieldError.checkNotNull(x, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'x');
+    BuiltValueNullFieldError.checkNotNull(y, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'y');
+    BuiltValueNullFieldError.checkNotNull(a, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'a');
+    BuiltValueNullFieldError.checkNotNull(forceIcon, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'forceIcon');
+    BuiltValueNullFieldError.checkNotNull(mode, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'mode');
+    BuiltValueNullFieldError.checkNotNull(
+        mimeFallback, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'mimeFallback');
+  }
+
+  @override
+  PreviewGetPreviewByFileIdRequestApplicationJson rebuild(
+          void Function(PreviewGetPreviewByFileIdRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PreviewGetPreviewByFileIdRequestApplicationJsonBuilder toBuilder() =>
+      PreviewGetPreviewByFileIdRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PreviewGetPreviewByFileIdRequestApplicationJson &&
+        fileId == other.fileId &&
+        x == other.x &&
+        y == other.y &&
+        a == other.a &&
+        forceIcon == other.forceIcon &&
+        mode == other.mode &&
+        mimeFallback == other.mimeFallback;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, fileId.hashCode);
+    _$hash = $jc(_$hash, x.hashCode);
+    _$hash = $jc(_$hash, y.hashCode);
+    _$hash = $jc(_$hash, a.hashCode);
+    _$hash = $jc(_$hash, forceIcon.hashCode);
+    _$hash = $jc(_$hash, mode.hashCode);
+    _$hash = $jc(_$hash, mimeFallback.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PreviewGetPreviewByFileIdRequestApplicationJson')
+          ..add('fileId', fileId)
+          ..add('x', x)
+          ..add('y', y)
+          ..add('a', a)
+          ..add('forceIcon', forceIcon)
+          ..add('mode', mode)
+          ..add('mimeFallback', mimeFallback))
+        .toString();
+  }
+}
+
+class PreviewGetPreviewByFileIdRequestApplicationJsonBuilder
+    implements
+        Builder<PreviewGetPreviewByFileIdRequestApplicationJson,
+            PreviewGetPreviewByFileIdRequestApplicationJsonBuilder>,
+        $PreviewGetPreviewByFileIdRequestApplicationJsonInterfaceBuilder {
+  _$PreviewGetPreviewByFileIdRequestApplicationJson? _$v;
+
+  int? _fileId;
+  int? get fileId => _$this._fileId;
+  set fileId(covariant int? fileId) => _$this._fileId = fileId;
+
+  int? _x;
+  int? get x => _$this._x;
+  set x(covariant int? x) => _$this._x = x;
+
+  int? _y;
+  int? get y => _$this._y;
+  set y(covariant int? y) => _$this._y = y;
+
+  bool? _a;
+  bool? get a => _$this._a;
+  set a(covariant bool? a) => _$this._a = a;
+
+  bool? _forceIcon;
+  bool? get forceIcon => _$this._forceIcon;
+  set forceIcon(covariant bool? forceIcon) => _$this._forceIcon = forceIcon;
+
+  String? _mode;
+  String? get mode => _$this._mode;
+  set mode(covariant String? mode) => _$this._mode = mode;
+
+  bool? _mimeFallback;
+  bool? get mimeFallback => _$this._mimeFallback;
+  set mimeFallback(covariant bool? mimeFallback) => _$this._mimeFallback = mimeFallback;
+
+  PreviewGetPreviewByFileIdRequestApplicationJsonBuilder() {
+    PreviewGetPreviewByFileIdRequestApplicationJson._defaults(this);
+  }
+
+  PreviewGetPreviewByFileIdRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _fileId = $v.fileId;
+      _x = $v.x;
+      _y = $v.y;
+      _a = $v.a;
+      _forceIcon = $v.forceIcon;
+      _mode = $v.mode;
+      _mimeFallback = $v.mimeFallback;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PreviewGetPreviewByFileIdRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PreviewGetPreviewByFileIdRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PreviewGetPreviewByFileIdRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PreviewGetPreviewByFileIdRequestApplicationJson build() => _build();
+
+  _$PreviewGetPreviewByFileIdRequestApplicationJson _build() {
+    PreviewGetPreviewByFileIdRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$PreviewGetPreviewByFileIdRequestApplicationJson._(
+            fileId: BuiltValueNullFieldError.checkNotNull(
+                fileId, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'fileId'),
+            x: BuiltValueNullFieldError.checkNotNull(x, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'x'),
+            y: BuiltValueNullFieldError.checkNotNull(y, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'y'),
+            a: BuiltValueNullFieldError.checkNotNull(a, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'a'),
+            forceIcon: BuiltValueNullFieldError.checkNotNull(
+                forceIcon, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'forceIcon'),
+            mode:
+                BuiltValueNullFieldError.checkNotNull(mode, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'mode'),
+            mimeFallback: BuiltValueNullFieldError.checkNotNull(
+                mimeFallback, r'PreviewGetPreviewByFileIdRequestApplicationJson', 'mimeFallback'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ProfileApiSetVisibilityRequestApplicationJsonInterfaceBuilder {
+  void replace($ProfileApiSetVisibilityRequestApplicationJsonInterface other);
+  void update(void Function($ProfileApiSetVisibilityRequestApplicationJsonInterfaceBuilder) updates);
+  String? get paramId;
+  set paramId(String? paramId);
+
+  String? get visibility;
+  set visibility(String? visibility);
+}
+
+class _$ProfileApiSetVisibilityRequestApplicationJson extends ProfileApiSetVisibilityRequestApplicationJson {
+  @override
+  final String paramId;
+  @override
+  final String visibility;
+
+  factory _$ProfileApiSetVisibilityRequestApplicationJson(
+          [void Function(ProfileApiSetVisibilityRequestApplicationJsonBuilder)? updates]) =>
+      (ProfileApiSetVisibilityRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ProfileApiSetVisibilityRequestApplicationJson._({required this.paramId, required this.visibility}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(paramId, r'ProfileApiSetVisibilityRequestApplicationJson', 'paramId');
+    BuiltValueNullFieldError.checkNotNull(visibility, r'ProfileApiSetVisibilityRequestApplicationJson', 'visibility');
+  }
+
+  @override
+  ProfileApiSetVisibilityRequestApplicationJson rebuild(
+          void Function(ProfileApiSetVisibilityRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ProfileApiSetVisibilityRequestApplicationJsonBuilder toBuilder() =>
+      ProfileApiSetVisibilityRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ProfileApiSetVisibilityRequestApplicationJson &&
+        paramId == other.paramId &&
+        visibility == other.visibility;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, paramId.hashCode);
+    _$hash = $jc(_$hash, visibility.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ProfileApiSetVisibilityRequestApplicationJson')
+          ..add('paramId', paramId)
+          ..add('visibility', visibility))
+        .toString();
+  }
+}
+
+class ProfileApiSetVisibilityRequestApplicationJsonBuilder
+    implements
+        Builder<ProfileApiSetVisibilityRequestApplicationJson, ProfileApiSetVisibilityRequestApplicationJsonBuilder>,
+        $ProfileApiSetVisibilityRequestApplicationJsonInterfaceBuilder {
+  _$ProfileApiSetVisibilityRequestApplicationJson? _$v;
+
+  String? _paramId;
+  String? get paramId => _$this._paramId;
+  set paramId(covariant String? paramId) => _$this._paramId = paramId;
+
+  String? _visibility;
+  String? get visibility => _$this._visibility;
+  set visibility(covariant String? visibility) => _$this._visibility = visibility;
+
+  ProfileApiSetVisibilityRequestApplicationJsonBuilder() {
+    ProfileApiSetVisibilityRequestApplicationJson._defaults(this);
+  }
+
+  ProfileApiSetVisibilityRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _paramId = $v.paramId;
+      _visibility = $v.visibility;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ProfileApiSetVisibilityRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ProfileApiSetVisibilityRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ProfileApiSetVisibilityRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ProfileApiSetVisibilityRequestApplicationJson build() => _build();
+
+  _$ProfileApiSetVisibilityRequestApplicationJson _build() {
+    ProfileApiSetVisibilityRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ProfileApiSetVisibilityRequestApplicationJson._(
+            paramId: BuiltValueNullFieldError.checkNotNull(
+                paramId, r'ProfileApiSetVisibilityRequestApplicationJson', 'paramId'),
+            visibility: BuiltValueNullFieldError.checkNotNull(
+                visibility, r'ProfileApiSetVisibilityRequestApplicationJson', 'visibility'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ProfileApiSetVisibilityResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ProfileApiSetVisibilityResponseApplicationJson_OcsInterface other);
   void update(void Function($ProfileApiSetVisibilityResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -26551,6 +29536,136 @@ class ProfileApiSetVisibilityResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ReferenceApiExtractRequestApplicationJsonInterfaceBuilder {
+  void replace($ReferenceApiExtractRequestApplicationJsonInterface other);
+  void update(void Function($ReferenceApiExtractRequestApplicationJsonInterfaceBuilder) updates);
+  String? get text;
+  set text(String? text);
+
+  bool? get resolve;
+  set resolve(bool? resolve);
+
+  int? get limit;
+  set limit(int? limit);
+}
+
+class _$ReferenceApiExtractRequestApplicationJson extends ReferenceApiExtractRequestApplicationJson {
+  @override
+  final String text;
+  @override
+  final bool resolve;
+  @override
+  final int limit;
+
+  factory _$ReferenceApiExtractRequestApplicationJson(
+          [void Function(ReferenceApiExtractRequestApplicationJsonBuilder)? updates]) =>
+      (ReferenceApiExtractRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ReferenceApiExtractRequestApplicationJson._({required this.text, required this.resolve, required this.limit})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(text, r'ReferenceApiExtractRequestApplicationJson', 'text');
+    BuiltValueNullFieldError.checkNotNull(resolve, r'ReferenceApiExtractRequestApplicationJson', 'resolve');
+    BuiltValueNullFieldError.checkNotNull(limit, r'ReferenceApiExtractRequestApplicationJson', 'limit');
+  }
+
+  @override
+  ReferenceApiExtractRequestApplicationJson rebuild(
+          void Function(ReferenceApiExtractRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ReferenceApiExtractRequestApplicationJsonBuilder toBuilder() =>
+      ReferenceApiExtractRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ReferenceApiExtractRequestApplicationJson &&
+        text == other.text &&
+        resolve == other.resolve &&
+        limit == other.limit;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, text.hashCode);
+    _$hash = $jc(_$hash, resolve.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ReferenceApiExtractRequestApplicationJson')
+          ..add('text', text)
+          ..add('resolve', resolve)
+          ..add('limit', limit))
+        .toString();
+  }
+}
+
+class ReferenceApiExtractRequestApplicationJsonBuilder
+    implements
+        Builder<ReferenceApiExtractRequestApplicationJson, ReferenceApiExtractRequestApplicationJsonBuilder>,
+        $ReferenceApiExtractRequestApplicationJsonInterfaceBuilder {
+  _$ReferenceApiExtractRequestApplicationJson? _$v;
+
+  String? _text;
+  String? get text => _$this._text;
+  set text(covariant String? text) => _$this._text = text;
+
+  bool? _resolve;
+  bool? get resolve => _$this._resolve;
+  set resolve(covariant bool? resolve) => _$this._resolve = resolve;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  ReferenceApiExtractRequestApplicationJsonBuilder() {
+    ReferenceApiExtractRequestApplicationJson._defaults(this);
+  }
+
+  ReferenceApiExtractRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _text = $v.text;
+      _resolve = $v.resolve;
+      _limit = $v.limit;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ReferenceApiExtractRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ReferenceApiExtractRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ReferenceApiExtractRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ReferenceApiExtractRequestApplicationJson build() => _build();
+
+  _$ReferenceApiExtractRequestApplicationJson _build() {
+    ReferenceApiExtractRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ReferenceApiExtractRequestApplicationJson._(
+            text: BuiltValueNullFieldError.checkNotNull(text, r'ReferenceApiExtractRequestApplicationJson', 'text'),
+            resolve:
+                BuiltValueNullFieldError.checkNotNull(resolve, r'ReferenceApiExtractRequestApplicationJson', 'resolve'),
+            limit: BuiltValueNullFieldError.checkNotNull(limit, r'ReferenceApiExtractRequestApplicationJson', 'limit'));
     replace(_$result);
     return _$result;
   }
@@ -27048,6 +30163,103 @@ class ReferenceApiExtractResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $ReferenceApiResolveOneRequestApplicationJsonInterfaceBuilder {
+  void replace($ReferenceApiResolveOneRequestApplicationJsonInterface other);
+  void update(void Function($ReferenceApiResolveOneRequestApplicationJsonInterfaceBuilder) updates);
+  String? get reference;
+  set reference(String? reference);
+}
+
+class _$ReferenceApiResolveOneRequestApplicationJson extends ReferenceApiResolveOneRequestApplicationJson {
+  @override
+  final String reference;
+
+  factory _$ReferenceApiResolveOneRequestApplicationJson(
+          [void Function(ReferenceApiResolveOneRequestApplicationJsonBuilder)? updates]) =>
+      (ReferenceApiResolveOneRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ReferenceApiResolveOneRequestApplicationJson._({required this.reference}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(reference, r'ReferenceApiResolveOneRequestApplicationJson', 'reference');
+  }
+
+  @override
+  ReferenceApiResolveOneRequestApplicationJson rebuild(
+          void Function(ReferenceApiResolveOneRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ReferenceApiResolveOneRequestApplicationJsonBuilder toBuilder() =>
+      ReferenceApiResolveOneRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ReferenceApiResolveOneRequestApplicationJson && reference == other.reference;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, reference.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ReferenceApiResolveOneRequestApplicationJson')..add('reference', reference))
+        .toString();
+  }
+}
+
+class ReferenceApiResolveOneRequestApplicationJsonBuilder
+    implements
+        Builder<ReferenceApiResolveOneRequestApplicationJson, ReferenceApiResolveOneRequestApplicationJsonBuilder>,
+        $ReferenceApiResolveOneRequestApplicationJsonInterfaceBuilder {
+  _$ReferenceApiResolveOneRequestApplicationJson? _$v;
+
+  String? _reference;
+  String? get reference => _$this._reference;
+  set reference(covariant String? reference) => _$this._reference = reference;
+
+  ReferenceApiResolveOneRequestApplicationJsonBuilder() {
+    ReferenceApiResolveOneRequestApplicationJson._defaults(this);
+  }
+
+  ReferenceApiResolveOneRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _reference = $v.reference;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ReferenceApiResolveOneRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ReferenceApiResolveOneRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ReferenceApiResolveOneRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ReferenceApiResolveOneRequestApplicationJson build() => _build();
+
+  _$ReferenceApiResolveOneRequestApplicationJson _build() {
+    ReferenceApiResolveOneRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ReferenceApiResolveOneRequestApplicationJson._(
+            reference: BuiltValueNullFieldError.checkNotNull(
+                reference, r'ReferenceApiResolveOneRequestApplicationJson', 'reference'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($ReferenceApiResolveOneResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
@@ -27382,6 +30594,130 @@ class ReferenceApiResolveOneResponseApplicationJsonBuilder
         ocs.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(r'ReferenceApiResolveOneResponseApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ReferenceApiResolveRequestApplicationJsonInterfaceBuilder {
+  void replace($ReferenceApiResolveRequestApplicationJsonInterface other);
+  void update(void Function($ReferenceApiResolveRequestApplicationJsonInterfaceBuilder) updates);
+  ListBuilder<String> get references;
+  set references(ListBuilder<String>? references);
+
+  int? get limit;
+  set limit(int? limit);
+}
+
+class _$ReferenceApiResolveRequestApplicationJson extends ReferenceApiResolveRequestApplicationJson {
+  @override
+  final BuiltList<String> references;
+  @override
+  final int limit;
+
+  factory _$ReferenceApiResolveRequestApplicationJson(
+          [void Function(ReferenceApiResolveRequestApplicationJsonBuilder)? updates]) =>
+      (ReferenceApiResolveRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ReferenceApiResolveRequestApplicationJson._({required this.references, required this.limit}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(references, r'ReferenceApiResolveRequestApplicationJson', 'references');
+    BuiltValueNullFieldError.checkNotNull(limit, r'ReferenceApiResolveRequestApplicationJson', 'limit');
+  }
+
+  @override
+  ReferenceApiResolveRequestApplicationJson rebuild(
+          void Function(ReferenceApiResolveRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ReferenceApiResolveRequestApplicationJsonBuilder toBuilder() =>
+      ReferenceApiResolveRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ReferenceApiResolveRequestApplicationJson && references == other.references && limit == other.limit;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, references.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ReferenceApiResolveRequestApplicationJson')
+          ..add('references', references)
+          ..add('limit', limit))
+        .toString();
+  }
+}
+
+class ReferenceApiResolveRequestApplicationJsonBuilder
+    implements
+        Builder<ReferenceApiResolveRequestApplicationJson, ReferenceApiResolveRequestApplicationJsonBuilder>,
+        $ReferenceApiResolveRequestApplicationJsonInterfaceBuilder {
+  _$ReferenceApiResolveRequestApplicationJson? _$v;
+
+  ListBuilder<String>? _references;
+  ListBuilder<String> get references => _$this._references ??= ListBuilder<String>();
+  set references(covariant ListBuilder<String>? references) => _$this._references = references;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  ReferenceApiResolveRequestApplicationJsonBuilder() {
+    ReferenceApiResolveRequestApplicationJson._defaults(this);
+  }
+
+  ReferenceApiResolveRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _references = $v.references.toBuilder();
+      _limit = $v.limit;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ReferenceApiResolveRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ReferenceApiResolveRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ReferenceApiResolveRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ReferenceApiResolveRequestApplicationJson build() => _build();
+
+  _$ReferenceApiResolveRequestApplicationJson _build() {
+    ReferenceApiResolveRequestApplicationJson._validate(this);
+    _$ReferenceApiResolveRequestApplicationJson _$result;
+    try {
+      _$result = _$v ??
+          _$ReferenceApiResolveRequestApplicationJson._(
+              references: references.build(),
+              limit:
+                  BuiltValueNullFieldError.checkNotNull(limit, r'ReferenceApiResolveRequestApplicationJson', 'limit'));
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'references';
+        references.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'ReferenceApiResolveRequestApplicationJson', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -28128,6 +31464,100 @@ class ReferenceApiGetProvidersInfoResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ReferenceApiTouchProviderRequestApplicationJsonInterfaceBuilder {
+  void replace($ReferenceApiTouchProviderRequestApplicationJsonInterface other);
+  void update(void Function($ReferenceApiTouchProviderRequestApplicationJsonInterfaceBuilder) updates);
+  int? get timestamp;
+  set timestamp(int? timestamp);
+}
+
+class _$ReferenceApiTouchProviderRequestApplicationJson extends ReferenceApiTouchProviderRequestApplicationJson {
+  @override
+  final int? timestamp;
+
+  factory _$ReferenceApiTouchProviderRequestApplicationJson(
+          [void Function(ReferenceApiTouchProviderRequestApplicationJsonBuilder)? updates]) =>
+      (ReferenceApiTouchProviderRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ReferenceApiTouchProviderRequestApplicationJson._({this.timestamp}) : super._();
+
+  @override
+  ReferenceApiTouchProviderRequestApplicationJson rebuild(
+          void Function(ReferenceApiTouchProviderRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ReferenceApiTouchProviderRequestApplicationJsonBuilder toBuilder() =>
+      ReferenceApiTouchProviderRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ReferenceApiTouchProviderRequestApplicationJson && timestamp == other.timestamp;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, timestamp.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ReferenceApiTouchProviderRequestApplicationJson')
+          ..add('timestamp', timestamp))
+        .toString();
+  }
+}
+
+class ReferenceApiTouchProviderRequestApplicationJsonBuilder
+    implements
+        Builder<ReferenceApiTouchProviderRequestApplicationJson,
+            ReferenceApiTouchProviderRequestApplicationJsonBuilder>,
+        $ReferenceApiTouchProviderRequestApplicationJsonInterfaceBuilder {
+  _$ReferenceApiTouchProviderRequestApplicationJson? _$v;
+
+  int? _timestamp;
+  int? get timestamp => _$this._timestamp;
+  set timestamp(covariant int? timestamp) => _$this._timestamp = timestamp;
+
+  ReferenceApiTouchProviderRequestApplicationJsonBuilder() {
+    ReferenceApiTouchProviderRequestApplicationJson._defaults(this);
+  }
+
+  ReferenceApiTouchProviderRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _timestamp = $v.timestamp;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ReferenceApiTouchProviderRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ReferenceApiTouchProviderRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ReferenceApiTouchProviderRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ReferenceApiTouchProviderRequestApplicationJson build() => _build();
+
+  _$ReferenceApiTouchProviderRequestApplicationJson _build() {
+    ReferenceApiTouchProviderRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$ReferenceApiTouchProviderRequestApplicationJson._(timestamp: timestamp);
     replace(_$result);
     return _$result;
   }
@@ -29915,6 +33345,156 @@ class TextProcessingApiTaskTypesResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $TextProcessingApiScheduleRequestApplicationJsonInterfaceBuilder {
+  void replace($TextProcessingApiScheduleRequestApplicationJsonInterface other);
+  void update(void Function($TextProcessingApiScheduleRequestApplicationJsonInterfaceBuilder) updates);
+  String? get input;
+  set input(String? input);
+
+  String? get type;
+  set type(String? type);
+
+  String? get appId;
+  set appId(String? appId);
+
+  String? get identifier;
+  set identifier(String? identifier);
+}
+
+class _$TextProcessingApiScheduleRequestApplicationJson extends TextProcessingApiScheduleRequestApplicationJson {
+  @override
+  final String input;
+  @override
+  final String type;
+  @override
+  final String appId;
+  @override
+  final String identifier;
+
+  factory _$TextProcessingApiScheduleRequestApplicationJson(
+          [void Function(TextProcessingApiScheduleRequestApplicationJsonBuilder)? updates]) =>
+      (TextProcessingApiScheduleRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$TextProcessingApiScheduleRequestApplicationJson._(
+      {required this.input, required this.type, required this.appId, required this.identifier})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(input, r'TextProcessingApiScheduleRequestApplicationJson', 'input');
+    BuiltValueNullFieldError.checkNotNull(type, r'TextProcessingApiScheduleRequestApplicationJson', 'type');
+    BuiltValueNullFieldError.checkNotNull(appId, r'TextProcessingApiScheduleRequestApplicationJson', 'appId');
+    BuiltValueNullFieldError.checkNotNull(identifier, r'TextProcessingApiScheduleRequestApplicationJson', 'identifier');
+  }
+
+  @override
+  TextProcessingApiScheduleRequestApplicationJson rebuild(
+          void Function(TextProcessingApiScheduleRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  TextProcessingApiScheduleRequestApplicationJsonBuilder toBuilder() =>
+      TextProcessingApiScheduleRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TextProcessingApiScheduleRequestApplicationJson &&
+        input == other.input &&
+        type == other.type &&
+        appId == other.appId &&
+        identifier == other.identifier;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, input.hashCode);
+    _$hash = $jc(_$hash, type.hashCode);
+    _$hash = $jc(_$hash, appId.hashCode);
+    _$hash = $jc(_$hash, identifier.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'TextProcessingApiScheduleRequestApplicationJson')
+          ..add('input', input)
+          ..add('type', type)
+          ..add('appId', appId)
+          ..add('identifier', identifier))
+        .toString();
+  }
+}
+
+class TextProcessingApiScheduleRequestApplicationJsonBuilder
+    implements
+        Builder<TextProcessingApiScheduleRequestApplicationJson,
+            TextProcessingApiScheduleRequestApplicationJsonBuilder>,
+        $TextProcessingApiScheduleRequestApplicationJsonInterfaceBuilder {
+  _$TextProcessingApiScheduleRequestApplicationJson? _$v;
+
+  String? _input;
+  String? get input => _$this._input;
+  set input(covariant String? input) => _$this._input = input;
+
+  String? _type;
+  String? get type => _$this._type;
+  set type(covariant String? type) => _$this._type = type;
+
+  String? _appId;
+  String? get appId => _$this._appId;
+  set appId(covariant String? appId) => _$this._appId = appId;
+
+  String? _identifier;
+  String? get identifier => _$this._identifier;
+  set identifier(covariant String? identifier) => _$this._identifier = identifier;
+
+  TextProcessingApiScheduleRequestApplicationJsonBuilder() {
+    TextProcessingApiScheduleRequestApplicationJson._defaults(this);
+  }
+
+  TextProcessingApiScheduleRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _input = $v.input;
+      _type = $v.type;
+      _appId = $v.appId;
+      _identifier = $v.identifier;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant TextProcessingApiScheduleRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$TextProcessingApiScheduleRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(TextProcessingApiScheduleRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  TextProcessingApiScheduleRequestApplicationJson build() => _build();
+
+  _$TextProcessingApiScheduleRequestApplicationJson _build() {
+    TextProcessingApiScheduleRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$TextProcessingApiScheduleRequestApplicationJson._(
+            input: BuiltValueNullFieldError.checkNotNull(
+                input, r'TextProcessingApiScheduleRequestApplicationJson', 'input'),
+            type:
+                BuiltValueNullFieldError.checkNotNull(type, r'TextProcessingApiScheduleRequestApplicationJson', 'type'),
+            appId: BuiltValueNullFieldError.checkNotNull(
+                appId, r'TextProcessingApiScheduleRequestApplicationJson', 'appId'),
+            identifier: BuiltValueNullFieldError.checkNotNull(
+                identifier, r'TextProcessingApiScheduleRequestApplicationJson', 'identifier'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $TextProcessingTaskInterfaceBuilder {
   void replace($TextProcessingTaskInterface other);
   void update(void Function($TextProcessingTaskInterfaceBuilder) updates);
@@ -31170,6 +34750,101 @@ class TextProcessingApiDeleteTaskResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $TextProcessingApiListTasksByAppRequestApplicationJsonInterfaceBuilder {
+  void replace($TextProcessingApiListTasksByAppRequestApplicationJsonInterface other);
+  void update(void Function($TextProcessingApiListTasksByAppRequestApplicationJsonInterfaceBuilder) updates);
+  String? get identifier;
+  set identifier(String? identifier);
+}
+
+class _$TextProcessingApiListTasksByAppRequestApplicationJson
+    extends TextProcessingApiListTasksByAppRequestApplicationJson {
+  @override
+  final String? identifier;
+
+  factory _$TextProcessingApiListTasksByAppRequestApplicationJson(
+          [void Function(TextProcessingApiListTasksByAppRequestApplicationJsonBuilder)? updates]) =>
+      (TextProcessingApiListTasksByAppRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$TextProcessingApiListTasksByAppRequestApplicationJson._({this.identifier}) : super._();
+
+  @override
+  TextProcessingApiListTasksByAppRequestApplicationJson rebuild(
+          void Function(TextProcessingApiListTasksByAppRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  TextProcessingApiListTasksByAppRequestApplicationJsonBuilder toBuilder() =>
+      TextProcessingApiListTasksByAppRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TextProcessingApiListTasksByAppRequestApplicationJson && identifier == other.identifier;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, identifier.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'TextProcessingApiListTasksByAppRequestApplicationJson')
+          ..add('identifier', identifier))
+        .toString();
+  }
+}
+
+class TextProcessingApiListTasksByAppRequestApplicationJsonBuilder
+    implements
+        Builder<TextProcessingApiListTasksByAppRequestApplicationJson,
+            TextProcessingApiListTasksByAppRequestApplicationJsonBuilder>,
+        $TextProcessingApiListTasksByAppRequestApplicationJsonInterfaceBuilder {
+  _$TextProcessingApiListTasksByAppRequestApplicationJson? _$v;
+
+  String? _identifier;
+  String? get identifier => _$this._identifier;
+  set identifier(covariant String? identifier) => _$this._identifier = identifier;
+
+  TextProcessingApiListTasksByAppRequestApplicationJsonBuilder() {
+    TextProcessingApiListTasksByAppRequestApplicationJson._defaults(this);
+  }
+
+  TextProcessingApiListTasksByAppRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _identifier = $v.identifier;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant TextProcessingApiListTasksByAppRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$TextProcessingApiListTasksByAppRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(TextProcessingApiListTasksByAppRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  TextProcessingApiListTasksByAppRequestApplicationJson build() => _build();
+
+  _$TextProcessingApiListTasksByAppRequestApplicationJson _build() {
+    TextProcessingApiListTasksByAppRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$TextProcessingApiListTasksByAppRequestApplicationJson._(identifier: identifier);
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($TextProcessingApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
@@ -31853,6 +35528,156 @@ class TextToImageApiIsAvailableResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $TextToImageApiScheduleRequestApplicationJsonInterfaceBuilder {
+  void replace($TextToImageApiScheduleRequestApplicationJsonInterface other);
+  void update(void Function($TextToImageApiScheduleRequestApplicationJsonInterfaceBuilder) updates);
+  String? get input;
+  set input(String? input);
+
+  String? get appId;
+  set appId(String? appId);
+
+  String? get identifier;
+  set identifier(String? identifier);
+
+  int? get numberOfImages;
+  set numberOfImages(int? numberOfImages);
+}
+
+class _$TextToImageApiScheduleRequestApplicationJson extends TextToImageApiScheduleRequestApplicationJson {
+  @override
+  final String input;
+  @override
+  final String appId;
+  @override
+  final String identifier;
+  @override
+  final int numberOfImages;
+
+  factory _$TextToImageApiScheduleRequestApplicationJson(
+          [void Function(TextToImageApiScheduleRequestApplicationJsonBuilder)? updates]) =>
+      (TextToImageApiScheduleRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$TextToImageApiScheduleRequestApplicationJson._(
+      {required this.input, required this.appId, required this.identifier, required this.numberOfImages})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(input, r'TextToImageApiScheduleRequestApplicationJson', 'input');
+    BuiltValueNullFieldError.checkNotNull(appId, r'TextToImageApiScheduleRequestApplicationJson', 'appId');
+    BuiltValueNullFieldError.checkNotNull(identifier, r'TextToImageApiScheduleRequestApplicationJson', 'identifier');
+    BuiltValueNullFieldError.checkNotNull(
+        numberOfImages, r'TextToImageApiScheduleRequestApplicationJson', 'numberOfImages');
+  }
+
+  @override
+  TextToImageApiScheduleRequestApplicationJson rebuild(
+          void Function(TextToImageApiScheduleRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  TextToImageApiScheduleRequestApplicationJsonBuilder toBuilder() =>
+      TextToImageApiScheduleRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TextToImageApiScheduleRequestApplicationJson &&
+        input == other.input &&
+        appId == other.appId &&
+        identifier == other.identifier &&
+        numberOfImages == other.numberOfImages;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, input.hashCode);
+    _$hash = $jc(_$hash, appId.hashCode);
+    _$hash = $jc(_$hash, identifier.hashCode);
+    _$hash = $jc(_$hash, numberOfImages.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'TextToImageApiScheduleRequestApplicationJson')
+          ..add('input', input)
+          ..add('appId', appId)
+          ..add('identifier', identifier)
+          ..add('numberOfImages', numberOfImages))
+        .toString();
+  }
+}
+
+class TextToImageApiScheduleRequestApplicationJsonBuilder
+    implements
+        Builder<TextToImageApiScheduleRequestApplicationJson, TextToImageApiScheduleRequestApplicationJsonBuilder>,
+        $TextToImageApiScheduleRequestApplicationJsonInterfaceBuilder {
+  _$TextToImageApiScheduleRequestApplicationJson? _$v;
+
+  String? _input;
+  String? get input => _$this._input;
+  set input(covariant String? input) => _$this._input = input;
+
+  String? _appId;
+  String? get appId => _$this._appId;
+  set appId(covariant String? appId) => _$this._appId = appId;
+
+  String? _identifier;
+  String? get identifier => _$this._identifier;
+  set identifier(covariant String? identifier) => _$this._identifier = identifier;
+
+  int? _numberOfImages;
+  int? get numberOfImages => _$this._numberOfImages;
+  set numberOfImages(covariant int? numberOfImages) => _$this._numberOfImages = numberOfImages;
+
+  TextToImageApiScheduleRequestApplicationJsonBuilder() {
+    TextToImageApiScheduleRequestApplicationJson._defaults(this);
+  }
+
+  TextToImageApiScheduleRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _input = $v.input;
+      _appId = $v.appId;
+      _identifier = $v.identifier;
+      _numberOfImages = $v.numberOfImages;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant TextToImageApiScheduleRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$TextToImageApiScheduleRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(TextToImageApiScheduleRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  TextToImageApiScheduleRequestApplicationJson build() => _build();
+
+  _$TextToImageApiScheduleRequestApplicationJson _build() {
+    TextToImageApiScheduleRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$TextToImageApiScheduleRequestApplicationJson._(
+            input:
+                BuiltValueNullFieldError.checkNotNull(input, r'TextToImageApiScheduleRequestApplicationJson', 'input'),
+            appId:
+                BuiltValueNullFieldError.checkNotNull(appId, r'TextToImageApiScheduleRequestApplicationJson', 'appId'),
+            identifier: BuiltValueNullFieldError.checkNotNull(
+                identifier, r'TextToImageApiScheduleRequestApplicationJson', 'identifier'),
+            numberOfImages: BuiltValueNullFieldError.checkNotNull(
+                numberOfImages, r'TextToImageApiScheduleRequestApplicationJson', 'numberOfImages'));
     replace(_$result);
     return _$result;
   }
@@ -33084,6 +36909,100 @@ class TextToImageApiDeleteTaskResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $TextToImageApiListTasksByAppRequestApplicationJsonInterfaceBuilder {
+  void replace($TextToImageApiListTasksByAppRequestApplicationJsonInterface other);
+  void update(void Function($TextToImageApiListTasksByAppRequestApplicationJsonInterfaceBuilder) updates);
+  String? get identifier;
+  set identifier(String? identifier);
+}
+
+class _$TextToImageApiListTasksByAppRequestApplicationJson extends TextToImageApiListTasksByAppRequestApplicationJson {
+  @override
+  final String? identifier;
+
+  factory _$TextToImageApiListTasksByAppRequestApplicationJson(
+          [void Function(TextToImageApiListTasksByAppRequestApplicationJsonBuilder)? updates]) =>
+      (TextToImageApiListTasksByAppRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$TextToImageApiListTasksByAppRequestApplicationJson._({this.identifier}) : super._();
+
+  @override
+  TextToImageApiListTasksByAppRequestApplicationJson rebuild(
+          void Function(TextToImageApiListTasksByAppRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  TextToImageApiListTasksByAppRequestApplicationJsonBuilder toBuilder() =>
+      TextToImageApiListTasksByAppRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TextToImageApiListTasksByAppRequestApplicationJson && identifier == other.identifier;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, identifier.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'TextToImageApiListTasksByAppRequestApplicationJson')
+          ..add('identifier', identifier))
+        .toString();
+  }
+}
+
+class TextToImageApiListTasksByAppRequestApplicationJsonBuilder
+    implements
+        Builder<TextToImageApiListTasksByAppRequestApplicationJson,
+            TextToImageApiListTasksByAppRequestApplicationJsonBuilder>,
+        $TextToImageApiListTasksByAppRequestApplicationJsonInterfaceBuilder {
+  _$TextToImageApiListTasksByAppRequestApplicationJson? _$v;
+
+  String? _identifier;
+  String? get identifier => _$this._identifier;
+  set identifier(covariant String? identifier) => _$this._identifier = identifier;
+
+  TextToImageApiListTasksByAppRequestApplicationJsonBuilder() {
+    TextToImageApiListTasksByAppRequestApplicationJson._defaults(this);
+  }
+
+  TextToImageApiListTasksByAppRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _identifier = $v.identifier;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant TextToImageApiListTasksByAppRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$TextToImageApiListTasksByAppRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(TextToImageApiListTasksByAppRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  TextToImageApiListTasksByAppRequestApplicationJson build() => _build();
+
+  _$TextToImageApiListTasksByAppRequestApplicationJson _build() {
+    TextToImageApiListTasksByAppRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$TextToImageApiListTasksByAppRequestApplicationJson._(identifier: identifier);
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($TextToImageApiListTasksByAppResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
@@ -33955,6 +37874,135 @@ class TranslationApiLanguagesResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $TranslationApiTranslateRequestApplicationJsonInterfaceBuilder {
+  void replace($TranslationApiTranslateRequestApplicationJsonInterface other);
+  void update(void Function($TranslationApiTranslateRequestApplicationJsonInterfaceBuilder) updates);
+  String? get text;
+  set text(String? text);
+
+  String? get fromLanguage;
+  set fromLanguage(String? fromLanguage);
+
+  String? get toLanguage;
+  set toLanguage(String? toLanguage);
+}
+
+class _$TranslationApiTranslateRequestApplicationJson extends TranslationApiTranslateRequestApplicationJson {
+  @override
+  final String text;
+  @override
+  final String? fromLanguage;
+  @override
+  final String toLanguage;
+
+  factory _$TranslationApiTranslateRequestApplicationJson(
+          [void Function(TranslationApiTranslateRequestApplicationJsonBuilder)? updates]) =>
+      (TranslationApiTranslateRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$TranslationApiTranslateRequestApplicationJson._({required this.text, this.fromLanguage, required this.toLanguage})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(text, r'TranslationApiTranslateRequestApplicationJson', 'text');
+    BuiltValueNullFieldError.checkNotNull(toLanguage, r'TranslationApiTranslateRequestApplicationJson', 'toLanguage');
+  }
+
+  @override
+  TranslationApiTranslateRequestApplicationJson rebuild(
+          void Function(TranslationApiTranslateRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  TranslationApiTranslateRequestApplicationJsonBuilder toBuilder() =>
+      TranslationApiTranslateRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TranslationApiTranslateRequestApplicationJson &&
+        text == other.text &&
+        fromLanguage == other.fromLanguage &&
+        toLanguage == other.toLanguage;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, text.hashCode);
+    _$hash = $jc(_$hash, fromLanguage.hashCode);
+    _$hash = $jc(_$hash, toLanguage.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'TranslationApiTranslateRequestApplicationJson')
+          ..add('text', text)
+          ..add('fromLanguage', fromLanguage)
+          ..add('toLanguage', toLanguage))
+        .toString();
+  }
+}
+
+class TranslationApiTranslateRequestApplicationJsonBuilder
+    implements
+        Builder<TranslationApiTranslateRequestApplicationJson, TranslationApiTranslateRequestApplicationJsonBuilder>,
+        $TranslationApiTranslateRequestApplicationJsonInterfaceBuilder {
+  _$TranslationApiTranslateRequestApplicationJson? _$v;
+
+  String? _text;
+  String? get text => _$this._text;
+  set text(covariant String? text) => _$this._text = text;
+
+  String? _fromLanguage;
+  String? get fromLanguage => _$this._fromLanguage;
+  set fromLanguage(covariant String? fromLanguage) => _$this._fromLanguage = fromLanguage;
+
+  String? _toLanguage;
+  String? get toLanguage => _$this._toLanguage;
+  set toLanguage(covariant String? toLanguage) => _$this._toLanguage = toLanguage;
+
+  TranslationApiTranslateRequestApplicationJsonBuilder() {
+    TranslationApiTranslateRequestApplicationJson._defaults(this);
+  }
+
+  TranslationApiTranslateRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _text = $v.text;
+      _fromLanguage = $v.fromLanguage;
+      _toLanguage = $v.toLanguage;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant TranslationApiTranslateRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$TranslationApiTranslateRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(TranslationApiTranslateRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  TranslationApiTranslateRequestApplicationJson build() => _build();
+
+  _$TranslationApiTranslateRequestApplicationJson _build() {
+    TranslationApiTranslateRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$TranslationApiTranslateRequestApplicationJson._(
+            text: BuiltValueNullFieldError.checkNotNull(text, r'TranslationApiTranslateRequestApplicationJson', 'text'),
+            fromLanguage: fromLanguage,
+            toLanguage: BuiltValueNullFieldError.checkNotNull(
+                toLanguage, r'TranslationApiTranslateRequestApplicationJson', 'toLanguage'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $TranslationApiTranslateResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($TranslationApiTranslateResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($TranslationApiTranslateResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
@@ -34295,6 +38343,104 @@ class TranslationApiTranslateResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $UnifiedSearchGetProvidersRequestApplicationJsonInterfaceBuilder {
+  void replace($UnifiedSearchGetProvidersRequestApplicationJsonInterface other);
+  void update(void Function($UnifiedSearchGetProvidersRequestApplicationJsonInterfaceBuilder) updates);
+  String? get from;
+  set from(String? from);
+}
+
+class _$UnifiedSearchGetProvidersRequestApplicationJson extends UnifiedSearchGetProvidersRequestApplicationJson {
+  @override
+  final String from;
+
+  factory _$UnifiedSearchGetProvidersRequestApplicationJson(
+          [void Function(UnifiedSearchGetProvidersRequestApplicationJsonBuilder)? updates]) =>
+      (UnifiedSearchGetProvidersRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UnifiedSearchGetProvidersRequestApplicationJson._({required this.from}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(from, r'UnifiedSearchGetProvidersRequestApplicationJson', 'from');
+  }
+
+  @override
+  UnifiedSearchGetProvidersRequestApplicationJson rebuild(
+          void Function(UnifiedSearchGetProvidersRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UnifiedSearchGetProvidersRequestApplicationJsonBuilder toBuilder() =>
+      UnifiedSearchGetProvidersRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UnifiedSearchGetProvidersRequestApplicationJson && from == other.from;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, from.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UnifiedSearchGetProvidersRequestApplicationJson')..add('from', from))
+        .toString();
+  }
+}
+
+class UnifiedSearchGetProvidersRequestApplicationJsonBuilder
+    implements
+        Builder<UnifiedSearchGetProvidersRequestApplicationJson,
+            UnifiedSearchGetProvidersRequestApplicationJsonBuilder>,
+        $UnifiedSearchGetProvidersRequestApplicationJsonInterfaceBuilder {
+  _$UnifiedSearchGetProvidersRequestApplicationJson? _$v;
+
+  String? _from;
+  String? get from => _$this._from;
+  set from(covariant String? from) => _$this._from = from;
+
+  UnifiedSearchGetProvidersRequestApplicationJsonBuilder() {
+    UnifiedSearchGetProvidersRequestApplicationJson._defaults(this);
+  }
+
+  UnifiedSearchGetProvidersRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _from = $v.from;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UnifiedSearchGetProvidersRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UnifiedSearchGetProvidersRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UnifiedSearchGetProvidersRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UnifiedSearchGetProvidersRequestApplicationJson build() => _build();
+
+  _$UnifiedSearchGetProvidersRequestApplicationJson _build() {
+    UnifiedSearchGetProvidersRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UnifiedSearchGetProvidersRequestApplicationJson._(
+            from: BuiltValueNullFieldError.checkNotNull(
+                from, r'UnifiedSearchGetProvidersRequestApplicationJson', 'from'));
     replace(_$result);
     return _$result;
   }
@@ -34751,6 +38897,164 @@ class UnifiedSearchGetProvidersResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $UnifiedSearchSearchRequestApplicationJsonInterfaceBuilder {
+  void replace($UnifiedSearchSearchRequestApplicationJsonInterface other);
+  void update(void Function($UnifiedSearchSearchRequestApplicationJsonInterfaceBuilder) updates);
+  String? get term;
+  set term(String? term);
+
+  int? get sortOrder;
+  set sortOrder(int? sortOrder);
+
+  int? get limit;
+  set limit(int? limit);
+
+  UnifiedSearchSearchRequestApplicationJson_Cursor? get cursor;
+  set cursor(UnifiedSearchSearchRequestApplicationJson_Cursor? cursor);
+
+  String? get from;
+  set from(String? from);
+}
+
+class _$UnifiedSearchSearchRequestApplicationJson extends UnifiedSearchSearchRequestApplicationJson {
+  @override
+  final String term;
+  @override
+  final int? sortOrder;
+  @override
+  final int? limit;
+  @override
+  final UnifiedSearchSearchRequestApplicationJson_Cursor? cursor;
+  @override
+  final String from;
+
+  factory _$UnifiedSearchSearchRequestApplicationJson(
+          [void Function(UnifiedSearchSearchRequestApplicationJsonBuilder)? updates]) =>
+      (UnifiedSearchSearchRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UnifiedSearchSearchRequestApplicationJson._(
+      {required this.term, this.sortOrder, this.limit, this.cursor, required this.from})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(term, r'UnifiedSearchSearchRequestApplicationJson', 'term');
+    BuiltValueNullFieldError.checkNotNull(from, r'UnifiedSearchSearchRequestApplicationJson', 'from');
+  }
+
+  @override
+  UnifiedSearchSearchRequestApplicationJson rebuild(
+          void Function(UnifiedSearchSearchRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UnifiedSearchSearchRequestApplicationJsonBuilder toBuilder() =>
+      UnifiedSearchSearchRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    final dynamic _$dynamicOther = other;
+    return other is UnifiedSearchSearchRequestApplicationJson &&
+        term == other.term &&
+        sortOrder == other.sortOrder &&
+        limit == other.limit &&
+        cursor == _$dynamicOther.cursor &&
+        from == other.from;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, term.hashCode);
+    _$hash = $jc(_$hash, sortOrder.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jc(_$hash, cursor.hashCode);
+    _$hash = $jc(_$hash, from.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UnifiedSearchSearchRequestApplicationJson')
+          ..add('term', term)
+          ..add('sortOrder', sortOrder)
+          ..add('limit', limit)
+          ..add('cursor', cursor)
+          ..add('from', from))
+        .toString();
+  }
+}
+
+class UnifiedSearchSearchRequestApplicationJsonBuilder
+    implements
+        Builder<UnifiedSearchSearchRequestApplicationJson, UnifiedSearchSearchRequestApplicationJsonBuilder>,
+        $UnifiedSearchSearchRequestApplicationJsonInterfaceBuilder {
+  _$UnifiedSearchSearchRequestApplicationJson? _$v;
+
+  String? _term;
+  String? get term => _$this._term;
+  set term(covariant String? term) => _$this._term = term;
+
+  int? _sortOrder;
+  int? get sortOrder => _$this._sortOrder;
+  set sortOrder(covariant int? sortOrder) => _$this._sortOrder = sortOrder;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  UnifiedSearchSearchRequestApplicationJson_Cursor? _cursor;
+  UnifiedSearchSearchRequestApplicationJson_Cursor? get cursor => _$this._cursor;
+  set cursor(covariant UnifiedSearchSearchRequestApplicationJson_Cursor? cursor) => _$this._cursor = cursor;
+
+  String? _from;
+  String? get from => _$this._from;
+  set from(covariant String? from) => _$this._from = from;
+
+  UnifiedSearchSearchRequestApplicationJsonBuilder() {
+    UnifiedSearchSearchRequestApplicationJson._defaults(this);
+  }
+
+  UnifiedSearchSearchRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _term = $v.term;
+      _sortOrder = $v.sortOrder;
+      _limit = $v.limit;
+      _cursor = $v.cursor;
+      _from = $v.from;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UnifiedSearchSearchRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UnifiedSearchSearchRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UnifiedSearchSearchRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UnifiedSearchSearchRequestApplicationJson build() => _build();
+
+  _$UnifiedSearchSearchRequestApplicationJson _build() {
+    UnifiedSearchSearchRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UnifiedSearchSearchRequestApplicationJson._(
+            term: BuiltValueNullFieldError.checkNotNull(term, r'UnifiedSearchSearchRequestApplicationJson', 'term'),
+            sortOrder: sortOrder,
+            limit: limit,
+            cursor: cursor,
+            from: BuiltValueNullFieldError.checkNotNull(from, r'UnifiedSearchSearchRequestApplicationJson', 'from'));
     replace(_$result);
     return _$result;
   }
@@ -35858,6 +40162,101 @@ class WhatsNewGetResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $WhatsNewDismissRequestApplicationJsonInterfaceBuilder {
+  void replace($WhatsNewDismissRequestApplicationJsonInterface other);
+  void update(void Function($WhatsNewDismissRequestApplicationJsonInterfaceBuilder) updates);
+  String? get version;
+  set version(String? version);
+}
+
+class _$WhatsNewDismissRequestApplicationJson extends WhatsNewDismissRequestApplicationJson {
+  @override
+  final String version;
+
+  factory _$WhatsNewDismissRequestApplicationJson(
+          [void Function(WhatsNewDismissRequestApplicationJsonBuilder)? updates]) =>
+      (WhatsNewDismissRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$WhatsNewDismissRequestApplicationJson._({required this.version}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(version, r'WhatsNewDismissRequestApplicationJson', 'version');
+  }
+
+  @override
+  WhatsNewDismissRequestApplicationJson rebuild(void Function(WhatsNewDismissRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  WhatsNewDismissRequestApplicationJsonBuilder toBuilder() =>
+      WhatsNewDismissRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is WhatsNewDismissRequestApplicationJson && version == other.version;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, version.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'WhatsNewDismissRequestApplicationJson')..add('version', version)).toString();
+  }
+}
+
+class WhatsNewDismissRequestApplicationJsonBuilder
+    implements
+        Builder<WhatsNewDismissRequestApplicationJson, WhatsNewDismissRequestApplicationJsonBuilder>,
+        $WhatsNewDismissRequestApplicationJsonInterfaceBuilder {
+  _$WhatsNewDismissRequestApplicationJson? _$v;
+
+  String? _version;
+  String? get version => _$this._version;
+  set version(covariant String? version) => _$this._version = version;
+
+  WhatsNewDismissRequestApplicationJsonBuilder() {
+    WhatsNewDismissRequestApplicationJson._defaults(this);
+  }
+
+  WhatsNewDismissRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _version = $v.version;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant WhatsNewDismissRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$WhatsNewDismissRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(WhatsNewDismissRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  WhatsNewDismissRequestApplicationJson build() => _build();
+
+  _$WhatsNewDismissRequestApplicationJson _build() {
+    WhatsNewDismissRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$WhatsNewDismissRequestApplicationJson._(
+            version:
+                BuiltValueNullFieldError.checkNotNull(version, r'WhatsNewDismissRequestApplicationJson', 'version'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $WhatsNewDismissResponseApplicationJson_OcsInterfaceBuilder {
   void replace($WhatsNewDismissResponseApplicationJson_OcsInterface other);
   void update(void Function($WhatsNewDismissResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -36087,6 +40486,98 @@ class WhatsNewDismissResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $WipeCheckWipeRequestApplicationJsonInterfaceBuilder {
+  void replace($WipeCheckWipeRequestApplicationJsonInterface other);
+  void update(void Function($WipeCheckWipeRequestApplicationJsonInterfaceBuilder) updates);
+  String? get token;
+  set token(String? token);
+}
+
+class _$WipeCheckWipeRequestApplicationJson extends WipeCheckWipeRequestApplicationJson {
+  @override
+  final String token;
+
+  factory _$WipeCheckWipeRequestApplicationJson([void Function(WipeCheckWipeRequestApplicationJsonBuilder)? updates]) =>
+      (WipeCheckWipeRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$WipeCheckWipeRequestApplicationJson._({required this.token}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(token, r'WipeCheckWipeRequestApplicationJson', 'token');
+  }
+
+  @override
+  WipeCheckWipeRequestApplicationJson rebuild(void Function(WipeCheckWipeRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  WipeCheckWipeRequestApplicationJsonBuilder toBuilder() => WipeCheckWipeRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is WipeCheckWipeRequestApplicationJson && token == other.token;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, token.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'WipeCheckWipeRequestApplicationJson')..add('token', token)).toString();
+  }
+}
+
+class WipeCheckWipeRequestApplicationJsonBuilder
+    implements
+        Builder<WipeCheckWipeRequestApplicationJson, WipeCheckWipeRequestApplicationJsonBuilder>,
+        $WipeCheckWipeRequestApplicationJsonInterfaceBuilder {
+  _$WipeCheckWipeRequestApplicationJson? _$v;
+
+  String? _token;
+  String? get token => _$this._token;
+  set token(covariant String? token) => _$this._token = token;
+
+  WipeCheckWipeRequestApplicationJsonBuilder() {
+    WipeCheckWipeRequestApplicationJson._defaults(this);
+  }
+
+  WipeCheckWipeRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _token = $v.token;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant WipeCheckWipeRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$WipeCheckWipeRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(WipeCheckWipeRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  WipeCheckWipeRequestApplicationJson build() => _build();
+
+  _$WipeCheckWipeRequestApplicationJson _build() {
+    WipeCheckWipeRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$WipeCheckWipeRequestApplicationJson._(
+            token: BuiltValueNullFieldError.checkNotNull(token, r'WipeCheckWipeRequestApplicationJson', 'token'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $WipeCheckWipeResponseApplicationJsonInterfaceBuilder {
   void replace($WipeCheckWipeResponseApplicationJsonInterface other);
   void update(void Function($WipeCheckWipeResponseApplicationJsonInterfaceBuilder) updates);
@@ -36176,6 +40667,98 @@ class WipeCheckWipeResponseApplicationJsonBuilder
     final _$result = _$v ??
         _$WipeCheckWipeResponseApplicationJson._(
             wipe: BuiltValueNullFieldError.checkNotNull(wipe, r'WipeCheckWipeResponseApplicationJson', 'wipe'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $WipeWipeDoneRequestApplicationJsonInterfaceBuilder {
+  void replace($WipeWipeDoneRequestApplicationJsonInterface other);
+  void update(void Function($WipeWipeDoneRequestApplicationJsonInterfaceBuilder) updates);
+  String? get token;
+  set token(String? token);
+}
+
+class _$WipeWipeDoneRequestApplicationJson extends WipeWipeDoneRequestApplicationJson {
+  @override
+  final String token;
+
+  factory _$WipeWipeDoneRequestApplicationJson([void Function(WipeWipeDoneRequestApplicationJsonBuilder)? updates]) =>
+      (WipeWipeDoneRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$WipeWipeDoneRequestApplicationJson._({required this.token}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(token, r'WipeWipeDoneRequestApplicationJson', 'token');
+  }
+
+  @override
+  WipeWipeDoneRequestApplicationJson rebuild(void Function(WipeWipeDoneRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  WipeWipeDoneRequestApplicationJsonBuilder toBuilder() => WipeWipeDoneRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is WipeWipeDoneRequestApplicationJson && token == other.token;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, token.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'WipeWipeDoneRequestApplicationJson')..add('token', token)).toString();
+  }
+}
+
+class WipeWipeDoneRequestApplicationJsonBuilder
+    implements
+        Builder<WipeWipeDoneRequestApplicationJson, WipeWipeDoneRequestApplicationJsonBuilder>,
+        $WipeWipeDoneRequestApplicationJsonInterfaceBuilder {
+  _$WipeWipeDoneRequestApplicationJson? _$v;
+
+  String? _token;
+  String? get token => _$this._token;
+  set token(covariant String? token) => _$this._token = token;
+
+  WipeWipeDoneRequestApplicationJsonBuilder() {
+    WipeWipeDoneRequestApplicationJson._defaults(this);
+  }
+
+  WipeWipeDoneRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _token = $v.token;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant WipeWipeDoneRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$WipeWipeDoneRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(WipeWipeDoneRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  WipeWipeDoneRequestApplicationJson build() => _build();
+
+  _$WipeWipeDoneRequestApplicationJson _build() {
+    WipeWipeDoneRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$WipeWipeDoneRequestApplicationJson._(
+            token: BuiltValueNullFieldError.checkNotNull(token, r'WipeWipeDoneRequestApplicationJson', 'token'));
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/core.openapi.json
+++ b/packages/nextcloud/lib/src/api/core.openapi.json
@@ -2037,16 +2037,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "password",
-                        "in": "query",
-                        "description": "The password of the user",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "password"
+                                ],
+                                "properties": {
+                                    "password": {
+                                        "type": "string",
+                                        "description": "The password of the user"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -2144,66 +2154,56 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "search",
-                        "in": "query",
-                        "description": "Text to search for",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "itemType",
-                        "in": "query",
-                        "description": "Type of the items to search for",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "itemId",
-                        "in": "query",
-                        "description": "ID of the items to search for",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "sorter",
-                        "in": "query",
-                        "description": "can be piped, top prio first, e.g.: \"commenters|share-recipients\"",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "shareTypes[]",
-                        "in": "query",
-                        "description": "Types of shares to search for",
-                        "schema": {
-                            "type": "array",
-                            "default": [],
-                            "items": {
-                                "type": "integer",
-                                "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "search"
+                                ],
+                                "properties": {
+                                    "search": {
+                                        "type": "string",
+                                        "description": "Text to search for"
+                                    },
+                                    "itemType": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Type of the items to search for"
+                                    },
+                                    "itemId": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "ID of the items to search for"
+                                    },
+                                    "sorter": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "can be piped, top prio first, e.g.: \"commenters|share-recipients\""
+                                    },
+                                    "shareTypes": {
+                                        "type": "array",
+                                        "default": [],
+                                        "description": "Types of shares to search for",
+                                        "items": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 10,
+                                        "description": "Maximum number of results to return"
+                                    }
+                                }
                             }
                         }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Maximum number of results to return",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 10
-                        }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -2392,25 +2392,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "resourceType",
+                                    "resourceId"
+                                ],
+                                "properties": {
+                                    "resourceType": {
+                                        "type": "string",
+                                        "description": "Name of the resource"
+                                    },
+                                    "resourceId": {
+                                        "type": "string",
+                                        "description": "ID of the resource"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "resourceType",
-                        "in": "query",
-                        "description": "Name of the resource",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "resourceId",
-                        "in": "query",
-                        "description": "ID of the resource",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "collectionId",
                         "in": "path",
@@ -2535,25 +2541,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "resourceType",
+                                    "resourceId"
+                                ],
+                                "properties": {
+                                    "resourceType": {
+                                        "type": "string",
+                                        "description": "Name of the resource"
+                                    },
+                                    "resourceId": {
+                                        "type": "string",
+                                        "description": "ID of the resource"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "resourceType",
-                        "in": "query",
-                        "description": "Name of the resource",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "resourceId",
-                        "in": "query",
-                        "description": "ID of the resource",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "collectionId",
                         "in": "path",
@@ -2678,16 +2690,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "collectionName",
-                        "in": "query",
-                        "description": "New name",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "collectionName"
+                                ],
+                                "properties": {
+                                    "collectionName": {
+                                        "type": "string",
+                                        "description": "New name"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "collectionId",
                         "in": "path",
@@ -3025,16 +3047,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "name",
-                        "in": "query",
-                        "description": "Name of the collection",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Name of the collection"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "baseResourceType",
                         "in": "path",
@@ -3314,20 +3346,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "absolute",
-                        "in": "query",
-                        "description": "Rewrite URLs to absolute ones",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "absolute": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Rewrite URLs to absolute ones"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -3394,20 +3430,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "absolute",
-                        "in": "query",
-                        "description": "Rewrite URLs to absolute ones",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "absolute": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Rewrite URLs to absolute ones"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -3642,25 +3682,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "paramId",
+                                    "visibility"
+                                ],
+                                "properties": {
+                                    "paramId": {
+                                        "type": "string",
+                                        "description": "ID of the parameter"
+                                    },
+                                    "visibility": {
+                                        "type": "string",
+                                        "description": "New visibility"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "paramId",
-                        "in": "query",
-                        "description": "ID of the parameter",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "visibility",
-                        "in": "query",
-                        "description": "New visibility",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "targetUserId",
                         "in": "path",
@@ -3812,39 +3858,37 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "text"
+                                ],
+                                "properties": {
+                                    "text": {
+                                        "type": "string",
+                                        "description": "Text to extract from"
+                                    },
+                                    "resolve": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Resolve the references"
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 1,
+                                        "description": "Maximum amount of references to extract"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "text",
-                        "in": "query",
-                        "description": "Text to extract from",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "resolve",
-                        "in": "query",
-                        "description": "Resolve the references",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Maximum amount of references to extract",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 1
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -3917,16 +3961,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "reference",
-                        "in": "query",
-                        "description": "Reference to resolve",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "reference"
+                                ],
+                                "properties": {
+                                    "reference": {
+                                        "type": "string",
+                                        "description": "Reference to resolve"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -3997,29 +4051,35 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "references[]",
-                        "in": "query",
-                        "description": "References to resolve",
-                        "required": true,
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "references"
+                                ],
+                                "properties": {
+                                    "references": {
+                                        "type": "array",
+                                        "description": "References to resolve",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 1,
+                                        "description": "Maximum amount of references to resolve"
+                                    }
+                                }
                             }
                         }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Maximum amount of references to resolve",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 1
-                        }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -4156,17 +4216,25 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "timestamp",
-                        "in": "query",
-                        "description": "Timestamp of the last usage",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "timestamp": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Timestamp of the last usage"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "providerId",
                         "in": "path",
@@ -4505,43 +4573,41 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "input",
+                                    "type",
+                                    "appId"
+                                ],
+                                "properties": {
+                                    "input": {
+                                        "type": "string",
+                                        "description": "Input text"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "description": "Type of the task"
+                                    },
+                                    "appId": {
+                                        "type": "string",
+                                        "description": "ID of the app that will execute the task"
+                                    },
+                                    "identifier": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "An arbitrary identifier for the task"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "input",
-                        "in": "query",
-                        "description": "Input text",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "type",
-                        "in": "query",
-                        "description": "Type of the task",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "appId",
-                        "in": "query",
-                        "description": "ID of the app that will execute the task",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "identifier",
-                        "in": "query",
-                        "description": "An arbitrary identifier for the task",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -5033,16 +5099,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "identifier",
-                        "in": "query",
-                        "description": "An arbitrary identifier for the task",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "identifier": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "An arbitrary identifier for the task"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "appId",
                         "in": "path",
@@ -5232,44 +5306,42 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "input",
+                                    "appId"
+                                ],
+                                "properties": {
+                                    "input": {
+                                        "type": "string",
+                                        "description": "Input text"
+                                    },
+                                    "appId": {
+                                        "type": "string",
+                                        "description": "ID of the app that will execute the task"
+                                    },
+                                    "identifier": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "An arbitrary identifier for the task"
+                                    },
+                                    "numberOfImages": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 8,
+                                        "description": "The number of images to generate"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "input",
-                        "in": "query",
-                        "description": "Input text",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "appId",
-                        "in": "query",
-                        "description": "ID of the app that will execute the task",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "identifier",
-                        "in": "query",
-                        "description": "An arbitrary identifier for the task",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "numberOfImages",
-                        "in": "query",
-                        "description": "The number of images to generate",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 8
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -5862,16 +5934,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "identifier",
-                        "in": "query",
-                        "description": "An arbitrary identifier for the task",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "identifier": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "An arbitrary identifier for the task"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "appId",
                         "in": "path",
@@ -6088,34 +6168,36 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "text",
+                                    "toLanguage"
+                                ],
+                                "properties": {
+                                    "text": {
+                                        "type": "string",
+                                        "description": "Text to be translated"
+                                    },
+                                    "fromLanguage": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Language to translate from"
+                                    },
+                                    "toLanguage": {
+                                        "type": "string",
+                                        "description": "Language to translate to"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "text",
-                        "in": "query",
-                        "description": "Text to be translated",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "fromLanguage",
-                        "in": "query",
-                        "description": "Language to translate from",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "toLanguage",
-                        "in": "query",
-                        "description": "Language to translate to",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -6315,16 +6397,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "from",
-                        "in": "query",
-                        "description": "the url the user is currently at",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "from": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "the url the user is currently at"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -6389,62 +6479,54 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "term",
-                        "in": "query",
-                        "description": "Term to search",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "sortOrder",
-                        "in": "query",
-                        "description": "Order of entries",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Maximum amount of entries",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "cursor",
-                        "in": "query",
-                        "description": "Offset for searching",
-                        "schema": {
-                            "nullable": true,
-                            "oneOf": [
-                                {
-                                    "type": "integer",
-                                    "format": "int64"
-                                },
-                                {
-                                    "type": "string"
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "term": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Term to search"
+                                    },
+                                    "sortOrder": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Order of entries"
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Maximum amount of entries"
+                                    },
+                                    "cursor": {
+                                        "nullable": true,
+                                        "description": "Offset for searching",
+                                        "oneOf": [
+                                            {
+                                                "type": "integer",
+                                                "format": "int64"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    },
+                                    "from": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "The current user URL"
+                                    }
                                 }
-                            ]
+                            }
                         }
-                    },
-                    {
-                        "name": "from",
-                        "in": "query",
-                        "description": "The current user URL",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "providerId",
                         "in": "path",
@@ -6643,16 +6725,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "version",
-                        "in": "query",
-                        "description": "Version to dismiss the changes for",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "version"
+                                ],
+                                "properties": {
+                                    "version": {
+                                        "type": "string",
+                                        "description": "Version to dismiss the changes for"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -6858,17 +6950,25 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "token",
-                        "in": "query",
-                        "description": "Token of the flow",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "token"
+                                ],
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "description": "Token of the flow"
+                                    }
+                                }
+                            }
                         }
                     }
-                ],
+                },
                 "responses": {
                     "200": {
                         "description": "Login flow credentials returned",
@@ -6937,21 +7037,25 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "darkTheme",
-                        "in": "query",
-                        "description": "Return dark avatar",
-                        "schema": {
-                            "type": "integer",
-                            "nullable": true,
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "darkTheme": {
+                                        "type": "boolean",
+                                        "nullable": true,
+                                        "default": false,
+                                        "description": "Return dark avatar"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "guestName",
                         "in": "path",
@@ -7080,17 +7184,25 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "password",
-                        "in": "query",
-                        "description": "The password of the user",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "password"
+                                ],
+                                "properties": {
+                                    "password": {
+                                        "type": "string",
+                                        "description": "The password of the user"
+                                    }
+                                }
+                            }
                         }
                     }
-                ],
+                },
                 "responses": {
                     "200": {
                         "description": "Password confirmation succeeded",
@@ -7245,85 +7357,55 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "file",
-                        "in": "query",
-                        "description": "Path of the file",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "x",
-                        "in": "query",
-                        "description": "Width of the preview",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 32
-                        }
-                    },
-                    {
-                        "name": "y",
-                        "in": "query",
-                        "description": "Height of the preview",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 32
-                        }
-                    },
-                    {
-                        "name": "a",
-                        "in": "query",
-                        "description": "Whether to not crop the preview",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "forceIcon",
-                        "in": "query",
-                        "description": "Force returning an icon",
-                        "schema": {
-                            "type": "integer",
-                            "default": 1,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "mode",
-                        "in": "query",
-                        "description": "How to crop the image",
-                        "schema": {
-                            "type": "string",
-                            "default": "fill"
-                        }
-                    },
-                    {
-                        "name": "mimeFallback",
-                        "in": "query",
-                        "description": "Whether to fallback to the mime icon if no preview is available",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "file": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Path of the file"
+                                    },
+                                    "x": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 32,
+                                        "description": "Width of the preview"
+                                    },
+                                    "y": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 32,
+                                        "description": "Height of the preview"
+                                    },
+                                    "a": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to not crop the preview"
+                                    },
+                                    "forceIcon": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "Force returning an icon"
+                                    },
+                                    "mode": {
+                                        "type": "string",
+                                        "default": "fill",
+                                        "description": "How to crop the image"
+                                    },
+                                    "mimeFallback": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to fallback to the mime icon if no preview is available"
+                                    }
+                                }
+                            }
                         }
                     }
-                ],
+                },
                 "responses": {
                     "200": {
                         "description": "Preview returned",
@@ -7388,86 +7470,56 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "fileId",
-                        "in": "query",
-                        "description": "ID of the file",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": -1
-                        }
-                    },
-                    {
-                        "name": "x",
-                        "in": "query",
-                        "description": "Width of the preview",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 32
-                        }
-                    },
-                    {
-                        "name": "y",
-                        "in": "query",
-                        "description": "Height of the preview",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 32
-                        }
-                    },
-                    {
-                        "name": "a",
-                        "in": "query",
-                        "description": "Whether to not crop the preview",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "forceIcon",
-                        "in": "query",
-                        "description": "Force returning an icon",
-                        "schema": {
-                            "type": "integer",
-                            "default": 1,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "mode",
-                        "in": "query",
-                        "description": "How to crop the image",
-                        "schema": {
-                            "type": "string",
-                            "default": "fill"
-                        }
-                    },
-                    {
-                        "name": "mimeFallback",
-                        "in": "query",
-                        "description": "Whether to fallback to the mime icon if no preview is available",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "fileId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": -1,
+                                        "description": "ID of the file"
+                                    },
+                                    "x": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 32,
+                                        "description": "Width of the preview"
+                                    },
+                                    "y": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 32,
+                                        "description": "Height of the preview"
+                                    },
+                                    "a": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to not crop the preview"
+                                    },
+                                    "forceIcon": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "Force returning an icon"
+                                    },
+                                    "mode": {
+                                        "type": "string",
+                                        "default": "fill",
+                                        "description": "How to crop the image"
+                                    },
+                                    "mimeFallback": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to fallback to the mime icon if no preview is available"
+                                    }
+                                }
+                            }
                         }
                     }
-                ],
+                },
                 "responses": {
                     "200": {
                         "description": "Preview returned",
@@ -7585,17 +7637,25 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "token",
-                        "in": "query",
-                        "description": "App password",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "token"
+                                ],
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "description": "App password"
+                                    }
+                                }
+                            }
                         }
                     }
-                ],
+                },
                 "responses": {
                     "200": {
                         "description": "Device should be wiped",
@@ -7642,17 +7702,25 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "token",
-                        "in": "query",
-                        "description": "App password",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "token"
+                                ],
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "description": "App password"
+                                    }
+                                }
+                            }
                         }
                     }
-                ],
+                },
                 "responses": {
                     "200": {
                         "description": "Wipe finished successfully",

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.dart
@@ -103,9 +103,9 @@ class $DashboardApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -174,27 +174,27 @@ class $DashboardApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $sinceIds = _$jsonSerializers.serialize(
+    final __sinceIds = _$jsonSerializers.serialize(
       sinceIds,
       specifiedType: const FullType(ContentString, [
         FullType(BuiltMap, [FullType(String), FullType(String)]),
       ]),
     );
-    _parameters['sinceIds'] = $sinceIds;
+    _parameters['sinceIds'] = __sinceIds;
 
-    var $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    $limit ??= 7;
+    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    __limit ??= 7;
     _i5.checkNumber(
-      $limit,
+      __limit,
       'limit',
       maximum: 30,
       minimum: 1,
     );
-    _parameters['limit'] = $limit;
+    _parameters['limit'] = __limit;
 
-    var $widgets = _$jsonSerializers.serialize(widgets, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    $widgets ??= const [];
-    _parameters['widgets%5B%5D'] = $widgets;
+    var __widgets = _$jsonSerializers.serialize(widgets, specifiedType: const FullType(BuiltList, [FullType(String)]));
+    __widgets ??= const [];
+    _parameters['widgets%5B%5D'] = __widgets;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/dashboard/api/v1/widget-items{?sinceIds*,limit*,widgets%5B%5D*}')
         .expand(_parameters);
@@ -218,9 +218,9 @@ class $DashboardApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -298,27 +298,27 @@ class $DashboardApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $sinceIds = _$jsonSerializers.serialize(
+    final __sinceIds = _$jsonSerializers.serialize(
       sinceIds,
       specifiedType: const FullType(ContentString, [
         FullType(BuiltMap, [FullType(String), FullType(String)]),
       ]),
     );
-    _parameters['sinceIds'] = $sinceIds;
+    _parameters['sinceIds'] = __sinceIds;
 
-    var $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    $limit ??= 7;
+    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    __limit ??= 7;
     _i5.checkNumber(
-      $limit,
+      __limit,
       'limit',
       maximum: 30,
       minimum: 1,
     );
-    _parameters['limit'] = $limit;
+    _parameters['limit'] = __limit;
 
-    var $widgets = _$jsonSerializers.serialize(widgets, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    $widgets ??= const [];
-    _parameters['widgets%5B%5D'] = $widgets;
+    var __widgets = _$jsonSerializers.serialize(widgets, specifiedType: const FullType(BuiltList, [FullType(String)]));
+    __widgets ??= const [];
+    _parameters['widgets%5B%5D'] = __widgets;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/dashboard/api/v2/widget-items{?sinceIds*,limit*,widgets%5B%5D*}')
         .expand(_parameters);
@@ -342,9 +342,9 @@ class $DashboardApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.dart
@@ -16,18 +16,18 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
+
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:built_value/standard_json_plugin.dart' as _i8;
+import 'package:built_value/standard_json_plugin.dart' as _i7;
 import 'package:collection/collection.dart' as _i4;
-import 'package:dynamite_runtime/built_value.dart' as _i7;
+import 'package:dynamite_runtime/built_value.dart' as _i6;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/models.dart';
 import 'package:dynamite_runtime/utils.dart' as _i5;
 import 'package:http/http.dart' as _i3;
 import 'package:meta/meta.dart' as _i2;
-import 'package:uri/uri.dart' as _i6;
 
 part 'dashboard.openapi.g.dart';
 
@@ -155,9 +155,6 @@ class $DashboardApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [sinceIds] Array indexed by widget Ids, contains date/id from which we want the new items.
-  ///   * [limit] Limit number of result items per widget. Defaults to `7`.
-  ///   * [widgets] Limit results to specific widgets. Defaults to `[]`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -168,36 +165,10 @@ class $DashboardApiClient {
   ///  * [$getWidgetItems_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getWidgetItems_Request({
-    ContentString<BuiltMap<String, String>>? sinceIds,
-    int? limit,
-    BuiltList<String>? widgets,
     bool? oCSAPIRequest,
+    DashboardApiGetWidgetItemsRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    final __sinceIds = _$jsonSerializers.serialize(
-      sinceIds,
-      specifiedType: const FullType(ContentString, [
-        FullType(BuiltMap, [FullType(String), FullType(String)]),
-      ]),
-    );
-    _parameters['sinceIds'] = __sinceIds;
-
-    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    __limit ??= 7;
-    _i5.checkNumber(
-      __limit,
-      'limit',
-      maximum: 30,
-      minimum: 1,
-    );
-    _parameters['limit'] = __limit;
-
-    var __widgets = _$jsonSerializers.serialize(widgets, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    __widgets ??= const [];
-    _parameters['widgets%5B%5D'] = __widgets;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/apps/dashboard/api/v1/widget-items{?sinceIds*,limit*,widgets%5B%5D*}')
-        .expand(_parameters);
+    const _path = '/ocs/v2.php/apps/dashboard/api/v1/widget-items';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -222,6 +193,20 @@ class $DashboardApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(DashboardApiGetWidgetItemsRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              DashboardApiGetWidgetItemsRequestApplicationJson(),
+              specifiedType: const FullType(DashboardApiGetWidgetItemsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -231,9 +216,6 @@ class $DashboardApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [sinceIds] Array indexed by widget Ids, contains date/id from which we want the new items.
-  ///   * [limit] Limit number of result items per widget. Defaults to `7`.
-  ///   * [widgets] Limit results to specific widgets. Defaults to `[]`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -243,16 +225,12 @@ class $DashboardApiClient {
   ///  * [$getWidgetItems_Request] for the request send by this method.
   ///  * [$getWidgetItems_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<DashboardApiGetWidgetItemsResponseApplicationJson, void>> getWidgetItems({
-    ContentString<BuiltMap<String, String>>? sinceIds,
-    int? limit,
-    BuiltList<String>? widgets,
     bool? oCSAPIRequest,
+    DashboardApiGetWidgetItemsRequestApplicationJson? $body,
   }) async {
     final _request = $getWidgetItems_Request(
-      sinceIds: sinceIds,
-      limit: limit,
-      widgets: widgets,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -279,9 +257,6 @@ class $DashboardApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [sinceIds] Array indexed by widget Ids, contains date/id from which we want the new items.
-  ///   * [limit] Limit number of result items per widget, not more than 30 are allowed. Defaults to `7`.
-  ///   * [widgets] Limit results to specific widgets. Defaults to `[]`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -292,36 +267,10 @@ class $DashboardApiClient {
   ///  * [$getWidgetItemsV2_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getWidgetItemsV2_Request({
-    ContentString<BuiltMap<String, String>>? sinceIds,
-    int? limit,
-    BuiltList<String>? widgets,
     bool? oCSAPIRequest,
+    DashboardApiGetWidgetItemsV2RequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    final __sinceIds = _$jsonSerializers.serialize(
-      sinceIds,
-      specifiedType: const FullType(ContentString, [
-        FullType(BuiltMap, [FullType(String), FullType(String)]),
-      ]),
-    );
-    _parameters['sinceIds'] = __sinceIds;
-
-    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    __limit ??= 7;
-    _i5.checkNumber(
-      __limit,
-      'limit',
-      maximum: 30,
-      minimum: 1,
-    );
-    _parameters['limit'] = __limit;
-
-    var __widgets = _$jsonSerializers.serialize(widgets, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    __widgets ??= const [];
-    _parameters['widgets%5B%5D'] = __widgets;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/apps/dashboard/api/v2/widget-items{?sinceIds*,limit*,widgets%5B%5D*}')
-        .expand(_parameters);
+    const _path = '/ocs/v2.php/apps/dashboard/api/v2/widget-items';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -346,6 +295,20 @@ class $DashboardApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(DashboardApiGetWidgetItemsV2RequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              DashboardApiGetWidgetItemsV2RequestApplicationJson(),
+              specifiedType: const FullType(DashboardApiGetWidgetItemsV2RequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -355,9 +318,6 @@ class $DashboardApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [sinceIds] Array indexed by widget Ids, contains date/id from which we want the new items.
-  ///   * [limit] Limit number of result items per widget, not more than 30 are allowed. Defaults to `7`.
-  ///   * [widgets] Limit results to specific widgets. Defaults to `[]`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -367,16 +327,12 @@ class $DashboardApiClient {
   ///  * [$getWidgetItemsV2_Request] for the request send by this method.
   ///  * [$getWidgetItemsV2_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<DashboardApiGetWidgetItemsV2ResponseApplicationJson, void>> getWidgetItemsV2({
-    ContentString<BuiltMap<String, String>>? sinceIds,
-    int? limit,
-    BuiltList<String>? widgets,
     bool? oCSAPIRequest,
+    DashboardApiGetWidgetItemsV2RequestApplicationJson? $body,
   }) async {
     final _request = $getWidgetItemsV2_Request(
-      sinceIds: sinceIds,
-      limit: limit,
-      widgets: widgets,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -700,6 +656,104 @@ abstract class DashboardApiGetWidgetsResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $DashboardApiGetWidgetItemsRequestApplicationJsonInterface {
+  static final _$sinceIds = _$jsonSerializers.deserialize(
+    const [],
+    specifiedType: const FullType(BuiltMap, [FullType(String), FullType(String)]),
+  )! as BuiltMap<String, String>;
+
+  static final _$limit = _$jsonSerializers.deserialize(
+    7,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$widgets = _$jsonSerializers.deserialize(
+    const [],
+    specifiedType: const FullType(BuiltList, [FullType(String)]),
+  )! as BuiltList<String>;
+
+  /// Array indexed by widget Ids, contains date/id from which we want the new items.
+  BuiltMap<String, String> get sinceIds;
+
+  /// Limit number of result items per widget.
+  int get limit;
+
+  /// Limit results to specific widgets.
+  BuiltList<String> get widgets;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DashboardApiGetWidgetItemsRequestApplicationJsonInterfaceBuilder].
+  $DashboardApiGetWidgetItemsRequestApplicationJsonInterface rebuild(
+    void Function($DashboardApiGetWidgetItemsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DashboardApiGetWidgetItemsRequestApplicationJsonInterfaceBuilder].
+  $DashboardApiGetWidgetItemsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DashboardApiGetWidgetItemsRequestApplicationJsonInterfaceBuilder b) {
+    b.sinceIds.replace(_$sinceIds);
+    b.limit = _$limit;
+    b.widgets.replace(_$widgets);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DashboardApiGetWidgetItemsRequestApplicationJsonInterfaceBuilder b) {
+    _i5.checkNumber(
+      b.limit,
+      'limit',
+      maximum: 30,
+      minimum: 1,
+    );
+  }
+}
+
+abstract class DashboardApiGetWidgetItemsRequestApplicationJson
+    implements
+        $DashboardApiGetWidgetItemsRequestApplicationJsonInterface,
+        Built<DashboardApiGetWidgetItemsRequestApplicationJson,
+            DashboardApiGetWidgetItemsRequestApplicationJsonBuilder> {
+  /// Creates a new DashboardApiGetWidgetItemsRequestApplicationJson object using the builder pattern.
+  factory DashboardApiGetWidgetItemsRequestApplicationJson([
+    void Function(DashboardApiGetWidgetItemsRequestApplicationJsonBuilder)? b,
+  ]) = _$DashboardApiGetWidgetItemsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const DashboardApiGetWidgetItemsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory DashboardApiGetWidgetItemsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for DashboardApiGetWidgetItemsRequestApplicationJson.
+  static Serializer<DashboardApiGetWidgetItemsRequestApplicationJson> get serializer =>
+      _$dashboardApiGetWidgetItemsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DashboardApiGetWidgetItemsRequestApplicationJsonBuilder b) {
+    $DashboardApiGetWidgetItemsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DashboardApiGetWidgetItemsRequestApplicationJsonBuilder b) {
+    $DashboardApiGetWidgetItemsRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $WidgetItemInterface {
   String get subtitle;
   String get title;
@@ -884,6 +938,104 @@ abstract class DashboardApiGetWidgetItemsResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(DashboardApiGetWidgetItemsResponseApplicationJsonBuilder b) {
     $DashboardApiGetWidgetItemsResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $DashboardApiGetWidgetItemsV2RequestApplicationJsonInterface {
+  static final _$sinceIds = _$jsonSerializers.deserialize(
+    const [],
+    specifiedType: const FullType(BuiltMap, [FullType(String), FullType(String)]),
+  )! as BuiltMap<String, String>;
+
+  static final _$limit = _$jsonSerializers.deserialize(
+    7,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$widgets = _$jsonSerializers.deserialize(
+    const [],
+    specifiedType: const FullType(BuiltList, [FullType(String)]),
+  )! as BuiltList<String>;
+
+  /// Array indexed by widget Ids, contains date/id from which we want the new items.
+  BuiltMap<String, String> get sinceIds;
+
+  /// Limit number of result items per widget, not more than 30 are allowed.
+  int get limit;
+
+  /// Limit results to specific widgets.
+  BuiltList<String> get widgets;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DashboardApiGetWidgetItemsV2RequestApplicationJsonInterfaceBuilder].
+  $DashboardApiGetWidgetItemsV2RequestApplicationJsonInterface rebuild(
+    void Function($DashboardApiGetWidgetItemsV2RequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DashboardApiGetWidgetItemsV2RequestApplicationJsonInterfaceBuilder].
+  $DashboardApiGetWidgetItemsV2RequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DashboardApiGetWidgetItemsV2RequestApplicationJsonInterfaceBuilder b) {
+    b.sinceIds.replace(_$sinceIds);
+    b.limit = _$limit;
+    b.widgets.replace(_$widgets);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DashboardApiGetWidgetItemsV2RequestApplicationJsonInterfaceBuilder b) {
+    _i5.checkNumber(
+      b.limit,
+      'limit',
+      maximum: 30,
+      minimum: 1,
+    );
+  }
+}
+
+abstract class DashboardApiGetWidgetItemsV2RequestApplicationJson
+    implements
+        $DashboardApiGetWidgetItemsV2RequestApplicationJsonInterface,
+        Built<DashboardApiGetWidgetItemsV2RequestApplicationJson,
+            DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder> {
+  /// Creates a new DashboardApiGetWidgetItemsV2RequestApplicationJson object using the builder pattern.
+  factory DashboardApiGetWidgetItemsV2RequestApplicationJson([
+    void Function(DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder)? b,
+  ]) = _$DashboardApiGetWidgetItemsV2RequestApplicationJson;
+
+  // coverage:ignore-start
+  const DashboardApiGetWidgetItemsV2RequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory DashboardApiGetWidgetItemsV2RequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for DashboardApiGetWidgetItemsV2RequestApplicationJson.
+  static Serializer<DashboardApiGetWidgetItemsV2RequestApplicationJson> get serializer =>
+      _$dashboardApiGetWidgetItemsV2RequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder b) {
+    $DashboardApiGetWidgetItemsV2RequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder b) {
+    $DashboardApiGetWidgetItemsV2RequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -1103,16 +1255,14 @@ final Serializers _$serializers = (Serializers().toBuilder()
         MapBuilder<String, Widget>.new,
       )
       ..addBuilderFactory(
+        const FullType(DashboardApiGetWidgetItemsRequestApplicationJson),
+        DashboardApiGetWidgetItemsRequestApplicationJsonBuilder.new,
+      )
+      ..add(DashboardApiGetWidgetItemsRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(BuiltMap, [FullType(String), FullType(String)]),
         MapBuilder<String, String>.new,
       )
-      ..addBuilderFactory(
-        const FullType(ContentString, [
-          FullType(BuiltMap, [FullType(String), FullType(String)]),
-        ]),
-        ContentStringBuilder<BuiltMap<String, String>>.new,
-      )
-      ..add(ContentString.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(String)]), ListBuilder<String>.new)
       ..addBuilderFactory(
         const FullType(DashboardApiGetWidgetItemsResponseApplicationJson),
@@ -1134,6 +1284,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ]),
         MapBuilder<String, BuiltList<WidgetItem>>.new,
       )
+      ..addBuilderFactory(
+        const FullType(DashboardApiGetWidgetItemsV2RequestApplicationJson),
+        DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder.new,
+      )
+      ..add(DashboardApiGetWidgetItemsV2RequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(DashboardApiGetWidgetItemsV2ResponseApplicationJson),
         DashboardApiGetWidgetItemsV2ResponseApplicationJsonBuilder.new,
@@ -1159,9 +1314,9 @@ final Serializers _$serializers = (Serializers().toBuilder()
 @_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
-      ..add(_i7.DynamiteDoubleSerializer())
-      ..addPlugin(_i8.StandardJsonPlugin())
-      ..addPlugin(const _i7.HeaderPlugin())
-      ..addPlugin(const _i7.ContentStringPlugin()))
+      ..add(_i6.DynamiteDoubleSerializer())
+      ..addPlugin(_i7.StandardJsonPlugin())
+      ..addPlugin(const _i6.HeaderPlugin())
+      ..addPlugin(const _i6.ContentStringPlugin()))
     .build();
 // coverage:ignore-end

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.g.dart
@@ -14,6 +14,9 @@ Serializer<DashboardApiGetWidgetsResponseApplicationJson_Ocs>
     _$DashboardApiGetWidgetsResponseApplicationJson_OcsSerializer();
 Serializer<DashboardApiGetWidgetsResponseApplicationJson> _$dashboardApiGetWidgetsResponseApplicationJsonSerializer =
     _$DashboardApiGetWidgetsResponseApplicationJsonSerializer();
+Serializer<DashboardApiGetWidgetItemsRequestApplicationJson>
+    _$dashboardApiGetWidgetItemsRequestApplicationJsonSerializer =
+    _$DashboardApiGetWidgetItemsRequestApplicationJsonSerializer();
 Serializer<WidgetItem> _$widgetItemSerializer = _$WidgetItemSerializer();
 Serializer<DashboardApiGetWidgetItemsResponseApplicationJson_Ocs>
     _$dashboardApiGetWidgetItemsResponseApplicationJsonOcsSerializer =
@@ -21,6 +24,9 @@ Serializer<DashboardApiGetWidgetItemsResponseApplicationJson_Ocs>
 Serializer<DashboardApiGetWidgetItemsResponseApplicationJson>
     _$dashboardApiGetWidgetItemsResponseApplicationJsonSerializer =
     _$DashboardApiGetWidgetItemsResponseApplicationJsonSerializer();
+Serializer<DashboardApiGetWidgetItemsV2RequestApplicationJson>
+    _$dashboardApiGetWidgetItemsV2RequestApplicationJsonSerializer =
+    _$DashboardApiGetWidgetItemsV2RequestApplicationJsonSerializer();
 Serializer<WidgetItems> _$widgetItemsSerializer = _$WidgetItemsSerializer();
 Serializer<DashboardApiGetWidgetItemsV2ResponseApplicationJson_Ocs>
     _$dashboardApiGetWidgetItemsV2ResponseApplicationJsonOcsSerializer =
@@ -332,6 +338,61 @@ class _$DashboardApiGetWidgetsResponseApplicationJsonSerializer
   }
 }
 
+class _$DashboardApiGetWidgetItemsRequestApplicationJsonSerializer
+    implements StructuredSerializer<DashboardApiGetWidgetItemsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    DashboardApiGetWidgetItemsRequestApplicationJson,
+    _$DashboardApiGetWidgetItemsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'DashboardApiGetWidgetItemsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, DashboardApiGetWidgetItemsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'sinceIds',
+      serializers.serialize(object.sinceIds,
+          specifiedType: const FullType(BuiltMap, [FullType(String), FullType(String)])),
+      'limit',
+      serializers.serialize(object.limit, specifiedType: const FullType(int)),
+      'widgets',
+      serializers.serialize(object.widgets, specifiedType: const FullType(BuiltList, [FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  DashboardApiGetWidgetItemsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = DashboardApiGetWidgetItemsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'sinceIds':
+          result.sinceIds.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, [FullType(String), FullType(String)]))!);
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'widgets':
+          result.widgets.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, [FullType(String)]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$WidgetItemSerializer implements StructuredSerializer<WidgetItem> {
   @override
   final Iterable<Type> types = const [WidgetItem, _$WidgetItem];
@@ -488,6 +549,61 @@ class _$DashboardApiGetWidgetItemsResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(DashboardApiGetWidgetItemsResponseApplicationJson_Ocs))!
               as DashboardApiGetWidgetItemsResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$DashboardApiGetWidgetItemsV2RequestApplicationJsonSerializer
+    implements StructuredSerializer<DashboardApiGetWidgetItemsV2RequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    DashboardApiGetWidgetItemsV2RequestApplicationJson,
+    _$DashboardApiGetWidgetItemsV2RequestApplicationJson
+  ];
+  @override
+  final String wireName = 'DashboardApiGetWidgetItemsV2RequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, DashboardApiGetWidgetItemsV2RequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'sinceIds',
+      serializers.serialize(object.sinceIds,
+          specifiedType: const FullType(BuiltMap, [FullType(String), FullType(String)])),
+      'limit',
+      serializers.serialize(object.limit, specifiedType: const FullType(int)),
+      'widgets',
+      serializers.serialize(object.widgets, specifiedType: const FullType(BuiltList, [FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  DashboardApiGetWidgetItemsV2RequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'sinceIds':
+          result.sinceIds.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, [FullType(String), FullType(String)]))!);
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'widgets':
+          result.widgets.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, [FullType(String)]))! as BuiltList<Object?>);
           break;
       }
     }
@@ -1386,6 +1502,154 @@ class DashboardApiGetWidgetsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $DashboardApiGetWidgetItemsRequestApplicationJsonInterfaceBuilder {
+  void replace($DashboardApiGetWidgetItemsRequestApplicationJsonInterface other);
+  void update(void Function($DashboardApiGetWidgetItemsRequestApplicationJsonInterfaceBuilder) updates);
+  MapBuilder<String, String> get sinceIds;
+  set sinceIds(MapBuilder<String, String>? sinceIds);
+
+  int? get limit;
+  set limit(int? limit);
+
+  ListBuilder<String> get widgets;
+  set widgets(ListBuilder<String>? widgets);
+}
+
+class _$DashboardApiGetWidgetItemsRequestApplicationJson extends DashboardApiGetWidgetItemsRequestApplicationJson {
+  @override
+  final BuiltMap<String, String> sinceIds;
+  @override
+  final int limit;
+  @override
+  final BuiltList<String> widgets;
+
+  factory _$DashboardApiGetWidgetItemsRequestApplicationJson(
+          [void Function(DashboardApiGetWidgetItemsRequestApplicationJsonBuilder)? updates]) =>
+      (DashboardApiGetWidgetItemsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$DashboardApiGetWidgetItemsRequestApplicationJson._(
+      {required this.sinceIds, required this.limit, required this.widgets})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(sinceIds, r'DashboardApiGetWidgetItemsRequestApplicationJson', 'sinceIds');
+    BuiltValueNullFieldError.checkNotNull(limit, r'DashboardApiGetWidgetItemsRequestApplicationJson', 'limit');
+    BuiltValueNullFieldError.checkNotNull(widgets, r'DashboardApiGetWidgetItemsRequestApplicationJson', 'widgets');
+  }
+
+  @override
+  DashboardApiGetWidgetItemsRequestApplicationJson rebuild(
+          void Function(DashboardApiGetWidgetItemsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DashboardApiGetWidgetItemsRequestApplicationJsonBuilder toBuilder() =>
+      DashboardApiGetWidgetItemsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DashboardApiGetWidgetItemsRequestApplicationJson &&
+        sinceIds == other.sinceIds &&
+        limit == other.limit &&
+        widgets == other.widgets;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, sinceIds.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jc(_$hash, widgets.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'DashboardApiGetWidgetItemsRequestApplicationJson')
+          ..add('sinceIds', sinceIds)
+          ..add('limit', limit)
+          ..add('widgets', widgets))
+        .toString();
+  }
+}
+
+class DashboardApiGetWidgetItemsRequestApplicationJsonBuilder
+    implements
+        Builder<DashboardApiGetWidgetItemsRequestApplicationJson,
+            DashboardApiGetWidgetItemsRequestApplicationJsonBuilder>,
+        $DashboardApiGetWidgetItemsRequestApplicationJsonInterfaceBuilder {
+  _$DashboardApiGetWidgetItemsRequestApplicationJson? _$v;
+
+  MapBuilder<String, String>? _sinceIds;
+  MapBuilder<String, String> get sinceIds => _$this._sinceIds ??= MapBuilder<String, String>();
+  set sinceIds(covariant MapBuilder<String, String>? sinceIds) => _$this._sinceIds = sinceIds;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  ListBuilder<String>? _widgets;
+  ListBuilder<String> get widgets => _$this._widgets ??= ListBuilder<String>();
+  set widgets(covariant ListBuilder<String>? widgets) => _$this._widgets = widgets;
+
+  DashboardApiGetWidgetItemsRequestApplicationJsonBuilder() {
+    DashboardApiGetWidgetItemsRequestApplicationJson._defaults(this);
+  }
+
+  DashboardApiGetWidgetItemsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _sinceIds = $v.sinceIds.toBuilder();
+      _limit = $v.limit;
+      _widgets = $v.widgets.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant DashboardApiGetWidgetItemsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$DashboardApiGetWidgetItemsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(DashboardApiGetWidgetItemsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DashboardApiGetWidgetItemsRequestApplicationJson build() => _build();
+
+  _$DashboardApiGetWidgetItemsRequestApplicationJson _build() {
+    DashboardApiGetWidgetItemsRequestApplicationJson._validate(this);
+    _$DashboardApiGetWidgetItemsRequestApplicationJson _$result;
+    try {
+      _$result = _$v ??
+          _$DashboardApiGetWidgetItemsRequestApplicationJson._(
+              sinceIds: sinceIds.build(),
+              limit: BuiltValueNullFieldError.checkNotNull(
+                  limit, r'DashboardApiGetWidgetItemsRequestApplicationJson', 'limit'),
+              widgets: widgets.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'sinceIds';
+        sinceIds.build();
+
+        _$failedField = 'widgets';
+        widgets.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'DashboardApiGetWidgetItemsRequestApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $WidgetItemInterfaceBuilder {
   void replace($WidgetItemInterface other);
   void update(void Function($WidgetItemInterfaceBuilder) updates);
@@ -1785,6 +2049,154 @@ class DashboardApiGetWidgetItemsResponseApplicationJsonBuilder
       } catch (e) {
         throw BuiltValueNestedFieldError(
             r'DashboardApiGetWidgetItemsResponseApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $DashboardApiGetWidgetItemsV2RequestApplicationJsonInterfaceBuilder {
+  void replace($DashboardApiGetWidgetItemsV2RequestApplicationJsonInterface other);
+  void update(void Function($DashboardApiGetWidgetItemsV2RequestApplicationJsonInterfaceBuilder) updates);
+  MapBuilder<String, String> get sinceIds;
+  set sinceIds(MapBuilder<String, String>? sinceIds);
+
+  int? get limit;
+  set limit(int? limit);
+
+  ListBuilder<String> get widgets;
+  set widgets(ListBuilder<String>? widgets);
+}
+
+class _$DashboardApiGetWidgetItemsV2RequestApplicationJson extends DashboardApiGetWidgetItemsV2RequestApplicationJson {
+  @override
+  final BuiltMap<String, String> sinceIds;
+  @override
+  final int limit;
+  @override
+  final BuiltList<String> widgets;
+
+  factory _$DashboardApiGetWidgetItemsV2RequestApplicationJson(
+          [void Function(DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder)? updates]) =>
+      (DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$DashboardApiGetWidgetItemsV2RequestApplicationJson._(
+      {required this.sinceIds, required this.limit, required this.widgets})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(sinceIds, r'DashboardApiGetWidgetItemsV2RequestApplicationJson', 'sinceIds');
+    BuiltValueNullFieldError.checkNotNull(limit, r'DashboardApiGetWidgetItemsV2RequestApplicationJson', 'limit');
+    BuiltValueNullFieldError.checkNotNull(widgets, r'DashboardApiGetWidgetItemsV2RequestApplicationJson', 'widgets');
+  }
+
+  @override
+  DashboardApiGetWidgetItemsV2RequestApplicationJson rebuild(
+          void Function(DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder toBuilder() =>
+      DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DashboardApiGetWidgetItemsV2RequestApplicationJson &&
+        sinceIds == other.sinceIds &&
+        limit == other.limit &&
+        widgets == other.widgets;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, sinceIds.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jc(_$hash, widgets.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'DashboardApiGetWidgetItemsV2RequestApplicationJson')
+          ..add('sinceIds', sinceIds)
+          ..add('limit', limit)
+          ..add('widgets', widgets))
+        .toString();
+  }
+}
+
+class DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder
+    implements
+        Builder<DashboardApiGetWidgetItemsV2RequestApplicationJson,
+            DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder>,
+        $DashboardApiGetWidgetItemsV2RequestApplicationJsonInterfaceBuilder {
+  _$DashboardApiGetWidgetItemsV2RequestApplicationJson? _$v;
+
+  MapBuilder<String, String>? _sinceIds;
+  MapBuilder<String, String> get sinceIds => _$this._sinceIds ??= MapBuilder<String, String>();
+  set sinceIds(covariant MapBuilder<String, String>? sinceIds) => _$this._sinceIds = sinceIds;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  ListBuilder<String>? _widgets;
+  ListBuilder<String> get widgets => _$this._widgets ??= ListBuilder<String>();
+  set widgets(covariant ListBuilder<String>? widgets) => _$this._widgets = widgets;
+
+  DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder() {
+    DashboardApiGetWidgetItemsV2RequestApplicationJson._defaults(this);
+  }
+
+  DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _sinceIds = $v.sinceIds.toBuilder();
+      _limit = $v.limit;
+      _widgets = $v.widgets.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant DashboardApiGetWidgetItemsV2RequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$DashboardApiGetWidgetItemsV2RequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(DashboardApiGetWidgetItemsV2RequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DashboardApiGetWidgetItemsV2RequestApplicationJson build() => _build();
+
+  _$DashboardApiGetWidgetItemsV2RequestApplicationJson _build() {
+    DashboardApiGetWidgetItemsV2RequestApplicationJson._validate(this);
+    _$DashboardApiGetWidgetItemsV2RequestApplicationJson _$result;
+    try {
+      _$result = _$v ??
+          _$DashboardApiGetWidgetItemsV2RequestApplicationJson._(
+              sinceIds: sinceIds.build(),
+              limit: BuiltValueNullFieldError.checkNotNull(
+                  limit, r'DashboardApiGetWidgetItemsV2RequestApplicationJson', 'limit'),
+              widgets: widgets.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'sinceIds';
+        sinceIds.build();
+
+        _$failedField = 'widgets';
+        widgets.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'DashboardApiGetWidgetItemsV2RequestApplicationJson', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.json
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.json
@@ -252,48 +252,43 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "sinceIds",
-                        "in": "query",
-                        "description": "Array indexed by widget Ids, contains date/id from which we want the new items",
-                        "schema": {
-                            "type": "string",
-                            "contentMediaType": "application/json",
-                            "contentSchema": {
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
                                 "type": "object",
-                                "default": [],
-                                "description": "Array indexed by widget Ids, contains date/id from which we want the new items",
-                                "additionalProperties": {
-                                    "type": "string"
+                                "properties": {
+                                    "sinceIds": {
+                                        "type": "object",
+                                        "default": [],
+                                        "description": "Array indexed by widget Ids, contains date/id from which we want the new items",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 7,
+                                        "description": "Limit number of result items per widget",
+                                        "minimum": 1,
+                                        "maximum": 30
+                                    },
+                                    "widgets": {
+                                        "type": "array",
+                                        "default": [],
+                                        "description": "Limit results to specific widgets",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Limit number of result items per widget",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 7,
-                            "minimum": 1,
-                            "maximum": 30
-                        }
-                    },
-                    {
-                        "name": "widgets[]",
-                        "in": "query",
-                        "description": "Limit results to specific widgets",
-                        "schema": {
-                            "type": "array",
-                            "default": [],
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -360,48 +355,43 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "sinceIds",
-                        "in": "query",
-                        "description": "Array indexed by widget Ids, contains date/id from which we want the new items",
-                        "schema": {
-                            "type": "string",
-                            "contentMediaType": "application/json",
-                            "contentSchema": {
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
                                 "type": "object",
-                                "default": [],
-                                "description": "Array indexed by widget Ids, contains date/id from which we want the new items",
-                                "additionalProperties": {
-                                    "type": "string"
+                                "properties": {
+                                    "sinceIds": {
+                                        "type": "object",
+                                        "default": [],
+                                        "description": "Array indexed by widget Ids, contains date/id from which we want the new items",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 7,
+                                        "description": "Limit number of result items per widget, not more than 30 are allowed",
+                                        "minimum": 1,
+                                        "maximum": 30
+                                    },
+                                    "widgets": {
+                                        "type": "array",
+                                        "default": [],
+                                        "description": "Limit results to specific widgets",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Limit number of result items per widget, not more than 30 are allowed",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 7,
-                            "minimum": 1,
-                            "maximum": 30
-                        }
-                    },
-                    {
-                        "name": "widgets[]",
-                        "in": "query",
-                        "description": "Limit results to specific widgets",
-                        "schema": {
-                            "type": "array",
-                            "default": [],
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",

--- a/packages/nextcloud/lib/src/api/dav.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.dart
@@ -16,17 +16,19 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
+
 import 'package:built_value/built_value.dart';
 import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart' as _i8;
-import 'package:collection/collection.dart' as _i5;
+import 'package:collection/collection.dart' as _i4;
 import 'package:dynamite_runtime/built_value.dart' as _i7;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i6;
+import 'package:dynamite_runtime/utils.dart' as _i5;
 import 'package:http/http.dart' as _i3;
 import 'package:meta/meta.dart' as _i2;
-import 'package:uri/uri.dart' as _i4;
+import 'package:uri/uri.dart' as _i6;
 
 part 'dav.openapi.g.dart';
 
@@ -72,8 +74,6 @@ class $DirectClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [fileId] ID of the file.
-  ///   * [expirationTime] Duration until the link expires.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -87,23 +87,15 @@ class $DirectClient {
   ///  * [$getUrl_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getUrl_Request({
-    required int fileId,
-    required int expirationTime,
+    required DirectGetUrlRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
-    _parameters['fileId'] = __fileId;
-
-    final __expirationTime = _$jsonSerializers.serialize(expirationTime, specifiedType: const FullType(int));
-    _parameters['expirationTime'] = __expirationTime;
-
-    final _path = _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/direct{?fileId*,expirationTime*}').expand(_parameters);
+    const _path = '/ocs/v2.php/apps/dav/api/v1/direct';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -121,8 +113,11 @@ class $DirectClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json
+        .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(DirectGetUrlRequestApplicationJson)));
     return _request;
   }
 
@@ -132,8 +127,6 @@ class $DirectClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [fileId] ID of the file.
-  ///   * [expirationTime] Duration until the link expires.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -146,14 +139,12 @@ class $DirectClient {
   ///  * [$getUrl_Request] for the request send by this method.
   ///  * [$getUrl_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<DirectGetUrlResponseApplicationJson, void>> getUrl({
-    required int fileId,
-    required int expirationTime,
+    required DirectGetUrlRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $getUrl_Request(
-      fileId: fileId,
-      expirationTime: expirationTime,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -206,12 +197,12 @@ class $OutOfOfficeClient {
     final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
     _parameters['userId'] = __userId;
 
-    final _path = _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}/now').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}/now').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -229,7 +220,7 @@ class $OutOfOfficeClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -304,12 +295,12 @@ class $OutOfOfficeClient {
     final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
     _parameters['userId'] = __userId;
 
-    final _path = _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -327,7 +318,7 @@ class $OutOfOfficeClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -381,10 +372,6 @@ class $OutOfOfficeClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [firstDay] First day of the absence in format `YYYY-MM-DD`.
-  ///   * [lastDay] Last day of the absence in format `YYYY-MM-DD`.
-  ///   * [status] Short text that is set as user status during the absence.
-  ///   * [message] Longer multiline message that is shown to others during the absence.
   ///   * [userId]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -398,37 +385,20 @@ class $OutOfOfficeClient {
   ///  * [$setOutOfOffice_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setOutOfOffice_Request({
-    required String firstDay,
-    required String lastDay,
-    required String status,
-    required String message,
     required String userId,
+    required OutOfOfficeSetOutOfOfficeRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __firstDay = _$jsonSerializers.serialize(firstDay, specifiedType: const FullType(String));
-    _parameters['firstDay'] = __firstDay;
-
-    final __lastDay = _$jsonSerializers.serialize(lastDay, specifiedType: const FullType(String));
-    _parameters['lastDay'] = __lastDay;
-
-    final __status = _$jsonSerializers.serialize(status, specifiedType: const FullType(String));
-    _parameters['status'] = __status;
-
-    final __message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
-    _parameters['message'] = __message;
-
     final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
     _parameters['userId'] = __userId;
 
-    final _path =
-        _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}{?firstDay*,lastDay*,status*,message*}')
-            .expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -446,8 +416,15 @@ class $OutOfOfficeClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(OutOfOfficeSetOutOfOfficeRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -457,10 +434,6 @@ class $OutOfOfficeClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [firstDay] First day of the absence in format `YYYY-MM-DD`.
-  ///   * [lastDay] Last day of the absence in format `YYYY-MM-DD`.
-  ///   * [status] Short text that is set as user status during the absence.
-  ///   * [message] Longer multiline message that is shown to others during the absence.
   ///   * [userId]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -473,20 +446,14 @@ class $OutOfOfficeClient {
   ///  * [$setOutOfOffice_Request] for the request send by this method.
   ///  * [$setOutOfOffice_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<OutOfOfficeSetOutOfOfficeResponseApplicationJson, void>> setOutOfOffice({
-    required String firstDay,
-    required String lastDay,
-    required String status,
-    required String message,
     required String userId,
+    required OutOfOfficeSetOutOfOfficeRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setOutOfOffice_Request(
-      firstDay: firstDay,
-      lastDay: lastDay,
-      status: status,
-      message: message,
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -532,12 +499,12 @@ class $OutOfOfficeClient {
     final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
     _parameters['userId'] = __userId;
 
-    final _path = _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -555,7 +522,7 @@ class $OutOfOfficeClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -591,6 +558,72 @@ class $OutOfOfficeClient {
     final _rawResponse =
         _i1.ResponseConverter<OutOfOfficeClearOutOfOfficeResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $DirectGetUrlRequestApplicationJsonInterface {
+  /// ID of the file.
+  int get fileId;
+
+  /// Duration until the link expires.
+  int get expirationTime;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectGetUrlRequestApplicationJsonInterfaceBuilder].
+  $DirectGetUrlRequestApplicationJsonInterface rebuild(
+    void Function($DirectGetUrlRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectGetUrlRequestApplicationJsonInterfaceBuilder].
+  $DirectGetUrlRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectGetUrlRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectGetUrlRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class DirectGetUrlRequestApplicationJson
+    implements
+        $DirectGetUrlRequestApplicationJsonInterface,
+        Built<DirectGetUrlRequestApplicationJson, DirectGetUrlRequestApplicationJsonBuilder> {
+  /// Creates a new DirectGetUrlRequestApplicationJson object using the builder pattern.
+  factory DirectGetUrlRequestApplicationJson([void Function(DirectGetUrlRequestApplicationJsonBuilder)? b]) =
+      _$DirectGetUrlRequestApplicationJson;
+
+  // coverage:ignore-start
+  const DirectGetUrlRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory DirectGetUrlRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for DirectGetUrlRequestApplicationJson.
+  static Serializer<DirectGetUrlRequestApplicationJson> get serializer =>
+      _$directGetUrlRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectGetUrlRequestApplicationJsonBuilder b) {
+    $DirectGetUrlRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectGetUrlRequestApplicationJsonBuilder b) {
+    $DirectGetUrlRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -1286,6 +1319,79 @@ abstract class OutOfOfficeGetOutOfOfficeResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterface {
+  /// First day of the absence in format `YYYY-MM-DD`.
+  String get firstDay;
+
+  /// Last day of the absence in format `YYYY-MM-DD`.
+  String get lastDay;
+
+  /// Short text that is set as user status during the absence.
+  String get status;
+
+  /// Longer multiline message that is shown to others during the absence.
+  String get message;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterfaceBuilder].
+  $OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterface rebuild(
+    void Function($OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterfaceBuilder].
+  $OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class OutOfOfficeSetOutOfOfficeRequestApplicationJson
+    implements
+        $OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterface,
+        Built<OutOfOfficeSetOutOfOfficeRequestApplicationJson, OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder> {
+  /// Creates a new OutOfOfficeSetOutOfOfficeRequestApplicationJson object using the builder pattern.
+  factory OutOfOfficeSetOutOfOfficeRequestApplicationJson([
+    void Function(OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder)? b,
+  ]) = _$OutOfOfficeSetOutOfOfficeRequestApplicationJson;
+
+  // coverage:ignore-start
+  const OutOfOfficeSetOutOfOfficeRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory OutOfOfficeSetOutOfOfficeRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for OutOfOfficeSetOutOfOfficeRequestApplicationJson.
+  static Serializer<OutOfOfficeSetOutOfOfficeRequestApplicationJson> get serializer =>
+      _$outOfOfficeSetOutOfOfficeRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder b) {
+    $OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder b) {
+    $OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   OutOfOfficeData get data;
@@ -1662,6 +1768,11 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
+        const FullType(DirectGetUrlRequestApplicationJson),
+        DirectGetUrlRequestApplicationJsonBuilder.new,
+      )
+      ..add(DirectGetUrlRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(DirectGetUrlResponseApplicationJson),
         DirectGetUrlResponseApplicationJsonBuilder.new,
       )
@@ -1704,6 +1815,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(const FullType(OutOfOfficeData), OutOfOfficeDataBuilder.new)
       ..add(OutOfOfficeData.serializer)
+      ..addBuilderFactory(
+        const FullType(OutOfOfficeSetOutOfOfficeRequestApplicationJson),
+        OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder.new,
+      )
+      ..add(OutOfOfficeSetOutOfOfficeRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(OutOfOfficeSetOutOfOfficeResponseApplicationJson),
         OutOfOfficeSetOutOfOfficeResponseApplicationJsonBuilder.new,

--- a/packages/nextcloud/lib/src/api/dav.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.dart
@@ -92,11 +92,11 @@ class $DirectClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
-    _parameters['fileId'] = $fileId;
+    final __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
+    _parameters['fileId'] = __fileId;
 
-    final $expirationTime = _$jsonSerializers.serialize(expirationTime, specifiedType: const FullType(int));
-    _parameters['expirationTime'] = $expirationTime;
+    final __expirationTime = _$jsonSerializers.serialize(expirationTime, specifiedType: const FullType(int));
+    _parameters['expirationTime'] = __expirationTime;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/direct{?fileId*,expirationTime*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -119,9 +119,9 @@ class $DirectClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -203,8 +203,8 @@ class $OutOfOfficeClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}/now').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -227,9 +227,9 @@ class $OutOfOfficeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -301,8 +301,8 @@ class $OutOfOfficeClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -325,9 +325,9 @@ class $OutOfOfficeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -406,20 +406,20 @@ class $OutOfOfficeClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $firstDay = _$jsonSerializers.serialize(firstDay, specifiedType: const FullType(String));
-    _parameters['firstDay'] = $firstDay;
+    final __firstDay = _$jsonSerializers.serialize(firstDay, specifiedType: const FullType(String));
+    _parameters['firstDay'] = __firstDay;
 
-    final $lastDay = _$jsonSerializers.serialize(lastDay, specifiedType: const FullType(String));
-    _parameters['lastDay'] = $lastDay;
+    final __lastDay = _$jsonSerializers.serialize(lastDay, specifiedType: const FullType(String));
+    _parameters['lastDay'] = __lastDay;
 
-    final $status = _$jsonSerializers.serialize(status, specifiedType: const FullType(String));
-    _parameters['status'] = $status;
+    final __status = _$jsonSerializers.serialize(status, specifiedType: const FullType(String));
+    _parameters['status'] = __status;
 
-    final $message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
-    _parameters['message'] = $message;
+    final __message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
+    _parameters['message'] = __message;
 
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path =
         _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}{?firstDay*,lastDay*,status*,message*}')
@@ -444,9 +444,9 @@ class $OutOfOfficeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -529,8 +529,8 @@ class $OutOfOfficeClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/dav/api/v1/outOfOffice/{userId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -553,9 +553,9 @@ class $OutOfOfficeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/dav.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.g.dart
@@ -6,6 +6,8 @@ part of 'dav.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
+Serializer<DirectGetUrlRequestApplicationJson> _$directGetUrlRequestApplicationJsonSerializer =
+    _$DirectGetUrlRequestApplicationJsonSerializer();
 Serializer<OCSMeta> _$oCSMetaSerializer = _$OCSMetaSerializer();
 Serializer<DirectGetUrlResponseApplicationJson_Ocs_Data> _$directGetUrlResponseApplicationJsonOcsDataSerializer =
     _$DirectGetUrlResponseApplicationJson_Ocs_DataSerializer();
@@ -28,6 +30,9 @@ Serializer<OutOfOfficeGetOutOfOfficeResponseApplicationJson_Ocs>
 Serializer<OutOfOfficeGetOutOfOfficeResponseApplicationJson>
     _$outOfOfficeGetOutOfOfficeResponseApplicationJsonSerializer =
     _$OutOfOfficeGetOutOfOfficeResponseApplicationJsonSerializer();
+Serializer<OutOfOfficeSetOutOfOfficeRequestApplicationJson>
+    _$outOfOfficeSetOutOfOfficeRequestApplicationJsonSerializer =
+    _$OutOfOfficeSetOutOfOfficeRequestApplicationJsonSerializer();
 Serializer<OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs>
     _$outOfOfficeSetOutOfOfficeResponseApplicationJsonOcsSerializer =
     _$OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsSerializer();
@@ -42,6 +47,50 @@ Serializer<OutOfOfficeClearOutOfOfficeResponseApplicationJson>
     _$OutOfOfficeClearOutOfOfficeResponseApplicationJsonSerializer();
 Serializer<Capabilities_Dav> _$capabilitiesDavSerializer = _$Capabilities_DavSerializer();
 Serializer<Capabilities> _$capabilitiesSerializer = _$CapabilitiesSerializer();
+
+class _$DirectGetUrlRequestApplicationJsonSerializer
+    implements StructuredSerializer<DirectGetUrlRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [DirectGetUrlRequestApplicationJson, _$DirectGetUrlRequestApplicationJson];
+  @override
+  final String wireName = 'DirectGetUrlRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, DirectGetUrlRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'fileId',
+      serializers.serialize(object.fileId, specifiedType: const FullType(int)),
+      'expirationTime',
+      serializers.serialize(object.expirationTime, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  DirectGetUrlRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = DirectGetUrlRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'fileId':
+          result.fileId = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'expirationTime':
+          result.expirationTime = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
 
 class _$OCSMetaSerializer implements StructuredSerializer<OCSMeta> {
   @override
@@ -605,6 +654,63 @@ class _$OutOfOfficeGetOutOfOfficeResponseApplicationJsonSerializer
   }
 }
 
+class _$OutOfOfficeSetOutOfOfficeRequestApplicationJsonSerializer
+    implements StructuredSerializer<OutOfOfficeSetOutOfOfficeRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    OutOfOfficeSetOutOfOfficeRequestApplicationJson,
+    _$OutOfOfficeSetOutOfOfficeRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'OutOfOfficeSetOutOfOfficeRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, OutOfOfficeSetOutOfOfficeRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'firstDay',
+      serializers.serialize(object.firstDay, specifiedType: const FullType(String)),
+      'lastDay',
+      serializers.serialize(object.lastDay, specifiedType: const FullType(String)),
+      'status',
+      serializers.serialize(object.status, specifiedType: const FullType(String)),
+      'message',
+      serializers.serialize(object.message, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  OutOfOfficeSetOutOfOfficeRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'firstDay':
+          result.firstDay = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastDay':
+          result.lastDay = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'status':
+          result.status = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'message':
+          result.message = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$OutOfOfficeSetOutOfOfficeResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<OutOfOfficeSetOutOfOfficeResponseApplicationJson_Ocs> {
   @override
@@ -879,6 +985,117 @@ class _$CapabilitiesSerializer implements StructuredSerializer<Capabilities> {
     }
 
     return result.build();
+  }
+}
+
+abstract mixin class $DirectGetUrlRequestApplicationJsonInterfaceBuilder {
+  void replace($DirectGetUrlRequestApplicationJsonInterface other);
+  void update(void Function($DirectGetUrlRequestApplicationJsonInterfaceBuilder) updates);
+  int? get fileId;
+  set fileId(int? fileId);
+
+  int? get expirationTime;
+  set expirationTime(int? expirationTime);
+}
+
+class _$DirectGetUrlRequestApplicationJson extends DirectGetUrlRequestApplicationJson {
+  @override
+  final int fileId;
+  @override
+  final int expirationTime;
+
+  factory _$DirectGetUrlRequestApplicationJson([void Function(DirectGetUrlRequestApplicationJsonBuilder)? updates]) =>
+      (DirectGetUrlRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$DirectGetUrlRequestApplicationJson._({required this.fileId, required this.expirationTime}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(fileId, r'DirectGetUrlRequestApplicationJson', 'fileId');
+    BuiltValueNullFieldError.checkNotNull(expirationTime, r'DirectGetUrlRequestApplicationJson', 'expirationTime');
+  }
+
+  @override
+  DirectGetUrlRequestApplicationJson rebuild(void Function(DirectGetUrlRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DirectGetUrlRequestApplicationJsonBuilder toBuilder() => DirectGetUrlRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DirectGetUrlRequestApplicationJson &&
+        fileId == other.fileId &&
+        expirationTime == other.expirationTime;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, fileId.hashCode);
+    _$hash = $jc(_$hash, expirationTime.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'DirectGetUrlRequestApplicationJson')
+          ..add('fileId', fileId)
+          ..add('expirationTime', expirationTime))
+        .toString();
+  }
+}
+
+class DirectGetUrlRequestApplicationJsonBuilder
+    implements
+        Builder<DirectGetUrlRequestApplicationJson, DirectGetUrlRequestApplicationJsonBuilder>,
+        $DirectGetUrlRequestApplicationJsonInterfaceBuilder {
+  _$DirectGetUrlRequestApplicationJson? _$v;
+
+  int? _fileId;
+  int? get fileId => _$this._fileId;
+  set fileId(covariant int? fileId) => _$this._fileId = fileId;
+
+  int? _expirationTime;
+  int? get expirationTime => _$this._expirationTime;
+  set expirationTime(covariant int? expirationTime) => _$this._expirationTime = expirationTime;
+
+  DirectGetUrlRequestApplicationJsonBuilder() {
+    DirectGetUrlRequestApplicationJson._defaults(this);
+  }
+
+  DirectGetUrlRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _fileId = $v.fileId;
+      _expirationTime = $v.expirationTime;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant DirectGetUrlRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$DirectGetUrlRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(DirectGetUrlRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DirectGetUrlRequestApplicationJson build() => _build();
+
+  _$DirectGetUrlRequestApplicationJson _build() {
+    DirectGetUrlRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$DirectGetUrlRequestApplicationJson._(
+            fileId: BuiltValueNullFieldError.checkNotNull(fileId, r'DirectGetUrlRequestApplicationJson', 'fileId'),
+            expirationTime: BuiltValueNullFieldError.checkNotNull(
+                expirationTime, r'DirectGetUrlRequestApplicationJson', 'expirationTime'));
+    replace(_$result);
+    return _$result;
   }
 }
 
@@ -2279,6 +2496,156 @@ class OutOfOfficeGetOutOfOfficeResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterfaceBuilder {
+  void replace($OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterface other);
+  void update(void Function($OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterfaceBuilder) updates);
+  String? get firstDay;
+  set firstDay(String? firstDay);
+
+  String? get lastDay;
+  set lastDay(String? lastDay);
+
+  String? get status;
+  set status(String? status);
+
+  String? get message;
+  set message(String? message);
+}
+
+class _$OutOfOfficeSetOutOfOfficeRequestApplicationJson extends OutOfOfficeSetOutOfOfficeRequestApplicationJson {
+  @override
+  final String firstDay;
+  @override
+  final String lastDay;
+  @override
+  final String status;
+  @override
+  final String message;
+
+  factory _$OutOfOfficeSetOutOfOfficeRequestApplicationJson(
+          [void Function(OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder)? updates]) =>
+      (OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$OutOfOfficeSetOutOfOfficeRequestApplicationJson._(
+      {required this.firstDay, required this.lastDay, required this.status, required this.message})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(firstDay, r'OutOfOfficeSetOutOfOfficeRequestApplicationJson', 'firstDay');
+    BuiltValueNullFieldError.checkNotNull(lastDay, r'OutOfOfficeSetOutOfOfficeRequestApplicationJson', 'lastDay');
+    BuiltValueNullFieldError.checkNotNull(status, r'OutOfOfficeSetOutOfOfficeRequestApplicationJson', 'status');
+    BuiltValueNullFieldError.checkNotNull(message, r'OutOfOfficeSetOutOfOfficeRequestApplicationJson', 'message');
+  }
+
+  @override
+  OutOfOfficeSetOutOfOfficeRequestApplicationJson rebuild(
+          void Function(OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder toBuilder() =>
+      OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OutOfOfficeSetOutOfOfficeRequestApplicationJson &&
+        firstDay == other.firstDay &&
+        lastDay == other.lastDay &&
+        status == other.status &&
+        message == other.message;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, firstDay.hashCode);
+    _$hash = $jc(_$hash, lastDay.hashCode);
+    _$hash = $jc(_$hash, status.hashCode);
+    _$hash = $jc(_$hash, message.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OutOfOfficeSetOutOfOfficeRequestApplicationJson')
+          ..add('firstDay', firstDay)
+          ..add('lastDay', lastDay)
+          ..add('status', status)
+          ..add('message', message))
+        .toString();
+  }
+}
+
+class OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder
+    implements
+        Builder<OutOfOfficeSetOutOfOfficeRequestApplicationJson,
+            OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder>,
+        $OutOfOfficeSetOutOfOfficeRequestApplicationJsonInterfaceBuilder {
+  _$OutOfOfficeSetOutOfOfficeRequestApplicationJson? _$v;
+
+  String? _firstDay;
+  String? get firstDay => _$this._firstDay;
+  set firstDay(covariant String? firstDay) => _$this._firstDay = firstDay;
+
+  String? _lastDay;
+  String? get lastDay => _$this._lastDay;
+  set lastDay(covariant String? lastDay) => _$this._lastDay = lastDay;
+
+  String? _status;
+  String? get status => _$this._status;
+  set status(covariant String? status) => _$this._status = status;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(covariant String? message) => _$this._message = message;
+
+  OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder() {
+    OutOfOfficeSetOutOfOfficeRequestApplicationJson._defaults(this);
+  }
+
+  OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _firstDay = $v.firstDay;
+      _lastDay = $v.lastDay;
+      _status = $v.status;
+      _message = $v.message;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OutOfOfficeSetOutOfOfficeRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OutOfOfficeSetOutOfOfficeRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(OutOfOfficeSetOutOfOfficeRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OutOfOfficeSetOutOfOfficeRequestApplicationJson build() => _build();
+
+  _$OutOfOfficeSetOutOfOfficeRequestApplicationJson _build() {
+    OutOfOfficeSetOutOfOfficeRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$OutOfOfficeSetOutOfOfficeRequestApplicationJson._(
+            firstDay: BuiltValueNullFieldError.checkNotNull(
+                firstDay, r'OutOfOfficeSetOutOfOfficeRequestApplicationJson', 'firstDay'),
+            lastDay: BuiltValueNullFieldError.checkNotNull(
+                lastDay, r'OutOfOfficeSetOutOfOfficeRequestApplicationJson', 'lastDay'),
+            status: BuiltValueNullFieldError.checkNotNull(
+                status, r'OutOfOfficeSetOutOfOfficeRequestApplicationJson', 'status'),
+            message: BuiltValueNullFieldError.checkNotNull(
+                message, r'OutOfOfficeSetOutOfOfficeRequestApplicationJson', 'message'));
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/dav.openapi.json
+++ b/packages/nextcloud/lib/src/api/dav.openapi.json
@@ -163,27 +163,33 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "fileId",
+                                    "expirationTime"
+                                ],
+                                "properties": {
+                                    "fileId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "ID of the file"
+                                    },
+                                    "expirationTime": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Duration until the link expires"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "fileId",
-                        "in": "query",
-                        "description": "ID of the file",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "expirationTime",
-                        "in": "query",
-                        "description": "Duration until the link expires",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -534,43 +540,41 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "firstDay",
+                                    "lastDay",
+                                    "status",
+                                    "message"
+                                ],
+                                "properties": {
+                                    "firstDay": {
+                                        "type": "string",
+                                        "description": "First day of the absence in format `YYYY-MM-DD`"
+                                    },
+                                    "lastDay": {
+                                        "type": "string",
+                                        "description": "Last day of the absence in format `YYYY-MM-DD`"
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "description": "Short text that is set as user status during the absence"
+                                    },
+                                    "message": {
+                                        "type": "string",
+                                        "description": "Longer multiline message that is shown to others during the absence"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "firstDay",
-                        "in": "query",
-                        "description": "First day of the absence in format `YYYY-MM-DD`",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "lastDay",
-                        "in": "query",
-                        "description": "Last day of the absence in format `YYYY-MM-DD`",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "status",
-                        "in": "query",
-                        "description": "Short text that is set as user status during the absence",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "message",
-                        "in": "query",
-                        "description": "Longer multiline message that is shown to others during the absence",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "userId",
                         "in": "path",

--- a/packages/nextcloud/lib/src/api/files.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.dart
@@ -16,6 +16,7 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:built_collection/built_collection.dart';
@@ -381,9 +382,6 @@ class $DirectEditingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [path] Path of the file.
-  ///   * [editorId] ID of the editor.
-  ///   * [fileId] ID of the file.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -396,23 +394,10 @@ class $DirectEditingClient {
   ///  * [$open_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $open_Request({
-    required String path,
-    String? editorId,
-    int? fileId,
+    required DirectEditingOpenRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = __path;
-
-    final __editorId = _$jsonSerializers.serialize(editorId, specifiedType: const FullType(String));
-    _parameters['editorId'] = __editorId;
-
-    final __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
-    _parameters['fileId'] = __fileId;
-
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/open{?path*,editorId*,fileId*}')
-        .expand(_parameters);
+    const _path = '/ocs/v2.php/apps/files/api/v1/directEditing/open';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -437,6 +422,10 @@ class $DirectEditingClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(DirectEditingOpenRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -446,9 +435,6 @@ class $DirectEditingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [path] Path of the file.
-  ///   * [editorId] ID of the editor.
-  ///   * [fileId] ID of the file.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -460,16 +446,12 @@ class $DirectEditingClient {
   ///  * [$open_Request] for the request send by this method.
   ///  * [$open_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<DirectEditingOpenResponseApplicationJson, void>> open({
-    required String path,
-    String? editorId,
-    int? fileId,
+    required DirectEditingOpenRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $open_Request(
-      path: path,
-      editorId: editorId,
-      fileId: fileId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -496,10 +478,6 @@ class $DirectEditingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [path] Path of the file.
-  ///   * [editorId] ID of the editor.
-  ///   * [creatorId] ID of the creator.
-  ///   * [templateId] ID of the template.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -512,28 +490,10 @@ class $DirectEditingClient {
   ///  * [$create_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $create_Request({
-    required String path,
-    required String editorId,
-    required String creatorId,
-    String? templateId,
+    required DirectEditingCreateRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = __path;
-
-    final __editorId = _$jsonSerializers.serialize(editorId, specifiedType: const FullType(String));
-    _parameters['editorId'] = __editorId;
-
-    final __creatorId = _$jsonSerializers.serialize(creatorId, specifiedType: const FullType(String));
-    _parameters['creatorId'] = __creatorId;
-
-    final __templateId = _$jsonSerializers.serialize(templateId, specifiedType: const FullType(String));
-    _parameters['templateId'] = __templateId;
-
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/create{?path*,editorId*,creatorId*,templateId*}')
-            .expand(_parameters);
+    const _path = '/ocs/v2.php/apps/files/api/v1/directEditing/create';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -558,6 +518,10 @@ class $DirectEditingClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(DirectEditingCreateRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -567,10 +531,6 @@ class $DirectEditingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [path] Path of the file.
-  ///   * [editorId] ID of the editor.
-  ///   * [creatorId] ID of the creator.
-  ///   * [templateId] ID of the template.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -582,18 +542,12 @@ class $DirectEditingClient {
   ///  * [$create_Request] for the request send by this method.
   ///  * [$create_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<DirectEditingCreateResponseApplicationJson, void>> create({
-    required String path,
-    required String editorId,
-    required String creatorId,
-    String? templateId,
+    required DirectEditingCreateRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $create_Request(
-      path: path,
-      editorId: editorId,
-      creatorId: creatorId,
-      templateId: templateId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -627,7 +581,6 @@ class $OpenLocalEditorClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [path] Path of the file.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -639,14 +592,10 @@ class $OpenLocalEditorClient {
   ///  * [$create_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $create_Request({
-    required String path,
+    required OpenLocalEditorCreateRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = __path;
-
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/openlocaleditor{?path*}').expand(_parameters);
+    const _path = '/ocs/v2.php/apps/files/api/v1/openlocaleditor';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -671,6 +620,10 @@ class $OpenLocalEditorClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(OpenLocalEditorCreateRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -680,7 +633,6 @@ class $OpenLocalEditorClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [path] Path of the file.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -691,12 +643,12 @@ class $OpenLocalEditorClient {
   ///  * [$create_Request] for the request send by this method.
   ///  * [$create_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<OpenLocalEditorCreateResponseApplicationJson, void>> create({
-    required String path,
+    required OpenLocalEditorCreateRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $create_Request(
-      path: path,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -723,7 +675,6 @@ class $OpenLocalEditorClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [path] Path of the file.
   ///   * [token] Token of the local editor.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -736,18 +687,15 @@ class $OpenLocalEditorClient {
   ///  * [$validate_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $validate_Request({
-    required String path,
     required String token,
+    required OpenLocalEditorValidateRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = __path;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _parameters['token'] = __token;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/openlocaleditor/{token}{?path*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/openlocaleditor/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -772,6 +720,13 @@ class $OpenLocalEditorClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(OpenLocalEditorValidateRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -781,7 +736,6 @@ class $OpenLocalEditorClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [path] Path of the file.
   ///   * [token] Token of the local editor.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -793,14 +747,14 @@ class $OpenLocalEditorClient {
   ///  * [$validate_Request] for the request send by this method.
   ///  * [$validate_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<OpenLocalEditorValidateResponseApplicationJson, void>> validate({
-    required String path,
     required String token,
+    required OpenLocalEditorValidateRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $validate_Request(
-      path: path,
       token: token,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -913,9 +867,6 @@ class $TemplateClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [filePath] Path of the file.
-  ///   * [templatePath] Name of the template. Defaults to `""`.
-  ///   * [templateType] Type of the template. Defaults to `"user"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -927,26 +878,10 @@ class $TemplateClient {
   ///  * [$create_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $create_Request({
-    required String filePath,
-    String? templatePath,
-    String? templateType,
+    required TemplateCreateRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __filePath = _$jsonSerializers.serialize(filePath, specifiedType: const FullType(String));
-    _parameters['filePath'] = __filePath;
-
-    var __templatePath = _$jsonSerializers.serialize(templatePath, specifiedType: const FullType(String));
-    __templatePath ??= '';
-    _parameters['templatePath'] = __templatePath;
-
-    var __templateType = _$jsonSerializers.serialize(templateType, specifiedType: const FullType(String));
-    __templateType ??= 'user';
-    _parameters['templateType'] = __templateType;
-
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/templates/create{?filePath*,templatePath*,templateType*}')
-            .expand(_parameters);
+    const _path = '/ocs/v2.php/apps/files/api/v1/templates/create';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -971,6 +906,10 @@ class $TemplateClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(TemplateCreateRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -980,9 +919,6 @@ class $TemplateClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [filePath] Path of the file.
-  ///   * [templatePath] Name of the template. Defaults to `""`.
-  ///   * [templateType] Type of the template. Defaults to `"user"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -993,16 +929,12 @@ class $TemplateClient {
   ///  * [$create_Request] for the request send by this method.
   ///  * [$create_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<TemplateCreateResponseApplicationJson, void>> create({
-    required String filePath,
-    String? templatePath,
-    String? templateType,
+    required TemplateCreateRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $create_Request(
-      filePath: filePath,
-      templatePath: templatePath,
-      templateType: templateType,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1028,8 +960,6 @@ class $TemplateClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [templatePath] Path of the template directory. Defaults to `""`.
-  ///   * [copySystemTemplates] Whether to copy the system templates to the template directory. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -1041,24 +971,10 @@ class $TemplateClient {
   ///  * [$path_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $path_Request({
-    String? templatePath,
-    TemplatePathCopySystemTemplates? copySystemTemplates,
     bool? oCSAPIRequest,
+    TemplatePathRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    var __templatePath = _$jsonSerializers.serialize(templatePath, specifiedType: const FullType(String));
-    __templatePath ??= '';
-    _parameters['templatePath'] = __templatePath;
-
-    var __copySystemTemplates = _$jsonSerializers.serialize(
-      copySystemTemplates,
-      specifiedType: const FullType(TemplatePathCopySystemTemplates),
-    );
-    __copySystemTemplates ??= 0;
-    _parameters['copySystemTemplates'] = __copySystemTemplates;
-
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/templates/path{?templatePath*,copySystemTemplates*}')
-        .expand(_parameters);
+    const _path = '/ocs/v2.php/apps/files/api/v1/templates/path';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1083,6 +999,17 @@ class $TemplateClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(TemplatePathRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              TemplatePathRequestApplicationJson(),
+              specifiedType: const FullType(TemplatePathRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -1092,8 +1019,6 @@ class $TemplateClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [templatePath] Path of the template directory. Defaults to `""`.
-  ///   * [copySystemTemplates] Whether to copy the system templates to the template directory. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -1104,14 +1029,12 @@ class $TemplateClient {
   ///  * [$path_Request] for the request send by this method.
   ///  * [$path_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<TemplatePathResponseApplicationJson, void>> path({
-    String? templatePath,
-    TemplatePathCopySystemTemplates? copySystemTemplates,
     bool? oCSAPIRequest,
+    TemplatePathRequestApplicationJson? $body,
   }) async {
     final _request = $path_Request(
-      templatePath: templatePath,
-      copySystemTemplates: copySystemTemplates,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1145,8 +1068,6 @@ class $TransferOwnershipClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [recipient] Username of the recipient.
-  ///   * [path] Path of the file.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -1159,19 +1080,10 @@ class $TransferOwnershipClient {
   ///  * [$transfer_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $transfer_Request({
-    required String recipient,
-    required String path,
+    required TransferOwnershipTransferRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __recipient = _$jsonSerializers.serialize(recipient, specifiedType: const FullType(String));
-    _parameters['recipient'] = __recipient;
-
-    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = __path;
-
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership{?recipient*,path*}').expand(_parameters);
+    const _path = '/ocs/v2.php/apps/files/api/v1/transferownership';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1196,6 +1108,13 @@ class $TransferOwnershipClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(TransferOwnershipTransferRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -1205,8 +1124,6 @@ class $TransferOwnershipClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [recipient] Username of the recipient.
-  ///   * [path] Path of the file.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -1218,14 +1135,12 @@ class $TransferOwnershipClient {
   ///  * [$transfer_Request] for the request send by this method.
   ///  * [$transfer_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<TransferOwnershipTransferResponseApplicationJson, void>> transfer({
-    required String recipient,
-    required String path,
+    required TransferOwnershipTransferRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $transfer_Request(
-      recipient: recipient,
-      path: path,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2083,6 +1998,75 @@ abstract class DirectEditingTemplatesResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $DirectEditingOpenRequestApplicationJsonInterface {
+  /// Path of the file.
+  String get path;
+
+  /// ID of the editor.
+  String? get editorId;
+
+  /// ID of the file.
+  int? get fileId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingOpenRequestApplicationJsonInterfaceBuilder].
+  $DirectEditingOpenRequestApplicationJsonInterface rebuild(
+    void Function($DirectEditingOpenRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingOpenRequestApplicationJsonInterfaceBuilder].
+  $DirectEditingOpenRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingOpenRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingOpenRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class DirectEditingOpenRequestApplicationJson
+    implements
+        $DirectEditingOpenRequestApplicationJsonInterface,
+        Built<DirectEditingOpenRequestApplicationJson, DirectEditingOpenRequestApplicationJsonBuilder> {
+  /// Creates a new DirectEditingOpenRequestApplicationJson object using the builder pattern.
+  factory DirectEditingOpenRequestApplicationJson([void Function(DirectEditingOpenRequestApplicationJsonBuilder)? b]) =
+      _$DirectEditingOpenRequestApplicationJson;
+
+  // coverage:ignore-start
+  const DirectEditingOpenRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory DirectEditingOpenRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for DirectEditingOpenRequestApplicationJson.
+  static Serializer<DirectEditingOpenRequestApplicationJson> get serializer =>
+      _$directEditingOpenRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingOpenRequestApplicationJsonBuilder b) {
+    $DirectEditingOpenRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingOpenRequestApplicationJsonBuilder b) {
+    $DirectEditingOpenRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $DirectEditingOpenResponseApplicationJson_Ocs_DataInterface {
   String get url;
 
@@ -2270,6 +2254,79 @@ abstract class DirectEditingOpenResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(DirectEditingOpenResponseApplicationJsonBuilder b) {
     $DirectEditingOpenResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $DirectEditingCreateRequestApplicationJsonInterface {
+  /// Path of the file.
+  String get path;
+
+  /// ID of the editor.
+  String get editorId;
+
+  /// ID of the creator.
+  String get creatorId;
+
+  /// ID of the template.
+  String? get templateId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DirectEditingCreateRequestApplicationJsonInterfaceBuilder].
+  $DirectEditingCreateRequestApplicationJsonInterface rebuild(
+    void Function($DirectEditingCreateRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DirectEditingCreateRequestApplicationJsonInterfaceBuilder].
+  $DirectEditingCreateRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DirectEditingCreateRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DirectEditingCreateRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class DirectEditingCreateRequestApplicationJson
+    implements
+        $DirectEditingCreateRequestApplicationJsonInterface,
+        Built<DirectEditingCreateRequestApplicationJson, DirectEditingCreateRequestApplicationJsonBuilder> {
+  /// Creates a new DirectEditingCreateRequestApplicationJson object using the builder pattern.
+  factory DirectEditingCreateRequestApplicationJson([
+    void Function(DirectEditingCreateRequestApplicationJsonBuilder)? b,
+  ]) = _$DirectEditingCreateRequestApplicationJson;
+
+  // coverage:ignore-start
+  const DirectEditingCreateRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory DirectEditingCreateRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for DirectEditingCreateRequestApplicationJson.
+  static Serializer<DirectEditingCreateRequestApplicationJson> get serializer =>
+      _$directEditingCreateRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DirectEditingCreateRequestApplicationJsonBuilder b) {
+    $DirectEditingCreateRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DirectEditingCreateRequestApplicationJsonBuilder b) {
+    $DirectEditingCreateRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -2465,6 +2522,70 @@ abstract class DirectEditingCreateResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $OpenLocalEditorCreateRequestApplicationJsonInterface {
+  /// Path of the file.
+  String get path;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OpenLocalEditorCreateRequestApplicationJsonInterfaceBuilder].
+  $OpenLocalEditorCreateRequestApplicationJsonInterface rebuild(
+    void Function($OpenLocalEditorCreateRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OpenLocalEditorCreateRequestApplicationJsonInterfaceBuilder].
+  $OpenLocalEditorCreateRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OpenLocalEditorCreateRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OpenLocalEditorCreateRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class OpenLocalEditorCreateRequestApplicationJson
+    implements
+        $OpenLocalEditorCreateRequestApplicationJsonInterface,
+        Built<OpenLocalEditorCreateRequestApplicationJson, OpenLocalEditorCreateRequestApplicationJsonBuilder> {
+  /// Creates a new OpenLocalEditorCreateRequestApplicationJson object using the builder pattern.
+  factory OpenLocalEditorCreateRequestApplicationJson([
+    void Function(OpenLocalEditorCreateRequestApplicationJsonBuilder)? b,
+  ]) = _$OpenLocalEditorCreateRequestApplicationJson;
+
+  // coverage:ignore-start
+  const OpenLocalEditorCreateRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory OpenLocalEditorCreateRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for OpenLocalEditorCreateRequestApplicationJson.
+  static Serializer<OpenLocalEditorCreateRequestApplicationJson> get serializer =>
+      _$openLocalEditorCreateRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OpenLocalEditorCreateRequestApplicationJsonBuilder b) {
+    $OpenLocalEditorCreateRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenLocalEditorCreateRequestApplicationJsonBuilder b) {
+    $OpenLocalEditorCreateRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $OpenLocalEditorCreateResponseApplicationJson_Ocs_DataInterface {
   String? get userId;
   String get pathHash;
@@ -2656,6 +2777,70 @@ abstract class OpenLocalEditorCreateResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(OpenLocalEditorCreateResponseApplicationJsonBuilder b) {
     $OpenLocalEditorCreateResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $OpenLocalEditorValidateRequestApplicationJsonInterface {
+  /// Path of the file.
+  String get path;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$OpenLocalEditorValidateRequestApplicationJsonInterfaceBuilder].
+  $OpenLocalEditorValidateRequestApplicationJsonInterface rebuild(
+    void Function($OpenLocalEditorValidateRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$OpenLocalEditorValidateRequestApplicationJsonInterfaceBuilder].
+  $OpenLocalEditorValidateRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($OpenLocalEditorValidateRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($OpenLocalEditorValidateRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class OpenLocalEditorValidateRequestApplicationJson
+    implements
+        $OpenLocalEditorValidateRequestApplicationJsonInterface,
+        Built<OpenLocalEditorValidateRequestApplicationJson, OpenLocalEditorValidateRequestApplicationJsonBuilder> {
+  /// Creates a new OpenLocalEditorValidateRequestApplicationJson object using the builder pattern.
+  factory OpenLocalEditorValidateRequestApplicationJson([
+    void Function(OpenLocalEditorValidateRequestApplicationJsonBuilder)? b,
+  ]) = _$OpenLocalEditorValidateRequestApplicationJson;
+
+  // coverage:ignore-start
+  const OpenLocalEditorValidateRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory OpenLocalEditorValidateRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for OpenLocalEditorValidateRequestApplicationJson.
+  static Serializer<OpenLocalEditorValidateRequestApplicationJson> get serializer =>
+      _$openLocalEditorValidateRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(OpenLocalEditorValidateRequestApplicationJsonBuilder b) {
+    $OpenLocalEditorValidateRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(OpenLocalEditorValidateRequestApplicationJsonBuilder b) {
+    $OpenLocalEditorValidateRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -3044,6 +3229,89 @@ abstract class TemplateListResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $TemplateCreateRequestApplicationJsonInterface {
+  static final _$templatePath = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$templateType = _$jsonSerializers.deserialize(
+    'user',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// Path of the file.
+  String get filePath;
+
+  /// Name of the template.
+  String get templatePath;
+
+  /// Type of the template.
+  String get templateType;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TemplateCreateRequestApplicationJsonInterfaceBuilder].
+  $TemplateCreateRequestApplicationJsonInterface rebuild(
+    void Function($TemplateCreateRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TemplateCreateRequestApplicationJsonInterfaceBuilder].
+  $TemplateCreateRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TemplateCreateRequestApplicationJsonInterfaceBuilder b) {
+    b.templatePath = _$templatePath;
+    b.templateType = _$templateType;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TemplateCreateRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class TemplateCreateRequestApplicationJson
+    implements
+        $TemplateCreateRequestApplicationJsonInterface,
+        Built<TemplateCreateRequestApplicationJson, TemplateCreateRequestApplicationJsonBuilder> {
+  /// Creates a new TemplateCreateRequestApplicationJson object using the builder pattern.
+  factory TemplateCreateRequestApplicationJson([void Function(TemplateCreateRequestApplicationJsonBuilder)? b]) =
+      _$TemplateCreateRequestApplicationJson;
+
+  // coverage:ignore-start
+  const TemplateCreateRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory TemplateCreateRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for TemplateCreateRequestApplicationJson.
+  static Serializer<TemplateCreateRequestApplicationJson> get serializer =>
+      _$templateCreateRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TemplateCreateRequestApplicationJsonBuilder b) {
+    $TemplateCreateRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TemplateCreateRequestApplicationJsonBuilder b) {
+    $TemplateCreateRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $TemplateFileInterface {
   String get basename;
   String get etag;
@@ -3231,68 +3499,84 @@ abstract class TemplateCreateResponseApplicationJson
   }
 }
 
-class TemplatePathCopySystemTemplates extends EnumClass {
-  const TemplatePathCopySystemTemplates._(super.name);
+@BuiltValue(instantiable: false)
+sealed class $TemplatePathRequestApplicationJsonInterface {
+  static final _$templatePath = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const TemplatePathCopySystemTemplates $0 = _$templatePathCopySystemTemplates$0;
+  static final _$copySystemTemplates = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const TemplatePathCopySystemTemplates $1 = _$templatePathCopySystemTemplates$1;
+  /// Path of the template directory.
+  String get templatePath;
 
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<TemplatePathCopySystemTemplates> get values => _$templatePathCopySystemTemplatesValues;
-  // coverage:ignore-end
+  /// Whether to copy the system templates to the template directory.
+  bool get copySystemTemplates;
 
-  /// Returns the enum value associated to the [name].
-  static TemplatePathCopySystemTemplates valueOf(String name) => _$valueOfTemplatePathCopySystemTemplates(name);
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TemplatePathRequestApplicationJsonInterfaceBuilder].
+  $TemplatePathRequestApplicationJsonInterface rebuild(
+    void Function($TemplatePathRequestApplicationJsonInterfaceBuilder) updates,
+  );
 
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+  /// Converts the instance to a builder [$TemplatePathRequestApplicationJsonInterfaceBuilder].
+  $TemplatePathRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TemplatePathRequestApplicationJsonInterfaceBuilder b) {
+    b.templatePath = _$templatePath;
+    b.copySystemTemplates = _$copySystemTemplates;
+  }
 
-  /// Serializer for TemplatePathCopySystemTemplates.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<TemplatePathCopySystemTemplates> get serializer =>
-      const _$TemplatePathCopySystemTemplatesSerializer();
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TemplatePathRequestApplicationJsonInterfaceBuilder b) {}
 }
 
-class _$TemplatePathCopySystemTemplatesSerializer implements PrimitiveSerializer<TemplatePathCopySystemTemplates> {
-  const _$TemplatePathCopySystemTemplatesSerializer();
+abstract class TemplatePathRequestApplicationJson
+    implements
+        $TemplatePathRequestApplicationJsonInterface,
+        Built<TemplatePathRequestApplicationJson, TemplatePathRequestApplicationJsonBuilder> {
+  /// Creates a new TemplatePathRequestApplicationJson object using the builder pattern.
+  factory TemplatePathRequestApplicationJson([void Function(TemplatePathRequestApplicationJsonBuilder)? b]) =
+      _$TemplatePathRequestApplicationJson;
 
-  static const Map<TemplatePathCopySystemTemplates, Object> _toWire = <TemplatePathCopySystemTemplates, Object>{
-    TemplatePathCopySystemTemplates.$0: 0,
-    TemplatePathCopySystemTemplates.$1: 1,
-  };
+  // coverage:ignore-start
+  const TemplatePathRequestApplicationJson._();
+  // coverage:ignore-end
 
-  static const Map<Object, TemplatePathCopySystemTemplates> _fromWire = <Object, TemplatePathCopySystemTemplates>{
-    0: TemplatePathCopySystemTemplates.$0,
-    1: TemplatePathCopySystemTemplates.$1,
-  };
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory TemplatePathRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
 
-  @override
-  Iterable<Type> get types => const [TemplatePathCopySystemTemplates];
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
 
-  @override
-  String get wireName => 'TemplatePathCopySystemTemplates';
+  /// Serializer for TemplatePathRequestApplicationJson.
+  static Serializer<TemplatePathRequestApplicationJson> get serializer =>
+      _$templatePathRequestApplicationJsonSerializer;
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    TemplatePathCopySystemTemplates object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TemplatePathRequestApplicationJsonBuilder b) {
+    $TemplatePathRequestApplicationJsonInterface._defaults(b);
+  }
 
-  @override
-  TemplatePathCopySystemTemplates deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TemplatePathRequestApplicationJsonBuilder b) {
+    $TemplatePathRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -3482,6 +3766,73 @@ abstract class TemplatePathResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(TemplatePathResponseApplicationJsonBuilder b) {
     $TemplatePathResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $TransferOwnershipTransferRequestApplicationJsonInterface {
+  /// Username of the recipient.
+  String get recipient;
+
+  /// Path of the file.
+  String get path;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$TransferOwnershipTransferRequestApplicationJsonInterfaceBuilder].
+  $TransferOwnershipTransferRequestApplicationJsonInterface rebuild(
+    void Function($TransferOwnershipTransferRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$TransferOwnershipTransferRequestApplicationJsonInterfaceBuilder].
+  $TransferOwnershipTransferRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($TransferOwnershipTransferRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($TransferOwnershipTransferRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class TransferOwnershipTransferRequestApplicationJson
+    implements
+        $TransferOwnershipTransferRequestApplicationJsonInterface,
+        Built<TransferOwnershipTransferRequestApplicationJson, TransferOwnershipTransferRequestApplicationJsonBuilder> {
+  /// Creates a new TransferOwnershipTransferRequestApplicationJson object using the builder pattern.
+  factory TransferOwnershipTransferRequestApplicationJson([
+    void Function(TransferOwnershipTransferRequestApplicationJsonBuilder)? b,
+  ]) = _$TransferOwnershipTransferRequestApplicationJson;
+
+  // coverage:ignore-start
+  const TransferOwnershipTransferRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory TransferOwnershipTransferRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for TransferOwnershipTransferRequestApplicationJson.
+  static Serializer<TransferOwnershipTransferRequestApplicationJson> get serializer =>
+      _$transferOwnershipTransferRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(TransferOwnershipTransferRequestApplicationJsonBuilder b) {
+    $TransferOwnershipTransferRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(TransferOwnershipTransferRequestApplicationJsonBuilder b) {
+    $TransferOwnershipTransferRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -4126,6 +4477,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         MapBuilder<String, DirectEditingTemplatesResponseApplicationJson_Ocs_Data_Templates>.new,
       )
       ..addBuilderFactory(
+        const FullType(DirectEditingOpenRequestApplicationJson),
+        DirectEditingOpenRequestApplicationJsonBuilder.new,
+      )
+      ..add(DirectEditingOpenRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(DirectEditingOpenResponseApplicationJson),
         DirectEditingOpenResponseApplicationJsonBuilder.new,
       )
@@ -4140,6 +4496,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         DirectEditingOpenResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(DirectEditingOpenResponseApplicationJson_Ocs_Data.serializer)
+      ..addBuilderFactory(
+        const FullType(DirectEditingCreateRequestApplicationJson),
+        DirectEditingCreateRequestApplicationJsonBuilder.new,
+      )
+      ..add(DirectEditingCreateRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(DirectEditingCreateResponseApplicationJson),
         DirectEditingCreateResponseApplicationJsonBuilder.new,
@@ -4156,6 +4517,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(DirectEditingCreateResponseApplicationJson_Ocs_Data.serializer)
       ..addBuilderFactory(
+        const FullType(OpenLocalEditorCreateRequestApplicationJson),
+        OpenLocalEditorCreateRequestApplicationJsonBuilder.new,
+      )
+      ..add(OpenLocalEditorCreateRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(OpenLocalEditorCreateResponseApplicationJson),
         OpenLocalEditorCreateResponseApplicationJsonBuilder.new,
       )
@@ -4170,6 +4536,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         OpenLocalEditorCreateResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(OpenLocalEditorCreateResponseApplicationJson_Ocs_Data.serializer)
+      ..addBuilderFactory(
+        const FullType(OpenLocalEditorValidateRequestApplicationJson),
+        OpenLocalEditorValidateRequestApplicationJsonBuilder.new,
+      )
+      ..add(OpenLocalEditorValidateRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(OpenLocalEditorValidateResponseApplicationJson),
         OpenLocalEditorValidateResponseApplicationJsonBuilder.new,
@@ -4202,6 +4573,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ListBuilder<TemplateFileCreator>.new,
       )
       ..addBuilderFactory(
+        const FullType(TemplateCreateRequestApplicationJson),
+        TemplateCreateRequestApplicationJsonBuilder.new,
+      )
+      ..add(TemplateCreateRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(TemplateCreateResponseApplicationJson),
         TemplateCreateResponseApplicationJsonBuilder.new,
       )
@@ -4213,7 +4589,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(TemplateCreateResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(const FullType(TemplateFile), TemplateFileBuilder.new)
       ..add(TemplateFile.serializer)
-      ..add(TemplatePathCopySystemTemplates.serializer)
+      ..addBuilderFactory(
+        const FullType(TemplatePathRequestApplicationJson),
+        TemplatePathRequestApplicationJsonBuilder.new,
+      )
+      ..add(TemplatePathRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(TemplatePathResponseApplicationJson),
         TemplatePathResponseApplicationJsonBuilder.new,
@@ -4229,6 +4609,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         TemplatePathResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(TemplatePathResponseApplicationJson_Ocs_Data.serializer)
+      ..addBuilderFactory(
+        const FullType(TransferOwnershipTransferRequestApplicationJson),
+        TransferOwnershipTransferRequestApplicationJsonBuilder.new,
+      )
+      ..add(TransferOwnershipTransferRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(TransferOwnershipTransferResponseApplicationJson),
         TransferOwnershipTransferResponseApplicationJsonBuilder.new,

--- a/packages/nextcloud/lib/src/api/files.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.dart
@@ -100,19 +100,19 @@ class $ApiClient {
     required String file,
   }) {
     final _parameters = <String, Object?>{};
-    final $x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
-    _parameters['x'] = $x;
+    final __x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
+    _parameters['x'] = __x;
 
-    final $y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
-    _parameters['y'] = $y;
+    final __y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
+    _parameters['y'] = __y;
 
-    final $file = _$jsonSerializers.serialize(file, specifiedType: const FullType(String));
+    final __file = _$jsonSerializers.serialize(file, specifiedType: const FullType(String));
     _i4.checkString(
-      $file,
+      __file,
       'file',
       pattern: RegExp(r'^.+$'),
     );
-    _parameters['file'] = $file;
+    _parameters['file'] = __file;
 
     final _path = _i5.UriTemplate('/index.php/apps/files/api/v1/thumbnail/{x}/{y}/{file}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -227,9 +227,9 @@ class $DirectEditingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -295,11 +295,11 @@ class $DirectEditingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $editorId = _$jsonSerializers.serialize(editorId, specifiedType: const FullType(String));
-    _parameters['editorId'] = $editorId;
+    final __editorId = _$jsonSerializers.serialize(editorId, specifiedType: const FullType(String));
+    _parameters['editorId'] = __editorId;
 
-    final $creatorId = _$jsonSerializers.serialize(creatorId, specifiedType: const FullType(String));
-    _parameters['creatorId'] = $creatorId;
+    final __creatorId = _$jsonSerializers.serialize(creatorId, specifiedType: const FullType(String));
+    _parameters['creatorId'] = __creatorId;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/templates/{editorId}/{creatorId}')
         .expand(_parameters);
@@ -323,9 +323,9 @@ class $DirectEditingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -402,14 +402,14 @@ class $DirectEditingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = $path;
+    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
+    _parameters['path'] = __path;
 
-    final $editorId = _$jsonSerializers.serialize(editorId, specifiedType: const FullType(String));
-    _parameters['editorId'] = $editorId;
+    final __editorId = _$jsonSerializers.serialize(editorId, specifiedType: const FullType(String));
+    _parameters['editorId'] = __editorId;
 
-    final $fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
-    _parameters['fileId'] = $fileId;
+    final __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
+    _parameters['fileId'] = __fileId;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/open{?path*,editorId*,fileId*}')
         .expand(_parameters);
@@ -433,9 +433,9 @@ class $DirectEditingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -519,17 +519,17 @@ class $DirectEditingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = $path;
+    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
+    _parameters['path'] = __path;
 
-    final $editorId = _$jsonSerializers.serialize(editorId, specifiedType: const FullType(String));
-    _parameters['editorId'] = $editorId;
+    final __editorId = _$jsonSerializers.serialize(editorId, specifiedType: const FullType(String));
+    _parameters['editorId'] = __editorId;
 
-    final $creatorId = _$jsonSerializers.serialize(creatorId, specifiedType: const FullType(String));
-    _parameters['creatorId'] = $creatorId;
+    final __creatorId = _$jsonSerializers.serialize(creatorId, specifiedType: const FullType(String));
+    _parameters['creatorId'] = __creatorId;
 
-    final $templateId = _$jsonSerializers.serialize(templateId, specifiedType: const FullType(String));
-    _parameters['templateId'] = $templateId;
+    final __templateId = _$jsonSerializers.serialize(templateId, specifiedType: const FullType(String));
+    _parameters['templateId'] = __templateId;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/directEditing/create{?path*,editorId*,creatorId*,templateId*}')
@@ -554,9 +554,9 @@ class $DirectEditingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -643,8 +643,8 @@ class $OpenLocalEditorClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = $path;
+    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
+    _parameters['path'] = __path;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/openlocaleditor{?path*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -667,9 +667,9 @@ class $OpenLocalEditorClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -741,11 +741,11 @@ class $OpenLocalEditorClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = $path;
+    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
+    _parameters['path'] = __path;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _parameters['token'] = $token;
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    _parameters['token'] = __token;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/openlocaleditor/{token}{?path*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -768,9 +768,9 @@ class $OpenLocalEditorClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -864,9 +864,9 @@ class $TemplateClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -933,16 +933,16 @@ class $TemplateClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $filePath = _$jsonSerializers.serialize(filePath, specifiedType: const FullType(String));
-    _parameters['filePath'] = $filePath;
+    final __filePath = _$jsonSerializers.serialize(filePath, specifiedType: const FullType(String));
+    _parameters['filePath'] = __filePath;
 
-    var $templatePath = _$jsonSerializers.serialize(templatePath, specifiedType: const FullType(String));
-    $templatePath ??= '';
-    _parameters['templatePath'] = $templatePath;
+    var __templatePath = _$jsonSerializers.serialize(templatePath, specifiedType: const FullType(String));
+    __templatePath ??= '';
+    _parameters['templatePath'] = __templatePath;
 
-    var $templateType = _$jsonSerializers.serialize(templateType, specifiedType: const FullType(String));
-    $templateType ??= 'user';
-    _parameters['templateType'] = $templateType;
+    var __templateType = _$jsonSerializers.serialize(templateType, specifiedType: const FullType(String));
+    __templateType ??= 'user';
+    _parameters['templateType'] = __templateType;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/templates/create{?filePath*,templatePath*,templateType*}')
@@ -967,9 +967,9 @@ class $TemplateClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1046,16 +1046,16 @@ class $TemplateClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $templatePath = _$jsonSerializers.serialize(templatePath, specifiedType: const FullType(String));
-    $templatePath ??= '';
-    _parameters['templatePath'] = $templatePath;
+    var __templatePath = _$jsonSerializers.serialize(templatePath, specifiedType: const FullType(String));
+    __templatePath ??= '';
+    _parameters['templatePath'] = __templatePath;
 
-    var $copySystemTemplates = _$jsonSerializers.serialize(
+    var __copySystemTemplates = _$jsonSerializers.serialize(
       copySystemTemplates,
       specifiedType: const FullType(TemplatePathCopySystemTemplates),
     );
-    $copySystemTemplates ??= 0;
-    _parameters['copySystemTemplates'] = $copySystemTemplates;
+    __copySystemTemplates ??= 0;
+    _parameters['copySystemTemplates'] = __copySystemTemplates;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/templates/path{?templatePath*,copySystemTemplates*}')
         .expand(_parameters);
@@ -1079,9 +1079,9 @@ class $TemplateClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1164,11 +1164,11 @@ class $TransferOwnershipClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $recipient = _$jsonSerializers.serialize(recipient, specifiedType: const FullType(String));
-    _parameters['recipient'] = $recipient;
+    final __recipient = _$jsonSerializers.serialize(recipient, specifiedType: const FullType(String));
+    _parameters['recipient'] = __recipient;
 
-    final $path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = $path;
+    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
+    _parameters['path'] = __path;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership{?recipient*,path*}').expand(_parameters);
@@ -1192,9 +1192,9 @@ class $TransferOwnershipClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1269,8 +1269,8 @@ class $TransferOwnershipClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1293,9 +1293,9 @@ class $TransferOwnershipClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1367,8 +1367,8 @@ class $TransferOwnershipClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/files/api/v1/transferownership/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1391,9 +1391,9 @@ class $TransferOwnershipClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/files.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.g.dart
@@ -6,26 +6,6 @@ part of 'files.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-const TemplatePathCopySystemTemplates _$templatePathCopySystemTemplates$0 = TemplatePathCopySystemTemplates._('\$0');
-const TemplatePathCopySystemTemplates _$templatePathCopySystemTemplates$1 = TemplatePathCopySystemTemplates._('\$1');
-
-TemplatePathCopySystemTemplates _$valueOfTemplatePathCopySystemTemplates(String name) {
-  switch (name) {
-    case '\$0':
-      return _$templatePathCopySystemTemplates$0;
-    case '\$1':
-      return _$templatePathCopySystemTemplates$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<TemplatePathCopySystemTemplates> _$templatePathCopySystemTemplatesValues =
-    BuiltSet<TemplatePathCopySystemTemplates>(const <TemplatePathCopySystemTemplates>[
-  _$templatePathCopySystemTemplates$0,
-  _$templatePathCopySystemTemplates$1,
-]);
-
 Serializer<OCSMeta> _$oCSMetaSerializer = _$OCSMetaSerializer();
 Serializer<DirectEditingInfoResponseApplicationJson_Ocs_Data_Editors>
     _$directEditingInfoResponseApplicationJsonOcsDataEditorsSerializer =
@@ -51,6 +31,8 @@ Serializer<DirectEditingTemplatesResponseApplicationJson_Ocs>
     _$DirectEditingTemplatesResponseApplicationJson_OcsSerializer();
 Serializer<DirectEditingTemplatesResponseApplicationJson> _$directEditingTemplatesResponseApplicationJsonSerializer =
     _$DirectEditingTemplatesResponseApplicationJsonSerializer();
+Serializer<DirectEditingOpenRequestApplicationJson> _$directEditingOpenRequestApplicationJsonSerializer =
+    _$DirectEditingOpenRequestApplicationJsonSerializer();
 Serializer<DirectEditingOpenResponseApplicationJson_Ocs_Data>
     _$directEditingOpenResponseApplicationJsonOcsDataSerializer =
     _$DirectEditingOpenResponseApplicationJson_Ocs_DataSerializer();
@@ -58,6 +40,8 @@ Serializer<DirectEditingOpenResponseApplicationJson_Ocs> _$directEditingOpenResp
     _$DirectEditingOpenResponseApplicationJson_OcsSerializer();
 Serializer<DirectEditingOpenResponseApplicationJson> _$directEditingOpenResponseApplicationJsonSerializer =
     _$DirectEditingOpenResponseApplicationJsonSerializer();
+Serializer<DirectEditingCreateRequestApplicationJson> _$directEditingCreateRequestApplicationJsonSerializer =
+    _$DirectEditingCreateRequestApplicationJsonSerializer();
 Serializer<DirectEditingCreateResponseApplicationJson_Ocs_Data>
     _$directEditingCreateResponseApplicationJsonOcsDataSerializer =
     _$DirectEditingCreateResponseApplicationJson_Ocs_DataSerializer();
@@ -65,6 +49,8 @@ Serializer<DirectEditingCreateResponseApplicationJson_Ocs> _$directEditingCreate
     _$DirectEditingCreateResponseApplicationJson_OcsSerializer();
 Serializer<DirectEditingCreateResponseApplicationJson> _$directEditingCreateResponseApplicationJsonSerializer =
     _$DirectEditingCreateResponseApplicationJsonSerializer();
+Serializer<OpenLocalEditorCreateRequestApplicationJson> _$openLocalEditorCreateRequestApplicationJsonSerializer =
+    _$OpenLocalEditorCreateRequestApplicationJsonSerializer();
 Serializer<OpenLocalEditorCreateResponseApplicationJson_Ocs_Data>
     _$openLocalEditorCreateResponseApplicationJsonOcsDataSerializer =
     _$OpenLocalEditorCreateResponseApplicationJson_Ocs_DataSerializer();
@@ -73,6 +59,8 @@ Serializer<OpenLocalEditorCreateResponseApplicationJson_Ocs>
     _$OpenLocalEditorCreateResponseApplicationJson_OcsSerializer();
 Serializer<OpenLocalEditorCreateResponseApplicationJson> _$openLocalEditorCreateResponseApplicationJsonSerializer =
     _$OpenLocalEditorCreateResponseApplicationJsonSerializer();
+Serializer<OpenLocalEditorValidateRequestApplicationJson> _$openLocalEditorValidateRequestApplicationJsonSerializer =
+    _$OpenLocalEditorValidateRequestApplicationJsonSerializer();
 Serializer<OpenLocalEditorValidateResponseApplicationJson_Ocs_Data>
     _$openLocalEditorValidateResponseApplicationJsonOcsDataSerializer =
     _$OpenLocalEditorValidateResponseApplicationJson_Ocs_DataSerializer();
@@ -86,17 +74,24 @@ Serializer<TemplateListResponseApplicationJson_Ocs> _$templateListResponseApplic
     _$TemplateListResponseApplicationJson_OcsSerializer();
 Serializer<TemplateListResponseApplicationJson> _$templateListResponseApplicationJsonSerializer =
     _$TemplateListResponseApplicationJsonSerializer();
+Serializer<TemplateCreateRequestApplicationJson> _$templateCreateRequestApplicationJsonSerializer =
+    _$TemplateCreateRequestApplicationJsonSerializer();
 Serializer<TemplateFile> _$templateFileSerializer = _$TemplateFileSerializer();
 Serializer<TemplateCreateResponseApplicationJson_Ocs> _$templateCreateResponseApplicationJsonOcsSerializer =
     _$TemplateCreateResponseApplicationJson_OcsSerializer();
 Serializer<TemplateCreateResponseApplicationJson> _$templateCreateResponseApplicationJsonSerializer =
     _$TemplateCreateResponseApplicationJsonSerializer();
+Serializer<TemplatePathRequestApplicationJson> _$templatePathRequestApplicationJsonSerializer =
+    _$TemplatePathRequestApplicationJsonSerializer();
 Serializer<TemplatePathResponseApplicationJson_Ocs_Data> _$templatePathResponseApplicationJsonOcsDataSerializer =
     _$TemplatePathResponseApplicationJson_Ocs_DataSerializer();
 Serializer<TemplatePathResponseApplicationJson_Ocs> _$templatePathResponseApplicationJsonOcsSerializer =
     _$TemplatePathResponseApplicationJson_OcsSerializer();
 Serializer<TemplatePathResponseApplicationJson> _$templatePathResponseApplicationJsonSerializer =
     _$TemplatePathResponseApplicationJsonSerializer();
+Serializer<TransferOwnershipTransferRequestApplicationJson>
+    _$transferOwnershipTransferRequestApplicationJsonSerializer =
+    _$TransferOwnershipTransferRequestApplicationJsonSerializer();
 Serializer<TransferOwnershipTransferResponseApplicationJson_Ocs>
     _$transferOwnershipTransferResponseApplicationJsonOcsSerializer =
     _$TransferOwnershipTransferResponseApplicationJson_OcsSerializer();
@@ -682,6 +677,66 @@ class _$DirectEditingTemplatesResponseApplicationJsonSerializer
   }
 }
 
+class _$DirectEditingOpenRequestApplicationJsonSerializer
+    implements StructuredSerializer<DirectEditingOpenRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    DirectEditingOpenRequestApplicationJson,
+    _$DirectEditingOpenRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'DirectEditingOpenRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, DirectEditingOpenRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'path',
+      serializers.serialize(object.path, specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.editorId;
+    if (value != null) {
+      result
+        ..add('editorId')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.fileId;
+    if (value != null) {
+      result
+        ..add('fileId')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  DirectEditingOpenRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = DirectEditingOpenRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'path':
+          result.path = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'editorId':
+          result.editorId = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'fileId':
+          result.fileId = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$DirectEditingOpenResponseApplicationJson_Ocs_DataSerializer
     implements StructuredSerializer<DirectEditingOpenResponseApplicationJson_Ocs_Data> {
   @override
@@ -818,6 +873,67 @@ class _$DirectEditingOpenResponseApplicationJsonSerializer
   }
 }
 
+class _$DirectEditingCreateRequestApplicationJsonSerializer
+    implements StructuredSerializer<DirectEditingCreateRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    DirectEditingCreateRequestApplicationJson,
+    _$DirectEditingCreateRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'DirectEditingCreateRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, DirectEditingCreateRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'path',
+      serializers.serialize(object.path, specifiedType: const FullType(String)),
+      'editorId',
+      serializers.serialize(object.editorId, specifiedType: const FullType(String)),
+      'creatorId',
+      serializers.serialize(object.creatorId, specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.templateId;
+    if (value != null) {
+      result
+        ..add('templateId')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  DirectEditingCreateRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = DirectEditingCreateRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'path':
+          result.path = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'editorId':
+          result.editorId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'creatorId':
+          result.creatorId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'templateId':
+          result.templateId = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$DirectEditingCreateResponseApplicationJson_Ocs_DataSerializer
     implements StructuredSerializer<DirectEditingCreateResponseApplicationJson_Ocs_Data> {
   @override
@@ -946,6 +1062,48 @@ class _$DirectEditingCreateResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(DirectEditingCreateResponseApplicationJson_Ocs))!
               as DirectEditingCreateResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$OpenLocalEditorCreateRequestApplicationJsonSerializer
+    implements StructuredSerializer<OpenLocalEditorCreateRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    OpenLocalEditorCreateRequestApplicationJson,
+    _$OpenLocalEditorCreateRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'OpenLocalEditorCreateRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, OpenLocalEditorCreateRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'path',
+      serializers.serialize(object.path, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  OpenLocalEditorCreateRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = OpenLocalEditorCreateRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'path':
+          result.path = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -1103,6 +1261,48 @@ class _$OpenLocalEditorCreateResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(OpenLocalEditorCreateResponseApplicationJson_Ocs))!
               as OpenLocalEditorCreateResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$OpenLocalEditorValidateRequestApplicationJsonSerializer
+    implements StructuredSerializer<OpenLocalEditorValidateRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    OpenLocalEditorValidateRequestApplicationJson,
+    _$OpenLocalEditorValidateRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'OpenLocalEditorValidateRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, OpenLocalEditorValidateRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'path',
+      serializers.serialize(object.path, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  OpenLocalEditorValidateRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = OpenLocalEditorValidateRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'path':
+          result.path = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -1439,6 +1639,55 @@ class _$TemplateListResponseApplicationJsonSerializer
   }
 }
 
+class _$TemplateCreateRequestApplicationJsonSerializer
+    implements StructuredSerializer<TemplateCreateRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [TemplateCreateRequestApplicationJson, _$TemplateCreateRequestApplicationJson];
+  @override
+  final String wireName = 'TemplateCreateRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, TemplateCreateRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'filePath',
+      serializers.serialize(object.filePath, specifiedType: const FullType(String)),
+      'templatePath',
+      serializers.serialize(object.templatePath, specifiedType: const FullType(String)),
+      'templateType',
+      serializers.serialize(object.templateType, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  TemplateCreateRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = TemplateCreateRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'filePath':
+          result.filePath = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'templatePath':
+          result.templatePath = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'templateType':
+          result.templateType = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$TemplateFileSerializer implements StructuredSerializer<TemplateFile> {
   @override
   final Iterable<Type> types = const [TemplateFile, _$TemplateFile];
@@ -1610,6 +1859,50 @@ class _$TemplateCreateResponseApplicationJsonSerializer
   }
 }
 
+class _$TemplatePathRequestApplicationJsonSerializer
+    implements StructuredSerializer<TemplatePathRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [TemplatePathRequestApplicationJson, _$TemplatePathRequestApplicationJson];
+  @override
+  final String wireName = 'TemplatePathRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, TemplatePathRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'templatePath',
+      serializers.serialize(object.templatePath, specifiedType: const FullType(String)),
+      'copySystemTemplates',
+      serializers.serialize(object.copySystemTemplates, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  TemplatePathRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = TemplatePathRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'templatePath':
+          result.templatePath = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'copySystemTemplates':
+          result.copySystemTemplates = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$TemplatePathResponseApplicationJson_Ocs_DataSerializer
     implements StructuredSerializer<TemplatePathResponseApplicationJson_Ocs_Data> {
   @override
@@ -1741,6 +2034,53 @@ class _$TemplatePathResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(TemplatePathResponseApplicationJson_Ocs))!
                   as TemplatePathResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$TransferOwnershipTransferRequestApplicationJsonSerializer
+    implements StructuredSerializer<TransferOwnershipTransferRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    TransferOwnershipTransferRequestApplicationJson,
+    _$TransferOwnershipTransferRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'TransferOwnershipTransferRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, TransferOwnershipTransferRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'recipient',
+      serializers.serialize(object.recipient, specifiedType: const FullType(String)),
+      'path',
+      serializers.serialize(object.path, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  TransferOwnershipTransferRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = TransferOwnershipTransferRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'recipient':
+          result.recipient = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'path':
+          result.path = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -3584,6 +3924,132 @@ class DirectEditingTemplatesResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $DirectEditingOpenRequestApplicationJsonInterfaceBuilder {
+  void replace($DirectEditingOpenRequestApplicationJsonInterface other);
+  void update(void Function($DirectEditingOpenRequestApplicationJsonInterfaceBuilder) updates);
+  String? get path;
+  set path(String? path);
+
+  String? get editorId;
+  set editorId(String? editorId);
+
+  int? get fileId;
+  set fileId(int? fileId);
+}
+
+class _$DirectEditingOpenRequestApplicationJson extends DirectEditingOpenRequestApplicationJson {
+  @override
+  final String path;
+  @override
+  final String? editorId;
+  @override
+  final int? fileId;
+
+  factory _$DirectEditingOpenRequestApplicationJson(
+          [void Function(DirectEditingOpenRequestApplicationJsonBuilder)? updates]) =>
+      (DirectEditingOpenRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$DirectEditingOpenRequestApplicationJson._({required this.path, this.editorId, this.fileId}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(path, r'DirectEditingOpenRequestApplicationJson', 'path');
+  }
+
+  @override
+  DirectEditingOpenRequestApplicationJson rebuild(
+          void Function(DirectEditingOpenRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DirectEditingOpenRequestApplicationJsonBuilder toBuilder() =>
+      DirectEditingOpenRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DirectEditingOpenRequestApplicationJson &&
+        path == other.path &&
+        editorId == other.editorId &&
+        fileId == other.fileId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, path.hashCode);
+    _$hash = $jc(_$hash, editorId.hashCode);
+    _$hash = $jc(_$hash, fileId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'DirectEditingOpenRequestApplicationJson')
+          ..add('path', path)
+          ..add('editorId', editorId)
+          ..add('fileId', fileId))
+        .toString();
+  }
+}
+
+class DirectEditingOpenRequestApplicationJsonBuilder
+    implements
+        Builder<DirectEditingOpenRequestApplicationJson, DirectEditingOpenRequestApplicationJsonBuilder>,
+        $DirectEditingOpenRequestApplicationJsonInterfaceBuilder {
+  _$DirectEditingOpenRequestApplicationJson? _$v;
+
+  String? _path;
+  String? get path => _$this._path;
+  set path(covariant String? path) => _$this._path = path;
+
+  String? _editorId;
+  String? get editorId => _$this._editorId;
+  set editorId(covariant String? editorId) => _$this._editorId = editorId;
+
+  int? _fileId;
+  int? get fileId => _$this._fileId;
+  set fileId(covariant int? fileId) => _$this._fileId = fileId;
+
+  DirectEditingOpenRequestApplicationJsonBuilder() {
+    DirectEditingOpenRequestApplicationJson._defaults(this);
+  }
+
+  DirectEditingOpenRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _path = $v.path;
+      _editorId = $v.editorId;
+      _fileId = $v.fileId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant DirectEditingOpenRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$DirectEditingOpenRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(DirectEditingOpenRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DirectEditingOpenRequestApplicationJson build() => _build();
+
+  _$DirectEditingOpenRequestApplicationJson _build() {
+    DirectEditingOpenRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$DirectEditingOpenRequestApplicationJson._(
+            path: BuiltValueNullFieldError.checkNotNull(path, r'DirectEditingOpenRequestApplicationJson', 'path'),
+            editorId: editorId,
+            fileId: fileId);
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $DirectEditingOpenResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($DirectEditingOpenResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($DirectEditingOpenResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
@@ -3906,6 +4372,152 @@ class DirectEditingOpenResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $DirectEditingCreateRequestApplicationJsonInterfaceBuilder {
+  void replace($DirectEditingCreateRequestApplicationJsonInterface other);
+  void update(void Function($DirectEditingCreateRequestApplicationJsonInterfaceBuilder) updates);
+  String? get path;
+  set path(String? path);
+
+  String? get editorId;
+  set editorId(String? editorId);
+
+  String? get creatorId;
+  set creatorId(String? creatorId);
+
+  String? get templateId;
+  set templateId(String? templateId);
+}
+
+class _$DirectEditingCreateRequestApplicationJson extends DirectEditingCreateRequestApplicationJson {
+  @override
+  final String path;
+  @override
+  final String editorId;
+  @override
+  final String creatorId;
+  @override
+  final String? templateId;
+
+  factory _$DirectEditingCreateRequestApplicationJson(
+          [void Function(DirectEditingCreateRequestApplicationJsonBuilder)? updates]) =>
+      (DirectEditingCreateRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$DirectEditingCreateRequestApplicationJson._(
+      {required this.path, required this.editorId, required this.creatorId, this.templateId})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(path, r'DirectEditingCreateRequestApplicationJson', 'path');
+    BuiltValueNullFieldError.checkNotNull(editorId, r'DirectEditingCreateRequestApplicationJson', 'editorId');
+    BuiltValueNullFieldError.checkNotNull(creatorId, r'DirectEditingCreateRequestApplicationJson', 'creatorId');
+  }
+
+  @override
+  DirectEditingCreateRequestApplicationJson rebuild(
+          void Function(DirectEditingCreateRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DirectEditingCreateRequestApplicationJsonBuilder toBuilder() =>
+      DirectEditingCreateRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DirectEditingCreateRequestApplicationJson &&
+        path == other.path &&
+        editorId == other.editorId &&
+        creatorId == other.creatorId &&
+        templateId == other.templateId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, path.hashCode);
+    _$hash = $jc(_$hash, editorId.hashCode);
+    _$hash = $jc(_$hash, creatorId.hashCode);
+    _$hash = $jc(_$hash, templateId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'DirectEditingCreateRequestApplicationJson')
+          ..add('path', path)
+          ..add('editorId', editorId)
+          ..add('creatorId', creatorId)
+          ..add('templateId', templateId))
+        .toString();
+  }
+}
+
+class DirectEditingCreateRequestApplicationJsonBuilder
+    implements
+        Builder<DirectEditingCreateRequestApplicationJson, DirectEditingCreateRequestApplicationJsonBuilder>,
+        $DirectEditingCreateRequestApplicationJsonInterfaceBuilder {
+  _$DirectEditingCreateRequestApplicationJson? _$v;
+
+  String? _path;
+  String? get path => _$this._path;
+  set path(covariant String? path) => _$this._path = path;
+
+  String? _editorId;
+  String? get editorId => _$this._editorId;
+  set editorId(covariant String? editorId) => _$this._editorId = editorId;
+
+  String? _creatorId;
+  String? get creatorId => _$this._creatorId;
+  set creatorId(covariant String? creatorId) => _$this._creatorId = creatorId;
+
+  String? _templateId;
+  String? get templateId => _$this._templateId;
+  set templateId(covariant String? templateId) => _$this._templateId = templateId;
+
+  DirectEditingCreateRequestApplicationJsonBuilder() {
+    DirectEditingCreateRequestApplicationJson._defaults(this);
+  }
+
+  DirectEditingCreateRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _path = $v.path;
+      _editorId = $v.editorId;
+      _creatorId = $v.creatorId;
+      _templateId = $v.templateId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant DirectEditingCreateRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$DirectEditingCreateRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(DirectEditingCreateRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DirectEditingCreateRequestApplicationJson build() => _build();
+
+  _$DirectEditingCreateRequestApplicationJson _build() {
+    DirectEditingCreateRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$DirectEditingCreateRequestApplicationJson._(
+            path: BuiltValueNullFieldError.checkNotNull(path, r'DirectEditingCreateRequestApplicationJson', 'path'),
+            editorId: BuiltValueNullFieldError.checkNotNull(
+                editorId, r'DirectEditingCreateRequestApplicationJson', 'editorId'),
+            creatorId: BuiltValueNullFieldError.checkNotNull(
+                creatorId, r'DirectEditingCreateRequestApplicationJson', 'creatorId'),
+            templateId: templateId);
     replace(_$result);
     return _$result;
   }
@@ -4235,6 +4847,101 @@ class DirectEditingCreateResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $OpenLocalEditorCreateRequestApplicationJsonInterfaceBuilder {
+  void replace($OpenLocalEditorCreateRequestApplicationJsonInterface other);
+  void update(void Function($OpenLocalEditorCreateRequestApplicationJsonInterfaceBuilder) updates);
+  String? get path;
+  set path(String? path);
+}
+
+class _$OpenLocalEditorCreateRequestApplicationJson extends OpenLocalEditorCreateRequestApplicationJson {
+  @override
+  final String path;
+
+  factory _$OpenLocalEditorCreateRequestApplicationJson(
+          [void Function(OpenLocalEditorCreateRequestApplicationJsonBuilder)? updates]) =>
+      (OpenLocalEditorCreateRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$OpenLocalEditorCreateRequestApplicationJson._({required this.path}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(path, r'OpenLocalEditorCreateRequestApplicationJson', 'path');
+  }
+
+  @override
+  OpenLocalEditorCreateRequestApplicationJson rebuild(
+          void Function(OpenLocalEditorCreateRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenLocalEditorCreateRequestApplicationJsonBuilder toBuilder() =>
+      OpenLocalEditorCreateRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenLocalEditorCreateRequestApplicationJson && path == other.path;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, path.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenLocalEditorCreateRequestApplicationJson')..add('path', path)).toString();
+  }
+}
+
+class OpenLocalEditorCreateRequestApplicationJsonBuilder
+    implements
+        Builder<OpenLocalEditorCreateRequestApplicationJson, OpenLocalEditorCreateRequestApplicationJsonBuilder>,
+        $OpenLocalEditorCreateRequestApplicationJsonInterfaceBuilder {
+  _$OpenLocalEditorCreateRequestApplicationJson? _$v;
+
+  String? _path;
+  String? get path => _$this._path;
+  set path(covariant String? path) => _$this._path = path;
+
+  OpenLocalEditorCreateRequestApplicationJsonBuilder() {
+    OpenLocalEditorCreateRequestApplicationJson._defaults(this);
+  }
+
+  OpenLocalEditorCreateRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _path = $v.path;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OpenLocalEditorCreateRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenLocalEditorCreateRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(OpenLocalEditorCreateRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenLocalEditorCreateRequestApplicationJson build() => _build();
+
+  _$OpenLocalEditorCreateRequestApplicationJson _build() {
+    OpenLocalEditorCreateRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$OpenLocalEditorCreateRequestApplicationJson._(
+            path: BuiltValueNullFieldError.checkNotNull(path, r'OpenLocalEditorCreateRequestApplicationJson', 'path'));
     replace(_$result);
     return _$result;
   }
@@ -4617,6 +5324,103 @@ class OpenLocalEditorCreateResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $OpenLocalEditorValidateRequestApplicationJsonInterfaceBuilder {
+  void replace($OpenLocalEditorValidateRequestApplicationJsonInterface other);
+  void update(void Function($OpenLocalEditorValidateRequestApplicationJsonInterfaceBuilder) updates);
+  String? get path;
+  set path(String? path);
+}
+
+class _$OpenLocalEditorValidateRequestApplicationJson extends OpenLocalEditorValidateRequestApplicationJson {
+  @override
+  final String path;
+
+  factory _$OpenLocalEditorValidateRequestApplicationJson(
+          [void Function(OpenLocalEditorValidateRequestApplicationJsonBuilder)? updates]) =>
+      (OpenLocalEditorValidateRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$OpenLocalEditorValidateRequestApplicationJson._({required this.path}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(path, r'OpenLocalEditorValidateRequestApplicationJson', 'path');
+  }
+
+  @override
+  OpenLocalEditorValidateRequestApplicationJson rebuild(
+          void Function(OpenLocalEditorValidateRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  OpenLocalEditorValidateRequestApplicationJsonBuilder toBuilder() =>
+      OpenLocalEditorValidateRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is OpenLocalEditorValidateRequestApplicationJson && path == other.path;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, path.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'OpenLocalEditorValidateRequestApplicationJson')..add('path', path))
+        .toString();
+  }
+}
+
+class OpenLocalEditorValidateRequestApplicationJsonBuilder
+    implements
+        Builder<OpenLocalEditorValidateRequestApplicationJson, OpenLocalEditorValidateRequestApplicationJsonBuilder>,
+        $OpenLocalEditorValidateRequestApplicationJsonInterfaceBuilder {
+  _$OpenLocalEditorValidateRequestApplicationJson? _$v;
+
+  String? _path;
+  String? get path => _$this._path;
+  set path(covariant String? path) => _$this._path = path;
+
+  OpenLocalEditorValidateRequestApplicationJsonBuilder() {
+    OpenLocalEditorValidateRequestApplicationJson._defaults(this);
+  }
+
+  OpenLocalEditorValidateRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _path = $v.path;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant OpenLocalEditorValidateRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$OpenLocalEditorValidateRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(OpenLocalEditorValidateRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  OpenLocalEditorValidateRequestApplicationJson build() => _build();
+
+  _$OpenLocalEditorValidateRequestApplicationJson _build() {
+    OpenLocalEditorValidateRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$OpenLocalEditorValidateRequestApplicationJson._(
+            path:
+                BuiltValueNullFieldError.checkNotNull(path, r'OpenLocalEditorValidateRequestApplicationJson', 'path'));
     replace(_$result);
     return _$result;
   }
@@ -5448,6 +6252,138 @@ class TemplateListResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $TemplateCreateRequestApplicationJsonInterfaceBuilder {
+  void replace($TemplateCreateRequestApplicationJsonInterface other);
+  void update(void Function($TemplateCreateRequestApplicationJsonInterfaceBuilder) updates);
+  String? get filePath;
+  set filePath(String? filePath);
+
+  String? get templatePath;
+  set templatePath(String? templatePath);
+
+  String? get templateType;
+  set templateType(String? templateType);
+}
+
+class _$TemplateCreateRequestApplicationJson extends TemplateCreateRequestApplicationJson {
+  @override
+  final String filePath;
+  @override
+  final String templatePath;
+  @override
+  final String templateType;
+
+  factory _$TemplateCreateRequestApplicationJson(
+          [void Function(TemplateCreateRequestApplicationJsonBuilder)? updates]) =>
+      (TemplateCreateRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$TemplateCreateRequestApplicationJson._(
+      {required this.filePath, required this.templatePath, required this.templateType})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(filePath, r'TemplateCreateRequestApplicationJson', 'filePath');
+    BuiltValueNullFieldError.checkNotNull(templatePath, r'TemplateCreateRequestApplicationJson', 'templatePath');
+    BuiltValueNullFieldError.checkNotNull(templateType, r'TemplateCreateRequestApplicationJson', 'templateType');
+  }
+
+  @override
+  TemplateCreateRequestApplicationJson rebuild(void Function(TemplateCreateRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  TemplateCreateRequestApplicationJsonBuilder toBuilder() =>
+      TemplateCreateRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TemplateCreateRequestApplicationJson &&
+        filePath == other.filePath &&
+        templatePath == other.templatePath &&
+        templateType == other.templateType;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, filePath.hashCode);
+    _$hash = $jc(_$hash, templatePath.hashCode);
+    _$hash = $jc(_$hash, templateType.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'TemplateCreateRequestApplicationJson')
+          ..add('filePath', filePath)
+          ..add('templatePath', templatePath)
+          ..add('templateType', templateType))
+        .toString();
+  }
+}
+
+class TemplateCreateRequestApplicationJsonBuilder
+    implements
+        Builder<TemplateCreateRequestApplicationJson, TemplateCreateRequestApplicationJsonBuilder>,
+        $TemplateCreateRequestApplicationJsonInterfaceBuilder {
+  _$TemplateCreateRequestApplicationJson? _$v;
+
+  String? _filePath;
+  String? get filePath => _$this._filePath;
+  set filePath(covariant String? filePath) => _$this._filePath = filePath;
+
+  String? _templatePath;
+  String? get templatePath => _$this._templatePath;
+  set templatePath(covariant String? templatePath) => _$this._templatePath = templatePath;
+
+  String? _templateType;
+  String? get templateType => _$this._templateType;
+  set templateType(covariant String? templateType) => _$this._templateType = templateType;
+
+  TemplateCreateRequestApplicationJsonBuilder() {
+    TemplateCreateRequestApplicationJson._defaults(this);
+  }
+
+  TemplateCreateRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _filePath = $v.filePath;
+      _templatePath = $v.templatePath;
+      _templateType = $v.templateType;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant TemplateCreateRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$TemplateCreateRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(TemplateCreateRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  TemplateCreateRequestApplicationJson build() => _build();
+
+  _$TemplateCreateRequestApplicationJson _build() {
+    TemplateCreateRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$TemplateCreateRequestApplicationJson._(
+            filePath:
+                BuiltValueNullFieldError.checkNotNull(filePath, r'TemplateCreateRequestApplicationJson', 'filePath'),
+            templatePath: BuiltValueNullFieldError.checkNotNull(
+                templatePath, r'TemplateCreateRequestApplicationJson', 'templatePath'),
+            templateType: BuiltValueNullFieldError.checkNotNull(
+                templateType, r'TemplateCreateRequestApplicationJson', 'templateType'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $TemplateFileInterfaceBuilder {
   void replace($TemplateFileInterface other);
   void update(void Function($TemplateFileInterfaceBuilder) updates);
@@ -5895,6 +6831,119 @@ class TemplateCreateResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $TemplatePathRequestApplicationJsonInterfaceBuilder {
+  void replace($TemplatePathRequestApplicationJsonInterface other);
+  void update(void Function($TemplatePathRequestApplicationJsonInterfaceBuilder) updates);
+  String? get templatePath;
+  set templatePath(String? templatePath);
+
+  bool? get copySystemTemplates;
+  set copySystemTemplates(bool? copySystemTemplates);
+}
+
+class _$TemplatePathRequestApplicationJson extends TemplatePathRequestApplicationJson {
+  @override
+  final String templatePath;
+  @override
+  final bool copySystemTemplates;
+
+  factory _$TemplatePathRequestApplicationJson([void Function(TemplatePathRequestApplicationJsonBuilder)? updates]) =>
+      (TemplatePathRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$TemplatePathRequestApplicationJson._({required this.templatePath, required this.copySystemTemplates}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(templatePath, r'TemplatePathRequestApplicationJson', 'templatePath');
+    BuiltValueNullFieldError.checkNotNull(
+        copySystemTemplates, r'TemplatePathRequestApplicationJson', 'copySystemTemplates');
+  }
+
+  @override
+  TemplatePathRequestApplicationJson rebuild(void Function(TemplatePathRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  TemplatePathRequestApplicationJsonBuilder toBuilder() => TemplatePathRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TemplatePathRequestApplicationJson &&
+        templatePath == other.templatePath &&
+        copySystemTemplates == other.copySystemTemplates;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, templatePath.hashCode);
+    _$hash = $jc(_$hash, copySystemTemplates.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'TemplatePathRequestApplicationJson')
+          ..add('templatePath', templatePath)
+          ..add('copySystemTemplates', copySystemTemplates))
+        .toString();
+  }
+}
+
+class TemplatePathRequestApplicationJsonBuilder
+    implements
+        Builder<TemplatePathRequestApplicationJson, TemplatePathRequestApplicationJsonBuilder>,
+        $TemplatePathRequestApplicationJsonInterfaceBuilder {
+  _$TemplatePathRequestApplicationJson? _$v;
+
+  String? _templatePath;
+  String? get templatePath => _$this._templatePath;
+  set templatePath(covariant String? templatePath) => _$this._templatePath = templatePath;
+
+  bool? _copySystemTemplates;
+  bool? get copySystemTemplates => _$this._copySystemTemplates;
+  set copySystemTemplates(covariant bool? copySystemTemplates) => _$this._copySystemTemplates = copySystemTemplates;
+
+  TemplatePathRequestApplicationJsonBuilder() {
+    TemplatePathRequestApplicationJson._defaults(this);
+  }
+
+  TemplatePathRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _templatePath = $v.templatePath;
+      _copySystemTemplates = $v.copySystemTemplates;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant TemplatePathRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$TemplatePathRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(TemplatePathRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  TemplatePathRequestApplicationJson build() => _build();
+
+  _$TemplatePathRequestApplicationJson _build() {
+    TemplatePathRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$TemplatePathRequestApplicationJson._(
+            templatePath: BuiltValueNullFieldError.checkNotNull(
+                templatePath, r'TemplatePathRequestApplicationJson', 'templatePath'),
+            copySystemTemplates: BuiltValueNullFieldError.checkNotNull(
+                copySystemTemplates, r'TemplatePathRequestApplicationJson', 'copySystemTemplates'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $TemplatePathResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($TemplatePathResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($TemplatePathResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
@@ -6243,6 +7292,122 @@ class TemplatePathResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $TransferOwnershipTransferRequestApplicationJsonInterfaceBuilder {
+  void replace($TransferOwnershipTransferRequestApplicationJsonInterface other);
+  void update(void Function($TransferOwnershipTransferRequestApplicationJsonInterfaceBuilder) updates);
+  String? get recipient;
+  set recipient(String? recipient);
+
+  String? get path;
+  set path(String? path);
+}
+
+class _$TransferOwnershipTransferRequestApplicationJson extends TransferOwnershipTransferRequestApplicationJson {
+  @override
+  final String recipient;
+  @override
+  final String path;
+
+  factory _$TransferOwnershipTransferRequestApplicationJson(
+          [void Function(TransferOwnershipTransferRequestApplicationJsonBuilder)? updates]) =>
+      (TransferOwnershipTransferRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$TransferOwnershipTransferRequestApplicationJson._({required this.recipient, required this.path}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(recipient, r'TransferOwnershipTransferRequestApplicationJson', 'recipient');
+    BuiltValueNullFieldError.checkNotNull(path, r'TransferOwnershipTransferRequestApplicationJson', 'path');
+  }
+
+  @override
+  TransferOwnershipTransferRequestApplicationJson rebuild(
+          void Function(TransferOwnershipTransferRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  TransferOwnershipTransferRequestApplicationJsonBuilder toBuilder() =>
+      TransferOwnershipTransferRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is TransferOwnershipTransferRequestApplicationJson &&
+        recipient == other.recipient &&
+        path == other.path;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, recipient.hashCode);
+    _$hash = $jc(_$hash, path.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'TransferOwnershipTransferRequestApplicationJson')
+          ..add('recipient', recipient)
+          ..add('path', path))
+        .toString();
+  }
+}
+
+class TransferOwnershipTransferRequestApplicationJsonBuilder
+    implements
+        Builder<TransferOwnershipTransferRequestApplicationJson,
+            TransferOwnershipTransferRequestApplicationJsonBuilder>,
+        $TransferOwnershipTransferRequestApplicationJsonInterfaceBuilder {
+  _$TransferOwnershipTransferRequestApplicationJson? _$v;
+
+  String? _recipient;
+  String? get recipient => _$this._recipient;
+  set recipient(covariant String? recipient) => _$this._recipient = recipient;
+
+  String? _path;
+  String? get path => _$this._path;
+  set path(covariant String? path) => _$this._path = path;
+
+  TransferOwnershipTransferRequestApplicationJsonBuilder() {
+    TransferOwnershipTransferRequestApplicationJson._defaults(this);
+  }
+
+  TransferOwnershipTransferRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _recipient = $v.recipient;
+      _path = $v.path;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant TransferOwnershipTransferRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$TransferOwnershipTransferRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(TransferOwnershipTransferRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  TransferOwnershipTransferRequestApplicationJson build() => _build();
+
+  _$TransferOwnershipTransferRequestApplicationJson _build() {
+    TransferOwnershipTransferRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$TransferOwnershipTransferRequestApplicationJson._(
+            recipient: BuiltValueNullFieldError.checkNotNull(
+                recipient, r'TransferOwnershipTransferRequestApplicationJson', 'recipient'),
+            path: BuiltValueNullFieldError.checkNotNull(
+                path, r'TransferOwnershipTransferRequestApplicationJson', 'path'));
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/files.openapi.json
+++ b/packages/nextcloud/lib/src/api/files.openapi.json
@@ -594,35 +594,37 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "path"
+                                ],
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "description": "Path of the file"
+                                    },
+                                    "editorId": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "ID of the editor"
+                                    },
+                                    "fileId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "ID of the file"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "path",
-                        "in": "query",
-                        "description": "Path of the file",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "editorId",
-                        "in": "query",
-                        "description": "ID of the editor",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "fileId",
-                        "in": "query",
-                        "description": "ID of the file",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -767,43 +769,41 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "path",
+                                    "editorId",
+                                    "creatorId"
+                                ],
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "description": "Path of the file"
+                                    },
+                                    "editorId": {
+                                        "type": "string",
+                                        "description": "ID of the editor"
+                                    },
+                                    "creatorId": {
+                                        "type": "string",
+                                        "description": "ID of the creator"
+                                    },
+                                    "templateId": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "ID of the template"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "path",
-                        "in": "query",
-                        "description": "Path of the file",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "editorId",
-                        "in": "query",
-                        "description": "ID of the editor",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "creatorId",
-                        "in": "query",
-                        "description": "ID of the creator",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "templateId",
-                        "in": "query",
-                        "description": "ID of the template",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -1012,34 +1012,36 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "filePath"
+                                ],
+                                "properties": {
+                                    "filePath": {
+                                        "type": "string",
+                                        "description": "Path of the file"
+                                    },
+                                    "templatePath": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Name of the template"
+                                    },
+                                    "templateType": {
+                                        "type": "string",
+                                        "default": "user",
+                                        "description": "Type of the template"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "filePath",
-                        "in": "query",
-                        "description": "Path of the file",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "templatePath",
-                        "in": "query",
-                        "description": "Name of the template",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "templateType",
-                        "in": "query",
-                        "description": "Type of the template",
-                        "schema": {
-                            "type": "string",
-                            "default": "user"
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -1128,29 +1130,29 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "templatePath": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Path of the template directory"
+                                    },
+                                    "copySystemTemplates": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to copy the system templates to the template directory"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "templatePath",
-                        "in": "query",
-                        "description": "Path of the template directory",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "copySystemTemplates",
-                        "in": "query",
-                        "description": "Whether to copy the system templates to the template directory",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -1254,25 +1256,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "recipient",
+                                    "path"
+                                ],
+                                "properties": {
+                                    "recipient": {
+                                        "type": "string",
+                                        "description": "Username of the recipient"
+                                    },
+                                    "path": {
+                                        "type": "string",
+                                        "description": "Path of the file"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "recipient",
-                        "in": "query",
-                        "description": "Username of the recipient",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "path",
-                        "in": "query",
-                        "description": "Path of the file",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -1635,16 +1643,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "path",
-                        "in": "query",
-                        "description": "Path of the file",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "path"
+                                ],
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "description": "Path of the file"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -1755,16 +1773,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "path",
-                        "in": "query",
-                        "description": "Path of the file",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "path"
+                                ],
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "description": "Path of the file"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "token",
                         "in": "path",

--- a/packages/nextcloud/lib/src/api/files_external.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_external.openapi.dart
@@ -102,9 +102,9 @@ class $ApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
@@ -16,6 +16,8 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
+
 import 'package:built_value/built_value.dart';
 import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
@@ -177,7 +179,6 @@ class $ApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [dueDate] ISO 8601 formatted date time string.
   ///   * [version]
   ///   * [fileId] ID of the file.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -194,15 +195,12 @@ class $ApiClient {
   ///  * [$$set_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $$set_Request({
-    required String dueDate,
     required String version,
     required int fileId,
+    required ApiSetRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __dueDate = _$jsonSerializers.serialize(dueDate, specifiedType: const FullType(String));
-    _parameters['dueDate'] = __dueDate;
-
     final __version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
     _i4.checkString(
       __version,
@@ -214,8 +212,7 @@ class $ApiClient {
     final __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
     _parameters['fileId'] = __fileId;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}{?dueDate*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -240,6 +237,9 @@ class $ApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body =
+        json.encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(ApiSetRequestApplicationJson)));
     return _request;
   }
 
@@ -249,7 +249,6 @@ class $ApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [dueDate] ISO 8601 formatted date time string.
   ///   * [version]
   ///   * [fileId] ID of the file.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -265,16 +264,16 @@ class $ApiClient {
   ///  * [$$set_Request] for the request send by this method.
   ///  * [$$set_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ApiSetResponseApplicationJson, void>> $set({
-    required String dueDate,
     required String version,
     required int fileId,
+    required ApiSetRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $$set_Request(
-      dueDate: dueDate,
       version: version,
       fileId: fileId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -638,6 +637,66 @@ abstract class ApiGetResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ApiSetRequestApplicationJsonInterface {
+  /// ISO 8601 formatted date time string.
+  String get dueDate;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiSetRequestApplicationJsonInterfaceBuilder].
+  $ApiSetRequestApplicationJsonInterface rebuild(void Function($ApiSetRequestApplicationJsonInterfaceBuilder) updates);
+
+  /// Converts the instance to a builder [$ApiSetRequestApplicationJsonInterfaceBuilder].
+  $ApiSetRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiSetRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiSetRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ApiSetRequestApplicationJson
+    implements
+        $ApiSetRequestApplicationJsonInterface,
+        Built<ApiSetRequestApplicationJson, ApiSetRequestApplicationJsonBuilder> {
+  /// Creates a new ApiSetRequestApplicationJson object using the builder pattern.
+  factory ApiSetRequestApplicationJson([void Function(ApiSetRequestApplicationJsonBuilder)? b]) =
+      _$ApiSetRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ApiSetRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ApiSetRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ApiSetRequestApplicationJson.
+  static Serializer<ApiSetRequestApplicationJson> get serializer => _$apiSetRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiSetRequestApplicationJsonBuilder b) {
+    $ApiSetRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiSetRequestApplicationJsonBuilder b) {
+    $ApiSetRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ApiSetResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -906,6 +965,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ApiGetResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(ApiGetResponseApplicationJson_Ocs_Data.serializer)
+      ..addBuilderFactory(const FullType(ApiSetRequestApplicationJson), ApiSetRequestApplicationJsonBuilder.new)
+      ..add(ApiSetRequestApplicationJson.serializer)
       ..addBuilderFactory(const FullType(ApiSetResponseApplicationJson), ApiSetResponseApplicationJsonBuilder.new)
       ..add(ApiSetResponseApplicationJson.serializer)
       ..addBuilderFactory(

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
@@ -88,16 +88,16 @@ class $ApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
+    final __version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
     _i4.checkString(
-      $version,
+      __version,
       'version',
       pattern: RegExp(r'^1$'),
     );
-    _parameters['version'] = $version;
+    _parameters['version'] = __version;
 
-    final $fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
-    _parameters['fileId'] = $fileId;
+    final __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
+    _parameters['fileId'] = __fileId;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -120,9 +120,9 @@ class $ApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -200,19 +200,19 @@ class $ApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $dueDate = _$jsonSerializers.serialize(dueDate, specifiedType: const FullType(String));
-    _parameters['dueDate'] = $dueDate;
+    final __dueDate = _$jsonSerializers.serialize(dueDate, specifiedType: const FullType(String));
+    _parameters['dueDate'] = __dueDate;
 
-    final $version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
+    final __version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
     _i4.checkString(
-      $version,
+      __version,
       'version',
       pattern: RegExp(r'^1$'),
     );
-    _parameters['version'] = $version;
+    _parameters['version'] = __version;
 
-    final $fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
-    _parameters['fileId'] = $fileId;
+    final __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
+    _parameters['fileId'] = __fileId;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}{?dueDate*}').expand(_parameters);
@@ -236,9 +236,9 @@ class $ApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -318,16 +318,16 @@ class $ApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
+    final __version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
     _i4.checkString(
-      $version,
+      __version,
       'version',
       pattern: RegExp(r'^1$'),
     );
-    _parameters['version'] = $version;
+    _parameters['version'] = __version;
 
-    final $fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
-    _parameters['fileId'] = $fileId;
+    final __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
+    _parameters['fileId'] = __fileId;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/files_reminders/api/v{version}/{fileId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -350,9 +350,9 @@ class $ApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.g.dart
@@ -13,6 +13,8 @@ Serializer<ApiGetResponseApplicationJson_Ocs> _$apiGetResponseApplicationJsonOcs
     _$ApiGetResponseApplicationJson_OcsSerializer();
 Serializer<ApiGetResponseApplicationJson> _$apiGetResponseApplicationJsonSerializer =
     _$ApiGetResponseApplicationJsonSerializer();
+Serializer<ApiSetRequestApplicationJson> _$apiSetRequestApplicationJsonSerializer =
+    _$ApiSetRequestApplicationJsonSerializer();
 Serializer<ApiSetResponseApplicationJson_Ocs> _$apiSetResponseApplicationJsonOcsSerializer =
     _$ApiSetResponseApplicationJson_OcsSerializer();
 Serializer<ApiSetResponseApplicationJson> _$apiSetResponseApplicationJsonSerializer =
@@ -210,6 +212,44 @@ class _$ApiGetResponseApplicationJsonSerializer implements StructuredSerializer<
         case 'ocs':
           result.ocs.replace(serializers.deserialize(value,
               specifiedType: const FullType(ApiGetResponseApplicationJson_Ocs))! as ApiGetResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ApiSetRequestApplicationJsonSerializer implements StructuredSerializer<ApiSetRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ApiSetRequestApplicationJson, _$ApiSetRequestApplicationJson];
+  @override
+  final String wireName = 'ApiSetRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ApiSetRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'dueDate',
+      serializers.serialize(object.dueDate, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ApiSetRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ApiSetRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'dueDate':
+          result.dueDate = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -840,6 +880,98 @@ class ApiGetResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ApiSetRequestApplicationJsonInterfaceBuilder {
+  void replace($ApiSetRequestApplicationJsonInterface other);
+  void update(void Function($ApiSetRequestApplicationJsonInterfaceBuilder) updates);
+  String? get dueDate;
+  set dueDate(String? dueDate);
+}
+
+class _$ApiSetRequestApplicationJson extends ApiSetRequestApplicationJson {
+  @override
+  final String dueDate;
+
+  factory _$ApiSetRequestApplicationJson([void Function(ApiSetRequestApplicationJsonBuilder)? updates]) =>
+      (ApiSetRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ApiSetRequestApplicationJson._({required this.dueDate}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(dueDate, r'ApiSetRequestApplicationJson', 'dueDate');
+  }
+
+  @override
+  ApiSetRequestApplicationJson rebuild(void Function(ApiSetRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ApiSetRequestApplicationJsonBuilder toBuilder() => ApiSetRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ApiSetRequestApplicationJson && dueDate == other.dueDate;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, dueDate.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ApiSetRequestApplicationJson')..add('dueDate', dueDate)).toString();
+  }
+}
+
+class ApiSetRequestApplicationJsonBuilder
+    implements
+        Builder<ApiSetRequestApplicationJson, ApiSetRequestApplicationJsonBuilder>,
+        $ApiSetRequestApplicationJsonInterfaceBuilder {
+  _$ApiSetRequestApplicationJson? _$v;
+
+  String? _dueDate;
+  String? get dueDate => _$this._dueDate;
+  set dueDate(covariant String? dueDate) => _$this._dueDate = dueDate;
+
+  ApiSetRequestApplicationJsonBuilder() {
+    ApiSetRequestApplicationJson._defaults(this);
+  }
+
+  ApiSetRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _dueDate = $v.dueDate;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ApiSetRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ApiSetRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ApiSetRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ApiSetRequestApplicationJson build() => _build();
+
+  _$ApiSetRequestApplicationJson _build() {
+    ApiSetRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ApiSetRequestApplicationJson._(
+            dueDate: BuiltValueNullFieldError.checkNotNull(dueDate, r'ApiSetRequestApplicationJson', 'dueDate'));
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.json
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.json
@@ -178,16 +178,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "dueDate",
-                        "in": "query",
-                        "description": "ISO 8601 formatted date time string",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "dueDate"
+                                ],
+                                "properties": {
+                                    "dueDate": {
+                                        "type": "string",
+                                        "description": "ISO 8601 formatted date time string"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "version",
                         "in": "path",

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -115,9 +115,9 @@ class $DeletedShareapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -181,8 +181,8 @@ class $DeletedShareapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
+    _parameters['id'] = __id;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/deletedshares/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -205,9 +205,9 @@ class $DeletedShareapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -281,8 +281,8 @@ class $PublicPreviewClient {
   @_i2.experimental
   _i3.Request $directLink_Request({required String token}) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _parameters['token'] = $token;
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    _parameters['token'] = __token;
 
     final _path = _i6.UriTemplate('/index.php/s/{token}/preview').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -374,24 +374,24 @@ class $PublicPreviewClient {
     PublicPreviewGetPreviewA? a,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _parameters['token'] = $token;
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    _parameters['token'] = __token;
 
-    var $file = _$jsonSerializers.serialize(file, specifiedType: const FullType(String));
-    $file ??= '';
-    _parameters['file'] = $file;
+    var __file = _$jsonSerializers.serialize(file, specifiedType: const FullType(String));
+    __file ??= '';
+    _parameters['file'] = __file;
 
-    var $x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
-    $x ??= 32;
-    _parameters['x'] = $x;
+    var __x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
+    __x ??= 32;
+    _parameters['x'] = __x;
 
-    var $y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
-    $y ??= 32;
-    _parameters['y'] = $y;
+    var __y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
+    __y ??= 32;
+    _parameters['y'] = __y;
 
-    var $a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PublicPreviewGetPreviewA));
-    $a ??= 0;
-    _parameters['a'] = $a;
+    var __a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PublicPreviewGetPreviewA));
+    __a ??= 0;
+    _parameters['a'] = __a;
 
     final _path =
         _i6.UriTemplate('/index.php/apps/files_sharing/publicpreview/{token}{?file*,x*,y*,a*}').expand(_parameters);
@@ -513,9 +513,9 @@ class $RemoteClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -594,9 +594,9 @@ class $RemoteClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -662,8 +662,8 @@ class $RemoteClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/{id}').expand(_parameters);
@@ -687,9 +687,9 @@ class $RemoteClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -759,8 +759,8 @@ class $RemoteClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending/{id}').expand(_parameters);
@@ -784,9 +784,9 @@ class $RemoteClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -855,8 +855,8 @@ class $RemoteClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -879,9 +879,9 @@ class $RemoteClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -951,8 +951,8 @@ class $RemoteClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -975,9 +975,9 @@ class $RemoteClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1059,18 +1059,18 @@ class $ShareInfoClient {
     int? depth,
   }) {
     final _parameters = <String, Object?>{};
-    final $t = _$jsonSerializers.serialize(t, specifiedType: const FullType(String));
-    _parameters['t'] = $t;
+    final __t = _$jsonSerializers.serialize(t, specifiedType: const FullType(String));
+    _parameters['t'] = __t;
 
-    final $password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    _parameters['password'] = $password;
+    final __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
+    _parameters['password'] = __password;
 
-    final $dir = _$jsonSerializers.serialize(dir, specifiedType: const FullType(String));
-    _parameters['dir'] = $dir;
+    final __dir = _$jsonSerializers.serialize(dir, specifiedType: const FullType(String));
+    _parameters['dir'] = __dir;
 
-    var $depth = _$jsonSerializers.serialize(depth, specifiedType: const FullType(int));
-    $depth ??= -1;
-    _parameters['depth'] = $depth;
+    var __depth = _$jsonSerializers.serialize(depth, specifiedType: const FullType(int));
+    __depth ??= -1;
+    _parameters['depth'] = __depth;
 
     final _path =
         _i6.UriTemplate('/index.php/apps/files_sharing/shareinfo{?t*,password*,dir*,depth*}').expand(_parameters);
@@ -1181,25 +1181,25 @@ class $ShareapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $sharedWithMe = _$jsonSerializers.serialize(sharedWithMe, specifiedType: const FullType(String));
-    $sharedWithMe ??= 'false';
-    _parameters['shared_with_me'] = $sharedWithMe;
+    var __sharedWithMe = _$jsonSerializers.serialize(sharedWithMe, specifiedType: const FullType(String));
+    __sharedWithMe ??= 'false';
+    _parameters['shared_with_me'] = __sharedWithMe;
 
-    var $reshares = _$jsonSerializers.serialize(reshares, specifiedType: const FullType(String));
-    $reshares ??= 'false';
-    _parameters['reshares'] = $reshares;
+    var __reshares = _$jsonSerializers.serialize(reshares, specifiedType: const FullType(String));
+    __reshares ??= 'false';
+    _parameters['reshares'] = __reshares;
 
-    var $subfiles = _$jsonSerializers.serialize(subfiles, specifiedType: const FullType(String));
-    $subfiles ??= 'false';
-    _parameters['subfiles'] = $subfiles;
+    var __subfiles = _$jsonSerializers.serialize(subfiles, specifiedType: const FullType(String));
+    __subfiles ??= 'false';
+    _parameters['subfiles'] = __subfiles;
 
-    var $path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    $path ??= '';
-    _parameters['path'] = $path;
+    var __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
+    __path ??= '';
+    _parameters['path'] = __path;
 
-    var $includeTags = _$jsonSerializers.serialize(includeTags, specifiedType: const FullType(String));
-    $includeTags ??= 'false';
-    _parameters['include_tags'] = $includeTags;
+    var __includeTags = _$jsonSerializers.serialize(includeTags, specifiedType: const FullType(String));
+    __includeTags ??= 'false';
+    _parameters['include_tags'] = __includeTags;
 
     final _path = _i6.UriTemplate(
       '/ocs/v2.php/apps/files_sharing/api/v1/shares{?shared_with_me*,reshares*,subfiles*,path*,include_tags*}',
@@ -1224,9 +1224,9 @@ class $ShareapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1330,44 +1330,44 @@ class $ShareapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = $path;
+    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
+    _parameters['path'] = __path;
 
-    final $permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
-    _parameters['permissions'] = $permissions;
+    final __permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
+    _parameters['permissions'] = __permissions;
 
-    var $shareType = _$jsonSerializers.serialize(shareType, specifiedType: const FullType(int));
-    $shareType ??= -1;
-    _parameters['shareType'] = $shareType;
+    var __shareType = _$jsonSerializers.serialize(shareType, specifiedType: const FullType(int));
+    __shareType ??= -1;
+    _parameters['shareType'] = __shareType;
 
-    final $shareWith = _$jsonSerializers.serialize(shareWith, specifiedType: const FullType(String));
-    _parameters['shareWith'] = $shareWith;
+    final __shareWith = _$jsonSerializers.serialize(shareWith, specifiedType: const FullType(String));
+    _parameters['shareWith'] = __shareWith;
 
-    var $publicUpload = _$jsonSerializers.serialize(publicUpload, specifiedType: const FullType(String));
-    $publicUpload ??= 'false';
-    _parameters['publicUpload'] = $publicUpload;
+    var __publicUpload = _$jsonSerializers.serialize(publicUpload, specifiedType: const FullType(String));
+    __publicUpload ??= 'false';
+    _parameters['publicUpload'] = __publicUpload;
 
-    var $password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    $password ??= '';
-    _parameters['password'] = $password;
+    var __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
+    __password ??= '';
+    _parameters['password'] = __password;
 
-    final $sendPasswordByTalk = _$jsonSerializers.serialize(sendPasswordByTalk, specifiedType: const FullType(String));
-    _parameters['sendPasswordByTalk'] = $sendPasswordByTalk;
+    final __sendPasswordByTalk = _$jsonSerializers.serialize(sendPasswordByTalk, specifiedType: const FullType(String));
+    _parameters['sendPasswordByTalk'] = __sendPasswordByTalk;
 
-    var $expireDate = _$jsonSerializers.serialize(expireDate, specifiedType: const FullType(String));
-    $expireDate ??= '';
-    _parameters['expireDate'] = $expireDate;
+    var __expireDate = _$jsonSerializers.serialize(expireDate, specifiedType: const FullType(String));
+    __expireDate ??= '';
+    _parameters['expireDate'] = __expireDate;
 
-    var $note = _$jsonSerializers.serialize(note, specifiedType: const FullType(String));
-    $note ??= '';
-    _parameters['note'] = $note;
+    var __note = _$jsonSerializers.serialize(note, specifiedType: const FullType(String));
+    __note ??= '';
+    _parameters['note'] = __note;
 
-    var $label = _$jsonSerializers.serialize(label, specifiedType: const FullType(String));
-    $label ??= '';
-    _parameters['label'] = $label;
+    var __label = _$jsonSerializers.serialize(label, specifiedType: const FullType(String));
+    __label ??= '';
+    _parameters['label'] = __label;
 
-    final $attributes = _$jsonSerializers.serialize(attributes, specifiedType: const FullType(String));
-    _parameters['attributes'] = $attributes;
+    final __attributes = _$jsonSerializers.serialize(attributes, specifiedType: const FullType(String));
+    _parameters['attributes'] = __attributes;
 
     final _path = _i6.UriTemplate(
       '/ocs/v2.php/apps/files_sharing/api/v1/shares{?path*,permissions*,shareType*,shareWith*,publicUpload*,password*,sendPasswordByTalk*,expireDate*,note*,label*,attributes*}',
@@ -1392,9 +1392,9 @@ class $ShareapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1497,8 +1497,8 @@ class $ShareapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = $path;
+    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
+    _parameters['path'] = __path;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/inherited{?path*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1521,9 +1521,9 @@ class $ShareapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1609,9 +1609,9 @@ class $ShareapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1679,13 +1679,13 @@ class $ShareapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
+    _parameters['id'] = __id;
 
-    var $includeTags =
+    var __includeTags =
         _$jsonSerializers.serialize(includeTags, specifiedType: const FullType(ShareapiGetShareIncludeTags));
-    $includeTags ??= 0;
-    _parameters['include_tags'] = $includeTags;
+    __includeTags ??= 0;
+    _parameters['include_tags'] = __includeTags;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}{?include_tags*}').expand(_parameters);
@@ -1709,9 +1709,9 @@ class $ShareapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1804,35 +1804,35 @@ class $ShareapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
+    _parameters['id'] = __id;
 
-    final $permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
-    _parameters['permissions'] = $permissions;
+    final __permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
+    _parameters['permissions'] = __permissions;
 
-    final $password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    _parameters['password'] = $password;
+    final __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
+    _parameters['password'] = __password;
 
-    final $sendPasswordByTalk = _$jsonSerializers.serialize(sendPasswordByTalk, specifiedType: const FullType(String));
-    _parameters['sendPasswordByTalk'] = $sendPasswordByTalk;
+    final __sendPasswordByTalk = _$jsonSerializers.serialize(sendPasswordByTalk, specifiedType: const FullType(String));
+    _parameters['sendPasswordByTalk'] = __sendPasswordByTalk;
 
-    final $publicUpload = _$jsonSerializers.serialize(publicUpload, specifiedType: const FullType(String));
-    _parameters['publicUpload'] = $publicUpload;
+    final __publicUpload = _$jsonSerializers.serialize(publicUpload, specifiedType: const FullType(String));
+    _parameters['publicUpload'] = __publicUpload;
 
-    final $expireDate = _$jsonSerializers.serialize(expireDate, specifiedType: const FullType(String));
-    _parameters['expireDate'] = $expireDate;
+    final __expireDate = _$jsonSerializers.serialize(expireDate, specifiedType: const FullType(String));
+    _parameters['expireDate'] = __expireDate;
 
-    final $note = _$jsonSerializers.serialize(note, specifiedType: const FullType(String));
-    _parameters['note'] = $note;
+    final __note = _$jsonSerializers.serialize(note, specifiedType: const FullType(String));
+    _parameters['note'] = __note;
 
-    final $label = _$jsonSerializers.serialize(label, specifiedType: const FullType(String));
-    _parameters['label'] = $label;
+    final __label = _$jsonSerializers.serialize(label, specifiedType: const FullType(String));
+    _parameters['label'] = __label;
 
-    final $hideDownload = _$jsonSerializers.serialize(hideDownload, specifiedType: const FullType(String));
-    _parameters['hideDownload'] = $hideDownload;
+    final __hideDownload = _$jsonSerializers.serialize(hideDownload, specifiedType: const FullType(String));
+    _parameters['hideDownload'] = __hideDownload;
 
-    final $attributes = _$jsonSerializers.serialize(attributes, specifiedType: const FullType(String));
-    _parameters['attributes'] = $attributes;
+    final __attributes = _$jsonSerializers.serialize(attributes, specifiedType: const FullType(String));
+    _parameters['attributes'] = __attributes;
 
     final _path = _i6.UriTemplate(
       '/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}{?permissions*,password*,sendPasswordByTalk*,publicUpload*,expireDate*,note*,label*,hideDownload*,attributes*}',
@@ -1857,9 +1857,9 @@ class $ShareapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1959,8 +1959,8 @@ class $ShareapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
+    _parameters['id'] = __id;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1983,9 +1983,9 @@ class $ShareapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2057,8 +2057,8 @@ class $ShareapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
+    _parameters['id'] = __id;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/pending/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2081,9 +2081,9 @@ class $ShareapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2171,27 +2171,28 @@ class $ShareesapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    $search ??= '';
-    _parameters['search'] = $search;
+    var __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
+    __search ??= '';
+    _parameters['search'] = __search;
 
-    final $itemType = _$jsonSerializers.serialize(itemType, specifiedType: const FullType(String));
-    _parameters['itemType'] = $itemType;
+    final __itemType = _$jsonSerializers.serialize(itemType, specifiedType: const FullType(String));
+    _parameters['itemType'] = __itemType;
 
-    var $page = _$jsonSerializers.serialize(page, specifiedType: const FullType(int));
-    $page ??= 1;
-    _parameters['page'] = $page;
+    var __page = _$jsonSerializers.serialize(page, specifiedType: const FullType(int));
+    __page ??= 1;
+    _parameters['page'] = __page;
 
-    var $perPage = _$jsonSerializers.serialize(perPage, specifiedType: const FullType(int));
-    $perPage ??= 200;
-    _parameters['perPage'] = $perPage;
+    var __perPage = _$jsonSerializers.serialize(perPage, specifiedType: const FullType(int));
+    __perPage ??= 200;
+    _parameters['perPage'] = __perPage;
 
-    final $shareType = _$jsonSerializers.serialize(shareType, specifiedType: const FullType(ShareesapiSearchShareType));
-    _parameters['shareType'] = $shareType;
+    final __shareType =
+        _$jsonSerializers.serialize(shareType, specifiedType: const FullType(ShareesapiSearchShareType));
+    _parameters['shareType'] = __shareType;
 
-    var $lookup = _$jsonSerializers.serialize(lookup, specifiedType: const FullType(ShareesapiSearchLookup));
-    $lookup ??= 0;
-    _parameters['lookup'] = $lookup;
+    var __lookup = _$jsonSerializers.serialize(lookup, specifiedType: const FullType(ShareesapiSearchLookup));
+    __lookup ??= 0;
+    _parameters['lookup'] = __lookup;
 
     final _path = _i6.UriTemplate(
       '/ocs/v2.php/apps/files_sharing/api/v1/sharees{?search*,itemType*,page*,perPage*,shareType*,lookup*}',
@@ -2216,9 +2217,9 @@ class $ShareesapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2306,12 +2307,12 @@ class $ShareesapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $itemType = _$jsonSerializers.serialize(itemType, specifiedType: const FullType(String));
-    _parameters['itemType'] = $itemType;
+    final __itemType = _$jsonSerializers.serialize(itemType, specifiedType: const FullType(String));
+    _parameters['itemType'] = __itemType;
 
-    final $shareType =
+    final __shareType =
         _$jsonSerializers.serialize(shareType, specifiedType: const FullType(ShareesapiFindRecommendedShareType));
-    _parameters['shareType'] = $shareType;
+    _parameters['shareType'] = __shareType;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/sharees_recommended{?itemType*,shareType*}')
         .expand(_parameters);
@@ -2335,9 +2336,9 @@ class $ShareesapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -16,6 +16,7 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:built_collection/built_collection.dart';
@@ -350,10 +351,6 @@ class $PublicPreviewClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [file] File in the share. Defaults to `""`.
-  ///   * [x] Width of the preview. Defaults to `32`.
-  ///   * [y] Height of the preview. Defaults to `32`.
-  ///   * [a] Whether to not crop the preview. Defaults to `0`.
   ///   * [token] Token of the share.
   ///
   /// Status codes:
@@ -368,33 +365,13 @@ class $PublicPreviewClient {
   @_i2.experimental
   _i3.Request $getPreview_Request({
     required String token,
-    String? file,
-    int? x,
-    int? y,
-    PublicPreviewGetPreviewA? a,
+    PublicPreviewGetPreviewRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _parameters['token'] = __token;
 
-    var __file = _$jsonSerializers.serialize(file, specifiedType: const FullType(String));
-    __file ??= '';
-    _parameters['file'] = __file;
-
-    var __x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
-    __x ??= 32;
-    _parameters['x'] = __x;
-
-    var __y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
-    __y ??= 32;
-    _parameters['y'] = __y;
-
-    var __a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PublicPreviewGetPreviewA));
-    __a ??= 0;
-    _parameters['a'] = __a;
-
-    final _path =
-        _i6.UriTemplate('/index.php/apps/files_sharing/publicpreview/{token}{?file*,x*,y*,a*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/index.php/apps/files_sharing/publicpreview/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = '*/*';
@@ -413,6 +390,20 @@ class $PublicPreviewClient {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(PublicPreviewGetPreviewRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              PublicPreviewGetPreviewRequestApplicationJson(),
+              specifiedType: const FullType(PublicPreviewGetPreviewRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -422,10 +413,6 @@ class $PublicPreviewClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [file] File in the share. Defaults to `""`.
-  ///   * [x] Width of the preview. Defaults to `32`.
-  ///   * [y] Height of the preview. Defaults to `32`.
-  ///   * [a] Whether to not crop the preview. Defaults to `0`.
   ///   * [token] Token of the share.
   ///
   /// Status codes:
@@ -439,17 +426,11 @@ class $PublicPreviewClient {
   ///  * [$getPreview_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Uint8List, void>> getPreview({
     required String token,
-    String? file,
-    int? x,
-    int? y,
-    PublicPreviewGetPreviewA? a,
+    PublicPreviewGetPreviewRequestApplicationJson? $body,
   }) async {
     final _request = $getPreview_Request(
       token: token,
-      file: file,
-      x: x,
-      y: y,
-      a: a,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1037,12 +1018,6 @@ class $ShareInfoClient {
   /// Returns a `DynamiteRequest` backing the [info] operation.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [t] Token of the share.
-  ///   * [password] Password of the share.
-  ///   * [dir] Subdirectory to get info about.
-  ///   * [depth] Maximum depth to get info about. Defaults to `-1`.
-  ///
   /// Status codes:
   ///   * 200: Share info returned
   ///   * 403: Getting share info is not allowed
@@ -1052,28 +1027,8 @@ class $ShareInfoClient {
   ///  * [info] for a method executing this request and parsing the response.
   ///  * [$info_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $info_Request({
-    required String t,
-    String? password,
-    String? dir,
-    int? depth,
-  }) {
-    final _parameters = <String, Object?>{};
-    final __t = _$jsonSerializers.serialize(t, specifiedType: const FullType(String));
-    _parameters['t'] = __t;
-
-    final __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    _parameters['password'] = __password;
-
-    final __dir = _$jsonSerializers.serialize(dir, specifiedType: const FullType(String));
-    _parameters['dir'] = __dir;
-
-    var __depth = _$jsonSerializers.serialize(depth, specifiedType: const FullType(int));
-    __depth ??= -1;
-    _parameters['depth'] = __depth;
-
-    final _path =
-        _i6.UriTemplate('/index.php/apps/files_sharing/shareinfo{?t*,password*,dir*,depth*}').expand(_parameters);
+  _i3.Request $info_Request({required ShareInfoInfoRequestApplicationJson $body}) {
+    const _path = '/index.php/apps/files_sharing/shareinfo';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1092,6 +1047,9 @@ class $ShareInfoClient {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json
+        .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(ShareInfoInfoRequestApplicationJson)));
     return _request;
   }
 
@@ -1099,12 +1057,6 @@ class $ShareInfoClient {
   ///
   /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
-  ///
-  /// Parameters:
-  ///   * [t] Token of the share.
-  ///   * [password] Password of the share.
-  ///   * [dir] Subdirectory to get info about.
-  ///   * [depth] Maximum depth to get info about. Defaults to `-1`.
   ///
   /// Status codes:
   ///   * 200: Share info returned
@@ -1114,17 +1066,9 @@ class $ShareInfoClient {
   /// See:
   ///  * [$info_Request] for the request send by this method.
   ///  * [$info_Serializer] for a converter to parse the `Response` from an executed request.
-  Future<_i1.DynamiteResponse<ShareInfo, void>> info({
-    required String t,
-    String? password,
-    String? dir,
-    int? depth,
-  }) async {
+  Future<_i1.DynamiteResponse<ShareInfo, void>> info({required ShareInfoInfoRequestApplicationJson $body}) async {
     final _request = $info_Request(
-      t: t,
-      password: password,
-      dir: dir,
-      depth: depth,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1157,11 +1101,6 @@ class $ShareapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [sharedWithMe] Only get shares with the current user. Defaults to `"false"`.
-  ///   * [reshares] Only get shares by the current user and reshares. Defaults to `"false"`.
-  ///   * [subfiles] Only get all shares in a folder. Defaults to `"false"`.
-  ///   * [path] Get shares for a specific path. Defaults to `""`.
-  ///   * [includeTags] Include tags in the share. Defaults to `"false"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -1173,37 +1112,10 @@ class $ShareapiClient {
   ///  * [$getShares_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getShares_Request({
-    String? sharedWithMe,
-    String? reshares,
-    String? subfiles,
-    String? path,
-    String? includeTags,
     bool? oCSAPIRequest,
+    ShareapiGetSharesRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    var __sharedWithMe = _$jsonSerializers.serialize(sharedWithMe, specifiedType: const FullType(String));
-    __sharedWithMe ??= 'false';
-    _parameters['shared_with_me'] = __sharedWithMe;
-
-    var __reshares = _$jsonSerializers.serialize(reshares, specifiedType: const FullType(String));
-    __reshares ??= 'false';
-    _parameters['reshares'] = __reshares;
-
-    var __subfiles = _$jsonSerializers.serialize(subfiles, specifiedType: const FullType(String));
-    __subfiles ??= 'false';
-    _parameters['subfiles'] = __subfiles;
-
-    var __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    __path ??= '';
-    _parameters['path'] = __path;
-
-    var __includeTags = _$jsonSerializers.serialize(includeTags, specifiedType: const FullType(String));
-    __includeTags ??= 'false';
-    _parameters['include_tags'] = __includeTags;
-
-    final _path = _i6.UriTemplate(
-      '/ocs/v2.php/apps/files_sharing/api/v1/shares{?shared_with_me*,reshares*,subfiles*,path*,include_tags*}',
-    ).expand(_parameters);
+    const _path = '/ocs/v2.php/apps/files_sharing/api/v1/shares';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1228,6 +1140,17 @@ class $ShareapiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(ShareapiGetSharesRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ShareapiGetSharesRequestApplicationJson(),
+              specifiedType: const FullType(ShareapiGetSharesRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -1237,11 +1160,6 @@ class $ShareapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [sharedWithMe] Only get shares with the current user. Defaults to `"false"`.
-  ///   * [reshares] Only get shares by the current user and reshares. Defaults to `"false"`.
-  ///   * [subfiles] Only get all shares in a folder. Defaults to `"false"`.
-  ///   * [path] Get shares for a specific path. Defaults to `""`.
-  ///   * [includeTags] Include tags in the share. Defaults to `"false"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -1252,20 +1170,12 @@ class $ShareapiClient {
   ///  * [$getShares_Request] for the request send by this method.
   ///  * [$getShares_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ShareapiGetSharesResponseApplicationJson, void>> getShares({
-    String? sharedWithMe,
-    String? reshares,
-    String? subfiles,
-    String? path,
-    String? includeTags,
     bool? oCSAPIRequest,
+    ShareapiGetSharesRequestApplicationJson? $body,
   }) async {
     final _request = $getShares_Request(
-      sharedWithMe: sharedWithMe,
-      reshares: reshares,
-      subfiles: subfiles,
-      path: path,
-      includeTags: includeTags,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1292,17 +1202,6 @@ class $ShareapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [path] Path of the share.
-  ///   * [permissions] Permissions for the share.
-  ///   * [shareType] Type of the share. Defaults to `-1`.
-  ///   * [shareWith] The entity this should be shared with.
-  ///   * [publicUpload] If public uploading is allowed. Defaults to `"false"`.
-  ///   * [password] Password for the share. Defaults to `""`.
-  ///   * [sendPasswordByTalk] Send the password for the share over Talk.
-  ///   * [expireDate] Expiry date of the share using user timezone at 00:00. It means date in UTC timezone will be used. Defaults to `""`.
-  ///   * [note] Note for the share. Defaults to `""`.
-  ///   * [label] Label for the share (only used in link and email). Defaults to `""`.
-  ///   * [attributes] Additional attributes for the share.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -1316,62 +1215,10 @@ class $ShareapiClient {
   ///  * [$createShare_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $createShare_Request({
-    String? path,
-    int? permissions,
-    int? shareType,
-    String? shareWith,
-    String? publicUpload,
-    String? password,
-    String? sendPasswordByTalk,
-    String? expireDate,
-    String? note,
-    String? label,
-    String? attributes,
     bool? oCSAPIRequest,
+    ShareapiCreateShareRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = __path;
-
-    final __permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
-    _parameters['permissions'] = __permissions;
-
-    var __shareType = _$jsonSerializers.serialize(shareType, specifiedType: const FullType(int));
-    __shareType ??= -1;
-    _parameters['shareType'] = __shareType;
-
-    final __shareWith = _$jsonSerializers.serialize(shareWith, specifiedType: const FullType(String));
-    _parameters['shareWith'] = __shareWith;
-
-    var __publicUpload = _$jsonSerializers.serialize(publicUpload, specifiedType: const FullType(String));
-    __publicUpload ??= 'false';
-    _parameters['publicUpload'] = __publicUpload;
-
-    var __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    __password ??= '';
-    _parameters['password'] = __password;
-
-    final __sendPasswordByTalk = _$jsonSerializers.serialize(sendPasswordByTalk, specifiedType: const FullType(String));
-    _parameters['sendPasswordByTalk'] = __sendPasswordByTalk;
-
-    var __expireDate = _$jsonSerializers.serialize(expireDate, specifiedType: const FullType(String));
-    __expireDate ??= '';
-    _parameters['expireDate'] = __expireDate;
-
-    var __note = _$jsonSerializers.serialize(note, specifiedType: const FullType(String));
-    __note ??= '';
-    _parameters['note'] = __note;
-
-    var __label = _$jsonSerializers.serialize(label, specifiedType: const FullType(String));
-    __label ??= '';
-    _parameters['label'] = __label;
-
-    final __attributes = _$jsonSerializers.serialize(attributes, specifiedType: const FullType(String));
-    _parameters['attributes'] = __attributes;
-
-    final _path = _i6.UriTemplate(
-      '/ocs/v2.php/apps/files_sharing/api/v1/shares{?path*,permissions*,shareType*,shareWith*,publicUpload*,password*,sendPasswordByTalk*,expireDate*,note*,label*,attributes*}',
-    ).expand(_parameters);
+    const _path = '/ocs/v2.php/apps/files_sharing/api/v1/shares';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1396,6 +1243,20 @@ class $ShareapiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(ShareapiCreateShareRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ShareapiCreateShareRequestApplicationJson(),
+              specifiedType: const FullType(ShareapiCreateShareRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -1405,17 +1266,6 @@ class $ShareapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [path] Path of the share.
-  ///   * [permissions] Permissions for the share.
-  ///   * [shareType] Type of the share. Defaults to `-1`.
-  ///   * [shareWith] The entity this should be shared with.
-  ///   * [publicUpload] If public uploading is allowed. Defaults to `"false"`.
-  ///   * [password] Password for the share. Defaults to `""`.
-  ///   * [sendPasswordByTalk] Send the password for the share over Talk.
-  ///   * [expireDate] Expiry date of the share using user timezone at 00:00. It means date in UTC timezone will be used. Defaults to `""`.
-  ///   * [note] Note for the share. Defaults to `""`.
-  ///   * [label] Label for the share (only used in link and email). Defaults to `""`.
-  ///   * [attributes] Additional attributes for the share.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -1428,32 +1278,12 @@ class $ShareapiClient {
   ///  * [$createShare_Request] for the request send by this method.
   ///  * [$createShare_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ShareapiCreateShareResponseApplicationJson, void>> createShare({
-    String? path,
-    int? permissions,
-    int? shareType,
-    String? shareWith,
-    String? publicUpload,
-    String? password,
-    String? sendPasswordByTalk,
-    String? expireDate,
-    String? note,
-    String? label,
-    String? attributes,
     bool? oCSAPIRequest,
+    ShareapiCreateShareRequestApplicationJson? $body,
   }) async {
     final _request = $createShare_Request(
-      path: path,
-      permissions: permissions,
-      shareType: shareType,
-      shareWith: shareWith,
-      publicUpload: publicUpload,
-      password: password,
-      sendPasswordByTalk: sendPasswordByTalk,
-      expireDate: expireDate,
-      note: note,
-      label: label,
-      attributes: attributes,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1480,7 +1310,6 @@ class $ShareapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [path] Path all shares will be relative to.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -1493,14 +1322,10 @@ class $ShareapiClient {
   ///  * [$getInheritedShares_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getInheritedShares_Request({
-    required String path,
+    required ShareapiGetInheritedSharesRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __path = _$jsonSerializers.serialize(path, specifiedType: const FullType(String));
-    _parameters['path'] = __path;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/inherited{?path*}').expand(_parameters);
+    const _path = '/ocs/v2.php/apps/files_sharing/api/v1/shares/inherited';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1525,6 +1350,13 @@ class $ShareapiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(ShareapiGetInheritedSharesRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -1534,7 +1366,6 @@ class $ShareapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [path] Path all shares will be relative to.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -1546,12 +1377,12 @@ class $ShareapiClient {
   ///  * [$getInheritedShares_Request] for the request send by this method.
   ///  * [$getInheritedShares_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ShareapiGetInheritedSharesResponseApplicationJson, void>> getInheritedShares({
-    required String path,
+    required ShareapiGetInheritedSharesRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $getInheritedShares_Request(
-      path: path,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1661,7 +1492,6 @@ class $ShareapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [includeTags] Include tags in the share. Defaults to `0`.
   ///   * [id] ID of the share.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1675,20 +1505,14 @@ class $ShareapiClient {
   @_i2.experimental
   _i3.Request $getShare_Request({
     required String id,
-    ShareapiGetShareIncludeTags? includeTags,
     bool? oCSAPIRequest,
+    ShareapiGetShareRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
     _parameters['id'] = __id;
 
-    var __includeTags =
-        _$jsonSerializers.serialize(includeTags, specifiedType: const FullType(ShareapiGetShareIncludeTags));
-    __includeTags ??= 0;
-    _parameters['include_tags'] = __includeTags;
-
-    final _path =
-        _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}{?include_tags*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1713,6 +1537,17 @@ class $ShareapiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(ShareapiGetShareRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ShareapiGetShareRequestApplicationJson(),
+              specifiedType: const FullType(ShareapiGetShareRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -1722,7 +1557,6 @@ class $ShareapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [includeTags] Include tags in the share. Defaults to `0`.
   ///   * [id] ID of the share.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1735,13 +1569,13 @@ class $ShareapiClient {
   ///  * [$getShare_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ShareapiGetShareResponseApplicationJson, void>> getShare({
     required String id,
-    ShareapiGetShareIncludeTags? includeTags,
     bool? oCSAPIRequest,
+    ShareapiGetShareRequestApplicationJson? $body,
   }) async {
     final _request = $getShare_Request(
       id: id,
-      includeTags: includeTags,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1768,15 +1602,6 @@ class $ShareapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [permissions] New permissions.
-  ///   * [password] New password.
-  ///   * [sendPasswordByTalk] New condition if the password should be send over Talk.
-  ///   * [publicUpload] New condition if public uploading is allowed.
-  ///   * [expireDate] New expiry date.
-  ///   * [note] New note.
-  ///   * [label] New label.
-  ///   * [hideDownload] New condition if the download should be hidden.
-  ///   * [attributes] New additional attributes.
   ///   * [id] ID of the share.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1792,51 +1617,14 @@ class $ShareapiClient {
   @_i2.experimental
   _i3.Request $updateShare_Request({
     required String id,
-    int? permissions,
-    String? password,
-    String? sendPasswordByTalk,
-    String? publicUpload,
-    String? expireDate,
-    String? note,
-    String? label,
-    String? hideDownload,
-    String? attributes,
     bool? oCSAPIRequest,
+    ShareapiUpdateShareRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(String));
     _parameters['id'] = __id;
 
-    final __permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
-    _parameters['permissions'] = __permissions;
-
-    final __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    _parameters['password'] = __password;
-
-    final __sendPasswordByTalk = _$jsonSerializers.serialize(sendPasswordByTalk, specifiedType: const FullType(String));
-    _parameters['sendPasswordByTalk'] = __sendPasswordByTalk;
-
-    final __publicUpload = _$jsonSerializers.serialize(publicUpload, specifiedType: const FullType(String));
-    _parameters['publicUpload'] = __publicUpload;
-
-    final __expireDate = _$jsonSerializers.serialize(expireDate, specifiedType: const FullType(String));
-    _parameters['expireDate'] = __expireDate;
-
-    final __note = _$jsonSerializers.serialize(note, specifiedType: const FullType(String));
-    _parameters['note'] = __note;
-
-    final __label = _$jsonSerializers.serialize(label, specifiedType: const FullType(String));
-    _parameters['label'] = __label;
-
-    final __hideDownload = _$jsonSerializers.serialize(hideDownload, specifiedType: const FullType(String));
-    _parameters['hideDownload'] = __hideDownload;
-
-    final __attributes = _$jsonSerializers.serialize(attributes, specifiedType: const FullType(String));
-    _parameters['attributes'] = __attributes;
-
-    final _path = _i6.UriTemplate(
-      '/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}{?permissions*,password*,sendPasswordByTalk*,publicUpload*,expireDate*,note*,label*,hideDownload*,attributes*}',
-    ).expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/shares/{id}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1861,6 +1649,20 @@ class $ShareapiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(ShareapiUpdateShareRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ShareapiUpdateShareRequestApplicationJson(),
+              specifiedType: const FullType(ShareapiUpdateShareRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -1870,15 +1672,6 @@ class $ShareapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [permissions] New permissions.
-  ///   * [password] New password.
-  ///   * [sendPasswordByTalk] New condition if the password should be send over Talk.
-  ///   * [publicUpload] New condition if public uploading is allowed.
-  ///   * [expireDate] New expiry date.
-  ///   * [note] New note.
-  ///   * [label] New label.
-  ///   * [hideDownload] New condition if the download should be hidden.
-  ///   * [attributes] New additional attributes.
   ///   * [id] ID of the share.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1893,29 +1686,13 @@ class $ShareapiClient {
   ///  * [$updateShare_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ShareapiUpdateShareResponseApplicationJson, void>> updateShare({
     required String id,
-    int? permissions,
-    String? password,
-    String? sendPasswordByTalk,
-    String? publicUpload,
-    String? expireDate,
-    String? note,
-    String? label,
-    String? hideDownload,
-    String? attributes,
     bool? oCSAPIRequest,
+    ShareapiUpdateShareRequestApplicationJson? $body,
   }) async {
     final _request = $updateShare_Request(
       id: id,
-      permissions: permissions,
-      password: password,
-      sendPasswordByTalk: sendPasswordByTalk,
-      publicUpload: publicUpload,
-      expireDate: expireDate,
-      note: note,
-      label: label,
-      hideDownload: hideDownload,
-      attributes: attributes,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2145,12 +1922,6 @@ class $ShareesapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for. Defaults to `""`.
-  ///   * [itemType] Limit to specific item types.
-  ///   * [page] Page offset for searching. Defaults to `1`.
-  ///   * [perPage] Limit amount of search results per page. Defaults to `200`.
-  ///   * [shareType] Limit to specific share types.
-  ///   * [lookup] If a global lookup should be performed too. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2162,41 +1933,10 @@ class $ShareesapiClient {
   ///  * [$search_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $search_Request({
-    String? search,
-    String? itemType,
-    int? page,
-    int? perPage,
-    ShareesapiSearchShareType? shareType,
-    ShareesapiSearchLookup? lookup,
     bool? oCSAPIRequest,
+    ShareesapiSearchRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    var __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    __search ??= '';
-    _parameters['search'] = __search;
-
-    final __itemType = _$jsonSerializers.serialize(itemType, specifiedType: const FullType(String));
-    _parameters['itemType'] = __itemType;
-
-    var __page = _$jsonSerializers.serialize(page, specifiedType: const FullType(int));
-    __page ??= 1;
-    _parameters['page'] = __page;
-
-    var __perPage = _$jsonSerializers.serialize(perPage, specifiedType: const FullType(int));
-    __perPage ??= 200;
-    _parameters['perPage'] = __perPage;
-
-    final __shareType =
-        _$jsonSerializers.serialize(shareType, specifiedType: const FullType(ShareesapiSearchShareType));
-    _parameters['shareType'] = __shareType;
-
-    var __lookup = _$jsonSerializers.serialize(lookup, specifiedType: const FullType(ShareesapiSearchLookup));
-    __lookup ??= 0;
-    _parameters['lookup'] = __lookup;
-
-    final _path = _i6.UriTemplate(
-      '/ocs/v2.php/apps/files_sharing/api/v1/sharees{?search*,itemType*,page*,perPage*,shareType*,lookup*}',
-    ).expand(_parameters);
+    const _path = '/ocs/v2.php/apps/files_sharing/api/v1/sharees';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2221,6 +1961,17 @@ class $ShareesapiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(ShareesapiSearchRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ShareesapiSearchRequestApplicationJson(),
+              specifiedType: const FullType(ShareesapiSearchRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -2230,12 +1981,6 @@ class $ShareesapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for. Defaults to `""`.
-  ///   * [itemType] Limit to specific item types.
-  ///   * [page] Page offset for searching. Defaults to `1`.
-  ///   * [perPage] Limit amount of search results per page. Defaults to `200`.
-  ///   * [shareType] Limit to specific share types.
-  ///   * [lookup] If a global lookup should be performed too. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2246,22 +1991,12 @@ class $ShareesapiClient {
   ///  * [$search_Request] for the request send by this method.
   ///  * [$search_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ShareesapiSearchResponseApplicationJson, ShareesapiShareesapiSearchHeaders>> search({
-    String? search,
-    String? itemType,
-    int? page,
-    int? perPage,
-    ShareesapiSearchShareType? shareType,
-    ShareesapiSearchLookup? lookup,
     bool? oCSAPIRequest,
+    ShareesapiSearchRequestApplicationJson? $body,
   }) async {
     final _request = $search_Request(
-      search: search,
-      itemType: itemType,
-      page: page,
-      perPage: perPage,
-      shareType: shareType,
-      lookup: lookup,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2290,8 +2025,6 @@ class $ShareesapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [itemType] Limit to specific item types.
-  ///   * [shareType] Limit to specific share types.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2302,20 +2035,10 @@ class $ShareesapiClient {
   ///  * [$findRecommended_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $findRecommended_Request({
-    required String itemType,
-    ShareesapiFindRecommendedShareType? shareType,
+    required ShareesapiFindRecommendedRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __itemType = _$jsonSerializers.serialize(itemType, specifiedType: const FullType(String));
-    _parameters['itemType'] = __itemType;
-
-    final __shareType =
-        _$jsonSerializers.serialize(shareType, specifiedType: const FullType(ShareesapiFindRecommendedShareType));
-    _parameters['shareType'] = __shareType;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/apps/files_sharing/api/v1/sharees_recommended{?itemType*,shareType*}')
-        .expand(_parameters);
+    const _path = '/ocs/v2.php/apps/files_sharing/api/v1/sharees_recommended';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2340,6 +2063,13 @@ class $ShareesapiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(ShareesapiFindRecommendedRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -2349,8 +2079,6 @@ class $ShareesapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [itemType] Limit to specific item types.
-  ///   * [shareType] Limit to specific share types.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2360,14 +2088,12 @@ class $ShareesapiClient {
   ///  * [$findRecommended_Request] for the request send by this method.
   ///  * [$findRecommended_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ShareesapiFindRecommendedResponseApplicationJson, void>> findRecommended({
-    required String itemType,
-    ShareesapiFindRecommendedShareType? shareType,
+    required ShareesapiFindRecommendedRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $findRecommended_Request(
-      itemType: itemType,
-      shareType: shareType,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2778,67 +2504,103 @@ abstract class DeletedShareapiUndeleteResponseApplicationJson
   }
 }
 
-class PublicPreviewGetPreviewA extends EnumClass {
-  const PublicPreviewGetPreviewA._(super.name);
+@BuiltValue(instantiable: false)
+sealed class $PublicPreviewGetPreviewRequestApplicationJsonInterface {
+  static final _$file = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const PublicPreviewGetPreviewA $0 = _$publicPreviewGetPreviewA$0;
+  static final _$x = _$jsonSerializers.deserialize(
+    32,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const PublicPreviewGetPreviewA $1 = _$publicPreviewGetPreviewA$1;
+  static final _$y = _$jsonSerializers.deserialize(
+    32,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<PublicPreviewGetPreviewA> get values => _$publicPreviewGetPreviewAValues;
-  // coverage:ignore-end
+  static final _$a = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  /// Returns the enum value associated to the [name].
-  static PublicPreviewGetPreviewA valueOf(String name) => _$valueOfPublicPreviewGetPreviewA(name);
+  /// File in the share.
+  String get file;
 
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+  /// Width of the preview.
+  int get x;
 
-  /// Serializer for PublicPreviewGetPreviewA.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<PublicPreviewGetPreviewA> get serializer => const _$PublicPreviewGetPreviewASerializer();
+  /// Height of the preview.
+  int get y;
+
+  /// Whether to not crop the preview.
+  bool get a;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PublicPreviewGetPreviewRequestApplicationJsonInterfaceBuilder].
+  $PublicPreviewGetPreviewRequestApplicationJsonInterface rebuild(
+    void Function($PublicPreviewGetPreviewRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PublicPreviewGetPreviewRequestApplicationJsonInterfaceBuilder].
+  $PublicPreviewGetPreviewRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicPreviewGetPreviewRequestApplicationJsonInterfaceBuilder b) {
+    b.file = _$file;
+    b.x = _$x;
+    b.y = _$y;
+    b.a = _$a;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicPreviewGetPreviewRequestApplicationJsonInterfaceBuilder b) {}
 }
 
-class _$PublicPreviewGetPreviewASerializer implements PrimitiveSerializer<PublicPreviewGetPreviewA> {
-  const _$PublicPreviewGetPreviewASerializer();
+abstract class PublicPreviewGetPreviewRequestApplicationJson
+    implements
+        $PublicPreviewGetPreviewRequestApplicationJsonInterface,
+        Built<PublicPreviewGetPreviewRequestApplicationJson, PublicPreviewGetPreviewRequestApplicationJsonBuilder> {
+  /// Creates a new PublicPreviewGetPreviewRequestApplicationJson object using the builder pattern.
+  factory PublicPreviewGetPreviewRequestApplicationJson([
+    void Function(PublicPreviewGetPreviewRequestApplicationJsonBuilder)? b,
+  ]) = _$PublicPreviewGetPreviewRequestApplicationJson;
 
-  static const Map<PublicPreviewGetPreviewA, Object> _toWire = <PublicPreviewGetPreviewA, Object>{
-    PublicPreviewGetPreviewA.$0: 0,
-    PublicPreviewGetPreviewA.$1: 1,
-  };
+  // coverage:ignore-start
+  const PublicPreviewGetPreviewRequestApplicationJson._();
+  // coverage:ignore-end
 
-  static const Map<Object, PublicPreviewGetPreviewA> _fromWire = <Object, PublicPreviewGetPreviewA>{
-    0: PublicPreviewGetPreviewA.$0,
-    1: PublicPreviewGetPreviewA.$1,
-  };
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory PublicPreviewGetPreviewRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
 
-  @override
-  Iterable<Type> get types => const [PublicPreviewGetPreviewA];
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
 
-  @override
-  String get wireName => 'PublicPreviewGetPreviewA';
+  /// Serializer for PublicPreviewGetPreviewRequestApplicationJson.
+  static Serializer<PublicPreviewGetPreviewRequestApplicationJson> get serializer =>
+      _$publicPreviewGetPreviewRequestApplicationJsonSerializer;
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    PublicPreviewGetPreviewA object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicPreviewGetPreviewRequestApplicationJsonBuilder b) {
+    $PublicPreviewGetPreviewRequestApplicationJsonInterface._defaults(b);
+  }
 
-  @override
-  PublicPreviewGetPreviewA deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicPreviewGetPreviewRequestApplicationJsonBuilder b) {
+    $PublicPreviewGetPreviewRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -3674,6 +3436,86 @@ abstract class RemoteUnshareResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ShareInfoInfoRequestApplicationJsonInterface {
+  static final _$depth = _$jsonSerializers.deserialize(
+    -1,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// Token of the share.
+  String get t;
+
+  /// Password of the share.
+  String? get password;
+
+  /// Subdirectory to get info about.
+  String? get dir;
+
+  /// Maximum depth to get info about.
+  int get depth;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareInfoInfoRequestApplicationJsonInterfaceBuilder].
+  $ShareInfoInfoRequestApplicationJsonInterface rebuild(
+    void Function($ShareInfoInfoRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareInfoInfoRequestApplicationJsonInterfaceBuilder].
+  $ShareInfoInfoRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareInfoInfoRequestApplicationJsonInterfaceBuilder b) {
+    b.depth = _$depth;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareInfoInfoRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ShareInfoInfoRequestApplicationJson
+    implements
+        $ShareInfoInfoRequestApplicationJsonInterface,
+        Built<ShareInfoInfoRequestApplicationJson, ShareInfoInfoRequestApplicationJsonBuilder> {
+  /// Creates a new ShareInfoInfoRequestApplicationJson object using the builder pattern.
+  factory ShareInfoInfoRequestApplicationJson([void Function(ShareInfoInfoRequestApplicationJsonBuilder)? b]) =
+      _$ShareInfoInfoRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ShareInfoInfoRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ShareInfoInfoRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ShareInfoInfoRequestApplicationJson.
+  static Serializer<ShareInfoInfoRequestApplicationJson> get serializer =>
+      _$shareInfoInfoRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareInfoInfoRequestApplicationJsonBuilder b) {
+    $ShareInfoInfoRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareInfoInfoRequestApplicationJsonBuilder b) {
+    $ShareInfoInfoRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ShareInfoInterface {
   int get id;
   int get parentId;
@@ -3733,6 +3575,115 @@ abstract class ShareInfo implements $ShareInfoInterface, Built<ShareInfo, ShareI
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(ShareInfoBuilder b) {
     $ShareInfoInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ShareapiGetSharesRequestApplicationJsonInterface {
+  static final _$sharedWithMe = _$jsonSerializers.deserialize(
+    'false',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$reshares = _$jsonSerializers.deserialize(
+    'false',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$subfiles = _$jsonSerializers.deserialize(
+    'false',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$path = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$includeTags = _$jsonSerializers.deserialize(
+    'false',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// Only get shares with the current user.
+  @BuiltValueField(wireName: 'shared_with_me')
+  String get sharedWithMe;
+
+  /// Only get shares by the current user and reshares.
+  String get reshares;
+
+  /// Only get all shares in a folder.
+  String get subfiles;
+
+  /// Get shares for a specific path.
+  String get path;
+
+  /// Include tags in the share.
+  @BuiltValueField(wireName: 'include_tags')
+  String get includeTags;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiGetSharesRequestApplicationJsonInterfaceBuilder].
+  $ShareapiGetSharesRequestApplicationJsonInterface rebuild(
+    void Function($ShareapiGetSharesRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiGetSharesRequestApplicationJsonInterfaceBuilder].
+  $ShareapiGetSharesRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiGetSharesRequestApplicationJsonInterfaceBuilder b) {
+    b.sharedWithMe = _$sharedWithMe;
+    b.reshares = _$reshares;
+    b.subfiles = _$subfiles;
+    b.path = _$path;
+    b.includeTags = _$includeTags;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiGetSharesRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ShareapiGetSharesRequestApplicationJson
+    implements
+        $ShareapiGetSharesRequestApplicationJsonInterface,
+        Built<ShareapiGetSharesRequestApplicationJson, ShareapiGetSharesRequestApplicationJsonBuilder> {
+  /// Creates a new ShareapiGetSharesRequestApplicationJson object using the builder pattern.
+  factory ShareapiGetSharesRequestApplicationJson([void Function(ShareapiGetSharesRequestApplicationJsonBuilder)? b]) =
+      _$ShareapiGetSharesRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ShareapiGetSharesRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ShareapiGetSharesRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ShareapiGetSharesRequestApplicationJson.
+  static Serializer<ShareapiGetSharesRequestApplicationJson> get serializer =>
+      _$shareapiGetSharesRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiGetSharesRequestApplicationJsonBuilder b) {
+    $ShareapiGetSharesRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiGetSharesRequestApplicationJsonBuilder b) {
+    $ShareapiGetSharesRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -4228,6 +4179,138 @@ abstract class ShareapiGetSharesResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ShareapiCreateShareRequestApplicationJsonInterface {
+  static final _$shareType = _$jsonSerializers.deserialize(
+    -1,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$publicUpload = _$jsonSerializers.deserialize(
+    'false',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$password = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$expireDate = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$note = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$label = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// Path of the share.
+  String? get path;
+
+  /// Permissions for the share.
+  int? get permissions;
+
+  /// Type of the share.
+  int get shareType;
+
+  /// The entity this should be shared with.
+  String? get shareWith;
+
+  /// If public uploading is allowed.
+  String get publicUpload;
+
+  /// Password for the share.
+  String get password;
+
+  /// Send the password for the share over Talk.
+  String? get sendPasswordByTalk;
+
+  /// Expiry date of the share using user timezone at 00:00. It means date in UTC timezone will be used.
+  String get expireDate;
+
+  /// Note for the share.
+  String get note;
+
+  /// Label for the share (only used in link and email).
+  String get label;
+
+  /// Additional attributes for the share.
+  String? get attributes;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiCreateShareRequestApplicationJsonInterfaceBuilder].
+  $ShareapiCreateShareRequestApplicationJsonInterface rebuild(
+    void Function($ShareapiCreateShareRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiCreateShareRequestApplicationJsonInterfaceBuilder].
+  $ShareapiCreateShareRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiCreateShareRequestApplicationJsonInterfaceBuilder b) {
+    b.shareType = _$shareType;
+    b.publicUpload = _$publicUpload;
+    b.password = _$password;
+    b.expireDate = _$expireDate;
+    b.note = _$note;
+    b.label = _$label;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiCreateShareRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ShareapiCreateShareRequestApplicationJson
+    implements
+        $ShareapiCreateShareRequestApplicationJsonInterface,
+        Built<ShareapiCreateShareRequestApplicationJson, ShareapiCreateShareRequestApplicationJsonBuilder> {
+  /// Creates a new ShareapiCreateShareRequestApplicationJson object using the builder pattern.
+  factory ShareapiCreateShareRequestApplicationJson([
+    void Function(ShareapiCreateShareRequestApplicationJsonBuilder)? b,
+  ]) = _$ShareapiCreateShareRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ShareapiCreateShareRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ShareapiCreateShareRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ShareapiCreateShareRequestApplicationJson.
+  static Serializer<ShareapiCreateShareRequestApplicationJson> get serializer =>
+      _$shareapiCreateShareRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiCreateShareRequestApplicationJsonBuilder b) {
+    $ShareapiCreateShareRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiCreateShareRequestApplicationJsonBuilder b) {
+    $ShareapiCreateShareRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ShareapiCreateShareResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Share get data;
@@ -4351,6 +4434,71 @@ abstract class ShareapiCreateShareResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(ShareapiCreateShareResponseApplicationJsonBuilder b) {
     $ShareapiCreateShareResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ShareapiGetInheritedSharesRequestApplicationJsonInterface {
+  /// Path all shares will be relative to.
+  String get path;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiGetInheritedSharesRequestApplicationJsonInterfaceBuilder].
+  $ShareapiGetInheritedSharesRequestApplicationJsonInterface rebuild(
+    void Function($ShareapiGetInheritedSharesRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiGetInheritedSharesRequestApplicationJsonInterfaceBuilder].
+  $ShareapiGetInheritedSharesRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiGetInheritedSharesRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiGetInheritedSharesRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ShareapiGetInheritedSharesRequestApplicationJson
+    implements
+        $ShareapiGetInheritedSharesRequestApplicationJsonInterface,
+        Built<ShareapiGetInheritedSharesRequestApplicationJson,
+            ShareapiGetInheritedSharesRequestApplicationJsonBuilder> {
+  /// Creates a new ShareapiGetInheritedSharesRequestApplicationJson object using the builder pattern.
+  factory ShareapiGetInheritedSharesRequestApplicationJson([
+    void Function(ShareapiGetInheritedSharesRequestApplicationJsonBuilder)? b,
+  ]) = _$ShareapiGetInheritedSharesRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ShareapiGetInheritedSharesRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ShareapiGetInheritedSharesRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ShareapiGetInheritedSharesRequestApplicationJson.
+  static Serializer<ShareapiGetInheritedSharesRequestApplicationJson> get serializer =>
+      _$shareapiGetInheritedSharesRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiGetInheritedSharesRequestApplicationJsonBuilder b) {
+    $ShareapiGetInheritedSharesRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiGetInheritedSharesRequestApplicationJsonBuilder b) {
+    $ShareapiGetInheritedSharesRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -4611,67 +4759,76 @@ abstract class ShareapiPendingSharesResponseApplicationJson
   }
 }
 
-class ShareapiGetShareIncludeTags extends EnumClass {
-  const ShareapiGetShareIncludeTags._(super.name);
+@BuiltValue(instantiable: false)
+sealed class $ShareapiGetShareRequestApplicationJsonInterface {
+  static final _$includeTags = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ShareapiGetShareIncludeTags $0 = _$shareapiGetShareIncludeTags$0;
+  /// Include tags in the share.
+  @BuiltValueField(wireName: 'include_tags')
+  bool get includeTags;
 
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ShareapiGetShareIncludeTags $1 = _$shareapiGetShareIncludeTags$1;
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiGetShareRequestApplicationJsonInterfaceBuilder].
+  $ShareapiGetShareRequestApplicationJsonInterface rebuild(
+    void Function($ShareapiGetShareRequestApplicationJsonInterfaceBuilder) updates,
+  );
 
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<ShareapiGetShareIncludeTags> get values => _$shareapiGetShareIncludeTagsValues;
-  // coverage:ignore-end
+  /// Converts the instance to a builder [$ShareapiGetShareRequestApplicationJsonInterfaceBuilder].
+  $ShareapiGetShareRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiGetShareRequestApplicationJsonInterfaceBuilder b) {
+    b.includeTags = _$includeTags;
+  }
 
-  /// Returns the enum value associated to the [name].
-  static ShareapiGetShareIncludeTags valueOf(String name) => _$valueOfShareapiGetShareIncludeTags(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for ShareapiGetShareIncludeTags.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ShareapiGetShareIncludeTags> get serializer => const _$ShareapiGetShareIncludeTagsSerializer();
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiGetShareRequestApplicationJsonInterfaceBuilder b) {}
 }
 
-class _$ShareapiGetShareIncludeTagsSerializer implements PrimitiveSerializer<ShareapiGetShareIncludeTags> {
-  const _$ShareapiGetShareIncludeTagsSerializer();
+abstract class ShareapiGetShareRequestApplicationJson
+    implements
+        $ShareapiGetShareRequestApplicationJsonInterface,
+        Built<ShareapiGetShareRequestApplicationJson, ShareapiGetShareRequestApplicationJsonBuilder> {
+  /// Creates a new ShareapiGetShareRequestApplicationJson object using the builder pattern.
+  factory ShareapiGetShareRequestApplicationJson([void Function(ShareapiGetShareRequestApplicationJsonBuilder)? b]) =
+      _$ShareapiGetShareRequestApplicationJson;
 
-  static const Map<ShareapiGetShareIncludeTags, Object> _toWire = <ShareapiGetShareIncludeTags, Object>{
-    ShareapiGetShareIncludeTags.$0: 0,
-    ShareapiGetShareIncludeTags.$1: 1,
-  };
+  // coverage:ignore-start
+  const ShareapiGetShareRequestApplicationJson._();
+  // coverage:ignore-end
 
-  static const Map<Object, ShareapiGetShareIncludeTags> _fromWire = <Object, ShareapiGetShareIncludeTags>{
-    0: ShareapiGetShareIncludeTags.$0,
-    1: ShareapiGetShareIncludeTags.$1,
-  };
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ShareapiGetShareRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
 
-  @override
-  Iterable<Type> get types => const [ShareapiGetShareIncludeTags];
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
 
-  @override
-  String get wireName => 'ShareapiGetShareIncludeTags';
+  /// Serializer for ShareapiGetShareRequestApplicationJson.
+  static Serializer<ShareapiGetShareRequestApplicationJson> get serializer =>
+      _$shareapiGetShareRequestApplicationJsonSerializer;
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    ShareapiGetShareIncludeTags object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiGetShareRequestApplicationJsonBuilder b) {
+    $ShareapiGetShareRequestApplicationJsonInterface._defaults(b);
+  }
 
-  @override
-  ShareapiGetShareIncludeTags deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiGetShareRequestApplicationJsonBuilder b) {
+    $ShareapiGetShareRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -4797,6 +4954,94 @@ abstract class ShareapiGetShareResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(ShareapiGetShareResponseApplicationJsonBuilder b) {
     $ShareapiGetShareResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ShareapiUpdateShareRequestApplicationJsonInterface {
+  /// New permissions.
+  int? get permissions;
+
+  /// New password.
+  String? get password;
+
+  /// New condition if the password should be send over Talk.
+  String? get sendPasswordByTalk;
+
+  /// New condition if public uploading is allowed.
+  String? get publicUpload;
+
+  /// New expiry date.
+  String? get expireDate;
+
+  /// New note.
+  String? get note;
+
+  /// New label.
+  String? get label;
+
+  /// New condition if the download should be hidden.
+  String? get hideDownload;
+
+  /// New additional attributes.
+  String? get attributes;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareapiUpdateShareRequestApplicationJsonInterfaceBuilder].
+  $ShareapiUpdateShareRequestApplicationJsonInterface rebuild(
+    void Function($ShareapiUpdateShareRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareapiUpdateShareRequestApplicationJsonInterfaceBuilder].
+  $ShareapiUpdateShareRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareapiUpdateShareRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareapiUpdateShareRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ShareapiUpdateShareRequestApplicationJson
+    implements
+        $ShareapiUpdateShareRequestApplicationJsonInterface,
+        Built<ShareapiUpdateShareRequestApplicationJson, ShareapiUpdateShareRequestApplicationJsonBuilder> {
+  /// Creates a new ShareapiUpdateShareRequestApplicationJson object using the builder pattern.
+  factory ShareapiUpdateShareRequestApplicationJson([
+    void Function(ShareapiUpdateShareRequestApplicationJsonBuilder)? b,
+  ]) = _$ShareapiUpdateShareRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ShareapiUpdateShareRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ShareapiUpdateShareRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ShareapiUpdateShareRequestApplicationJson.
+  static Serializer<ShareapiUpdateShareRequestApplicationJson> get serializer =>
+      _$shareapiUpdateShareRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareapiUpdateShareRequestApplicationJsonBuilder b) {
+    $ShareapiUpdateShareRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareapiUpdateShareRequestApplicationJsonBuilder b) {
+    $ShareapiUpdateShareRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -5181,69 +5426,113 @@ abstract class ShareapiAcceptShareResponseApplicationJson
   }
 }
 
-typedef ShareesapiSearchShareType = ({BuiltList<int>? builtListInt, int? $int});
+/// Limit to specific share types.
+typedef ShareesapiSearchRequestApplicationJson_ShareType = ({BuiltList<int>? builtListInt, int? $int});
 
-class ShareesapiSearchLookup extends EnumClass {
-  const ShareesapiSearchLookup._(super.name);
+@BuiltValue(instantiable: false)
+sealed class $ShareesapiSearchRequestApplicationJsonInterface {
+  static final _$search = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ShareesapiSearchLookup $0 = _$shareesapiSearchLookup$0;
+  static final _$page = _$jsonSerializers.deserialize(
+    1,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ShareesapiSearchLookup $1 = _$shareesapiSearchLookup$1;
+  static final _$perPage = _$jsonSerializers.deserialize(
+    200,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<ShareesapiSearchLookup> get values => _$shareesapiSearchLookupValues;
-  // coverage:ignore-end
+  static final _$lookup = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  /// Returns the enum value associated to the [name].
-  static ShareesapiSearchLookup valueOf(String name) => _$valueOfShareesapiSearchLookup(name);
+  /// Text to search for.
+  String get search;
 
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+  /// Limit to specific item types.
+  String? get itemType;
 
-  /// Serializer for ShareesapiSearchLookup.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ShareesapiSearchLookup> get serializer => const _$ShareesapiSearchLookupSerializer();
+  /// Page offset for searching.
+  int get page;
+
+  /// Limit amount of search results per page.
+  int get perPage;
+
+  /// Limit to specific share types.
+  ShareesapiSearchRequestApplicationJson_ShareType? get shareType;
+
+  /// If a global lookup should be performed too.
+  bool get lookup;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareesapiSearchRequestApplicationJsonInterfaceBuilder].
+  $ShareesapiSearchRequestApplicationJsonInterface rebuild(
+    void Function($ShareesapiSearchRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareesapiSearchRequestApplicationJsonInterfaceBuilder].
+  $ShareesapiSearchRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareesapiSearchRequestApplicationJsonInterfaceBuilder b) {
+    b.search = _$search;
+    b.page = _$page;
+    b.perPage = _$perPage;
+    b.lookup = _$lookup;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareesapiSearchRequestApplicationJsonInterfaceBuilder b) {
+    b.shareType?.validateOneOf();
+  }
 }
 
-class _$ShareesapiSearchLookupSerializer implements PrimitiveSerializer<ShareesapiSearchLookup> {
-  const _$ShareesapiSearchLookupSerializer();
+abstract class ShareesapiSearchRequestApplicationJson
+    implements
+        $ShareesapiSearchRequestApplicationJsonInterface,
+        Built<ShareesapiSearchRequestApplicationJson, ShareesapiSearchRequestApplicationJsonBuilder> {
+  /// Creates a new ShareesapiSearchRequestApplicationJson object using the builder pattern.
+  factory ShareesapiSearchRequestApplicationJson([void Function(ShareesapiSearchRequestApplicationJsonBuilder)? b]) =
+      _$ShareesapiSearchRequestApplicationJson;
 
-  static const Map<ShareesapiSearchLookup, Object> _toWire = <ShareesapiSearchLookup, Object>{
-    ShareesapiSearchLookup.$0: 0,
-    ShareesapiSearchLookup.$1: 1,
-  };
+  // coverage:ignore-start
+  const ShareesapiSearchRequestApplicationJson._();
+  // coverage:ignore-end
 
-  static const Map<Object, ShareesapiSearchLookup> _fromWire = <Object, ShareesapiSearchLookup>{
-    0: ShareesapiSearchLookup.$0,
-    1: ShareesapiSearchLookup.$1,
-  };
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ShareesapiSearchRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
 
-  @override
-  Iterable<Type> get types => const [ShareesapiSearchLookup];
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
 
-  @override
-  String get wireName => 'ShareesapiSearchLookup';
+  /// Serializer for ShareesapiSearchRequestApplicationJson.
+  static Serializer<ShareesapiSearchRequestApplicationJson> get serializer =>
+      _$shareesapiSearchRequestApplicationJsonSerializer;
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    ShareesapiSearchLookup object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareesapiSearchRequestApplicationJsonBuilder b) {
+    $ShareesapiSearchRequestApplicationJsonInterface._defaults(b);
+  }
 
-  @override
-  ShareesapiSearchLookup deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareesapiSearchRequestApplicationJsonBuilder b) {
+    $ShareesapiSearchRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -6486,7 +6775,77 @@ abstract class ShareesapiShareesapiSearchHeaders
   }
 }
 
-typedef ShareesapiFindRecommendedShareType = ({BuiltList<int>? builtListInt, int? $int});
+/// Limit to specific share types.
+typedef ShareesapiFindRecommendedRequestApplicationJson_ShareType = ({BuiltList<int>? builtListInt, int? $int});
+
+@BuiltValue(instantiable: false)
+sealed class $ShareesapiFindRecommendedRequestApplicationJsonInterface {
+  /// Limit to specific item types.
+  String get itemType;
+
+  /// Limit to specific share types.
+  ShareesapiFindRecommendedRequestApplicationJson_ShareType? get shareType;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ShareesapiFindRecommendedRequestApplicationJsonInterfaceBuilder].
+  $ShareesapiFindRecommendedRequestApplicationJsonInterface rebuild(
+    void Function($ShareesapiFindRecommendedRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ShareesapiFindRecommendedRequestApplicationJsonInterfaceBuilder].
+  $ShareesapiFindRecommendedRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ShareesapiFindRecommendedRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ShareesapiFindRecommendedRequestApplicationJsonInterfaceBuilder b) {
+    b.shareType?.validateOneOf();
+  }
+}
+
+abstract class ShareesapiFindRecommendedRequestApplicationJson
+    implements
+        $ShareesapiFindRecommendedRequestApplicationJsonInterface,
+        Built<ShareesapiFindRecommendedRequestApplicationJson, ShareesapiFindRecommendedRequestApplicationJsonBuilder> {
+  /// Creates a new ShareesapiFindRecommendedRequestApplicationJson object using the builder pattern.
+  factory ShareesapiFindRecommendedRequestApplicationJson([
+    void Function(ShareesapiFindRecommendedRequestApplicationJsonBuilder)? b,
+  ]) = _$ShareesapiFindRecommendedRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ShareesapiFindRecommendedRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ShareesapiFindRecommendedRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ShareesapiFindRecommendedRequestApplicationJson.
+  static Serializer<ShareesapiFindRecommendedRequestApplicationJson> get serializer =>
+      _$shareesapiFindRecommendedRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ShareesapiFindRecommendedRequestApplicationJsonBuilder b) {
+    $ShareesapiFindRecommendedRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ShareesapiFindRecommendedRequestApplicationJsonBuilder b) {
+    $ShareesapiFindRecommendedRequestApplicationJsonInterface._validate(b);
+  }
+}
 
 @BuiltValue(instantiable: false)
 sealed class $ShareesRecommendedResult_ExactInterface {
@@ -7714,29 +8073,33 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
   }
 }
 
-/// Serialization extension for `ShareesapiSearchShareType`.
-extension $ShareesapiSearchShareTypeExtension on ShareesapiSearchShareType {
-  /// Serializer for ShareesapiSearchShareType.
+/// Serialization extension for `ShareesapiSearchRequestApplicationJson_ShareType`.
+extension $ShareesapiSearchRequestApplicationJson_ShareTypeExtension
+    on ShareesapiSearchRequestApplicationJson_ShareType {
+  /// Serializer for ShareesapiSearchRequestApplicationJson_ShareType.
   @BuiltValueSerializer(custom: true)
-  static Serializer<ShareesapiSearchShareType> get serializer => $07eaa0304017ba8abe7f9f20d6a736f3Extension._serializer;
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use `toJson` to serialize it back into json.
-  static ShareesapiSearchShareType fromJson(Object? json) => $07eaa0304017ba8abe7f9f20d6a736f3Extension._fromJson(json);
-}
-
-/// Serialization extension for `ShareesapiFindRecommendedShareType`.
-extension $ShareesapiFindRecommendedShareTypeExtension on ShareesapiFindRecommendedShareType {
-  /// Serializer for ShareesapiFindRecommendedShareType.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ShareesapiFindRecommendedShareType> get serializer =>
+  static Serializer<ShareesapiSearchRequestApplicationJson_ShareType> get serializer =>
       $07eaa0304017ba8abe7f9f20d6a736f3Extension._serializer;
 
   /// Creates a new object from the given [json] data.
   ///
   /// Use `toJson` to serialize it back into json.
-  static ShareesapiFindRecommendedShareType fromJson(Object? json) =>
+  static ShareesapiSearchRequestApplicationJson_ShareType fromJson(Object? json) =>
+      $07eaa0304017ba8abe7f9f20d6a736f3Extension._fromJson(json);
+}
+
+/// Serialization extension for `ShareesapiFindRecommendedRequestApplicationJson_ShareType`.
+extension $ShareesapiFindRecommendedRequestApplicationJson_ShareTypeExtension
+    on ShareesapiFindRecommendedRequestApplicationJson_ShareType {
+  /// Serializer for ShareesapiFindRecommendedRequestApplicationJson_ShareType.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ShareesapiFindRecommendedRequestApplicationJson_ShareType> get serializer =>
+      $07eaa0304017ba8abe7f9f20d6a736f3Extension._serializer;
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use `toJson` to serialize it back into json.
+  static ShareesapiFindRecommendedRequestApplicationJson_ShareType fromJson(Object? json) =>
       $07eaa0304017ba8abe7f9f20d6a736f3Extension._fromJson(json);
 }
 
@@ -7855,7 +8218,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         DeletedShareapiUndeleteResponseApplicationJson_OcsBuilder.new,
       )
       ..add(DeletedShareapiUndeleteResponseApplicationJson_Ocs.serializer)
-      ..add(PublicPreviewGetPreviewA.serializer)
+      ..addBuilderFactory(
+        const FullType(PublicPreviewGetPreviewRequestApplicationJson),
+        PublicPreviewGetPreviewRequestApplicationJsonBuilder.new,
+      )
+      ..add(PublicPreviewGetPreviewRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(RemoteGetSharesResponseApplicationJson),
         RemoteGetSharesResponseApplicationJsonBuilder.new,
@@ -7919,6 +8286,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RemoteUnshareResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RemoteUnshareResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(ShareInfoInfoRequestApplicationJson),
+        ShareInfoInfoRequestApplicationJsonBuilder.new,
+      )
+      ..add(ShareInfoInfoRequestApplicationJson.serializer)
       ..addBuilderFactory(const FullType(ShareInfo), ShareInfoBuilder.new)
       ..add(ShareInfo.serializer)
       ..addBuilderFactory(
@@ -7931,6 +8303,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ]),
         ListBuilder<BuiltMap<String, JsonObject>>.new,
       )
+      ..addBuilderFactory(
+        const FullType(ShareapiGetSharesRequestApplicationJson),
+        ShareapiGetSharesRequestApplicationJsonBuilder.new,
+      )
+      ..add(ShareapiGetSharesRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ShareapiGetSharesResponseApplicationJson),
         ShareapiGetSharesResponseApplicationJsonBuilder.new,
@@ -7950,6 +8327,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(Share_Status.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(Share)]), ListBuilder<Share>.new)
       ..addBuilderFactory(
+        const FullType(ShareapiCreateShareRequestApplicationJson),
+        ShareapiCreateShareRequestApplicationJsonBuilder.new,
+      )
+      ..add(ShareapiCreateShareRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(ShareapiCreateShareResponseApplicationJson),
         ShareapiCreateShareResponseApplicationJsonBuilder.new,
       )
@@ -7959,6 +8341,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ShareapiCreateShareResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ShareapiCreateShareResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(ShareapiGetInheritedSharesRequestApplicationJson),
+        ShareapiGetInheritedSharesRequestApplicationJsonBuilder.new,
+      )
+      ..add(ShareapiGetInheritedSharesRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ShareapiGetInheritedSharesResponseApplicationJson),
         ShareapiGetInheritedSharesResponseApplicationJsonBuilder.new,
@@ -7979,7 +8366,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ShareapiPendingSharesResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ShareapiPendingSharesResponseApplicationJson_Ocs.serializer)
-      ..add(ShareapiGetShareIncludeTags.serializer)
+      ..addBuilderFactory(
+        const FullType(ShareapiGetShareRequestApplicationJson),
+        ShareapiGetShareRequestApplicationJsonBuilder.new,
+      )
+      ..add(ShareapiGetShareRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ShareapiGetShareResponseApplicationJson),
         ShareapiGetShareResponseApplicationJsonBuilder.new,
@@ -7990,6 +8381,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ShareapiGetShareResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ShareapiGetShareResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(ShareapiUpdateShareRequestApplicationJson),
+        ShareapiUpdateShareRequestApplicationJsonBuilder.new,
+      )
+      ..add(ShareapiUpdateShareRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ShareapiUpdateShareResponseApplicationJson),
         ShareapiUpdateShareResponseApplicationJsonBuilder.new,
@@ -8020,9 +8416,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ShareapiAcceptShareResponseApplicationJson_OcsBuilder.new,
       )
       ..add(ShareapiAcceptShareResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(ShareesapiSearchRequestApplicationJson),
+        ShareesapiSearchRequestApplicationJsonBuilder.new,
+      )
+      ..add(ShareesapiSearchRequestApplicationJson.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(int)]), ListBuilder<int>.new)
       ..add($07eaa0304017ba8abe7f9f20d6a736f3Extension._serializer)
-      ..add(ShareesapiSearchLookup.serializer)
       ..addBuilderFactory(
         const FullType(ShareesapiSearchResponseApplicationJson),
         ShareesapiSearchResponseApplicationJsonBuilder.new,
@@ -8079,6 +8479,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ShareesapiShareesapiSearchHeadersBuilder.new,
       )
       ..add(ShareesapiShareesapiSearchHeaders.serializer)
+      ..addBuilderFactory(
+        const FullType(ShareesapiFindRecommendedRequestApplicationJson),
+        ShareesapiFindRecommendedRequestApplicationJsonBuilder.new,
+      )
+      ..add(ShareesapiFindRecommendedRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ShareesapiFindRecommendedResponseApplicationJson),
         ShareesapiFindRecommendedResponseApplicationJsonBuilder.new,

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.g.dart
@@ -6,26 +6,6 @@ part of 'files_sharing.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-const PublicPreviewGetPreviewA _$publicPreviewGetPreviewA$0 = PublicPreviewGetPreviewA._('\$0');
-const PublicPreviewGetPreviewA _$publicPreviewGetPreviewA$1 = PublicPreviewGetPreviewA._('\$1');
-
-PublicPreviewGetPreviewA _$valueOfPublicPreviewGetPreviewA(String name) {
-  switch (name) {
-    case '\$0':
-      return _$publicPreviewGetPreviewA$0;
-    case '\$1':
-      return _$publicPreviewGetPreviewA$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<PublicPreviewGetPreviewA> _$publicPreviewGetPreviewAValues =
-    BuiltSet<PublicPreviewGetPreviewA>(const <PublicPreviewGetPreviewA>[
-  _$publicPreviewGetPreviewA$0,
-  _$publicPreviewGetPreviewA$1,
-]);
-
 const Share_HideDownload _$shareHideDownload$0 = Share_HideDownload._('\$0');
 const Share_HideDownload _$shareHideDownload$1 = Share_HideDownload._('\$1');
 
@@ -83,46 +63,6 @@ final BuiltSet<Share_MailSend> _$shareMailSendValues = BuiltSet<Share_MailSend>(
   _$shareMailSend$1,
 ]);
 
-const ShareapiGetShareIncludeTags _$shareapiGetShareIncludeTags$0 = ShareapiGetShareIncludeTags._('\$0');
-const ShareapiGetShareIncludeTags _$shareapiGetShareIncludeTags$1 = ShareapiGetShareIncludeTags._('\$1');
-
-ShareapiGetShareIncludeTags _$valueOfShareapiGetShareIncludeTags(String name) {
-  switch (name) {
-    case '\$0':
-      return _$shareapiGetShareIncludeTags$0;
-    case '\$1':
-      return _$shareapiGetShareIncludeTags$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ShareapiGetShareIncludeTags> _$shareapiGetShareIncludeTagsValues =
-    BuiltSet<ShareapiGetShareIncludeTags>(const <ShareapiGetShareIncludeTags>[
-  _$shareapiGetShareIncludeTags$0,
-  _$shareapiGetShareIncludeTags$1,
-]);
-
-const ShareesapiSearchLookup _$shareesapiSearchLookup$0 = ShareesapiSearchLookup._('\$0');
-const ShareesapiSearchLookup _$shareesapiSearchLookup$1 = ShareesapiSearchLookup._('\$1');
-
-ShareesapiSearchLookup _$valueOfShareesapiSearchLookup(String name) {
-  switch (name) {
-    case '\$0':
-      return _$shareesapiSearchLookup$0;
-    case '\$1':
-      return _$shareesapiSearchLookup$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ShareesapiSearchLookup> _$shareesapiSearchLookupValues =
-    BuiltSet<ShareesapiSearchLookup>(const <ShareesapiSearchLookup>[
-  _$shareesapiSearchLookup$0,
-  _$shareesapiSearchLookup$1,
-]);
-
 Serializer<OCSMeta> _$oCSMetaSerializer = _$OCSMetaSerializer();
 Serializer<DeletedShare> _$deletedShareSerializer = _$DeletedShareSerializer();
 Serializer<DeletedShareapiIndexResponseApplicationJson_Ocs> _$deletedShareapiIndexResponseApplicationJsonOcsSerializer =
@@ -134,6 +74,8 @@ Serializer<DeletedShareapiUndeleteResponseApplicationJson_Ocs>
     _$DeletedShareapiUndeleteResponseApplicationJson_OcsSerializer();
 Serializer<DeletedShareapiUndeleteResponseApplicationJson> _$deletedShareapiUndeleteResponseApplicationJsonSerializer =
     _$DeletedShareapiUndeleteResponseApplicationJsonSerializer();
+Serializer<PublicPreviewGetPreviewRequestApplicationJson> _$publicPreviewGetPreviewRequestApplicationJsonSerializer =
+    _$PublicPreviewGetPreviewRequestApplicationJsonSerializer();
 Serializer<RemoteShare> _$remoteShareSerializer = _$RemoteShareSerializer();
 Serializer<RemoteGetSharesResponseApplicationJson_Ocs> _$remoteGetSharesResponseApplicationJsonOcsSerializer =
     _$RemoteGetSharesResponseApplicationJson_OcsSerializer();
@@ -159,17 +101,26 @@ Serializer<RemoteUnshareResponseApplicationJson_Ocs> _$remoteUnshareResponseAppl
     _$RemoteUnshareResponseApplicationJson_OcsSerializer();
 Serializer<RemoteUnshareResponseApplicationJson> _$remoteUnshareResponseApplicationJsonSerializer =
     _$RemoteUnshareResponseApplicationJsonSerializer();
+Serializer<ShareInfoInfoRequestApplicationJson> _$shareInfoInfoRequestApplicationJsonSerializer =
+    _$ShareInfoInfoRequestApplicationJsonSerializer();
 Serializer<ShareInfo> _$shareInfoSerializer = _$ShareInfoSerializer();
+Serializer<ShareapiGetSharesRequestApplicationJson> _$shareapiGetSharesRequestApplicationJsonSerializer =
+    _$ShareapiGetSharesRequestApplicationJsonSerializer();
 Serializer<Share_Status> _$shareStatusSerializer = _$Share_StatusSerializer();
 Serializer<Share> _$shareSerializer = _$ShareSerializer();
 Serializer<ShareapiGetSharesResponseApplicationJson_Ocs> _$shareapiGetSharesResponseApplicationJsonOcsSerializer =
     _$ShareapiGetSharesResponseApplicationJson_OcsSerializer();
 Serializer<ShareapiGetSharesResponseApplicationJson> _$shareapiGetSharesResponseApplicationJsonSerializer =
     _$ShareapiGetSharesResponseApplicationJsonSerializer();
+Serializer<ShareapiCreateShareRequestApplicationJson> _$shareapiCreateShareRequestApplicationJsonSerializer =
+    _$ShareapiCreateShareRequestApplicationJsonSerializer();
 Serializer<ShareapiCreateShareResponseApplicationJson_Ocs> _$shareapiCreateShareResponseApplicationJsonOcsSerializer =
     _$ShareapiCreateShareResponseApplicationJson_OcsSerializer();
 Serializer<ShareapiCreateShareResponseApplicationJson> _$shareapiCreateShareResponseApplicationJsonSerializer =
     _$ShareapiCreateShareResponseApplicationJsonSerializer();
+Serializer<ShareapiGetInheritedSharesRequestApplicationJson>
+    _$shareapiGetInheritedSharesRequestApplicationJsonSerializer =
+    _$ShareapiGetInheritedSharesRequestApplicationJsonSerializer();
 Serializer<ShareapiGetInheritedSharesResponseApplicationJson_Ocs>
     _$shareapiGetInheritedSharesResponseApplicationJsonOcsSerializer =
     _$ShareapiGetInheritedSharesResponseApplicationJson_OcsSerializer();
@@ -181,10 +132,14 @@ Serializer<ShareapiPendingSharesResponseApplicationJson_Ocs>
     _$ShareapiPendingSharesResponseApplicationJson_OcsSerializer();
 Serializer<ShareapiPendingSharesResponseApplicationJson> _$shareapiPendingSharesResponseApplicationJsonSerializer =
     _$ShareapiPendingSharesResponseApplicationJsonSerializer();
+Serializer<ShareapiGetShareRequestApplicationJson> _$shareapiGetShareRequestApplicationJsonSerializer =
+    _$ShareapiGetShareRequestApplicationJsonSerializer();
 Serializer<ShareapiGetShareResponseApplicationJson_Ocs> _$shareapiGetShareResponseApplicationJsonOcsSerializer =
     _$ShareapiGetShareResponseApplicationJson_OcsSerializer();
 Serializer<ShareapiGetShareResponseApplicationJson> _$shareapiGetShareResponseApplicationJsonSerializer =
     _$ShareapiGetShareResponseApplicationJsonSerializer();
+Serializer<ShareapiUpdateShareRequestApplicationJson> _$shareapiUpdateShareRequestApplicationJsonSerializer =
+    _$ShareapiUpdateShareRequestApplicationJsonSerializer();
 Serializer<ShareapiUpdateShareResponseApplicationJson_Ocs> _$shareapiUpdateShareResponseApplicationJsonOcsSerializer =
     _$ShareapiUpdateShareResponseApplicationJson_OcsSerializer();
 Serializer<ShareapiUpdateShareResponseApplicationJson> _$shareapiUpdateShareResponseApplicationJsonSerializer =
@@ -197,6 +152,8 @@ Serializer<ShareapiAcceptShareResponseApplicationJson_Ocs> _$shareapiAcceptShare
     _$ShareapiAcceptShareResponseApplicationJson_OcsSerializer();
 Serializer<ShareapiAcceptShareResponseApplicationJson> _$shareapiAcceptShareResponseApplicationJsonSerializer =
     _$ShareapiAcceptShareResponseApplicationJsonSerializer();
+Serializer<ShareesapiSearchRequestApplicationJson> _$shareesapiSearchRequestApplicationJsonSerializer =
+    _$ShareesapiSearchRequestApplicationJsonSerializer();
 Serializer<Sharee> _$shareeSerializer = _$ShareeSerializer();
 Serializer<ShareeValue> _$shareeValueSerializer = _$ShareeValueSerializer();
 Serializer<ShareeCircle_Value> _$shareeCircleValueSerializer = _$ShareeCircle_ValueSerializer();
@@ -220,6 +177,9 @@ Serializer<ShareesapiSearchResponseApplicationJson> _$shareesapiSearchResponseAp
     _$ShareesapiSearchResponseApplicationJsonSerializer();
 Serializer<ShareesapiShareesapiSearchHeaders> _$shareesapiShareesapiSearchHeadersSerializer =
     _$ShareesapiShareesapiSearchHeadersSerializer();
+Serializer<ShareesapiFindRecommendedRequestApplicationJson>
+    _$shareesapiFindRecommendedRequestApplicationJsonSerializer =
+    _$ShareesapiFindRecommendedRequestApplicationJsonSerializer();
 Serializer<ShareesRecommendedResult_Exact> _$shareesRecommendedResultExactSerializer =
     _$ShareesRecommendedResult_ExactSerializer();
 Serializer<ShareesRecommendedResult> _$shareesRecommendedResultSerializer = _$ShareesRecommendedResultSerializer();
@@ -658,6 +618,63 @@ class _$DeletedShareapiUndeleteResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(DeletedShareapiUndeleteResponseApplicationJson_Ocs))!
               as DeletedShareapiUndeleteResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$PublicPreviewGetPreviewRequestApplicationJsonSerializer
+    implements StructuredSerializer<PublicPreviewGetPreviewRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    PublicPreviewGetPreviewRequestApplicationJson,
+    _$PublicPreviewGetPreviewRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'PublicPreviewGetPreviewRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PublicPreviewGetPreviewRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'file',
+      serializers.serialize(object.file, specifiedType: const FullType(String)),
+      'x',
+      serializers.serialize(object.x, specifiedType: const FullType(int)),
+      'y',
+      serializers.serialize(object.y, specifiedType: const FullType(int)),
+      'a',
+      serializers.serialize(object.a, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  PublicPreviewGetPreviewRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PublicPreviewGetPreviewRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'file':
+          result.file = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'x':
+          result.x = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'y':
+          result.y = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'a':
+          result.a = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -1343,6 +1360,68 @@ class _$RemoteUnshareResponseApplicationJsonSerializer
   }
 }
 
+class _$ShareInfoInfoRequestApplicationJsonSerializer
+    implements StructuredSerializer<ShareInfoInfoRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ShareInfoInfoRequestApplicationJson, _$ShareInfoInfoRequestApplicationJson];
+  @override
+  final String wireName = 'ShareInfoInfoRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ShareInfoInfoRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      't',
+      serializers.serialize(object.t, specifiedType: const FullType(String)),
+      'depth',
+      serializers.serialize(object.depth, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.password;
+    if (value != null) {
+      result
+        ..add('password')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.dir;
+    if (value != null) {
+      result
+        ..add('dir')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  ShareInfoInfoRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ShareInfoInfoRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 't':
+          result.t = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'password':
+          result.password = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'dir':
+          result.dir = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'depth':
+          result.depth = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ShareInfoSerializer implements StructuredSerializer<ShareInfo> {
   @override
   final Iterable<Type> types = const [ShareInfo, _$ShareInfo];
@@ -1428,6 +1507,68 @@ class _$ShareInfoSerializer implements StructuredSerializer<ShareInfo> {
               specifiedType: const FullType(BuiltList, [
                 FullType(BuiltMap, [FullType(String), FullType(JsonObject)])
               ]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ShareapiGetSharesRequestApplicationJsonSerializer
+    implements StructuredSerializer<ShareapiGetSharesRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ShareapiGetSharesRequestApplicationJson,
+    _$ShareapiGetSharesRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ShareapiGetSharesRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ShareapiGetSharesRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'shared_with_me',
+      serializers.serialize(object.sharedWithMe, specifiedType: const FullType(String)),
+      'reshares',
+      serializers.serialize(object.reshares, specifiedType: const FullType(String)),
+      'subfiles',
+      serializers.serialize(object.subfiles, specifiedType: const FullType(String)),
+      'path',
+      serializers.serialize(object.path, specifiedType: const FullType(String)),
+      'include_tags',
+      serializers.serialize(object.includeTags, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ShareapiGetSharesRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ShareapiGetSharesRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'shared_with_me':
+          result.sharedWithMe = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'reshares':
+          result.reshares = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'subfiles':
+          result.subfiles = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'path':
+          result.path = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'include_tags':
+          result.includeTags = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -1902,6 +2043,118 @@ class _$ShareapiGetSharesResponseApplicationJsonSerializer
   }
 }
 
+class _$ShareapiCreateShareRequestApplicationJsonSerializer
+    implements StructuredSerializer<ShareapiCreateShareRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ShareapiCreateShareRequestApplicationJson,
+    _$ShareapiCreateShareRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ShareapiCreateShareRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ShareapiCreateShareRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'shareType',
+      serializers.serialize(object.shareType, specifiedType: const FullType(int)),
+      'publicUpload',
+      serializers.serialize(object.publicUpload, specifiedType: const FullType(String)),
+      'password',
+      serializers.serialize(object.password, specifiedType: const FullType(String)),
+      'expireDate',
+      serializers.serialize(object.expireDate, specifiedType: const FullType(String)),
+      'note',
+      serializers.serialize(object.note, specifiedType: const FullType(String)),
+      'label',
+      serializers.serialize(object.label, specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.path;
+    if (value != null) {
+      result
+        ..add('path')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.permissions;
+    if (value != null) {
+      result
+        ..add('permissions')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.shareWith;
+    if (value != null) {
+      result
+        ..add('shareWith')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.sendPasswordByTalk;
+    if (value != null) {
+      result
+        ..add('sendPasswordByTalk')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.attributes;
+    if (value != null) {
+      result
+        ..add('attributes')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  ShareapiCreateShareRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ShareapiCreateShareRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'path':
+          result.path = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'permissions':
+          result.permissions = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'shareType':
+          result.shareType = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'shareWith':
+          result.shareWith = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'publicUpload':
+          result.publicUpload = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'password':
+          result.password = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'sendPasswordByTalk':
+          result.sendPasswordByTalk = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'expireDate':
+          result.expireDate = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'note':
+          result.note = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'attributes':
+          result.attributes = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ShareapiCreateShareResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ShareapiCreateShareResponseApplicationJson_Ocs> {
   @override
@@ -1985,6 +2238,48 @@ class _$ShareapiCreateShareResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(ShareapiCreateShareResponseApplicationJson_Ocs))!
               as ShareapiCreateShareResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ShareapiGetInheritedSharesRequestApplicationJsonSerializer
+    implements StructuredSerializer<ShareapiGetInheritedSharesRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ShareapiGetInheritedSharesRequestApplicationJson,
+    _$ShareapiGetInheritedSharesRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ShareapiGetInheritedSharesRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ShareapiGetInheritedSharesRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'path',
+      serializers.serialize(object.path, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ShareapiGetInheritedSharesRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ShareapiGetInheritedSharesRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'path':
+          result.path = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -2180,6 +2475,45 @@ class _$ShareapiPendingSharesResponseApplicationJsonSerializer
   }
 }
 
+class _$ShareapiGetShareRequestApplicationJsonSerializer
+    implements StructuredSerializer<ShareapiGetShareRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ShareapiGetShareRequestApplicationJson, _$ShareapiGetShareRequestApplicationJson];
+  @override
+  final String wireName = 'ShareapiGetShareRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ShareapiGetShareRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'include_tags',
+      serializers.serialize(object.includeTags, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ShareapiGetShareRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ShareapiGetShareRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'include_tags':
+          result.includeTags = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ShareapiGetShareResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ShareapiGetShareResponseApplicationJson_Ocs> {
   @override
@@ -2263,6 +2597,123 @@ class _$ShareapiGetShareResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(ShareapiGetShareResponseApplicationJson_Ocs))!
               as ShareapiGetShareResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ShareapiUpdateShareRequestApplicationJsonSerializer
+    implements StructuredSerializer<ShareapiUpdateShareRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ShareapiUpdateShareRequestApplicationJson,
+    _$ShareapiUpdateShareRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ShareapiUpdateShareRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ShareapiUpdateShareRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.permissions;
+    if (value != null) {
+      result
+        ..add('permissions')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.password;
+    if (value != null) {
+      result
+        ..add('password')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.sendPasswordByTalk;
+    if (value != null) {
+      result
+        ..add('sendPasswordByTalk')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.publicUpload;
+    if (value != null) {
+      result
+        ..add('publicUpload')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.expireDate;
+    if (value != null) {
+      result
+        ..add('expireDate')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.note;
+    if (value != null) {
+      result
+        ..add('note')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.label;
+    if (value != null) {
+      result
+        ..add('label')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.hideDownload;
+    if (value != null) {
+      result
+        ..add('hideDownload')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.attributes;
+    if (value != null) {
+      result
+        ..add('attributes')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  ShareapiUpdateShareRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ShareapiUpdateShareRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'permissions':
+          result.permissions = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'password':
+          result.password = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'sendPasswordByTalk':
+          result.sendPasswordByTalk = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'publicUpload':
+          result.publicUpload = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'expireDate':
+          result.expireDate = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'note':
+          result.note = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'label':
+          result.label = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'hideDownload':
+          result.hideDownload = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'attributes':
+          result.attributes = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -2536,6 +2987,81 @@ class _$ShareapiAcceptShareResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(ShareapiAcceptShareResponseApplicationJson_Ocs))!
               as ShareapiAcceptShareResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ShareesapiSearchRequestApplicationJsonSerializer
+    implements StructuredSerializer<ShareesapiSearchRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ShareesapiSearchRequestApplicationJson, _$ShareesapiSearchRequestApplicationJson];
+  @override
+  final String wireName = 'ShareesapiSearchRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ShareesapiSearchRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'search',
+      serializers.serialize(object.search, specifiedType: const FullType(String)),
+      'page',
+      serializers.serialize(object.page, specifiedType: const FullType(int)),
+      'perPage',
+      serializers.serialize(object.perPage, specifiedType: const FullType(int)),
+      'lookup',
+      serializers.serialize(object.lookup, specifiedType: const FullType(bool)),
+    ];
+    Object? value;
+    value = object.itemType;
+    if (value != null) {
+      result
+        ..add('itemType')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.shareType;
+    if (value != null) {
+      result
+        ..add('shareType')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(ShareesapiSearchRequestApplicationJson_ShareType)));
+    }
+    return result;
+  }
+
+  @override
+  ShareesapiSearchRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ShareesapiSearchRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'search':
+          result.search = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'itemType':
+          result.itemType = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'page':
+          result.page = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'perPage':
+          result.perPage = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'shareType':
+          result.shareType = serializers.deserialize(value,
+                  specifiedType: const FullType(ShareesapiSearchRequestApplicationJson_ShareType))
+              as ShareesapiSearchRequestApplicationJson_ShareType?;
+          break;
+        case 'lookup':
+          result.lookup = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -3737,6 +4263,60 @@ class _$ShareesapiShareesapiSearchHeadersSerializer implements StructuredSeriali
       switch (key) {
         case 'link':
           result.link = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ShareesapiFindRecommendedRequestApplicationJsonSerializer
+    implements StructuredSerializer<ShareesapiFindRecommendedRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ShareesapiFindRecommendedRequestApplicationJson,
+    _$ShareesapiFindRecommendedRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ShareesapiFindRecommendedRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ShareesapiFindRecommendedRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'itemType',
+      serializers.serialize(object.itemType, specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.shareType;
+    if (value != null) {
+      result
+        ..add('shareType')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(ShareesapiFindRecommendedRequestApplicationJson_ShareType)));
+    }
+    return result;
+  }
+
+  @override
+  ShareesapiFindRecommendedRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ShareesapiFindRecommendedRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'itemType':
+          result.itemType = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'shareType':
+          result.shareType = serializers.deserialize(value,
+                  specifiedType: const FullType(ShareesapiFindRecommendedRequestApplicationJson_ShareType))
+              as ShareesapiFindRecommendedRequestApplicationJson_ShareType?;
           break;
       }
     }
@@ -5833,6 +6413,151 @@ class DeletedShareapiUndeleteResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $PublicPreviewGetPreviewRequestApplicationJsonInterfaceBuilder {
+  void replace($PublicPreviewGetPreviewRequestApplicationJsonInterface other);
+  void update(void Function($PublicPreviewGetPreviewRequestApplicationJsonInterfaceBuilder) updates);
+  String? get file;
+  set file(String? file);
+
+  int? get x;
+  set x(int? x);
+
+  int? get y;
+  set y(int? y);
+
+  bool? get a;
+  set a(bool? a);
+}
+
+class _$PublicPreviewGetPreviewRequestApplicationJson extends PublicPreviewGetPreviewRequestApplicationJson {
+  @override
+  final String file;
+  @override
+  final int x;
+  @override
+  final int y;
+  @override
+  final bool a;
+
+  factory _$PublicPreviewGetPreviewRequestApplicationJson(
+          [void Function(PublicPreviewGetPreviewRequestApplicationJsonBuilder)? updates]) =>
+      (PublicPreviewGetPreviewRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PublicPreviewGetPreviewRequestApplicationJson._(
+      {required this.file, required this.x, required this.y, required this.a})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(file, r'PublicPreviewGetPreviewRequestApplicationJson', 'file');
+    BuiltValueNullFieldError.checkNotNull(x, r'PublicPreviewGetPreviewRequestApplicationJson', 'x');
+    BuiltValueNullFieldError.checkNotNull(y, r'PublicPreviewGetPreviewRequestApplicationJson', 'y');
+    BuiltValueNullFieldError.checkNotNull(a, r'PublicPreviewGetPreviewRequestApplicationJson', 'a');
+  }
+
+  @override
+  PublicPreviewGetPreviewRequestApplicationJson rebuild(
+          void Function(PublicPreviewGetPreviewRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PublicPreviewGetPreviewRequestApplicationJsonBuilder toBuilder() =>
+      PublicPreviewGetPreviewRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PublicPreviewGetPreviewRequestApplicationJson &&
+        file == other.file &&
+        x == other.x &&
+        y == other.y &&
+        a == other.a;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, file.hashCode);
+    _$hash = $jc(_$hash, x.hashCode);
+    _$hash = $jc(_$hash, y.hashCode);
+    _$hash = $jc(_$hash, a.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PublicPreviewGetPreviewRequestApplicationJson')
+          ..add('file', file)
+          ..add('x', x)
+          ..add('y', y)
+          ..add('a', a))
+        .toString();
+  }
+}
+
+class PublicPreviewGetPreviewRequestApplicationJsonBuilder
+    implements
+        Builder<PublicPreviewGetPreviewRequestApplicationJson, PublicPreviewGetPreviewRequestApplicationJsonBuilder>,
+        $PublicPreviewGetPreviewRequestApplicationJsonInterfaceBuilder {
+  _$PublicPreviewGetPreviewRequestApplicationJson? _$v;
+
+  String? _file;
+  String? get file => _$this._file;
+  set file(covariant String? file) => _$this._file = file;
+
+  int? _x;
+  int? get x => _$this._x;
+  set x(covariant int? x) => _$this._x = x;
+
+  int? _y;
+  int? get y => _$this._y;
+  set y(covariant int? y) => _$this._y = y;
+
+  bool? _a;
+  bool? get a => _$this._a;
+  set a(covariant bool? a) => _$this._a = a;
+
+  PublicPreviewGetPreviewRequestApplicationJsonBuilder() {
+    PublicPreviewGetPreviewRequestApplicationJson._defaults(this);
+  }
+
+  PublicPreviewGetPreviewRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _file = $v.file;
+      _x = $v.x;
+      _y = $v.y;
+      _a = $v.a;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PublicPreviewGetPreviewRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PublicPreviewGetPreviewRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PublicPreviewGetPreviewRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PublicPreviewGetPreviewRequestApplicationJson build() => _build();
+
+  _$PublicPreviewGetPreviewRequestApplicationJson _build() {
+    PublicPreviewGetPreviewRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$PublicPreviewGetPreviewRequestApplicationJson._(
+            file: BuiltValueNullFieldError.checkNotNull(file, r'PublicPreviewGetPreviewRequestApplicationJson', 'file'),
+            x: BuiltValueNullFieldError.checkNotNull(x, r'PublicPreviewGetPreviewRequestApplicationJson', 'x'),
+            y: BuiltValueNullFieldError.checkNotNull(y, r'PublicPreviewGetPreviewRequestApplicationJson', 'y'),
+            a: BuiltValueNullFieldError.checkNotNull(a, r'PublicPreviewGetPreviewRequestApplicationJson', 'a'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RemoteShareInterfaceBuilder {
   void replace($RemoteShareInterface other);
   void update(void Function($RemoteShareInterfaceBuilder) updates);
@@ -7532,6 +8257,144 @@ class RemoteUnshareResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $ShareInfoInfoRequestApplicationJsonInterfaceBuilder {
+  void replace($ShareInfoInfoRequestApplicationJsonInterface other);
+  void update(void Function($ShareInfoInfoRequestApplicationJsonInterfaceBuilder) updates);
+  String? get t;
+  set t(String? t);
+
+  String? get password;
+  set password(String? password);
+
+  String? get dir;
+  set dir(String? dir);
+
+  int? get depth;
+  set depth(int? depth);
+}
+
+class _$ShareInfoInfoRequestApplicationJson extends ShareInfoInfoRequestApplicationJson {
+  @override
+  final String t;
+  @override
+  final String? password;
+  @override
+  final String? dir;
+  @override
+  final int depth;
+
+  factory _$ShareInfoInfoRequestApplicationJson([void Function(ShareInfoInfoRequestApplicationJsonBuilder)? updates]) =>
+      (ShareInfoInfoRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ShareInfoInfoRequestApplicationJson._({required this.t, this.password, this.dir, required this.depth}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(t, r'ShareInfoInfoRequestApplicationJson', 't');
+    BuiltValueNullFieldError.checkNotNull(depth, r'ShareInfoInfoRequestApplicationJson', 'depth');
+  }
+
+  @override
+  ShareInfoInfoRequestApplicationJson rebuild(void Function(ShareInfoInfoRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ShareInfoInfoRequestApplicationJsonBuilder toBuilder() => ShareInfoInfoRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ShareInfoInfoRequestApplicationJson &&
+        t == other.t &&
+        password == other.password &&
+        dir == other.dir &&
+        depth == other.depth;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, t.hashCode);
+    _$hash = $jc(_$hash, password.hashCode);
+    _$hash = $jc(_$hash, dir.hashCode);
+    _$hash = $jc(_$hash, depth.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ShareInfoInfoRequestApplicationJson')
+          ..add('t', t)
+          ..add('password', password)
+          ..add('dir', dir)
+          ..add('depth', depth))
+        .toString();
+  }
+}
+
+class ShareInfoInfoRequestApplicationJsonBuilder
+    implements
+        Builder<ShareInfoInfoRequestApplicationJson, ShareInfoInfoRequestApplicationJsonBuilder>,
+        $ShareInfoInfoRequestApplicationJsonInterfaceBuilder {
+  _$ShareInfoInfoRequestApplicationJson? _$v;
+
+  String? _t;
+  String? get t => _$this._t;
+  set t(covariant String? t) => _$this._t = t;
+
+  String? _password;
+  String? get password => _$this._password;
+  set password(covariant String? password) => _$this._password = password;
+
+  String? _dir;
+  String? get dir => _$this._dir;
+  set dir(covariant String? dir) => _$this._dir = dir;
+
+  int? _depth;
+  int? get depth => _$this._depth;
+  set depth(covariant int? depth) => _$this._depth = depth;
+
+  ShareInfoInfoRequestApplicationJsonBuilder() {
+    ShareInfoInfoRequestApplicationJson._defaults(this);
+  }
+
+  ShareInfoInfoRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _t = $v.t;
+      _password = $v.password;
+      _dir = $v.dir;
+      _depth = $v.depth;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ShareInfoInfoRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ShareInfoInfoRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ShareInfoInfoRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ShareInfoInfoRequestApplicationJson build() => _build();
+
+  _$ShareInfoInfoRequestApplicationJson _build() {
+    ShareInfoInfoRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ShareInfoInfoRequestApplicationJson._(
+            t: BuiltValueNullFieldError.checkNotNull(t, r'ShareInfoInfoRequestApplicationJson', 't'),
+            password: password,
+            dir: dir,
+            depth: BuiltValueNullFieldError.checkNotNull(depth, r'ShareInfoInfoRequestApplicationJson', 'depth'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ShareInfoInterfaceBuilder {
   void replace($ShareInfoInterface other);
   void update(void Function($ShareInfoInterfaceBuilder) updates);
@@ -7775,6 +8638,174 @@ class ShareInfoBuilder implements Builder<ShareInfo, ShareInfoBuilder>, $ShareIn
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ShareapiGetSharesRequestApplicationJsonInterfaceBuilder {
+  void replace($ShareapiGetSharesRequestApplicationJsonInterface other);
+  void update(void Function($ShareapiGetSharesRequestApplicationJsonInterfaceBuilder) updates);
+  String? get sharedWithMe;
+  set sharedWithMe(String? sharedWithMe);
+
+  String? get reshares;
+  set reshares(String? reshares);
+
+  String? get subfiles;
+  set subfiles(String? subfiles);
+
+  String? get path;
+  set path(String? path);
+
+  String? get includeTags;
+  set includeTags(String? includeTags);
+}
+
+class _$ShareapiGetSharesRequestApplicationJson extends ShareapiGetSharesRequestApplicationJson {
+  @override
+  final String sharedWithMe;
+  @override
+  final String reshares;
+  @override
+  final String subfiles;
+  @override
+  final String path;
+  @override
+  final String includeTags;
+
+  factory _$ShareapiGetSharesRequestApplicationJson(
+          [void Function(ShareapiGetSharesRequestApplicationJsonBuilder)? updates]) =>
+      (ShareapiGetSharesRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ShareapiGetSharesRequestApplicationJson._(
+      {required this.sharedWithMe,
+      required this.reshares,
+      required this.subfiles,
+      required this.path,
+      required this.includeTags})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(sharedWithMe, r'ShareapiGetSharesRequestApplicationJson', 'sharedWithMe');
+    BuiltValueNullFieldError.checkNotNull(reshares, r'ShareapiGetSharesRequestApplicationJson', 'reshares');
+    BuiltValueNullFieldError.checkNotNull(subfiles, r'ShareapiGetSharesRequestApplicationJson', 'subfiles');
+    BuiltValueNullFieldError.checkNotNull(path, r'ShareapiGetSharesRequestApplicationJson', 'path');
+    BuiltValueNullFieldError.checkNotNull(includeTags, r'ShareapiGetSharesRequestApplicationJson', 'includeTags');
+  }
+
+  @override
+  ShareapiGetSharesRequestApplicationJson rebuild(
+          void Function(ShareapiGetSharesRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ShareapiGetSharesRequestApplicationJsonBuilder toBuilder() =>
+      ShareapiGetSharesRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ShareapiGetSharesRequestApplicationJson &&
+        sharedWithMe == other.sharedWithMe &&
+        reshares == other.reshares &&
+        subfiles == other.subfiles &&
+        path == other.path &&
+        includeTags == other.includeTags;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, sharedWithMe.hashCode);
+    _$hash = $jc(_$hash, reshares.hashCode);
+    _$hash = $jc(_$hash, subfiles.hashCode);
+    _$hash = $jc(_$hash, path.hashCode);
+    _$hash = $jc(_$hash, includeTags.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ShareapiGetSharesRequestApplicationJson')
+          ..add('sharedWithMe', sharedWithMe)
+          ..add('reshares', reshares)
+          ..add('subfiles', subfiles)
+          ..add('path', path)
+          ..add('includeTags', includeTags))
+        .toString();
+  }
+}
+
+class ShareapiGetSharesRequestApplicationJsonBuilder
+    implements
+        Builder<ShareapiGetSharesRequestApplicationJson, ShareapiGetSharesRequestApplicationJsonBuilder>,
+        $ShareapiGetSharesRequestApplicationJsonInterfaceBuilder {
+  _$ShareapiGetSharesRequestApplicationJson? _$v;
+
+  String? _sharedWithMe;
+  String? get sharedWithMe => _$this._sharedWithMe;
+  set sharedWithMe(covariant String? sharedWithMe) => _$this._sharedWithMe = sharedWithMe;
+
+  String? _reshares;
+  String? get reshares => _$this._reshares;
+  set reshares(covariant String? reshares) => _$this._reshares = reshares;
+
+  String? _subfiles;
+  String? get subfiles => _$this._subfiles;
+  set subfiles(covariant String? subfiles) => _$this._subfiles = subfiles;
+
+  String? _path;
+  String? get path => _$this._path;
+  set path(covariant String? path) => _$this._path = path;
+
+  String? _includeTags;
+  String? get includeTags => _$this._includeTags;
+  set includeTags(covariant String? includeTags) => _$this._includeTags = includeTags;
+
+  ShareapiGetSharesRequestApplicationJsonBuilder() {
+    ShareapiGetSharesRequestApplicationJson._defaults(this);
+  }
+
+  ShareapiGetSharesRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _sharedWithMe = $v.sharedWithMe;
+      _reshares = $v.reshares;
+      _subfiles = $v.subfiles;
+      _path = $v.path;
+      _includeTags = $v.includeTags;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ShareapiGetSharesRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ShareapiGetSharesRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ShareapiGetSharesRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ShareapiGetSharesRequestApplicationJson build() => _build();
+
+  _$ShareapiGetSharesRequestApplicationJson _build() {
+    ShareapiGetSharesRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ShareapiGetSharesRequestApplicationJson._(
+            sharedWithMe: BuiltValueNullFieldError.checkNotNull(
+                sharedWithMe, r'ShareapiGetSharesRequestApplicationJson', 'sharedWithMe'),
+            reshares:
+                BuiltValueNullFieldError.checkNotNull(reshares, r'ShareapiGetSharesRequestApplicationJson', 'reshares'),
+            subfiles:
+                BuiltValueNullFieldError.checkNotNull(subfiles, r'ShareapiGetSharesRequestApplicationJson', 'subfiles'),
+            path: BuiltValueNullFieldError.checkNotNull(path, r'ShareapiGetSharesRequestApplicationJson', 'path'),
+            includeTags: BuiltValueNullFieldError.checkNotNull(
+                includeTags, r'ShareapiGetSharesRequestApplicationJson', 'includeTags'));
     replace(_$result);
     return _$result;
   }
@@ -8874,6 +9905,265 @@ class ShareapiGetSharesResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $ShareapiCreateShareRequestApplicationJsonInterfaceBuilder {
+  void replace($ShareapiCreateShareRequestApplicationJsonInterface other);
+  void update(void Function($ShareapiCreateShareRequestApplicationJsonInterfaceBuilder) updates);
+  String? get path;
+  set path(String? path);
+
+  int? get permissions;
+  set permissions(int? permissions);
+
+  int? get shareType;
+  set shareType(int? shareType);
+
+  String? get shareWith;
+  set shareWith(String? shareWith);
+
+  String? get publicUpload;
+  set publicUpload(String? publicUpload);
+
+  String? get password;
+  set password(String? password);
+
+  String? get sendPasswordByTalk;
+  set sendPasswordByTalk(String? sendPasswordByTalk);
+
+  String? get expireDate;
+  set expireDate(String? expireDate);
+
+  String? get note;
+  set note(String? note);
+
+  String? get label;
+  set label(String? label);
+
+  String? get attributes;
+  set attributes(String? attributes);
+}
+
+class _$ShareapiCreateShareRequestApplicationJson extends ShareapiCreateShareRequestApplicationJson {
+  @override
+  final String? path;
+  @override
+  final int? permissions;
+  @override
+  final int shareType;
+  @override
+  final String? shareWith;
+  @override
+  final String publicUpload;
+  @override
+  final String password;
+  @override
+  final String? sendPasswordByTalk;
+  @override
+  final String expireDate;
+  @override
+  final String note;
+  @override
+  final String label;
+  @override
+  final String? attributes;
+
+  factory _$ShareapiCreateShareRequestApplicationJson(
+          [void Function(ShareapiCreateShareRequestApplicationJsonBuilder)? updates]) =>
+      (ShareapiCreateShareRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ShareapiCreateShareRequestApplicationJson._(
+      {this.path,
+      this.permissions,
+      required this.shareType,
+      this.shareWith,
+      required this.publicUpload,
+      required this.password,
+      this.sendPasswordByTalk,
+      required this.expireDate,
+      required this.note,
+      required this.label,
+      this.attributes})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(shareType, r'ShareapiCreateShareRequestApplicationJson', 'shareType');
+    BuiltValueNullFieldError.checkNotNull(publicUpload, r'ShareapiCreateShareRequestApplicationJson', 'publicUpload');
+    BuiltValueNullFieldError.checkNotNull(password, r'ShareapiCreateShareRequestApplicationJson', 'password');
+    BuiltValueNullFieldError.checkNotNull(expireDate, r'ShareapiCreateShareRequestApplicationJson', 'expireDate');
+    BuiltValueNullFieldError.checkNotNull(note, r'ShareapiCreateShareRequestApplicationJson', 'note');
+    BuiltValueNullFieldError.checkNotNull(label, r'ShareapiCreateShareRequestApplicationJson', 'label');
+  }
+
+  @override
+  ShareapiCreateShareRequestApplicationJson rebuild(
+          void Function(ShareapiCreateShareRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ShareapiCreateShareRequestApplicationJsonBuilder toBuilder() =>
+      ShareapiCreateShareRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ShareapiCreateShareRequestApplicationJson &&
+        path == other.path &&
+        permissions == other.permissions &&
+        shareType == other.shareType &&
+        shareWith == other.shareWith &&
+        publicUpload == other.publicUpload &&
+        password == other.password &&
+        sendPasswordByTalk == other.sendPasswordByTalk &&
+        expireDate == other.expireDate &&
+        note == other.note &&
+        label == other.label &&
+        attributes == other.attributes;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, path.hashCode);
+    _$hash = $jc(_$hash, permissions.hashCode);
+    _$hash = $jc(_$hash, shareType.hashCode);
+    _$hash = $jc(_$hash, shareWith.hashCode);
+    _$hash = $jc(_$hash, publicUpload.hashCode);
+    _$hash = $jc(_$hash, password.hashCode);
+    _$hash = $jc(_$hash, sendPasswordByTalk.hashCode);
+    _$hash = $jc(_$hash, expireDate.hashCode);
+    _$hash = $jc(_$hash, note.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
+    _$hash = $jc(_$hash, attributes.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ShareapiCreateShareRequestApplicationJson')
+          ..add('path', path)
+          ..add('permissions', permissions)
+          ..add('shareType', shareType)
+          ..add('shareWith', shareWith)
+          ..add('publicUpload', publicUpload)
+          ..add('password', password)
+          ..add('sendPasswordByTalk', sendPasswordByTalk)
+          ..add('expireDate', expireDate)
+          ..add('note', note)
+          ..add('label', label)
+          ..add('attributes', attributes))
+        .toString();
+  }
+}
+
+class ShareapiCreateShareRequestApplicationJsonBuilder
+    implements
+        Builder<ShareapiCreateShareRequestApplicationJson, ShareapiCreateShareRequestApplicationJsonBuilder>,
+        $ShareapiCreateShareRequestApplicationJsonInterfaceBuilder {
+  _$ShareapiCreateShareRequestApplicationJson? _$v;
+
+  String? _path;
+  String? get path => _$this._path;
+  set path(covariant String? path) => _$this._path = path;
+
+  int? _permissions;
+  int? get permissions => _$this._permissions;
+  set permissions(covariant int? permissions) => _$this._permissions = permissions;
+
+  int? _shareType;
+  int? get shareType => _$this._shareType;
+  set shareType(covariant int? shareType) => _$this._shareType = shareType;
+
+  String? _shareWith;
+  String? get shareWith => _$this._shareWith;
+  set shareWith(covariant String? shareWith) => _$this._shareWith = shareWith;
+
+  String? _publicUpload;
+  String? get publicUpload => _$this._publicUpload;
+  set publicUpload(covariant String? publicUpload) => _$this._publicUpload = publicUpload;
+
+  String? _password;
+  String? get password => _$this._password;
+  set password(covariant String? password) => _$this._password = password;
+
+  String? _sendPasswordByTalk;
+  String? get sendPasswordByTalk => _$this._sendPasswordByTalk;
+  set sendPasswordByTalk(covariant String? sendPasswordByTalk) => _$this._sendPasswordByTalk = sendPasswordByTalk;
+
+  String? _expireDate;
+  String? get expireDate => _$this._expireDate;
+  set expireDate(covariant String? expireDate) => _$this._expireDate = expireDate;
+
+  String? _note;
+  String? get note => _$this._note;
+  set note(covariant String? note) => _$this._note = note;
+
+  String? _label;
+  String? get label => _$this._label;
+  set label(covariant String? label) => _$this._label = label;
+
+  String? _attributes;
+  String? get attributes => _$this._attributes;
+  set attributes(covariant String? attributes) => _$this._attributes = attributes;
+
+  ShareapiCreateShareRequestApplicationJsonBuilder() {
+    ShareapiCreateShareRequestApplicationJson._defaults(this);
+  }
+
+  ShareapiCreateShareRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _path = $v.path;
+      _permissions = $v.permissions;
+      _shareType = $v.shareType;
+      _shareWith = $v.shareWith;
+      _publicUpload = $v.publicUpload;
+      _password = $v.password;
+      _sendPasswordByTalk = $v.sendPasswordByTalk;
+      _expireDate = $v.expireDate;
+      _note = $v.note;
+      _label = $v.label;
+      _attributes = $v.attributes;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ShareapiCreateShareRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ShareapiCreateShareRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ShareapiCreateShareRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ShareapiCreateShareRequestApplicationJson build() => _build();
+
+  _$ShareapiCreateShareRequestApplicationJson _build() {
+    ShareapiCreateShareRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ShareapiCreateShareRequestApplicationJson._(
+            path: path,
+            permissions: permissions,
+            shareType: BuiltValueNullFieldError.checkNotNull(
+                shareType, r'ShareapiCreateShareRequestApplicationJson', 'shareType'),
+            shareWith: shareWith,
+            publicUpload: BuiltValueNullFieldError.checkNotNull(
+                publicUpload, r'ShareapiCreateShareRequestApplicationJson', 'publicUpload'),
+            password: BuiltValueNullFieldError.checkNotNull(
+                password, r'ShareapiCreateShareRequestApplicationJson', 'password'),
+            sendPasswordByTalk: sendPasswordByTalk,
+            expireDate: BuiltValueNullFieldError.checkNotNull(
+                expireDate, r'ShareapiCreateShareRequestApplicationJson', 'expireDate'),
+            note: BuiltValueNullFieldError.checkNotNull(note, r'ShareapiCreateShareRequestApplicationJson', 'note'),
+            label: BuiltValueNullFieldError.checkNotNull(label, r'ShareapiCreateShareRequestApplicationJson', 'label'),
+            attributes: attributes);
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ShareapiCreateShareResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ShareapiCreateShareResponseApplicationJson_OcsInterface other);
   void update(void Function($ShareapiCreateShareResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -9098,6 +10388,104 @@ class ShareapiCreateShareResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ShareapiGetInheritedSharesRequestApplicationJsonInterfaceBuilder {
+  void replace($ShareapiGetInheritedSharesRequestApplicationJsonInterface other);
+  void update(void Function($ShareapiGetInheritedSharesRequestApplicationJsonInterfaceBuilder) updates);
+  String? get path;
+  set path(String? path);
+}
+
+class _$ShareapiGetInheritedSharesRequestApplicationJson extends ShareapiGetInheritedSharesRequestApplicationJson {
+  @override
+  final String path;
+
+  factory _$ShareapiGetInheritedSharesRequestApplicationJson(
+          [void Function(ShareapiGetInheritedSharesRequestApplicationJsonBuilder)? updates]) =>
+      (ShareapiGetInheritedSharesRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ShareapiGetInheritedSharesRequestApplicationJson._({required this.path}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(path, r'ShareapiGetInheritedSharesRequestApplicationJson', 'path');
+  }
+
+  @override
+  ShareapiGetInheritedSharesRequestApplicationJson rebuild(
+          void Function(ShareapiGetInheritedSharesRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ShareapiGetInheritedSharesRequestApplicationJsonBuilder toBuilder() =>
+      ShareapiGetInheritedSharesRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ShareapiGetInheritedSharesRequestApplicationJson && path == other.path;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, path.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ShareapiGetInheritedSharesRequestApplicationJson')..add('path', path))
+        .toString();
+  }
+}
+
+class ShareapiGetInheritedSharesRequestApplicationJsonBuilder
+    implements
+        Builder<ShareapiGetInheritedSharesRequestApplicationJson,
+            ShareapiGetInheritedSharesRequestApplicationJsonBuilder>,
+        $ShareapiGetInheritedSharesRequestApplicationJsonInterfaceBuilder {
+  _$ShareapiGetInheritedSharesRequestApplicationJson? _$v;
+
+  String? _path;
+  String? get path => _$this._path;
+  set path(covariant String? path) => _$this._path = path;
+
+  ShareapiGetInheritedSharesRequestApplicationJsonBuilder() {
+    ShareapiGetInheritedSharesRequestApplicationJson._defaults(this);
+  }
+
+  ShareapiGetInheritedSharesRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _path = $v.path;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ShareapiGetInheritedSharesRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ShareapiGetInheritedSharesRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ShareapiGetInheritedSharesRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ShareapiGetInheritedSharesRequestApplicationJson build() => _build();
+
+  _$ShareapiGetInheritedSharesRequestApplicationJson _build() {
+    ShareapiGetInheritedSharesRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ShareapiGetInheritedSharesRequestApplicationJson._(
+            path: BuiltValueNullFieldError.checkNotNull(
+                path, r'ShareapiGetInheritedSharesRequestApplicationJson', 'path'));
     replace(_$result);
     return _$result;
   }
@@ -9568,6 +10956,103 @@ class ShareapiPendingSharesResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $ShareapiGetShareRequestApplicationJsonInterfaceBuilder {
+  void replace($ShareapiGetShareRequestApplicationJsonInterface other);
+  void update(void Function($ShareapiGetShareRequestApplicationJsonInterfaceBuilder) updates);
+  bool? get includeTags;
+  set includeTags(bool? includeTags);
+}
+
+class _$ShareapiGetShareRequestApplicationJson extends ShareapiGetShareRequestApplicationJson {
+  @override
+  final bool includeTags;
+
+  factory _$ShareapiGetShareRequestApplicationJson(
+          [void Function(ShareapiGetShareRequestApplicationJsonBuilder)? updates]) =>
+      (ShareapiGetShareRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ShareapiGetShareRequestApplicationJson._({required this.includeTags}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(includeTags, r'ShareapiGetShareRequestApplicationJson', 'includeTags');
+  }
+
+  @override
+  ShareapiGetShareRequestApplicationJson rebuild(
+          void Function(ShareapiGetShareRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ShareapiGetShareRequestApplicationJsonBuilder toBuilder() =>
+      ShareapiGetShareRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ShareapiGetShareRequestApplicationJson && includeTags == other.includeTags;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, includeTags.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ShareapiGetShareRequestApplicationJson')..add('includeTags', includeTags))
+        .toString();
+  }
+}
+
+class ShareapiGetShareRequestApplicationJsonBuilder
+    implements
+        Builder<ShareapiGetShareRequestApplicationJson, ShareapiGetShareRequestApplicationJsonBuilder>,
+        $ShareapiGetShareRequestApplicationJsonInterfaceBuilder {
+  _$ShareapiGetShareRequestApplicationJson? _$v;
+
+  bool? _includeTags;
+  bool? get includeTags => _$this._includeTags;
+  set includeTags(covariant bool? includeTags) => _$this._includeTags = includeTags;
+
+  ShareapiGetShareRequestApplicationJsonBuilder() {
+    ShareapiGetShareRequestApplicationJson._defaults(this);
+  }
+
+  ShareapiGetShareRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _includeTags = $v.includeTags;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ShareapiGetShareRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ShareapiGetShareRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ShareapiGetShareRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ShareapiGetShareRequestApplicationJson build() => _build();
+
+  _$ShareapiGetShareRequestApplicationJson _build() {
+    ShareapiGetShareRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ShareapiGetShareRequestApplicationJson._(
+            includeTags: BuiltValueNullFieldError.checkNotNull(
+                includeTags, r'ShareapiGetShareRequestApplicationJson', 'includeTags'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ShareapiGetShareResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ShareapiGetShareResponseApplicationJson_OcsInterface other);
   void update(void Function($ShareapiGetShareResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -9791,6 +11276,224 @@ class ShareapiGetShareResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ShareapiUpdateShareRequestApplicationJsonInterfaceBuilder {
+  void replace($ShareapiUpdateShareRequestApplicationJsonInterface other);
+  void update(void Function($ShareapiUpdateShareRequestApplicationJsonInterfaceBuilder) updates);
+  int? get permissions;
+  set permissions(int? permissions);
+
+  String? get password;
+  set password(String? password);
+
+  String? get sendPasswordByTalk;
+  set sendPasswordByTalk(String? sendPasswordByTalk);
+
+  String? get publicUpload;
+  set publicUpload(String? publicUpload);
+
+  String? get expireDate;
+  set expireDate(String? expireDate);
+
+  String? get note;
+  set note(String? note);
+
+  String? get label;
+  set label(String? label);
+
+  String? get hideDownload;
+  set hideDownload(String? hideDownload);
+
+  String? get attributes;
+  set attributes(String? attributes);
+}
+
+class _$ShareapiUpdateShareRequestApplicationJson extends ShareapiUpdateShareRequestApplicationJson {
+  @override
+  final int? permissions;
+  @override
+  final String? password;
+  @override
+  final String? sendPasswordByTalk;
+  @override
+  final String? publicUpload;
+  @override
+  final String? expireDate;
+  @override
+  final String? note;
+  @override
+  final String? label;
+  @override
+  final String? hideDownload;
+  @override
+  final String? attributes;
+
+  factory _$ShareapiUpdateShareRequestApplicationJson(
+          [void Function(ShareapiUpdateShareRequestApplicationJsonBuilder)? updates]) =>
+      (ShareapiUpdateShareRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ShareapiUpdateShareRequestApplicationJson._(
+      {this.permissions,
+      this.password,
+      this.sendPasswordByTalk,
+      this.publicUpload,
+      this.expireDate,
+      this.note,
+      this.label,
+      this.hideDownload,
+      this.attributes})
+      : super._();
+
+  @override
+  ShareapiUpdateShareRequestApplicationJson rebuild(
+          void Function(ShareapiUpdateShareRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ShareapiUpdateShareRequestApplicationJsonBuilder toBuilder() =>
+      ShareapiUpdateShareRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ShareapiUpdateShareRequestApplicationJson &&
+        permissions == other.permissions &&
+        password == other.password &&
+        sendPasswordByTalk == other.sendPasswordByTalk &&
+        publicUpload == other.publicUpload &&
+        expireDate == other.expireDate &&
+        note == other.note &&
+        label == other.label &&
+        hideDownload == other.hideDownload &&
+        attributes == other.attributes;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, permissions.hashCode);
+    _$hash = $jc(_$hash, password.hashCode);
+    _$hash = $jc(_$hash, sendPasswordByTalk.hashCode);
+    _$hash = $jc(_$hash, publicUpload.hashCode);
+    _$hash = $jc(_$hash, expireDate.hashCode);
+    _$hash = $jc(_$hash, note.hashCode);
+    _$hash = $jc(_$hash, label.hashCode);
+    _$hash = $jc(_$hash, hideDownload.hashCode);
+    _$hash = $jc(_$hash, attributes.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ShareapiUpdateShareRequestApplicationJson')
+          ..add('permissions', permissions)
+          ..add('password', password)
+          ..add('sendPasswordByTalk', sendPasswordByTalk)
+          ..add('publicUpload', publicUpload)
+          ..add('expireDate', expireDate)
+          ..add('note', note)
+          ..add('label', label)
+          ..add('hideDownload', hideDownload)
+          ..add('attributes', attributes))
+        .toString();
+  }
+}
+
+class ShareapiUpdateShareRequestApplicationJsonBuilder
+    implements
+        Builder<ShareapiUpdateShareRequestApplicationJson, ShareapiUpdateShareRequestApplicationJsonBuilder>,
+        $ShareapiUpdateShareRequestApplicationJsonInterfaceBuilder {
+  _$ShareapiUpdateShareRequestApplicationJson? _$v;
+
+  int? _permissions;
+  int? get permissions => _$this._permissions;
+  set permissions(covariant int? permissions) => _$this._permissions = permissions;
+
+  String? _password;
+  String? get password => _$this._password;
+  set password(covariant String? password) => _$this._password = password;
+
+  String? _sendPasswordByTalk;
+  String? get sendPasswordByTalk => _$this._sendPasswordByTalk;
+  set sendPasswordByTalk(covariant String? sendPasswordByTalk) => _$this._sendPasswordByTalk = sendPasswordByTalk;
+
+  String? _publicUpload;
+  String? get publicUpload => _$this._publicUpload;
+  set publicUpload(covariant String? publicUpload) => _$this._publicUpload = publicUpload;
+
+  String? _expireDate;
+  String? get expireDate => _$this._expireDate;
+  set expireDate(covariant String? expireDate) => _$this._expireDate = expireDate;
+
+  String? _note;
+  String? get note => _$this._note;
+  set note(covariant String? note) => _$this._note = note;
+
+  String? _label;
+  String? get label => _$this._label;
+  set label(covariant String? label) => _$this._label = label;
+
+  String? _hideDownload;
+  String? get hideDownload => _$this._hideDownload;
+  set hideDownload(covariant String? hideDownload) => _$this._hideDownload = hideDownload;
+
+  String? _attributes;
+  String? get attributes => _$this._attributes;
+  set attributes(covariant String? attributes) => _$this._attributes = attributes;
+
+  ShareapiUpdateShareRequestApplicationJsonBuilder() {
+    ShareapiUpdateShareRequestApplicationJson._defaults(this);
+  }
+
+  ShareapiUpdateShareRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _permissions = $v.permissions;
+      _password = $v.password;
+      _sendPasswordByTalk = $v.sendPasswordByTalk;
+      _publicUpload = $v.publicUpload;
+      _expireDate = $v.expireDate;
+      _note = $v.note;
+      _label = $v.label;
+      _hideDownload = $v.hideDownload;
+      _attributes = $v.attributes;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ShareapiUpdateShareRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ShareapiUpdateShareRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ShareapiUpdateShareRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ShareapiUpdateShareRequestApplicationJson build() => _build();
+
+  _$ShareapiUpdateShareRequestApplicationJson _build() {
+    ShareapiUpdateShareRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ShareapiUpdateShareRequestApplicationJson._(
+            permissions: permissions,
+            password: password,
+            sendPasswordByTalk: sendPasswordByTalk,
+            publicUpload: publicUpload,
+            expireDate: expireDate,
+            note: note,
+            label: label,
+            hideDownload: hideDownload,
+            attributes: attributes);
     replace(_$result);
     return _$result;
   }
@@ -10482,6 +12185,186 @@ class ShareapiAcceptShareResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ShareesapiSearchRequestApplicationJsonInterfaceBuilder {
+  void replace($ShareesapiSearchRequestApplicationJsonInterface other);
+  void update(void Function($ShareesapiSearchRequestApplicationJsonInterfaceBuilder) updates);
+  String? get search;
+  set search(String? search);
+
+  String? get itemType;
+  set itemType(String? itemType);
+
+  int? get page;
+  set page(int? page);
+
+  int? get perPage;
+  set perPage(int? perPage);
+
+  ShareesapiSearchRequestApplicationJson_ShareType? get shareType;
+  set shareType(ShareesapiSearchRequestApplicationJson_ShareType? shareType);
+
+  bool? get lookup;
+  set lookup(bool? lookup);
+}
+
+class _$ShareesapiSearchRequestApplicationJson extends ShareesapiSearchRequestApplicationJson {
+  @override
+  final String search;
+  @override
+  final String? itemType;
+  @override
+  final int page;
+  @override
+  final int perPage;
+  @override
+  final ShareesapiSearchRequestApplicationJson_ShareType? shareType;
+  @override
+  final bool lookup;
+
+  factory _$ShareesapiSearchRequestApplicationJson(
+          [void Function(ShareesapiSearchRequestApplicationJsonBuilder)? updates]) =>
+      (ShareesapiSearchRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ShareesapiSearchRequestApplicationJson._(
+      {required this.search,
+      this.itemType,
+      required this.page,
+      required this.perPage,
+      this.shareType,
+      required this.lookup})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(search, r'ShareesapiSearchRequestApplicationJson', 'search');
+    BuiltValueNullFieldError.checkNotNull(page, r'ShareesapiSearchRequestApplicationJson', 'page');
+    BuiltValueNullFieldError.checkNotNull(perPage, r'ShareesapiSearchRequestApplicationJson', 'perPage');
+    BuiltValueNullFieldError.checkNotNull(lookup, r'ShareesapiSearchRequestApplicationJson', 'lookup');
+  }
+
+  @override
+  ShareesapiSearchRequestApplicationJson rebuild(
+          void Function(ShareesapiSearchRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ShareesapiSearchRequestApplicationJsonBuilder toBuilder() =>
+      ShareesapiSearchRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    final dynamic _$dynamicOther = other;
+    return other is ShareesapiSearchRequestApplicationJson &&
+        search == other.search &&
+        itemType == other.itemType &&
+        page == other.page &&
+        perPage == other.perPage &&
+        shareType == _$dynamicOther.shareType &&
+        lookup == other.lookup;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, search.hashCode);
+    _$hash = $jc(_$hash, itemType.hashCode);
+    _$hash = $jc(_$hash, page.hashCode);
+    _$hash = $jc(_$hash, perPage.hashCode);
+    _$hash = $jc(_$hash, shareType.hashCode);
+    _$hash = $jc(_$hash, lookup.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ShareesapiSearchRequestApplicationJson')
+          ..add('search', search)
+          ..add('itemType', itemType)
+          ..add('page', page)
+          ..add('perPage', perPage)
+          ..add('shareType', shareType)
+          ..add('lookup', lookup))
+        .toString();
+  }
+}
+
+class ShareesapiSearchRequestApplicationJsonBuilder
+    implements
+        Builder<ShareesapiSearchRequestApplicationJson, ShareesapiSearchRequestApplicationJsonBuilder>,
+        $ShareesapiSearchRequestApplicationJsonInterfaceBuilder {
+  _$ShareesapiSearchRequestApplicationJson? _$v;
+
+  String? _search;
+  String? get search => _$this._search;
+  set search(covariant String? search) => _$this._search = search;
+
+  String? _itemType;
+  String? get itemType => _$this._itemType;
+  set itemType(covariant String? itemType) => _$this._itemType = itemType;
+
+  int? _page;
+  int? get page => _$this._page;
+  set page(covariant int? page) => _$this._page = page;
+
+  int? _perPage;
+  int? get perPage => _$this._perPage;
+  set perPage(covariant int? perPage) => _$this._perPage = perPage;
+
+  ShareesapiSearchRequestApplicationJson_ShareType? _shareType;
+  ShareesapiSearchRequestApplicationJson_ShareType? get shareType => _$this._shareType;
+  set shareType(covariant ShareesapiSearchRequestApplicationJson_ShareType? shareType) => _$this._shareType = shareType;
+
+  bool? _lookup;
+  bool? get lookup => _$this._lookup;
+  set lookup(covariant bool? lookup) => _$this._lookup = lookup;
+
+  ShareesapiSearchRequestApplicationJsonBuilder() {
+    ShareesapiSearchRequestApplicationJson._defaults(this);
+  }
+
+  ShareesapiSearchRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _search = $v.search;
+      _itemType = $v.itemType;
+      _page = $v.page;
+      _perPage = $v.perPage;
+      _shareType = $v.shareType;
+      _lookup = $v.lookup;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ShareesapiSearchRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ShareesapiSearchRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ShareesapiSearchRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ShareesapiSearchRequestApplicationJson build() => _build();
+
+  _$ShareesapiSearchRequestApplicationJson _build() {
+    ShareesapiSearchRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ShareesapiSearchRequestApplicationJson._(
+            search: BuiltValueNullFieldError.checkNotNull(search, r'ShareesapiSearchRequestApplicationJson', 'search'),
+            itemType: itemType,
+            page: BuiltValueNullFieldError.checkNotNull(page, r'ShareesapiSearchRequestApplicationJson', 'page'),
+            perPage:
+                BuiltValueNullFieldError.checkNotNull(perPage, r'ShareesapiSearchRequestApplicationJson', 'perPage'),
+            shareType: shareType,
+            lookup: BuiltValueNullFieldError.checkNotNull(lookup, r'ShareesapiSearchRequestApplicationJson', 'lookup'));
     replace(_$result);
     return _$result;
   }
@@ -13530,6 +15413,122 @@ class ShareesapiShareesapiSearchHeadersBuilder
   _$ShareesapiShareesapiSearchHeaders _build() {
     ShareesapiShareesapiSearchHeaders._validate(this);
     final _$result = _$v ?? _$ShareesapiShareesapiSearchHeaders._(link: link);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ShareesapiFindRecommendedRequestApplicationJsonInterfaceBuilder {
+  void replace($ShareesapiFindRecommendedRequestApplicationJsonInterface other);
+  void update(void Function($ShareesapiFindRecommendedRequestApplicationJsonInterfaceBuilder) updates);
+  String? get itemType;
+  set itemType(String? itemType);
+
+  ShareesapiFindRecommendedRequestApplicationJson_ShareType? get shareType;
+  set shareType(ShareesapiFindRecommendedRequestApplicationJson_ShareType? shareType);
+}
+
+class _$ShareesapiFindRecommendedRequestApplicationJson extends ShareesapiFindRecommendedRequestApplicationJson {
+  @override
+  final String itemType;
+  @override
+  final ShareesapiFindRecommendedRequestApplicationJson_ShareType? shareType;
+
+  factory _$ShareesapiFindRecommendedRequestApplicationJson(
+          [void Function(ShareesapiFindRecommendedRequestApplicationJsonBuilder)? updates]) =>
+      (ShareesapiFindRecommendedRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ShareesapiFindRecommendedRequestApplicationJson._({required this.itemType, this.shareType}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(itemType, r'ShareesapiFindRecommendedRequestApplicationJson', 'itemType');
+  }
+
+  @override
+  ShareesapiFindRecommendedRequestApplicationJson rebuild(
+          void Function(ShareesapiFindRecommendedRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ShareesapiFindRecommendedRequestApplicationJsonBuilder toBuilder() =>
+      ShareesapiFindRecommendedRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    final dynamic _$dynamicOther = other;
+    return other is ShareesapiFindRecommendedRequestApplicationJson &&
+        itemType == other.itemType &&
+        shareType == _$dynamicOther.shareType;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, itemType.hashCode);
+    _$hash = $jc(_$hash, shareType.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ShareesapiFindRecommendedRequestApplicationJson')
+          ..add('itemType', itemType)
+          ..add('shareType', shareType))
+        .toString();
+  }
+}
+
+class ShareesapiFindRecommendedRequestApplicationJsonBuilder
+    implements
+        Builder<ShareesapiFindRecommendedRequestApplicationJson,
+            ShareesapiFindRecommendedRequestApplicationJsonBuilder>,
+        $ShareesapiFindRecommendedRequestApplicationJsonInterfaceBuilder {
+  _$ShareesapiFindRecommendedRequestApplicationJson? _$v;
+
+  String? _itemType;
+  String? get itemType => _$this._itemType;
+  set itemType(covariant String? itemType) => _$this._itemType = itemType;
+
+  ShareesapiFindRecommendedRequestApplicationJson_ShareType? _shareType;
+  ShareesapiFindRecommendedRequestApplicationJson_ShareType? get shareType => _$this._shareType;
+  set shareType(covariant ShareesapiFindRecommendedRequestApplicationJson_ShareType? shareType) =>
+      _$this._shareType = shareType;
+
+  ShareesapiFindRecommendedRequestApplicationJsonBuilder() {
+    ShareesapiFindRecommendedRequestApplicationJson._defaults(this);
+  }
+
+  ShareesapiFindRecommendedRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _itemType = $v.itemType;
+      _shareType = $v.shareType;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ShareesapiFindRecommendedRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ShareesapiFindRecommendedRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ShareesapiFindRecommendedRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ShareesapiFindRecommendedRequestApplicationJson build() => _build();
+
+  _$ShareesapiFindRecommendedRequestApplicationJson _build() {
+    ShareesapiFindRecommendedRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ShareesapiFindRecommendedRequestApplicationJson._(
+            itemType: BuiltValueNullFieldError.checkNotNull(
+                itemType, r'ShareesapiFindRecommendedRequestApplicationJson', 'itemType'),
+            shareType: shareType);
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.json
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.json
@@ -1386,49 +1386,41 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "file": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "File in the share"
+                                    },
+                                    "x": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 32,
+                                        "description": "Width of the preview"
+                                    },
+                                    "y": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 32,
+                                        "description": "Height of the preview"
+                                    },
+                                    "a": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to not crop the preview"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "file",
-                        "in": "query",
-                        "description": "File in the share",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "x",
-                        "in": "query",
-                        "description": "Width of the preview",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 32
-                        }
-                    },
-                    {
-                        "name": "y",
-                        "in": "query",
-                        "description": "Height of the preview",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 32
-                        }
-                    },
-                    {
-                        "name": "a",
-                        "in": "query",
-                        "description": "Whether to not crop the preview",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
                     {
                         "name": "token",
                         "in": "path",
@@ -1494,45 +1486,41 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "t",
-                        "in": "query",
-                        "description": "Token of the share",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "password",
-                        "in": "query",
-                        "description": "Password of the share",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "dir",
-                        "in": "query",
-                        "description": "Subdirectory to get info about",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "depth",
-                        "in": "query",
-                        "description": "Maximum depth to get info about",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": -1
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "t"
+                                ],
+                                "properties": {
+                                    "t": {
+                                        "type": "string",
+                                        "description": "Token of the share"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Password of the share"
+                                    },
+                                    "dir": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Subdirectory to get info about"
+                                    },
+                                    "depth": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": -1,
+                                        "description": "Maximum depth to get info about"
+                                    }
+                                }
+                            }
                         }
                     }
-                ],
+                },
                 "responses": {
                     "200": {
                         "description": "Share info returned",
@@ -1578,52 +1566,44 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "shared_with_me": {
+                                        "type": "string",
+                                        "default": "false",
+                                        "description": "Only get shares with the current user"
+                                    },
+                                    "reshares": {
+                                        "type": "string",
+                                        "default": "false",
+                                        "description": "Only get shares by the current user and reshares"
+                                    },
+                                    "subfiles": {
+                                        "type": "string",
+                                        "default": "false",
+                                        "description": "Only get all shares in a folder"
+                                    },
+                                    "path": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Get shares for a specific path"
+                                    },
+                                    "include_tags": {
+                                        "type": "string",
+                                        "default": "false",
+                                        "description": "Include tags in the share"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "shared_with_me",
-                        "in": "query",
-                        "description": "Only get shares with the current user",
-                        "schema": {
-                            "type": "string",
-                            "default": "false"
-                        }
-                    },
-                    {
-                        "name": "reshares",
-                        "in": "query",
-                        "description": "Only get shares by the current user and reshares",
-                        "schema": {
-                            "type": "string",
-                            "default": "false"
-                        }
-                    },
-                    {
-                        "name": "subfiles",
-                        "in": "query",
-                        "description": "Only get all shares in a folder",
-                        "schema": {
-                            "type": "string",
-                            "default": "false"
-                        }
-                    },
-                    {
-                        "name": "path",
-                        "in": "query",
-                        "description": "Get shares for a specific path",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "include_tags",
-                        "in": "query",
-                        "description": "Include tags in the share",
-                        "schema": {
-                            "type": "string",
-                            "default": "false"
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -1713,108 +1693,76 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Path of the share"
+                                    },
+                                    "permissions": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Permissions for the share"
+                                    },
+                                    "shareType": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": -1,
+                                        "description": "Type of the share"
+                                    },
+                                    "shareWith": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "The entity this should be shared with"
+                                    },
+                                    "publicUpload": {
+                                        "type": "string",
+                                        "default": "false",
+                                        "description": "If public uploading is allowed"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Password for the share"
+                                    },
+                                    "sendPasswordByTalk": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Send the password for the share over Talk"
+                                    },
+                                    "expireDate": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Expiry date of the share using user timezone at 00:00. It means date in UTC timezone will be used."
+                                    },
+                                    "note": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Note for the share"
+                                    },
+                                    "label": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Label for the share (only used in link and email)"
+                                    },
+                                    "attributes": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Additional attributes for the share"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "path",
-                        "in": "query",
-                        "description": "Path of the share",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "permissions",
-                        "in": "query",
-                        "description": "Permissions for the share",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "shareType",
-                        "in": "query",
-                        "description": "Type of the share",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": -1
-                        }
-                    },
-                    {
-                        "name": "shareWith",
-                        "in": "query",
-                        "description": "The entity this should be shared with",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "publicUpload",
-                        "in": "query",
-                        "description": "If public uploading is allowed",
-                        "schema": {
-                            "type": "string",
-                            "default": "false"
-                        }
-                    },
-                    {
-                        "name": "password",
-                        "in": "query",
-                        "description": "Password for the share",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "sendPasswordByTalk",
-                        "in": "query",
-                        "description": "Send the password for the share over Talk",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "expireDate",
-                        "in": "query",
-                        "description": "Expiry date of the share using user timezone at 00:00. It means date in UTC timezone will be used.",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "note",
-                        "in": "query",
-                        "description": "Note for the share",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "label",
-                        "in": "query",
-                        "description": "Label for the share (only used in link and email)",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "attributes",
-                        "in": "query",
-                        "description": "Additional attributes for the share",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -1959,16 +1907,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "path",
-                        "in": "query",
-                        "description": "Path all shares will be relative to",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "path"
+                                ],
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "description": "Path all shares will be relative to"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -2134,20 +2092,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "include_tags",
-                        "in": "query",
-                        "description": "Include tags in the share",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "include_tags": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Include tags in the share"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "id",
                         "in": "path",
@@ -2243,89 +2205,65 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "permissions": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "New permissions"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "New password"
+                                    },
+                                    "sendPasswordByTalk": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "New condition if the password should be send over Talk"
+                                    },
+                                    "publicUpload": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "New condition if public uploading is allowed"
+                                    },
+                                    "expireDate": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "New expiry date"
+                                    },
+                                    "note": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "New note"
+                                    },
+                                    "label": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "New label"
+                                    },
+                                    "hideDownload": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "New condition if the download should be hidden"
+                                    },
+                                    "attributes": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "New additional attributes"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "permissions",
-                        "in": "query",
-                        "description": "New permissions",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "password",
-                        "in": "query",
-                        "description": "New password",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "sendPasswordByTalk",
-                        "in": "query",
-                        "description": "New condition if the password should be send over Talk",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "publicUpload",
-                        "in": "query",
-                        "description": "New condition if public uploading is allowed",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "expireDate",
-                        "in": "query",
-                        "description": "New expiry date",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "note",
-                        "in": "query",
-                        "description": "New note",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "label",
-                        "in": "query",
-                        "description": "New label",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "hideDownload",
-                        "in": "query",
-                        "description": "New condition if the download should be hidden",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "attributes",
-                        "in": "query",
-                        "description": "New additional attributes",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
                     {
                         "name": "id",
                         "in": "path",
@@ -2885,79 +2823,63 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "search",
-                        "in": "query",
-                        "description": "Text to search for",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "itemType",
-                        "in": "query",
-                        "description": "Limit to specific item types",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Page offset for searching",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 1
-                        }
-                    },
-                    {
-                        "name": "perPage",
-                        "in": "query",
-                        "description": "Limit amount of search results per page",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 200
-                        }
-                    },
-                    {
-                        "name": "shareType",
-                        "in": "query",
-                        "description": "Limit to specific share types",
-                        "schema": {
-                            "nullable": true,
-                            "oneOf": [
-                                {
-                                    "type": "integer",
-                                    "format": "int64"
-                                },
-                                {
-                                    "type": "array",
-                                    "items": {
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "search": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Text to search for"
+                                    },
+                                    "itemType": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Limit to specific item types"
+                                    },
+                                    "page": {
                                         "type": "integer",
-                                        "format": "int64"
+                                        "format": "int64",
+                                        "default": 1,
+                                        "description": "Page offset for searching"
+                                    },
+                                    "perPage": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 200,
+                                        "description": "Limit amount of search results per page"
+                                    },
+                                    "shareType": {
+                                        "nullable": true,
+                                        "description": "Limit to specific share types",
+                                        "oneOf": [
+                                            {
+                                                "type": "integer",
+                                                "format": "int64"
+                                            },
+                                            {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "lookup": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "If a global lookup should be performed too"
                                     }
                                 }
-                            ]
+                            }
                         }
-                    },
-                    {
-                        "name": "lookup",
-                        "in": "query",
-                        "description": "If a global lookup should be performed too",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -3053,37 +2975,43 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "itemType",
-                        "in": "query",
-                        "description": "Limit to specific item types",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "shareType",
-                        "in": "query",
-                        "description": "Limit to specific share types",
-                        "schema": {
-                            "nullable": true,
-                            "oneOf": [
-                                {
-                                    "type": "integer",
-                                    "format": "int64"
-                                },
-                                {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "integer",
-                                        "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "itemType"
+                                ],
+                                "properties": {
+                                    "itemType": {
+                                        "type": "string",
+                                        "description": "Limit to specific item types"
+                                    },
+                                    "shareType": {
+                                        "nullable": true,
+                                        "description": "Limit to specific share types",
+                                        "oneOf": [
+                                            {
+                                                "type": "integer",
+                                                "format": "int64"
+                                            },
+                                            {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                }
+                                            }
+                                        ]
                                     }
                                 }
-                            ]
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
@@ -92,21 +92,21 @@ class $PreviewClient {
     PreviewGetPreviewA? a,
   }) {
     final _parameters = <String, Object?>{};
-    var $fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
-    $fileId ??= -1;
-    _parameters['fileId'] = $fileId;
+    var __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
+    __fileId ??= -1;
+    _parameters['fileId'] = __fileId;
 
-    var $x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
-    $x ??= 32;
-    _parameters['x'] = $x;
+    var __x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
+    __x ??= 32;
+    _parameters['x'] = __x;
 
-    var $y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
-    $y ??= 32;
-    _parameters['y'] = $y;
+    var __y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
+    __y ??= 32;
+    _parameters['y'] = __y;
 
-    var $a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PreviewGetPreviewA));
-    $a ??= 0;
-    _parameters['a'] = $a;
+    var __a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PreviewGetPreviewA));
+    __a ??= 0;
+    _parameters['a'] = __a;
 
     final _path = _i4.UriTemplate('/index.php/apps/files_trashbin/preview{?fileId*,x*,y*,a*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
@@ -16,18 +16,17 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:built_value/standard_json_plugin.dart' as _i7;
-import 'package:collection/collection.dart' as _i5;
-import 'package:dynamite_runtime/built_value.dart' as _i6;
+import 'package:built_value/standard_json_plugin.dart' as _i6;
+import 'package:collection/collection.dart' as _i4;
+import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
 import 'package:http/http.dart' as _i3;
 import 'package:meta/meta.dart' as _i2;
-import 'package:uri/uri.dart' as _i4;
 
 part 'files_trashbin.openapi.g.dart';
 
@@ -70,12 +69,6 @@ class $PreviewClient {
   /// Returns a `DynamiteRequest` backing the [getPreview] operation.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [fileId] ID of the file. Defaults to `-1`.
-  ///   * [x] Width of the preview. Defaults to `32`.
-  ///   * [y] Height of the preview. Defaults to `32`.
-  ///   * [a] Whether to not crop the preview. Defaults to `0`.
-  ///
   /// Status codes:
   ///   * 200: Preview returned
   ///   * 400: Getting preview is not possible
@@ -85,35 +78,13 @@ class $PreviewClient {
   ///  * [getPreview] for a method executing this request and parsing the response.
   ///  * [$getPreview_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $getPreview_Request({
-    int? fileId,
-    int? x,
-    int? y,
-    PreviewGetPreviewA? a,
-  }) {
-    final _parameters = <String, Object?>{};
-    var __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
-    __fileId ??= -1;
-    _parameters['fileId'] = __fileId;
-
-    var __x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
-    __x ??= 32;
-    _parameters['x'] = __x;
-
-    var __y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
-    __y ??= 32;
-    _parameters['y'] = __y;
-
-    var __a = _$jsonSerializers.serialize(a, specifiedType: const FullType(PreviewGetPreviewA));
-    __a ??= 0;
-    _parameters['a'] = __a;
-
-    final _path = _i4.UriTemplate('/index.php/apps/files_trashbin/preview{?fileId*,x*,y*,a*}').expand(_parameters);
+  _i3.Request $getPreview_Request({PreviewGetPreviewRequestApplicationJson? $body}) {
+    const _path = '/index.php/apps/files_trashbin/preview';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = '*/*';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -129,6 +100,17 @@ class $PreviewClient {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(PreviewGetPreviewRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              PreviewGetPreviewRequestApplicationJson(),
+              specifiedType: const FullType(PreviewGetPreviewRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -136,12 +118,6 @@ class $PreviewClient {
   ///
   /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
-  ///
-  /// Parameters:
-  ///   * [fileId] ID of the file. Defaults to `-1`.
-  ///   * [x] Width of the preview. Defaults to `32`.
-  ///   * [y] Height of the preview. Defaults to `32`.
-  ///   * [a] Whether to not crop the preview. Defaults to `0`.
   ///
   /// Status codes:
   ///   * 200: Preview returned
@@ -151,17 +127,9 @@ class $PreviewClient {
   /// See:
   ///  * [$getPreview_Request] for the request send by this method.
   ///  * [$getPreview_Serializer] for a converter to parse the `Response` from an executed request.
-  Future<_i1.DynamiteResponse<Uint8List, void>> getPreview({
-    int? fileId,
-    int? x,
-    int? y,
-    PreviewGetPreviewA? a,
-  }) async {
+  Future<_i1.DynamiteResponse<Uint8List, void>> getPreview({PreviewGetPreviewRequestApplicationJson? $body}) async {
     final _request = $getPreview_Request(
-      fileId: fileId,
-      x: x,
-      y: y,
-      a: a,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -172,67 +140,102 @@ class $PreviewClient {
   }
 }
 
-class PreviewGetPreviewA extends EnumClass {
-  const PreviewGetPreviewA._(super.name);
+@BuiltValue(instantiable: false)
+sealed class $PreviewGetPreviewRequestApplicationJsonInterface {
+  static final _$fileId = _$jsonSerializers.deserialize(
+    -1,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const PreviewGetPreviewA $0 = _$previewGetPreviewA$0;
+  static final _$x = _$jsonSerializers.deserialize(
+    32,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const PreviewGetPreviewA $1 = _$previewGetPreviewA$1;
+  static final _$y = _$jsonSerializers.deserialize(
+    32,
+    specifiedType: const FullType(int),
+  )! as int;
 
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<PreviewGetPreviewA> get values => _$previewGetPreviewAValues;
-  // coverage:ignore-end
+  static final _$a = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  /// Returns the enum value associated to the [name].
-  static PreviewGetPreviewA valueOf(String name) => _$valueOfPreviewGetPreviewA(name);
+  /// ID of the file.
+  int get fileId;
 
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+  /// Width of the preview.
+  int get x;
 
-  /// Serializer for PreviewGetPreviewA.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<PreviewGetPreviewA> get serializer => const _$PreviewGetPreviewASerializer();
+  /// Height of the preview.
+  int get y;
+
+  /// Whether to not crop the preview.
+  bool get a;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreviewGetPreviewRequestApplicationJsonInterfaceBuilder].
+  $PreviewGetPreviewRequestApplicationJsonInterface rebuild(
+    void Function($PreviewGetPreviewRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreviewGetPreviewRequestApplicationJsonInterfaceBuilder].
+  $PreviewGetPreviewRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreviewGetPreviewRequestApplicationJsonInterfaceBuilder b) {
+    b.fileId = _$fileId;
+    b.x = _$x;
+    b.y = _$y;
+    b.a = _$a;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreviewGetPreviewRequestApplicationJsonInterfaceBuilder b) {}
 }
 
-class _$PreviewGetPreviewASerializer implements PrimitiveSerializer<PreviewGetPreviewA> {
-  const _$PreviewGetPreviewASerializer();
+abstract class PreviewGetPreviewRequestApplicationJson
+    implements
+        $PreviewGetPreviewRequestApplicationJsonInterface,
+        Built<PreviewGetPreviewRequestApplicationJson, PreviewGetPreviewRequestApplicationJsonBuilder> {
+  /// Creates a new PreviewGetPreviewRequestApplicationJson object using the builder pattern.
+  factory PreviewGetPreviewRequestApplicationJson([void Function(PreviewGetPreviewRequestApplicationJsonBuilder)? b]) =
+      _$PreviewGetPreviewRequestApplicationJson;
 
-  static const Map<PreviewGetPreviewA, Object> _toWire = <PreviewGetPreviewA, Object>{
-    PreviewGetPreviewA.$0: 0,
-    PreviewGetPreviewA.$1: 1,
-  };
+  // coverage:ignore-start
+  const PreviewGetPreviewRequestApplicationJson._();
+  // coverage:ignore-end
 
-  static const Map<Object, PreviewGetPreviewA> _fromWire = <Object, PreviewGetPreviewA>{
-    0: PreviewGetPreviewA.$0,
-    1: PreviewGetPreviewA.$1,
-  };
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory PreviewGetPreviewRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
 
-  @override
-  Iterable<Type> get types => const [PreviewGetPreviewA];
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
 
-  @override
-  String get wireName => 'PreviewGetPreviewA';
+  /// Serializer for PreviewGetPreviewRequestApplicationJson.
+  static Serializer<PreviewGetPreviewRequestApplicationJson> get serializer =>
+      _$previewGetPreviewRequestApplicationJsonSerializer;
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    PreviewGetPreviewA object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreviewGetPreviewRequestApplicationJsonBuilder b) {
+    $PreviewGetPreviewRequestApplicationJsonInterface._defaults(b);
+  }
 
-  @override
-  PreviewGetPreviewA deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreviewGetPreviewRequestApplicationJsonBuilder b) {
+    $PreviewGetPreviewRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -353,7 +356,11 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 @_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
-      ..add(PreviewGetPreviewA.serializer)
+      ..addBuilderFactory(
+        const FullType(PreviewGetPreviewRequestApplicationJson),
+        PreviewGetPreviewRequestApplicationJsonBuilder.new,
+      )
+      ..add(PreviewGetPreviewRequestApplicationJson.serializer)
       ..addBuilderFactory(const FullType(Capabilities), CapabilitiesBuilder.new)
       ..add(Capabilities.serializer)
       ..addBuilderFactory(const FullType(Capabilities_Files), Capabilities_FilesBuilder.new)
@@ -367,9 +374,9 @@ final Serializers _$serializers = (Serializers().toBuilder()
 @_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
-      ..add(_i6.DynamiteDoubleSerializer())
-      ..addPlugin(_i7.StandardJsonPlugin())
-      ..addPlugin(const _i6.HeaderPlugin())
-      ..addPlugin(const _i6.ContentStringPlugin()))
+      ..add(_i5.DynamiteDoubleSerializer())
+      ..addPlugin(_i6.StandardJsonPlugin())
+      ..addPlugin(const _i5.HeaderPlugin())
+      ..addPlugin(const _i5.ContentStringPlugin()))
     .build();
 // coverage:ignore-end

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.g.dart
@@ -6,27 +6,67 @@ part of 'files_trashbin.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-const PreviewGetPreviewA _$previewGetPreviewA$0 = PreviewGetPreviewA._('\$0');
-const PreviewGetPreviewA _$previewGetPreviewA$1 = PreviewGetPreviewA._('\$1');
-
-PreviewGetPreviewA _$valueOfPreviewGetPreviewA(String name) {
-  switch (name) {
-    case '\$0':
-      return _$previewGetPreviewA$0;
-    case '\$1':
-      return _$previewGetPreviewA$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<PreviewGetPreviewA> _$previewGetPreviewAValues = BuiltSet<PreviewGetPreviewA>(const <PreviewGetPreviewA>[
-  _$previewGetPreviewA$0,
-  _$previewGetPreviewA$1,
-]);
-
+Serializer<PreviewGetPreviewRequestApplicationJson> _$previewGetPreviewRequestApplicationJsonSerializer =
+    _$PreviewGetPreviewRequestApplicationJsonSerializer();
 Serializer<Capabilities_Files> _$capabilitiesFilesSerializer = _$Capabilities_FilesSerializer();
 Serializer<Capabilities> _$capabilitiesSerializer = _$CapabilitiesSerializer();
+
+class _$PreviewGetPreviewRequestApplicationJsonSerializer
+    implements StructuredSerializer<PreviewGetPreviewRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    PreviewGetPreviewRequestApplicationJson,
+    _$PreviewGetPreviewRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'PreviewGetPreviewRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PreviewGetPreviewRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'fileId',
+      serializers.serialize(object.fileId, specifiedType: const FullType(int)),
+      'x',
+      serializers.serialize(object.x, specifiedType: const FullType(int)),
+      'y',
+      serializers.serialize(object.y, specifiedType: const FullType(int)),
+      'a',
+      serializers.serialize(object.a, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  PreviewGetPreviewRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PreviewGetPreviewRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'fileId':
+          result.fileId = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'x':
+          result.x = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'y':
+          result.y = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'a':
+          result.a = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
 
 class _$Capabilities_FilesSerializer implements StructuredSerializer<Capabilities_Files> {
   @override
@@ -102,6 +142,150 @@ class _$CapabilitiesSerializer implements StructuredSerializer<Capabilities> {
     }
 
     return result.build();
+  }
+}
+
+abstract mixin class $PreviewGetPreviewRequestApplicationJsonInterfaceBuilder {
+  void replace($PreviewGetPreviewRequestApplicationJsonInterface other);
+  void update(void Function($PreviewGetPreviewRequestApplicationJsonInterfaceBuilder) updates);
+  int? get fileId;
+  set fileId(int? fileId);
+
+  int? get x;
+  set x(int? x);
+
+  int? get y;
+  set y(int? y);
+
+  bool? get a;
+  set a(bool? a);
+}
+
+class _$PreviewGetPreviewRequestApplicationJson extends PreviewGetPreviewRequestApplicationJson {
+  @override
+  final int fileId;
+  @override
+  final int x;
+  @override
+  final int y;
+  @override
+  final bool a;
+
+  factory _$PreviewGetPreviewRequestApplicationJson(
+          [void Function(PreviewGetPreviewRequestApplicationJsonBuilder)? updates]) =>
+      (PreviewGetPreviewRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PreviewGetPreviewRequestApplicationJson._({required this.fileId, required this.x, required this.y, required this.a})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(fileId, r'PreviewGetPreviewRequestApplicationJson', 'fileId');
+    BuiltValueNullFieldError.checkNotNull(x, r'PreviewGetPreviewRequestApplicationJson', 'x');
+    BuiltValueNullFieldError.checkNotNull(y, r'PreviewGetPreviewRequestApplicationJson', 'y');
+    BuiltValueNullFieldError.checkNotNull(a, r'PreviewGetPreviewRequestApplicationJson', 'a');
+  }
+
+  @override
+  PreviewGetPreviewRequestApplicationJson rebuild(
+          void Function(PreviewGetPreviewRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PreviewGetPreviewRequestApplicationJsonBuilder toBuilder() =>
+      PreviewGetPreviewRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PreviewGetPreviewRequestApplicationJson &&
+        fileId == other.fileId &&
+        x == other.x &&
+        y == other.y &&
+        a == other.a;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, fileId.hashCode);
+    _$hash = $jc(_$hash, x.hashCode);
+    _$hash = $jc(_$hash, y.hashCode);
+    _$hash = $jc(_$hash, a.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PreviewGetPreviewRequestApplicationJson')
+          ..add('fileId', fileId)
+          ..add('x', x)
+          ..add('y', y)
+          ..add('a', a))
+        .toString();
+  }
+}
+
+class PreviewGetPreviewRequestApplicationJsonBuilder
+    implements
+        Builder<PreviewGetPreviewRequestApplicationJson, PreviewGetPreviewRequestApplicationJsonBuilder>,
+        $PreviewGetPreviewRequestApplicationJsonInterfaceBuilder {
+  _$PreviewGetPreviewRequestApplicationJson? _$v;
+
+  int? _fileId;
+  int? get fileId => _$this._fileId;
+  set fileId(covariant int? fileId) => _$this._fileId = fileId;
+
+  int? _x;
+  int? get x => _$this._x;
+  set x(covariant int? x) => _$this._x = x;
+
+  int? _y;
+  int? get y => _$this._y;
+  set y(covariant int? y) => _$this._y = y;
+
+  bool? _a;
+  bool? get a => _$this._a;
+  set a(covariant bool? a) => _$this._a = a;
+
+  PreviewGetPreviewRequestApplicationJsonBuilder() {
+    PreviewGetPreviewRequestApplicationJson._defaults(this);
+  }
+
+  PreviewGetPreviewRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _fileId = $v.fileId;
+      _x = $v.x;
+      _y = $v.y;
+      _a = $v.a;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PreviewGetPreviewRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PreviewGetPreviewRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PreviewGetPreviewRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PreviewGetPreviewRequestApplicationJson build() => _build();
+
+  _$PreviewGetPreviewRequestApplicationJson _build() {
+    PreviewGetPreviewRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$PreviewGetPreviewRequestApplicationJson._(
+            fileId: BuiltValueNullFieldError.checkNotNull(fileId, r'PreviewGetPreviewRequestApplicationJson', 'fileId'),
+            x: BuiltValueNullFieldError.checkNotNull(x, r'PreviewGetPreviewRequestApplicationJson', 'x'),
+            y: BuiltValueNullFieldError.checkNotNull(y, r'PreviewGetPreviewRequestApplicationJson', 'y'),
+            a: BuiltValueNullFieldError.checkNotNull(a, r'PreviewGetPreviewRequestApplicationJson', 'a'));
+    replace(_$result);
+    return _$result;
   }
 }
 

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.json
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.json
@@ -58,51 +58,41 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "fileId",
-                        "in": "query",
-                        "description": "ID of the file",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": -1
-                        }
-                    },
-                    {
-                        "name": "x",
-                        "in": "query",
-                        "description": "Width of the preview",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 32
-                        }
-                    },
-                    {
-                        "name": "y",
-                        "in": "query",
-                        "description": "Height of the preview",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 32
-                        }
-                    },
-                    {
-                        "name": "a",
-                        "in": "query",
-                        "description": "Whether to not crop the preview",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "fileId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": -1,
+                                        "description": "ID of the file"
+                                    },
+                                    "x": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 32,
+                                        "description": "Width of the preview"
+                                    },
+                                    "y": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 32,
+                                        "description": "Height of the preview"
+                                    },
+                                    "a": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to not crop the preview"
+                                    }
+                                }
+                            }
                         }
                     }
-                ],
+                },
                 "responses": {
                     "200": {
                         "description": "Preview returned",

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.dart
@@ -16,17 +16,17 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:built_value/standard_json_plugin.dart' as _i7;
-import 'package:collection/collection.dart' as _i5;
-import 'package:dynamite_runtime/built_value.dart' as _i6;
+import 'package:built_value/standard_json_plugin.dart' as _i6;
+import 'package:collection/collection.dart' as _i4;
+import 'package:dynamite_runtime/built_value.dart' as _i5;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
 import 'package:http/http.dart' as _i3;
 import 'package:meta/meta.dart' as _i2;
-import 'package:uri/uri.dart' as _i4;
 
 part 'files_versions.openapi.g.dart';
 
@@ -69,12 +69,6 @@ class $PreviewClient {
   /// Returns a `DynamiteRequest` backing the [getPreview] operation.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
-  /// Parameters:
-  ///   * [file] Path of the file. Defaults to `""`.
-  ///   * [x] Width of the preview. Defaults to `44`.
-  ///   * [y] Height of the preview. Defaults to `44`.
-  ///   * [version] Version of the file to get the preview for. Defaults to `""`.
-  ///
   /// Status codes:
   ///   * 200: Preview returned
   ///   * 400: Getting preview is not possible
@@ -84,35 +78,13 @@ class $PreviewClient {
   ///  * [getPreview] for a method executing this request and parsing the response.
   ///  * [$getPreview_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $getPreview_Request({
-    String? file,
-    int? x,
-    int? y,
-    String? version,
-  }) {
-    final _parameters = <String, Object?>{};
-    var __file = _$jsonSerializers.serialize(file, specifiedType: const FullType(String));
-    __file ??= '';
-    _parameters['file'] = __file;
-
-    var __x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
-    __x ??= 44;
-    _parameters['x'] = __x;
-
-    var __y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
-    __y ??= 44;
-    _parameters['y'] = __y;
-
-    var __version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
-    __version ??= '';
-    _parameters['version'] = __version;
-
-    final _path = _i4.UriTemplate('/index.php/apps/files_versions/preview{?file*,x*,y*,version*}').expand(_parameters);
+  _i3.Request $getPreview_Request({PreviewGetPreviewRequestApplicationJson? $body}) {
+    const _path = '/index.php/apps/files_versions/preview';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = '*/*';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -128,6 +100,17 @@ class $PreviewClient {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(PreviewGetPreviewRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              PreviewGetPreviewRequestApplicationJson(),
+              specifiedType: const FullType(PreviewGetPreviewRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -135,12 +118,6 @@ class $PreviewClient {
   ///
   /// Returns a [Future] containing a `DynamiteResponse` with the status code, deserialized body and headers.
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
-  ///
-  /// Parameters:
-  ///   * [file] Path of the file. Defaults to `""`.
-  ///   * [x] Width of the preview. Defaults to `44`.
-  ///   * [y] Height of the preview. Defaults to `44`.
-  ///   * [version] Version of the file to get the preview for. Defaults to `""`.
   ///
   /// Status codes:
   ///   * 200: Preview returned
@@ -150,17 +127,9 @@ class $PreviewClient {
   /// See:
   ///  * [$getPreview_Request] for the request send by this method.
   ///  * [$getPreview_Serializer] for a converter to parse the `Response` from an executed request.
-  Future<_i1.DynamiteResponse<Uint8List, void>> getPreview({
-    String? file,
-    int? x,
-    int? y,
-    String? version,
-  }) async {
+  Future<_i1.DynamiteResponse<Uint8List, void>> getPreview({PreviewGetPreviewRequestApplicationJson? $body}) async {
     final _request = $getPreview_Request(
-      file: file,
-      x: x,
-      y: y,
-      version: version,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -168,6 +137,104 @@ class $PreviewClient {
     final _serializer = $getPreview_Serializer();
     final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $PreviewGetPreviewRequestApplicationJsonInterface {
+  static final _$file = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$x = _$jsonSerializers.deserialize(
+    44,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$y = _$jsonSerializers.deserialize(
+    44,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$version = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// Path of the file.
+  String get file;
+
+  /// Width of the preview.
+  int get x;
+
+  /// Height of the preview.
+  int get y;
+
+  /// Version of the file to get the preview for.
+  String get version;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreviewGetPreviewRequestApplicationJsonInterfaceBuilder].
+  $PreviewGetPreviewRequestApplicationJsonInterface rebuild(
+    void Function($PreviewGetPreviewRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreviewGetPreviewRequestApplicationJsonInterfaceBuilder].
+  $PreviewGetPreviewRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreviewGetPreviewRequestApplicationJsonInterfaceBuilder b) {
+    b.file = _$file;
+    b.x = _$x;
+    b.y = _$y;
+    b.version = _$version;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreviewGetPreviewRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class PreviewGetPreviewRequestApplicationJson
+    implements
+        $PreviewGetPreviewRequestApplicationJsonInterface,
+        Built<PreviewGetPreviewRequestApplicationJson, PreviewGetPreviewRequestApplicationJsonBuilder> {
+  /// Creates a new PreviewGetPreviewRequestApplicationJson object using the builder pattern.
+  factory PreviewGetPreviewRequestApplicationJson([void Function(PreviewGetPreviewRequestApplicationJsonBuilder)? b]) =
+      _$PreviewGetPreviewRequestApplicationJson;
+
+  // coverage:ignore-start
+  const PreviewGetPreviewRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory PreviewGetPreviewRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for PreviewGetPreviewRequestApplicationJson.
+  static Serializer<PreviewGetPreviewRequestApplicationJson> get serializer =>
+      _$previewGetPreviewRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreviewGetPreviewRequestApplicationJsonBuilder b) {
+    $PreviewGetPreviewRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreviewGetPreviewRequestApplicationJsonBuilder b) {
+    $PreviewGetPreviewRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -293,6 +360,11 @@ abstract class Capabilities implements $CapabilitiesInterface, Built<Capabilitie
 @_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
+      ..addBuilderFactory(
+        const FullType(PreviewGetPreviewRequestApplicationJson),
+        PreviewGetPreviewRequestApplicationJsonBuilder.new,
+      )
+      ..add(PreviewGetPreviewRequestApplicationJson.serializer)
       ..addBuilderFactory(const FullType(Capabilities), CapabilitiesBuilder.new)
       ..add(Capabilities.serializer)
       ..addBuilderFactory(const FullType(Capabilities_Files), Capabilities_FilesBuilder.new)
@@ -306,9 +378,9 @@ final Serializers _$serializers = (Serializers().toBuilder()
 @_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
-      ..add(_i6.DynamiteDoubleSerializer())
-      ..addPlugin(_i7.StandardJsonPlugin())
-      ..addPlugin(const _i6.HeaderPlugin())
-      ..addPlugin(const _i6.ContentStringPlugin()))
+      ..add(_i5.DynamiteDoubleSerializer())
+      ..addPlugin(_i6.StandardJsonPlugin())
+      ..addPlugin(const _i5.HeaderPlugin())
+      ..addPlugin(const _i5.ContentStringPlugin()))
     .build();
 // coverage:ignore-end

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.dart
@@ -91,21 +91,21 @@ class $PreviewClient {
     String? version,
   }) {
     final _parameters = <String, Object?>{};
-    var $file = _$jsonSerializers.serialize(file, specifiedType: const FullType(String));
-    $file ??= '';
-    _parameters['file'] = $file;
+    var __file = _$jsonSerializers.serialize(file, specifiedType: const FullType(String));
+    __file ??= '';
+    _parameters['file'] = __file;
 
-    var $x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
-    $x ??= 44;
-    _parameters['x'] = $x;
+    var __x = _$jsonSerializers.serialize(x, specifiedType: const FullType(int));
+    __x ??= 44;
+    _parameters['x'] = __x;
 
-    var $y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
-    $y ??= 44;
-    _parameters['y'] = $y;
+    var __y = _$jsonSerializers.serialize(y, specifiedType: const FullType(int));
+    __y ??= 44;
+    _parameters['y'] = __y;
 
-    var $version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
-    $version ??= '';
-    _parameters['version'] = $version;
+    var __version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
+    __version ??= '';
+    _parameters['version'] = __version;
 
     final _path = _i4.UriTemplate('/index.php/apps/files_versions/preview{?file*,x*,y*,version*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.g.dart
@@ -6,8 +6,67 @@ part of 'files_versions.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
+Serializer<PreviewGetPreviewRequestApplicationJson> _$previewGetPreviewRequestApplicationJsonSerializer =
+    _$PreviewGetPreviewRequestApplicationJsonSerializer();
 Serializer<Capabilities_Files> _$capabilitiesFilesSerializer = _$Capabilities_FilesSerializer();
 Serializer<Capabilities> _$capabilitiesSerializer = _$CapabilitiesSerializer();
+
+class _$PreviewGetPreviewRequestApplicationJsonSerializer
+    implements StructuredSerializer<PreviewGetPreviewRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    PreviewGetPreviewRequestApplicationJson,
+    _$PreviewGetPreviewRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'PreviewGetPreviewRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PreviewGetPreviewRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'file',
+      serializers.serialize(object.file, specifiedType: const FullType(String)),
+      'x',
+      serializers.serialize(object.x, specifiedType: const FullType(int)),
+      'y',
+      serializers.serialize(object.y, specifiedType: const FullType(int)),
+      'version',
+      serializers.serialize(object.version, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  PreviewGetPreviewRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PreviewGetPreviewRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'file':
+          result.file = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'x':
+          result.x = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'y':
+          result.y = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'version':
+          result.version = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
 
 class _$Capabilities_FilesSerializer implements StructuredSerializer<Capabilities_Files> {
   @override
@@ -93,6 +152,152 @@ class _$CapabilitiesSerializer implements StructuredSerializer<Capabilities> {
     }
 
     return result.build();
+  }
+}
+
+abstract mixin class $PreviewGetPreviewRequestApplicationJsonInterfaceBuilder {
+  void replace($PreviewGetPreviewRequestApplicationJsonInterface other);
+  void update(void Function($PreviewGetPreviewRequestApplicationJsonInterfaceBuilder) updates);
+  String? get file;
+  set file(String? file);
+
+  int? get x;
+  set x(int? x);
+
+  int? get y;
+  set y(int? y);
+
+  String? get version;
+  set version(String? version);
+}
+
+class _$PreviewGetPreviewRequestApplicationJson extends PreviewGetPreviewRequestApplicationJson {
+  @override
+  final String file;
+  @override
+  final int x;
+  @override
+  final int y;
+  @override
+  final String version;
+
+  factory _$PreviewGetPreviewRequestApplicationJson(
+          [void Function(PreviewGetPreviewRequestApplicationJsonBuilder)? updates]) =>
+      (PreviewGetPreviewRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PreviewGetPreviewRequestApplicationJson._(
+      {required this.file, required this.x, required this.y, required this.version})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(file, r'PreviewGetPreviewRequestApplicationJson', 'file');
+    BuiltValueNullFieldError.checkNotNull(x, r'PreviewGetPreviewRequestApplicationJson', 'x');
+    BuiltValueNullFieldError.checkNotNull(y, r'PreviewGetPreviewRequestApplicationJson', 'y');
+    BuiltValueNullFieldError.checkNotNull(version, r'PreviewGetPreviewRequestApplicationJson', 'version');
+  }
+
+  @override
+  PreviewGetPreviewRequestApplicationJson rebuild(
+          void Function(PreviewGetPreviewRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PreviewGetPreviewRequestApplicationJsonBuilder toBuilder() =>
+      PreviewGetPreviewRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PreviewGetPreviewRequestApplicationJson &&
+        file == other.file &&
+        x == other.x &&
+        y == other.y &&
+        version == other.version;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, file.hashCode);
+    _$hash = $jc(_$hash, x.hashCode);
+    _$hash = $jc(_$hash, y.hashCode);
+    _$hash = $jc(_$hash, version.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PreviewGetPreviewRequestApplicationJson')
+          ..add('file', file)
+          ..add('x', x)
+          ..add('y', y)
+          ..add('version', version))
+        .toString();
+  }
+}
+
+class PreviewGetPreviewRequestApplicationJsonBuilder
+    implements
+        Builder<PreviewGetPreviewRequestApplicationJson, PreviewGetPreviewRequestApplicationJsonBuilder>,
+        $PreviewGetPreviewRequestApplicationJsonInterfaceBuilder {
+  _$PreviewGetPreviewRequestApplicationJson? _$v;
+
+  String? _file;
+  String? get file => _$this._file;
+  set file(covariant String? file) => _$this._file = file;
+
+  int? _x;
+  int? get x => _$this._x;
+  set x(covariant int? x) => _$this._x = x;
+
+  int? _y;
+  int? get y => _$this._y;
+  set y(covariant int? y) => _$this._y = y;
+
+  String? _version;
+  String? get version => _$this._version;
+  set version(covariant String? version) => _$this._version = version;
+
+  PreviewGetPreviewRequestApplicationJsonBuilder() {
+    PreviewGetPreviewRequestApplicationJson._defaults(this);
+  }
+
+  PreviewGetPreviewRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _file = $v.file;
+      _x = $v.x;
+      _y = $v.y;
+      _version = $v.version;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PreviewGetPreviewRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PreviewGetPreviewRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PreviewGetPreviewRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PreviewGetPreviewRequestApplicationJson build() => _build();
+
+  _$PreviewGetPreviewRequestApplicationJson _build() {
+    PreviewGetPreviewRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$PreviewGetPreviewRequestApplicationJson._(
+            file: BuiltValueNullFieldError.checkNotNull(file, r'PreviewGetPreviewRequestApplicationJson', 'file'),
+            x: BuiltValueNullFieldError.checkNotNull(x, r'PreviewGetPreviewRequestApplicationJson', 'x'),
+            y: BuiltValueNullFieldError.checkNotNull(y, r'PreviewGetPreviewRequestApplicationJson', 'y'),
+            version:
+                BuiltValueNullFieldError.checkNotNull(version, r'PreviewGetPreviewRequestApplicationJson', 'version'));
+    replace(_$result);
+    return _$result;
   }
 }
 

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.json
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.json
@@ -66,46 +66,40 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "file",
-                        "in": "query",
-                        "description": "Path of the file",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "x",
-                        "in": "query",
-                        "description": "Width of the preview",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 44
-                        }
-                    },
-                    {
-                        "name": "y",
-                        "in": "query",
-                        "description": "Height of the preview",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 44
-                        }
-                    },
-                    {
-                        "name": "version",
-                        "in": "query",
-                        "description": "Version of the file to get the preview for",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "file": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Path of the file"
+                                    },
+                                    "x": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 44,
+                                        "description": "Width of the preview"
+                                    },
+                                    "y": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 44,
+                                        "description": "Height of the preview"
+                                    },
+                                    "version": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Version of the file to get the preview for"
+                                    }
+                                }
+                            }
                         }
                     }
-                ],
+                },
                 "responses": {
                     "200": {
                         "description": "Preview returned",

--- a/packages/nextcloud/lib/src/api/news.openapi.dart
+++ b/packages/nextcloud/lib/src/api/news.openapi.dart
@@ -197,8 +197,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $createFolder_Request({required String name}) {
     final _parameters = <String, Object?>{};
-    final $name = _$jsonSerializers.serialize(name, specifiedType: const FullType(String));
-    _parameters['name'] = $name;
+    final __name = _$jsonSerializers.serialize(name, specifiedType: const FullType(String));
+    _parameters['name'] = __name;
 
     final _path = _i5.UriTemplate('/index.php/apps/news/api/v1-3/folders{?name*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -275,11 +275,11 @@ class $Client extends _i1.DynamiteClient {
     required String name,
   }) {
     final _parameters = <String, Object?>{};
-    final $folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
-    _parameters['folderId'] = $folderId;
+    final __folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
+    _parameters['folderId'] = __folderId;
 
-    final $name = _$jsonSerializers.serialize(name, specifiedType: const FullType(String));
-    _parameters['name'] = $name;
+    final __name = _$jsonSerializers.serialize(name, specifiedType: const FullType(String));
+    _parameters['name'] = __name;
 
     final _path = _i5.UriTemplate('/index.php/apps/news/api/v1-3/folders/{folderId}{?name*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -353,8 +353,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $deleteFolder_Request({required int folderId}) {
     final _parameters = <String, Object?>{};
-    final $folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
-    _parameters['folderId'] = $folderId;
+    final __folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
+    _parameters['folderId'] = __folderId;
 
     final _path = _i5.UriTemplate('/index.php/apps/news/api/v1-3/folders/{folderId}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -427,11 +427,11 @@ class $Client extends _i1.DynamiteClient {
     required int newestItemId,
   }) {
     final _parameters = <String, Object?>{};
-    final $folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
-    _parameters['folderId'] = $folderId;
+    final __folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
+    _parameters['folderId'] = __folderId;
 
-    final $newestItemId = _$jsonSerializers.serialize(newestItemId, specifiedType: const FullType(int));
-    _parameters['newestItemId'] = $newestItemId;
+    final __newestItemId = _$jsonSerializers.serialize(newestItemId, specifiedType: const FullType(int));
+    _parameters['newestItemId'] = __newestItemId;
 
     final _path =
         _i5.UriTemplate('/index.php/apps/news/api/v1-3/folders/{folderId}/read{?newestItemId*}').expand(_parameters);
@@ -576,11 +576,11 @@ class $Client extends _i1.DynamiteClient {
     int? folderId,
   }) {
     final _parameters = <String, Object?>{};
-    final $url = _$jsonSerializers.serialize(url, specifiedType: const FullType(String));
-    _parameters['url'] = $url;
+    final __url = _$jsonSerializers.serialize(url, specifiedType: const FullType(String));
+    _parameters['url'] = __url;
 
-    final $folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
-    _parameters['folderId'] = $folderId;
+    final __folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
+    _parameters['folderId'] = __folderId;
 
     final _path = _i5.UriTemplate('/index.php/apps/news/api/v1-3/feeds{?url*,folderId*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -656,8 +656,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $deleteFeed_Request({required int feedId}) {
     final _parameters = <String, Object?>{};
-    final $feedId = _$jsonSerializers.serialize(feedId, specifiedType: const FullType(int));
-    _parameters['feedId'] = $feedId;
+    final __feedId = _$jsonSerializers.serialize(feedId, specifiedType: const FullType(int));
+    _parameters['feedId'] = __feedId;
 
     final _path = _i5.UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -730,11 +730,11 @@ class $Client extends _i1.DynamiteClient {
     int? folderId,
   }) {
     final _parameters = <String, Object?>{};
-    final $feedId = _$jsonSerializers.serialize(feedId, specifiedType: const FullType(int));
-    _parameters['feedId'] = $feedId;
+    final __feedId = _$jsonSerializers.serialize(feedId, specifiedType: const FullType(int));
+    _parameters['feedId'] = __feedId;
 
-    final $folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
-    _parameters['folderId'] = $folderId;
+    final __folderId = _$jsonSerializers.serialize(folderId, specifiedType: const FullType(int));
+    _parameters['folderId'] = __folderId;
 
     final _path = _i5.UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}/move{?folderId*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -814,11 +814,11 @@ class $Client extends _i1.DynamiteClient {
     required String feedTitle,
   }) {
     final _parameters = <String, Object?>{};
-    final $feedId = _$jsonSerializers.serialize(feedId, specifiedType: const FullType(int));
-    _parameters['feedId'] = $feedId;
+    final __feedId = _$jsonSerializers.serialize(feedId, specifiedType: const FullType(int));
+    _parameters['feedId'] = __feedId;
 
-    final $feedTitle = _$jsonSerializers.serialize(feedTitle, specifiedType: const FullType(String));
-    _parameters['feedTitle'] = $feedTitle;
+    final __feedTitle = _$jsonSerializers.serialize(feedTitle, specifiedType: const FullType(String));
+    _parameters['feedTitle'] = __feedTitle;
 
     final _path =
         _i5.UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}/rename{?feedTitle*}').expand(_parameters);
@@ -899,11 +899,11 @@ class $Client extends _i1.DynamiteClient {
     required int newestItemId,
   }) {
     final _parameters = <String, Object?>{};
-    final $feedId = _$jsonSerializers.serialize(feedId, specifiedType: const FullType(int));
-    _parameters['feedId'] = $feedId;
+    final __feedId = _$jsonSerializers.serialize(feedId, specifiedType: const FullType(int));
+    _parameters['feedId'] = __feedId;
 
-    final $newestItemId = _$jsonSerializers.serialize(newestItemId, specifiedType: const FullType(int));
-    _parameters['newestItemId'] = $newestItemId;
+    final __newestItemId = _$jsonSerializers.serialize(newestItemId, specifiedType: const FullType(int));
+    _parameters['newestItemId'] = __newestItemId;
 
     final _path =
         _i5.UriTemplate('/index.php/apps/news/api/v1-3/feeds/{feedId}/read{?newestItemId*}').expand(_parameters);
@@ -993,29 +993,29 @@ class $Client extends _i1.DynamiteClient {
     int? oldestFirst,
   }) {
     final _parameters = <String, Object?>{};
-    var $type = _$jsonSerializers.serialize(type, specifiedType: const FullType(int));
-    $type ??= 3;
-    _parameters['type'] = $type;
+    var __type = _$jsonSerializers.serialize(type, specifiedType: const FullType(int));
+    __type ??= 3;
+    _parameters['type'] = __type;
 
-    var $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    $id ??= 0;
-    _parameters['id'] = $id;
+    var __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    __id ??= 0;
+    _parameters['id'] = __id;
 
-    var $getRead = _$jsonSerializers.serialize(getRead, specifiedType: const FullType(int));
-    $getRead ??= 1;
-    _parameters['getRead'] = $getRead;
+    var __getRead = _$jsonSerializers.serialize(getRead, specifiedType: const FullType(int));
+    __getRead ??= 1;
+    _parameters['getRead'] = __getRead;
 
-    var $batchSize = _$jsonSerializers.serialize(batchSize, specifiedType: const FullType(int));
-    $batchSize ??= -1;
-    _parameters['batchSize'] = $batchSize;
+    var __batchSize = _$jsonSerializers.serialize(batchSize, specifiedType: const FullType(int));
+    __batchSize ??= -1;
+    _parameters['batchSize'] = __batchSize;
 
-    var $offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    $offset ??= 0;
-    _parameters['offset'] = $offset;
+    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
+    __offset ??= 0;
+    _parameters['offset'] = __offset;
 
-    var $oldestFirst = _$jsonSerializers.serialize(oldestFirst, specifiedType: const FullType(int));
-    $oldestFirst ??= 0;
-    _parameters['oldestFirst'] = $oldestFirst;
+    var __oldestFirst = _$jsonSerializers.serialize(oldestFirst, specifiedType: const FullType(int));
+    __oldestFirst ??= 0;
+    _parameters['oldestFirst'] = __oldestFirst;
 
     final _path =
         _i5.UriTemplate('/index.php/apps/news/api/v1-3/items{?type*,id*,getRead*,batchSize*,offset*,oldestFirst*}')
@@ -1114,17 +1114,17 @@ class $Client extends _i1.DynamiteClient {
     int? lastModified,
   }) {
     final _parameters = <String, Object?>{};
-    var $type = _$jsonSerializers.serialize(type, specifiedType: const FullType(int));
-    $type ??= 3;
-    _parameters['type'] = $type;
+    var __type = _$jsonSerializers.serialize(type, specifiedType: const FullType(int));
+    __type ??= 3;
+    _parameters['type'] = __type;
 
-    var $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    $id ??= 0;
-    _parameters['id'] = $id;
+    var __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    __id ??= 0;
+    _parameters['id'] = __id;
 
-    var $lastModified = _$jsonSerializers.serialize(lastModified, specifiedType: const FullType(int));
-    $lastModified ??= 0;
-    _parameters['lastModified'] = $lastModified;
+    var __lastModified = _$jsonSerializers.serialize(lastModified, specifiedType: const FullType(int));
+    __lastModified ??= 0;
+    _parameters['lastModified'] = __lastModified;
 
     final _path =
         _i5.UriTemplate('/index.php/apps/news/api/v1-3/items/updated{?type*,id*,lastModified*}').expand(_parameters);
@@ -1204,8 +1204,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $markArticleAsRead_Request({required int itemId}) {
     final _parameters = <String, Object?>{};
-    final $itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(int));
-    _parameters['itemId'] = $itemId;
+    final __itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(int));
+    _parameters['itemId'] = __itemId;
 
     final _path = _i5.UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/read').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -1272,8 +1272,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $markArticleAsUnread_Request({required int itemId}) {
     final _parameters = <String, Object?>{};
-    final $itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(int));
-    _parameters['itemId'] = $itemId;
+    final __itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(int));
+    _parameters['itemId'] = __itemId;
 
     final _path = _i5.UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/unread').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -1340,8 +1340,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $starArticle_Request({required int itemId}) {
     final _parameters = <String, Object?>{};
-    final $itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(int));
-    _parameters['itemId'] = $itemId;
+    final __itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(int));
+    _parameters['itemId'] = __itemId;
 
     final _path = _i5.UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/star').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -1408,8 +1408,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $unstarArticle_Request({required int itemId}) {
     final _parameters = <String, Object?>{};
-    final $itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(int));
-    _parameters['itemId'] = $itemId;
+    final __itemId = _$jsonSerializers.serialize(itemId, specifiedType: const FullType(int));
+    _parameters['itemId'] = __itemId;
 
     final _path = _i5.UriTemplate('/index.php/apps/news/api/v1-3/items/{itemId}/unstar').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');

--- a/packages/nextcloud/lib/src/api/notes.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notes.openapi.dart
@@ -86,23 +86,23 @@ class $Client extends _i1.DynamiteClient {
     String? ifNoneMatch,
   }) {
     final _parameters = <String, Object?>{};
-    final $category = _$jsonSerializers.serialize(category, specifiedType: const FullType(String));
-    _parameters['category'] = $category;
+    final __category = _$jsonSerializers.serialize(category, specifiedType: const FullType(String));
+    _parameters['category'] = __category;
 
-    var $exclude = _$jsonSerializers.serialize(exclude, specifiedType: const FullType(String));
-    $exclude ??= '';
-    _parameters['exclude'] = $exclude;
+    var __exclude = _$jsonSerializers.serialize(exclude, specifiedType: const FullType(String));
+    __exclude ??= '';
+    _parameters['exclude'] = __exclude;
 
-    var $pruneBefore = _$jsonSerializers.serialize(pruneBefore, specifiedType: const FullType(int));
-    $pruneBefore ??= 0;
-    _parameters['pruneBefore'] = $pruneBefore;
+    var __pruneBefore = _$jsonSerializers.serialize(pruneBefore, specifiedType: const FullType(int));
+    __pruneBefore ??= 0;
+    _parameters['pruneBefore'] = __pruneBefore;
 
-    var $chunkSize = _$jsonSerializers.serialize(chunkSize, specifiedType: const FullType(int));
-    $chunkSize ??= 0;
-    _parameters['chunkSize'] = $chunkSize;
+    var __chunkSize = _$jsonSerializers.serialize(chunkSize, specifiedType: const FullType(int));
+    __chunkSize ??= 0;
+    _parameters['chunkSize'] = __chunkSize;
 
-    final $chunkCursor = _$jsonSerializers.serialize(chunkCursor, specifiedType: const FullType(String));
-    _parameters['chunkCursor'] = $chunkCursor;
+    final __chunkCursor = _$jsonSerializers.serialize(chunkCursor, specifiedType: const FullType(String));
+    _parameters['chunkCursor'] = __chunkCursor;
 
     final _path =
         _i4.UriTemplate('/index.php/apps/notes/api/v1/notes{?category*,exclude*,pruneBefore*,chunkSize*,chunkCursor*}')
@@ -127,9 +127,9 @@ class $Client extends _i1.DynamiteClient {
     }
 
 // coverage:ignore-end
-    final $ifNoneMatch = _$jsonSerializers.serialize(ifNoneMatch, specifiedType: const FullType(String));
-    if ($ifNoneMatch != null) {
-      _request.headers['If-None-Match'] = const _i6.HeaderEncoder().convert($ifNoneMatch);
+    final __ifNoneMatch = _$jsonSerializers.serialize(ifNoneMatch, specifiedType: const FullType(String));
+    if (__ifNoneMatch != null) {
+      _request.headers['If-None-Match'] = const _i6.HeaderEncoder().convert(__ifNoneMatch);
     }
 
     return _request;
@@ -210,25 +210,25 @@ class $Client extends _i1.DynamiteClient {
     int? favorite,
   }) {
     final _parameters = <String, Object?>{};
-    var $category = _$jsonSerializers.serialize(category, specifiedType: const FullType(String));
-    $category ??= '';
-    _parameters['category'] = $category;
+    var __category = _$jsonSerializers.serialize(category, specifiedType: const FullType(String));
+    __category ??= '';
+    _parameters['category'] = __category;
 
-    var $title = _$jsonSerializers.serialize(title, specifiedType: const FullType(String));
-    $title ??= '';
-    _parameters['title'] = $title;
+    var __title = _$jsonSerializers.serialize(title, specifiedType: const FullType(String));
+    __title ??= '';
+    _parameters['title'] = __title;
 
-    var $content = _$jsonSerializers.serialize(content, specifiedType: const FullType(String));
-    $content ??= '';
-    _parameters['content'] = $content;
+    var __content = _$jsonSerializers.serialize(content, specifiedType: const FullType(String));
+    __content ??= '';
+    _parameters['content'] = __content;
 
-    var $modified = _$jsonSerializers.serialize(modified, specifiedType: const FullType(int));
-    $modified ??= 0;
-    _parameters['modified'] = $modified;
+    var __modified = _$jsonSerializers.serialize(modified, specifiedType: const FullType(int));
+    __modified ??= 0;
+    _parameters['modified'] = __modified;
 
-    var $favorite = _$jsonSerializers.serialize(favorite, specifiedType: const FullType(int));
-    $favorite ??= 0;
-    _parameters['favorite'] = $favorite;
+    var __favorite = _$jsonSerializers.serialize(favorite, specifiedType: const FullType(int));
+    __favorite ??= 0;
+    _parameters['favorite'] = __favorite;
 
     final _path = _i4.UriTemplate('/index.php/apps/notes/api/v1/notes{?category*,title*,content*,modified*,favorite*}')
         .expand(_parameters);
@@ -322,12 +322,12 @@ class $Client extends _i1.DynamiteClient {
     String? ifNoneMatch,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
-    var $exclude = _$jsonSerializers.serialize(exclude, specifiedType: const FullType(String));
-    $exclude ??= '';
-    _parameters['exclude'] = $exclude;
+    var __exclude = _$jsonSerializers.serialize(exclude, specifiedType: const FullType(String));
+    __exclude ??= '';
+    _parameters['exclude'] = __exclude;
 
     final _path = _i4.UriTemplate('/index.php/apps/notes/api/v1/notes/{id}{?exclude*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -350,9 +350,9 @@ class $Client extends _i1.DynamiteClient {
     }
 
 // coverage:ignore-end
-    final $ifNoneMatch = _$jsonSerializers.serialize(ifNoneMatch, specifiedType: const FullType(String));
-    if ($ifNoneMatch != null) {
-      _request.headers['If-None-Match'] = const _i6.HeaderEncoder().convert($ifNoneMatch);
+    final __ifNoneMatch = _$jsonSerializers.serialize(ifNoneMatch, specifiedType: const FullType(String));
+    if (__ifNoneMatch != null) {
+      _request.headers['If-None-Match'] = const _i6.HeaderEncoder().convert(__ifNoneMatch);
     }
 
     return _request;
@@ -426,23 +426,23 @@ class $Client extends _i1.DynamiteClient {
     String? ifMatch,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
-    final $content = _$jsonSerializers.serialize(content, specifiedType: const FullType(String));
-    _parameters['content'] = $content;
+    final __content = _$jsonSerializers.serialize(content, specifiedType: const FullType(String));
+    _parameters['content'] = __content;
 
-    final $modified = _$jsonSerializers.serialize(modified, specifiedType: const FullType(int));
-    _parameters['modified'] = $modified;
+    final __modified = _$jsonSerializers.serialize(modified, specifiedType: const FullType(int));
+    _parameters['modified'] = __modified;
 
-    final $title = _$jsonSerializers.serialize(title, specifiedType: const FullType(String));
-    _parameters['title'] = $title;
+    final __title = _$jsonSerializers.serialize(title, specifiedType: const FullType(String));
+    _parameters['title'] = __title;
 
-    final $category = _$jsonSerializers.serialize(category, specifiedType: const FullType(String));
-    _parameters['category'] = $category;
+    final __category = _$jsonSerializers.serialize(category, specifiedType: const FullType(String));
+    _parameters['category'] = __category;
 
-    final $favorite = _$jsonSerializers.serialize(favorite, specifiedType: const FullType(int));
-    _parameters['favorite'] = $favorite;
+    final __favorite = _$jsonSerializers.serialize(favorite, specifiedType: const FullType(int));
+    _parameters['favorite'] = __favorite;
 
     final _path =
         _i4.UriTemplate('/index.php/apps/notes/api/v1/notes/{id}{?content*,modified*,title*,category*,favorite*}')
@@ -467,9 +467,9 @@ class $Client extends _i1.DynamiteClient {
     }
 
 // coverage:ignore-end
-    final $ifMatch = _$jsonSerializers.serialize(ifMatch, specifiedType: const FullType(String));
-    if ($ifMatch != null) {
-      _request.headers['If-Match'] = const _i6.HeaderEncoder().convert($ifMatch);
+    final __ifMatch = _$jsonSerializers.serialize(ifMatch, specifiedType: const FullType(String));
+    if (__ifMatch != null) {
+      _request.headers['If-Match'] = const _i6.HeaderEncoder().convert(__ifMatch);
     }
 
     return _request;
@@ -539,8 +539,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $deleteNote_Request({required int id}) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
     final _path = _i4.UriTemplate('/index.php/apps/notes/api/v1/notes/{id}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -669,7 +669,7 @@ class $Client extends _i1.DynamiteClient {
   ///  * [updateSettings] for a method executing this request and parsing the response.
   ///  * [$updateSettings_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
-  _i3.Request $updateSettings_Request({required Settings settings}) {
+  _i3.Request $updateSettings_Request({required Settings $body}) {
     const _path = '/index.php/apps/notes/api/v1/settings';
     final _uri = Uri.parse('$baseURL$_path');
     final _request = _i3.Request('put', _uri);
@@ -692,7 +692,7 @@ class $Client extends _i1.DynamiteClient {
 
 // coverage:ignore-end
     _request.headers['Content-Type'] = 'application/json';
-    _request.body = json.encode(_$jsonSerializers.serialize(settings, specifiedType: const FullType(Settings)));
+    _request.body = json.encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(Settings)));
     return _request;
   }
 
@@ -705,9 +705,9 @@ class $Client extends _i1.DynamiteClient {
   /// See:
   ///  * [$updateSettings_Request] for the request send by this method.
   ///  * [$updateSettings_Serializer] for a converter to parse the `Response` from an executed request.
-  Future<_i1.DynamiteResponse<Settings, void>> updateSettings({required Settings settings}) async {
+  Future<_i1.DynamiteResponse<Settings, void>> updateSettings({required Settings $body}) async {
     final _request = $updateSettings_Request(
-      settings: settings,
+      $body: $body,
     );
     final _streamedResponse = await httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);

--- a/packages/nextcloud/lib/src/api/notifications.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.dart
@@ -104,20 +104,20 @@ class $ApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $shortMessage = _$jsonSerializers.serialize(shortMessage, specifiedType: const FullType(String));
-    _parameters['shortMessage'] = $shortMessage;
+    final __shortMessage = _$jsonSerializers.serialize(shortMessage, specifiedType: const FullType(String));
+    _parameters['shortMessage'] = __shortMessage;
 
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
-    var $longMessage = _$jsonSerializers.serialize(longMessage, specifiedType: const FullType(String));
-    $longMessage ??= '';
-    _parameters['longMessage'] = $longMessage;
+    var __longMessage = _$jsonSerializers.serialize(longMessage, specifiedType: const FullType(String));
+    __longMessage ??= '';
+    _parameters['longMessage'] = __longMessage;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ApiGenerateNotificationApiVersion));
-    $apiVersion ??= 'v2';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v2';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/notifications/api/{apiVersion}/admin_notifications/{userId}{?shortMessage*,longMessage*}',
@@ -142,9 +142,9 @@ class $ApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -234,10 +234,10 @@ class $EndpointClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(EndpointListNotificationsApiVersion));
-    $apiVersion ??= 'v2';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v2';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -260,9 +260,9 @@ class $EndpointClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -336,12 +336,12 @@ class $EndpointClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(EndpointDeleteAllNotificationsApiVersion),
     );
-    $apiVersion ??= 'v2';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v2';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -364,9 +364,9 @@ class $EndpointClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -438,13 +438,13 @@ class $EndpointClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(EndpointGetNotificationApiVersion));
-    $apiVersion ??= 'v2';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v2';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/{id}').expand(_parameters);
@@ -468,9 +468,9 @@ class $EndpointClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -546,13 +546,13 @@ class $EndpointClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
-    _parameters['id'] = $id;
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    _parameters['id'] = __id;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(EndpointDeleteNotificationApiVersion));
-    $apiVersion ??= 'v2';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v2';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/{id}').expand(_parameters);
@@ -576,9 +576,9 @@ class $EndpointClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -654,13 +654,13 @@ class $EndpointClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $ids = _$jsonSerializers.serialize(ids, specifiedType: const FullType(BuiltList, [FullType(int)]));
-    _parameters['ids%5B%5D'] = $ids;
+    final __ids = _$jsonSerializers.serialize(ids, specifiedType: const FullType(BuiltList, [FullType(int)]));
+    _parameters['ids%5B%5D'] = __ids;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(EndpointConfirmIdsForUserApiVersion));
-    $apiVersion ??= 'v2';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v2';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/exists{?ids%5B%5D*}')
         .expand(_parameters);
@@ -684,9 +684,9 @@ class $EndpointClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -774,19 +774,19 @@ class $PushClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $pushTokenHash = _$jsonSerializers.serialize(pushTokenHash, specifiedType: const FullType(String));
-    _parameters['pushTokenHash'] = $pushTokenHash;
+    final __pushTokenHash = _$jsonSerializers.serialize(pushTokenHash, specifiedType: const FullType(String));
+    _parameters['pushTokenHash'] = __pushTokenHash;
 
-    final $devicePublicKey = _$jsonSerializers.serialize(devicePublicKey, specifiedType: const FullType(String));
-    _parameters['devicePublicKey'] = $devicePublicKey;
+    final __devicePublicKey = _$jsonSerializers.serialize(devicePublicKey, specifiedType: const FullType(String));
+    _parameters['devicePublicKey'] = __devicePublicKey;
 
-    final $proxyServer = _$jsonSerializers.serialize(proxyServer, specifiedType: const FullType(String));
-    _parameters['proxyServer'] = $proxyServer;
+    final __proxyServer = _$jsonSerializers.serialize(proxyServer, specifiedType: const FullType(String));
+    _parameters['proxyServer'] = __proxyServer;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PushRegisterDeviceApiVersion));
-    $apiVersion ??= 'v2';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v2';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/notifications/api/{apiVersion}/push{?pushTokenHash*,devicePublicKey*,proxyServer*}',
@@ -811,9 +811,9 @@ class $PushClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -896,10 +896,10 @@ class $PushClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PushRemoveDeviceApiVersion));
-    $apiVersion ??= 'v2';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v2';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/push').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -922,9 +922,9 @@ class $PushClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1008,19 +1008,19 @@ class $SettingsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $batchSetting = _$jsonSerializers.serialize(batchSetting, specifiedType: const FullType(int));
-    _parameters['batchSetting'] = $batchSetting;
+    final __batchSetting = _$jsonSerializers.serialize(batchSetting, specifiedType: const FullType(int));
+    _parameters['batchSetting'] = __batchSetting;
 
-    final $soundNotification = _$jsonSerializers.serialize(soundNotification, specifiedType: const FullType(String));
-    _parameters['soundNotification'] = $soundNotification;
+    final __soundNotification = _$jsonSerializers.serialize(soundNotification, specifiedType: const FullType(String));
+    _parameters['soundNotification'] = __soundNotification;
 
-    final $soundTalk = _$jsonSerializers.serialize(soundTalk, specifiedType: const FullType(String));
-    _parameters['soundTalk'] = $soundTalk;
+    final __soundTalk = _$jsonSerializers.serialize(soundTalk, specifiedType: const FullType(String));
+    _parameters['soundTalk'] = __soundTalk;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SettingsPersonalApiVersion));
-    $apiVersion ??= 'v2';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v2';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/notifications/api/{apiVersion}/settings{?batchSetting*,soundNotification*,soundTalk*}',
@@ -1045,9 +1045,9 @@ class $SettingsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1131,18 +1131,18 @@ class $SettingsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $batchSetting = _$jsonSerializers.serialize(batchSetting, specifiedType: const FullType(int));
-    _parameters['batchSetting'] = $batchSetting;
+    final __batchSetting = _$jsonSerializers.serialize(batchSetting, specifiedType: const FullType(int));
+    _parameters['batchSetting'] = __batchSetting;
 
-    final $soundNotification = _$jsonSerializers.serialize(soundNotification, specifiedType: const FullType(String));
-    _parameters['soundNotification'] = $soundNotification;
+    final __soundNotification = _$jsonSerializers.serialize(soundNotification, specifiedType: const FullType(String));
+    _parameters['soundNotification'] = __soundNotification;
 
-    final $soundTalk = _$jsonSerializers.serialize(soundTalk, specifiedType: const FullType(String));
-    _parameters['soundTalk'] = $soundTalk;
+    final __soundTalk = _$jsonSerializers.serialize(soundTalk, specifiedType: const FullType(String));
+    _parameters['soundTalk'] = __soundTalk;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SettingsAdminApiVersion));
-    $apiVersion ??= 'v2';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SettingsAdminApiVersion));
+    __apiVersion ??= 'v2';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/notifications/api/{apiVersion}/settings/admin{?batchSetting*,soundNotification*,soundTalk*}',
@@ -1167,9 +1167,9 @@ class $SettingsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/notifications.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.dart
@@ -16,6 +16,8 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
+
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/json_object.dart';
@@ -80,8 +82,6 @@ class $ApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [shortMessage] Subject of the notification.
-  ///   * [longMessage] Message of the notification. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v2"`.
   ///   * [userId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -97,31 +97,22 @@ class $ApiClient {
   ///  * [$generateNotification_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $generateNotification_Request({
-    required String shortMessage,
     required String userId,
-    String? longMessage,
+    required ApiGenerateNotificationRequestApplicationJson $body,
     ApiGenerateNotificationApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __shortMessage = _$jsonSerializers.serialize(shortMessage, specifiedType: const FullType(String));
-    _parameters['shortMessage'] = __shortMessage;
-
     final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
     _parameters['userId'] = __userId;
-
-    var __longMessage = _$jsonSerializers.serialize(longMessage, specifiedType: const FullType(String));
-    __longMessage ??= '';
-    _parameters['longMessage'] = __longMessage;
 
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ApiGenerateNotificationApiVersion));
     __apiVersion ??= 'v2';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i4.UriTemplate(
-      '/ocs/v2.php/apps/notifications/api/{apiVersion}/admin_notifications/{userId}{?shortMessage*,longMessage*}',
-    ).expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/admin_notifications/{userId}')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -146,6 +137,13 @@ class $ApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(ApiGenerateNotificationRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -157,8 +155,6 @@ class $ApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [shortMessage] Subject of the notification.
-  ///   * [longMessage] Message of the notification. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v2"`.
   ///   * [userId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -173,18 +169,16 @@ class $ApiClient {
   ///  * [$generateNotification_Request] for the request send by this method.
   ///  * [$generateNotification_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ApiGenerateNotificationResponseApplicationJson, void>> generateNotification({
-    required String shortMessage,
     required String userId,
-    String? longMessage,
+    required ApiGenerateNotificationRequestApplicationJson $body,
     ApiGenerateNotificationApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $generateNotification_Request(
-      shortMessage: shortMessage,
       userId: userId,
-      longMessage: longMessage,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -636,7 +630,6 @@ class $EndpointClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [ids] IDs of the notifications to check.
   ///   * [apiVersion] Version of the API to use. Defaults to `"v2"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -649,21 +642,18 @@ class $EndpointClient {
   ///  * [$confirmIdsForUser_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $confirmIdsForUser_Request({
-    required BuiltList<int> ids,
+    required EndpointConfirmIdsForUserRequestApplicationJson $body,
     EndpointConfirmIdsForUserApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __ids = _$jsonSerializers.serialize(ids, specifiedType: const FullType(BuiltList, [FullType(int)]));
-    _parameters['ids%5B%5D'] = __ids;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(EndpointConfirmIdsForUserApiVersion));
     __apiVersion ??= 'v2';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/exists{?ids%5B%5D*}')
-        .expand(_parameters);
+    final _path =
+        _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/exists').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -688,6 +678,13 @@ class $EndpointClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(EndpointConfirmIdsForUserRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -697,7 +694,6 @@ class $EndpointClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [ids] IDs of the notifications to check.
   ///   * [apiVersion] Version of the API to use. Defaults to `"v2"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -709,14 +705,14 @@ class $EndpointClient {
   ///  * [$confirmIdsForUser_Request] for the request send by this method.
   ///  * [$confirmIdsForUser_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<EndpointConfirmIdsForUserResponseApplicationJson, void>> confirmIdsForUser({
-    required BuiltList<int> ids,
+    required EndpointConfirmIdsForUserRequestApplicationJson $body,
     EndpointConfirmIdsForUserApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $confirmIdsForUser_Request(
-      ids: ids,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -750,9 +746,6 @@ class $PushClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [pushTokenHash] Hash of the push token.
-  ///   * [devicePublicKey] Public key of the device.
-  ///   * [proxyServer] Proxy server to be used.
   ///   * [apiVersion] Defaults to `"v2"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -767,30 +760,17 @@ class $PushClient {
   ///  * [$registerDevice_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $registerDevice_Request({
-    required String pushTokenHash,
-    required String devicePublicKey,
-    required String proxyServer,
+    required PushRegisterDeviceRequestApplicationJson $body,
     PushRegisterDeviceApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __pushTokenHash = _$jsonSerializers.serialize(pushTokenHash, specifiedType: const FullType(String));
-    _parameters['pushTokenHash'] = __pushTokenHash;
-
-    final __devicePublicKey = _$jsonSerializers.serialize(devicePublicKey, specifiedType: const FullType(String));
-    _parameters['devicePublicKey'] = __devicePublicKey;
-
-    final __proxyServer = _$jsonSerializers.serialize(proxyServer, specifiedType: const FullType(String));
-    _parameters['proxyServer'] = __proxyServer;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PushRegisterDeviceApiVersion));
     __apiVersion ??= 'v2';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i4.UriTemplate(
-      '/ocs/v2.php/apps/notifications/api/{apiVersion}/push{?pushTokenHash*,devicePublicKey*,proxyServer*}',
-    ).expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/push').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -815,6 +795,10 @@ class $PushClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(PushRegisterDeviceRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -824,9 +808,6 @@ class $PushClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [pushTokenHash] Hash of the push token.
-  ///   * [devicePublicKey] Public key of the device.
-  ///   * [proxyServer] Proxy server to be used.
   ///   * [apiVersion] Defaults to `"v2"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -840,18 +821,14 @@ class $PushClient {
   ///  * [$registerDevice_Request] for the request send by this method.
   ///  * [$registerDevice_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<PushRegisterDeviceResponseApplicationJson, void>> registerDevice({
-    required String pushTokenHash,
-    required String devicePublicKey,
-    required String proxyServer,
+    required PushRegisterDeviceRequestApplicationJson $body,
     PushRegisterDeviceApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $registerDevice_Request(
-      pushTokenHash: pushTokenHash,
-      devicePublicKey: devicePublicKey,
-      proxyServer: proxyServer,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -987,9 +964,6 @@ class $SettingsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [batchSetting] How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4).
-  ///   * [soundNotification] Enable sound for notifications ('yes' or 'no').
-  ///   * [soundTalk] Enable sound for Talk notifications ('yes' or 'no').
   ///   * [apiVersion] Defaults to `"v2"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1001,30 +975,17 @@ class $SettingsClient {
   ///  * [$personal_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $personal_Request({
-    required int batchSetting,
-    required String soundNotification,
-    required String soundTalk,
+    required SettingsPersonalRequestApplicationJson $body,
     SettingsPersonalApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __batchSetting = _$jsonSerializers.serialize(batchSetting, specifiedType: const FullType(int));
-    _parameters['batchSetting'] = __batchSetting;
-
-    final __soundNotification = _$jsonSerializers.serialize(soundNotification, specifiedType: const FullType(String));
-    _parameters['soundNotification'] = __soundNotification;
-
-    final __soundTalk = _$jsonSerializers.serialize(soundTalk, specifiedType: const FullType(String));
-    _parameters['soundTalk'] = __soundTalk;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SettingsPersonalApiVersion));
     __apiVersion ??= 'v2';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i4.UriTemplate(
-      '/ocs/v2.php/apps/notifications/api/{apiVersion}/settings{?batchSetting*,soundNotification*,soundTalk*}',
-    ).expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/settings').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1049,6 +1010,10 @@ class $SettingsClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(SettingsPersonalRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -1058,9 +1023,6 @@ class $SettingsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [batchSetting] How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4).
-  ///   * [soundNotification] Enable sound for notifications ('yes' or 'no').
-  ///   * [soundTalk] Enable sound for Talk notifications ('yes' or 'no').
   ///   * [apiVersion] Defaults to `"v2"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1071,18 +1033,14 @@ class $SettingsClient {
   ///  * [$personal_Request] for the request send by this method.
   ///  * [$personal_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<SettingsPersonalResponseApplicationJson, void>> personal({
-    required int batchSetting,
-    required String soundNotification,
-    required String soundTalk,
+    required SettingsPersonalRequestApplicationJson $body,
     SettingsPersonalApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $personal_Request(
-      batchSetting: batchSetting,
-      soundNotification: soundNotification,
-      soundTalk: soundTalk,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1110,9 +1068,6 @@ class $SettingsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [batchSetting] How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4).
-  ///   * [soundNotification] Enable sound for notifications ('yes' or 'no').
-  ///   * [soundTalk] Enable sound for Talk notifications ('yes' or 'no').
   ///   * [apiVersion] Defaults to `"v2"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1124,29 +1079,16 @@ class $SettingsClient {
   ///  * [$admin_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $admin_Request({
-    required int batchSetting,
-    required String soundNotification,
-    required String soundTalk,
+    required SettingsAdminRequestApplicationJson $body,
     SettingsAdminApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __batchSetting = _$jsonSerializers.serialize(batchSetting, specifiedType: const FullType(int));
-    _parameters['batchSetting'] = __batchSetting;
-
-    final __soundNotification = _$jsonSerializers.serialize(soundNotification, specifiedType: const FullType(String));
-    _parameters['soundNotification'] = __soundNotification;
-
-    final __soundTalk = _$jsonSerializers.serialize(soundTalk, specifiedType: const FullType(String));
-    _parameters['soundTalk'] = __soundTalk;
-
     var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SettingsAdminApiVersion));
     __apiVersion ??= 'v2';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i4.UriTemplate(
-      '/ocs/v2.php/apps/notifications/api/{apiVersion}/settings/admin{?batchSetting*,soundNotification*,soundTalk*}',
-    ).expand(_parameters);
+    final _path = _i4.UriTemplate('/ocs/v2.php/apps/notifications/api/{apiVersion}/settings/admin').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1171,6 +1113,9 @@ class $SettingsClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json
+        .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(SettingsAdminRequestApplicationJson)));
     return _request;
   }
 
@@ -1182,9 +1127,6 @@ class $SettingsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [batchSetting] How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4).
-  ///   * [soundNotification] Enable sound for notifications ('yes' or 'no').
-  ///   * [soundTalk] Enable sound for Talk notifications ('yes' or 'no').
   ///   * [apiVersion] Defaults to `"v2"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1195,18 +1137,14 @@ class $SettingsClient {
   ///  * [$admin_Request] for the request send by this method.
   ///  * [$admin_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<SettingsAdminResponseApplicationJson, void>> admin({
-    required int batchSetting,
-    required String soundNotification,
-    required String soundTalk,
+    required SettingsAdminRequestApplicationJson $body,
     SettingsAdminApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $admin_Request(
-      batchSetting: batchSetting,
-      soundNotification: soundNotification,
-      soundTalk: soundTalk,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1278,6 +1216,81 @@ class _$ApiGenerateNotificationApiVersionSerializer implements PrimitiveSerializ
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ApiGenerateNotificationRequestApplicationJsonInterface {
+  static final _$longMessage = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// Subject of the notification.
+  String get shortMessage;
+
+  /// Message of the notification.
+  String get longMessage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGenerateNotificationRequestApplicationJsonInterfaceBuilder].
+  $ApiGenerateNotificationRequestApplicationJsonInterface rebuild(
+    void Function($ApiGenerateNotificationRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGenerateNotificationRequestApplicationJsonInterfaceBuilder].
+  $ApiGenerateNotificationRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiGenerateNotificationRequestApplicationJsonInterfaceBuilder b) {
+    b.longMessage = _$longMessage;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiGenerateNotificationRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ApiGenerateNotificationRequestApplicationJson
+    implements
+        $ApiGenerateNotificationRequestApplicationJsonInterface,
+        Built<ApiGenerateNotificationRequestApplicationJson, ApiGenerateNotificationRequestApplicationJsonBuilder> {
+  /// Creates a new ApiGenerateNotificationRequestApplicationJson object using the builder pattern.
+  factory ApiGenerateNotificationRequestApplicationJson([
+    void Function(ApiGenerateNotificationRequestApplicationJsonBuilder)? b,
+  ]) = _$ApiGenerateNotificationRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ApiGenerateNotificationRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ApiGenerateNotificationRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ApiGenerateNotificationRequestApplicationJson.
+  static Serializer<ApiGenerateNotificationRequestApplicationJson> get serializer =>
+      _$apiGenerateNotificationRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiGenerateNotificationRequestApplicationJsonBuilder b) {
+    $ApiGenerateNotificationRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiGenerateNotificationRequestApplicationJsonBuilder b) {
+    $ApiGenerateNotificationRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -2500,6 +2513,70 @@ class _$EndpointConfirmIdsForUserApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
+sealed class $EndpointConfirmIdsForUserRequestApplicationJsonInterface {
+  /// IDs of the notifications to check.
+  BuiltList<int> get ids;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$EndpointConfirmIdsForUserRequestApplicationJsonInterfaceBuilder].
+  $EndpointConfirmIdsForUserRequestApplicationJsonInterface rebuild(
+    void Function($EndpointConfirmIdsForUserRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$EndpointConfirmIdsForUserRequestApplicationJsonInterfaceBuilder].
+  $EndpointConfirmIdsForUserRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($EndpointConfirmIdsForUserRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($EndpointConfirmIdsForUserRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class EndpointConfirmIdsForUserRequestApplicationJson
+    implements
+        $EndpointConfirmIdsForUserRequestApplicationJsonInterface,
+        Built<EndpointConfirmIdsForUserRequestApplicationJson, EndpointConfirmIdsForUserRequestApplicationJsonBuilder> {
+  /// Creates a new EndpointConfirmIdsForUserRequestApplicationJson object using the builder pattern.
+  factory EndpointConfirmIdsForUserRequestApplicationJson([
+    void Function(EndpointConfirmIdsForUserRequestApplicationJsonBuilder)? b,
+  ]) = _$EndpointConfirmIdsForUserRequestApplicationJson;
+
+  // coverage:ignore-start
+  const EndpointConfirmIdsForUserRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory EndpointConfirmIdsForUserRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for EndpointConfirmIdsForUserRequestApplicationJson.
+  static Serializer<EndpointConfirmIdsForUserRequestApplicationJson> get serializer =>
+      _$endpointConfirmIdsForUserRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(EndpointConfirmIdsForUserRequestApplicationJsonBuilder b) {
+    $EndpointConfirmIdsForUserRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(EndpointConfirmIdsForUserRequestApplicationJsonBuilder b) {
+    $EndpointConfirmIdsForUserRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $EndpointConfirmIdsForUserResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<int> get data;
@@ -2682,6 +2759,76 @@ class _$PushRegisterDeviceApiVersionSerializer implements PrimitiveSerializer<Pu
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $PushRegisterDeviceRequestApplicationJsonInterface {
+  /// Hash of the push token.
+  String get pushTokenHash;
+
+  /// Public key of the device.
+  String get devicePublicKey;
+
+  /// Proxy server to be used.
+  String get proxyServer;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PushRegisterDeviceRequestApplicationJsonInterfaceBuilder].
+  $PushRegisterDeviceRequestApplicationJsonInterface rebuild(
+    void Function($PushRegisterDeviceRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PushRegisterDeviceRequestApplicationJsonInterfaceBuilder].
+  $PushRegisterDeviceRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PushRegisterDeviceRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PushRegisterDeviceRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class PushRegisterDeviceRequestApplicationJson
+    implements
+        $PushRegisterDeviceRequestApplicationJsonInterface,
+        Built<PushRegisterDeviceRequestApplicationJson, PushRegisterDeviceRequestApplicationJsonBuilder> {
+  /// Creates a new PushRegisterDeviceRequestApplicationJson object using the builder pattern.
+  factory PushRegisterDeviceRequestApplicationJson([
+    void Function(PushRegisterDeviceRequestApplicationJsonBuilder)? b,
+  ]) = _$PushRegisterDeviceRequestApplicationJson;
+
+  // coverage:ignore-start
+  const PushRegisterDeviceRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory PushRegisterDeviceRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for PushRegisterDeviceRequestApplicationJson.
+  static Serializer<PushRegisterDeviceRequestApplicationJson> get serializer =>
+      _$pushRegisterDeviceRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PushRegisterDeviceRequestApplicationJsonBuilder b) {
+    $PushRegisterDeviceRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PushRegisterDeviceRequestApplicationJsonBuilder b) {
+    $PushRegisterDeviceRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -3106,6 +3253,75 @@ class _$SettingsPersonalApiVersionSerializer implements PrimitiveSerializer<Sett
 }
 
 @BuiltValue(instantiable: false)
+sealed class $SettingsPersonalRequestApplicationJsonInterface {
+  /// How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4).
+  int get batchSetting;
+
+  /// Enable sound for notifications ('yes' or 'no').
+  String get soundNotification;
+
+  /// Enable sound for Talk notifications ('yes' or 'no').
+  String get soundTalk;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsPersonalRequestApplicationJsonInterfaceBuilder].
+  $SettingsPersonalRequestApplicationJsonInterface rebuild(
+    void Function($SettingsPersonalRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SettingsPersonalRequestApplicationJsonInterfaceBuilder].
+  $SettingsPersonalRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsPersonalRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsPersonalRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class SettingsPersonalRequestApplicationJson
+    implements
+        $SettingsPersonalRequestApplicationJsonInterface,
+        Built<SettingsPersonalRequestApplicationJson, SettingsPersonalRequestApplicationJsonBuilder> {
+  /// Creates a new SettingsPersonalRequestApplicationJson object using the builder pattern.
+  factory SettingsPersonalRequestApplicationJson([void Function(SettingsPersonalRequestApplicationJsonBuilder)? b]) =
+      _$SettingsPersonalRequestApplicationJson;
+
+  // coverage:ignore-start
+  const SettingsPersonalRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory SettingsPersonalRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for SettingsPersonalRequestApplicationJson.
+  static Serializer<SettingsPersonalRequestApplicationJson> get serializer =>
+      _$settingsPersonalRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsPersonalRequestApplicationJsonBuilder b) {
+    $SettingsPersonalRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsPersonalRequestApplicationJsonBuilder b) {
+    $SettingsPersonalRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $SettingsPersonalResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -3285,6 +3501,75 @@ class _$SettingsAdminApiVersionSerializer implements PrimitiveSerializer<Setting
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $SettingsAdminRequestApplicationJsonInterface {
+  /// How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4).
+  int get batchSetting;
+
+  /// Enable sound for notifications ('yes' or 'no').
+  String get soundNotification;
+
+  /// Enable sound for Talk notifications ('yes' or 'no').
+  String get soundTalk;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsAdminRequestApplicationJsonInterfaceBuilder].
+  $SettingsAdminRequestApplicationJsonInterface rebuild(
+    void Function($SettingsAdminRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SettingsAdminRequestApplicationJsonInterfaceBuilder].
+  $SettingsAdminRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsAdminRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsAdminRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class SettingsAdminRequestApplicationJson
+    implements
+        $SettingsAdminRequestApplicationJsonInterface,
+        Built<SettingsAdminRequestApplicationJson, SettingsAdminRequestApplicationJsonBuilder> {
+  /// Creates a new SettingsAdminRequestApplicationJson object using the builder pattern.
+  factory SettingsAdminRequestApplicationJson([void Function(SettingsAdminRequestApplicationJsonBuilder)? b]) =
+      _$SettingsAdminRequestApplicationJson;
+
+  // coverage:ignore-start
+  const SettingsAdminRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory SettingsAdminRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for SettingsAdminRequestApplicationJson.
+  static Serializer<SettingsAdminRequestApplicationJson> get serializer =>
+      _$settingsAdminRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsAdminRequestApplicationJsonBuilder b) {
+    $SettingsAdminRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsAdminRequestApplicationJsonBuilder b) {
+    $SettingsAdminRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -3540,6 +3825,11 @@ final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ApiGenerateNotificationApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(ApiGenerateNotificationRequestApplicationJson),
+        ApiGenerateNotificationRequestApplicationJsonBuilder.new,
+      )
+      ..add(ApiGenerateNotificationRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(ApiGenerateNotificationResponseApplicationJson),
         ApiGenerateNotificationResponseApplicationJsonBuilder.new,
       )
@@ -3613,8 +3903,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
         EndpointDeleteNotificationResponseApplicationJson_OcsBuilder.new,
       )
       ..add(EndpointDeleteNotificationResponseApplicationJson_Ocs.serializer)
-      ..addBuilderFactory(const FullType(BuiltList, [FullType(int)]), ListBuilder<int>.new)
       ..add(EndpointConfirmIdsForUserApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(EndpointConfirmIdsForUserRequestApplicationJson),
+        EndpointConfirmIdsForUserRequestApplicationJsonBuilder.new,
+      )
+      ..add(EndpointConfirmIdsForUserRequestApplicationJson.serializer)
+      ..addBuilderFactory(const FullType(BuiltList, [FullType(int)]), ListBuilder<int>.new)
       ..addBuilderFactory(
         const FullType(EndpointConfirmIdsForUserResponseApplicationJson),
         EndpointConfirmIdsForUserResponseApplicationJsonBuilder.new,
@@ -3626,6 +3921,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(EndpointConfirmIdsForUserResponseApplicationJson_Ocs.serializer)
       ..add(PushRegisterDeviceApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(PushRegisterDeviceRequestApplicationJson),
+        PushRegisterDeviceRequestApplicationJsonBuilder.new,
+      )
+      ..add(PushRegisterDeviceRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(PushRegisterDeviceResponseApplicationJson),
         PushRegisterDeviceResponseApplicationJsonBuilder.new,
@@ -3651,6 +3951,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(PushRemoveDeviceResponseApplicationJson_Ocs.serializer)
       ..add(SettingsPersonalApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(SettingsPersonalRequestApplicationJson),
+        SettingsPersonalRequestApplicationJsonBuilder.new,
+      )
+      ..add(SettingsPersonalRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(SettingsPersonalResponseApplicationJson),
         SettingsPersonalResponseApplicationJsonBuilder.new,
       )
@@ -3661,6 +3966,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(SettingsPersonalResponseApplicationJson_Ocs.serializer)
       ..add(SettingsAdminApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(SettingsAdminRequestApplicationJson),
+        SettingsAdminRequestApplicationJsonBuilder.new,
+      )
+      ..add(SettingsAdminRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(SettingsAdminResponseApplicationJson),
         SettingsAdminResponseApplicationJsonBuilder.new,

--- a/packages/nextcloud/lib/src/api/notifications.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.g.dart
@@ -202,6 +202,8 @@ final BuiltSet<SettingsAdminApiVersion> _$settingsAdminApiVersionValues =
   _$settingsAdminApiVersionV2,
 ]);
 
+Serializer<ApiGenerateNotificationRequestApplicationJson> _$apiGenerateNotificationRequestApplicationJsonSerializer =
+    _$ApiGenerateNotificationRequestApplicationJsonSerializer();
 Serializer<OCSMeta> _$oCSMetaSerializer = _$OCSMetaSerializer();
 Serializer<ApiGenerateNotificationResponseApplicationJson_Ocs>
     _$apiGenerateNotificationResponseApplicationJsonOcsSerializer =
@@ -235,12 +237,17 @@ Serializer<EndpointDeleteNotificationResponseApplicationJson_Ocs>
 Serializer<EndpointDeleteNotificationResponseApplicationJson>
     _$endpointDeleteNotificationResponseApplicationJsonSerializer =
     _$EndpointDeleteNotificationResponseApplicationJsonSerializer();
+Serializer<EndpointConfirmIdsForUserRequestApplicationJson>
+    _$endpointConfirmIdsForUserRequestApplicationJsonSerializer =
+    _$EndpointConfirmIdsForUserRequestApplicationJsonSerializer();
 Serializer<EndpointConfirmIdsForUserResponseApplicationJson_Ocs>
     _$endpointConfirmIdsForUserResponseApplicationJsonOcsSerializer =
     _$EndpointConfirmIdsForUserResponseApplicationJson_OcsSerializer();
 Serializer<EndpointConfirmIdsForUserResponseApplicationJson>
     _$endpointConfirmIdsForUserResponseApplicationJsonSerializer =
     _$EndpointConfirmIdsForUserResponseApplicationJsonSerializer();
+Serializer<PushRegisterDeviceRequestApplicationJson> _$pushRegisterDeviceRequestApplicationJsonSerializer =
+    _$PushRegisterDeviceRequestApplicationJsonSerializer();
 Serializer<PushDevice> _$pushDeviceSerializer = _$PushDeviceSerializer();
 Serializer<PushRegisterDeviceResponseApplicationJson_Ocs> _$pushRegisterDeviceResponseApplicationJsonOcsSerializer =
     _$PushRegisterDeviceResponseApplicationJson_OcsSerializer();
@@ -250,16 +257,67 @@ Serializer<PushRemoveDeviceResponseApplicationJson_Ocs> _$pushRemoveDeviceRespon
     _$PushRemoveDeviceResponseApplicationJson_OcsSerializer();
 Serializer<PushRemoveDeviceResponseApplicationJson> _$pushRemoveDeviceResponseApplicationJsonSerializer =
     _$PushRemoveDeviceResponseApplicationJsonSerializer();
+Serializer<SettingsPersonalRequestApplicationJson> _$settingsPersonalRequestApplicationJsonSerializer =
+    _$SettingsPersonalRequestApplicationJsonSerializer();
 Serializer<SettingsPersonalResponseApplicationJson_Ocs> _$settingsPersonalResponseApplicationJsonOcsSerializer =
     _$SettingsPersonalResponseApplicationJson_OcsSerializer();
 Serializer<SettingsPersonalResponseApplicationJson> _$settingsPersonalResponseApplicationJsonSerializer =
     _$SettingsPersonalResponseApplicationJsonSerializer();
+Serializer<SettingsAdminRequestApplicationJson> _$settingsAdminRequestApplicationJsonSerializer =
+    _$SettingsAdminRequestApplicationJsonSerializer();
 Serializer<SettingsAdminResponseApplicationJson_Ocs> _$settingsAdminResponseApplicationJsonOcsSerializer =
     _$SettingsAdminResponseApplicationJson_OcsSerializer();
 Serializer<SettingsAdminResponseApplicationJson> _$settingsAdminResponseApplicationJsonSerializer =
     _$SettingsAdminResponseApplicationJsonSerializer();
 Serializer<Capabilities_Notifications> _$capabilitiesNotificationsSerializer = _$Capabilities_NotificationsSerializer();
 Serializer<Capabilities> _$capabilitiesSerializer = _$CapabilitiesSerializer();
+
+class _$ApiGenerateNotificationRequestApplicationJsonSerializer
+    implements StructuredSerializer<ApiGenerateNotificationRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ApiGenerateNotificationRequestApplicationJson,
+    _$ApiGenerateNotificationRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ApiGenerateNotificationRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ApiGenerateNotificationRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'shortMessage',
+      serializers.serialize(object.shortMessage, specifiedType: const FullType(String)),
+      'longMessage',
+      serializers.serialize(object.longMessage, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ApiGenerateNotificationRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ApiGenerateNotificationRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'shortMessage':
+          result.shortMessage = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'longMessage':
+          result.longMessage = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
 
 class _$OCSMetaSerializer implements StructuredSerializer<OCSMeta> {
   @override
@@ -1038,6 +1096,49 @@ class _$EndpointDeleteNotificationResponseApplicationJsonSerializer
   }
 }
 
+class _$EndpointConfirmIdsForUserRequestApplicationJsonSerializer
+    implements StructuredSerializer<EndpointConfirmIdsForUserRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    EndpointConfirmIdsForUserRequestApplicationJson,
+    _$EndpointConfirmIdsForUserRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'EndpointConfirmIdsForUserRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, EndpointConfirmIdsForUserRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'ids',
+      serializers.serialize(object.ids, specifiedType: const FullType(BuiltList, [FullType(int)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  EndpointConfirmIdsForUserRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = EndpointConfirmIdsForUserRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'ids':
+          result.ids.replace(serializers.deserialize(value, specifiedType: const FullType(BuiltList, [FullType(int)]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$EndpointConfirmIdsForUserResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<EndpointConfirmIdsForUserResponseApplicationJson_Ocs> {
   @override
@@ -1124,6 +1225,58 @@ class _$EndpointConfirmIdsForUserResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(EndpointConfirmIdsForUserResponseApplicationJson_Ocs))!
               as EndpointConfirmIdsForUserResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$PushRegisterDeviceRequestApplicationJsonSerializer
+    implements StructuredSerializer<PushRegisterDeviceRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    PushRegisterDeviceRequestApplicationJson,
+    _$PushRegisterDeviceRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'PushRegisterDeviceRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PushRegisterDeviceRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'pushTokenHash',
+      serializers.serialize(object.pushTokenHash, specifiedType: const FullType(String)),
+      'devicePublicKey',
+      serializers.serialize(object.devicePublicKey, specifiedType: const FullType(String)),
+      'proxyServer',
+      serializers.serialize(object.proxyServer, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  PushRegisterDeviceRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PushRegisterDeviceRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'pushTokenHash':
+          result.pushTokenHash = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'devicePublicKey':
+          result.devicePublicKey = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'proxyServer':
+          result.proxyServer = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -1362,6 +1515,55 @@ class _$PushRemoveDeviceResponseApplicationJsonSerializer
   }
 }
 
+class _$SettingsPersonalRequestApplicationJsonSerializer
+    implements StructuredSerializer<SettingsPersonalRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [SettingsPersonalRequestApplicationJson, _$SettingsPersonalRequestApplicationJson];
+  @override
+  final String wireName = 'SettingsPersonalRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, SettingsPersonalRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'batchSetting',
+      serializers.serialize(object.batchSetting, specifiedType: const FullType(int)),
+      'soundNotification',
+      serializers.serialize(object.soundNotification, specifiedType: const FullType(String)),
+      'soundTalk',
+      serializers.serialize(object.soundTalk, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  SettingsPersonalRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = SettingsPersonalRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'batchSetting':
+          result.batchSetting = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'soundNotification':
+          result.soundNotification = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'soundTalk':
+          result.soundTalk = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$SettingsPersonalResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<SettingsPersonalResponseApplicationJson_Ocs> {
   @override
@@ -1445,6 +1647,55 @@ class _$SettingsPersonalResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(SettingsPersonalResponseApplicationJson_Ocs))!
               as SettingsPersonalResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SettingsAdminRequestApplicationJsonSerializer
+    implements StructuredSerializer<SettingsAdminRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [SettingsAdminRequestApplicationJson, _$SettingsAdminRequestApplicationJson];
+  @override
+  final String wireName = 'SettingsAdminRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, SettingsAdminRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'batchSetting',
+      serializers.serialize(object.batchSetting, specifiedType: const FullType(int)),
+      'soundNotification',
+      serializers.serialize(object.soundNotification, specifiedType: const FullType(String)),
+      'soundTalk',
+      serializers.serialize(object.soundTalk, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  SettingsAdminRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = SettingsAdminRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'batchSetting':
+          result.batchSetting = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'soundNotification':
+          result.soundNotification = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'soundTalk':
+          result.soundTalk = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -1628,6 +1879,123 @@ class _$CapabilitiesSerializer implements StructuredSerializer<Capabilities> {
     }
 
     return result.build();
+  }
+}
+
+abstract mixin class $ApiGenerateNotificationRequestApplicationJsonInterfaceBuilder {
+  void replace($ApiGenerateNotificationRequestApplicationJsonInterface other);
+  void update(void Function($ApiGenerateNotificationRequestApplicationJsonInterfaceBuilder) updates);
+  String? get shortMessage;
+  set shortMessage(String? shortMessage);
+
+  String? get longMessage;
+  set longMessage(String? longMessage);
+}
+
+class _$ApiGenerateNotificationRequestApplicationJson extends ApiGenerateNotificationRequestApplicationJson {
+  @override
+  final String shortMessage;
+  @override
+  final String longMessage;
+
+  factory _$ApiGenerateNotificationRequestApplicationJson(
+          [void Function(ApiGenerateNotificationRequestApplicationJsonBuilder)? updates]) =>
+      (ApiGenerateNotificationRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ApiGenerateNotificationRequestApplicationJson._({required this.shortMessage, required this.longMessage})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        shortMessage, r'ApiGenerateNotificationRequestApplicationJson', 'shortMessage');
+    BuiltValueNullFieldError.checkNotNull(longMessage, r'ApiGenerateNotificationRequestApplicationJson', 'longMessage');
+  }
+
+  @override
+  ApiGenerateNotificationRequestApplicationJson rebuild(
+          void Function(ApiGenerateNotificationRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ApiGenerateNotificationRequestApplicationJsonBuilder toBuilder() =>
+      ApiGenerateNotificationRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ApiGenerateNotificationRequestApplicationJson &&
+        shortMessage == other.shortMessage &&
+        longMessage == other.longMessage;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, shortMessage.hashCode);
+    _$hash = $jc(_$hash, longMessage.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ApiGenerateNotificationRequestApplicationJson')
+          ..add('shortMessage', shortMessage)
+          ..add('longMessage', longMessage))
+        .toString();
+  }
+}
+
+class ApiGenerateNotificationRequestApplicationJsonBuilder
+    implements
+        Builder<ApiGenerateNotificationRequestApplicationJson, ApiGenerateNotificationRequestApplicationJsonBuilder>,
+        $ApiGenerateNotificationRequestApplicationJsonInterfaceBuilder {
+  _$ApiGenerateNotificationRequestApplicationJson? _$v;
+
+  String? _shortMessage;
+  String? get shortMessage => _$this._shortMessage;
+  set shortMessage(covariant String? shortMessage) => _$this._shortMessage = shortMessage;
+
+  String? _longMessage;
+  String? get longMessage => _$this._longMessage;
+  set longMessage(covariant String? longMessage) => _$this._longMessage = longMessage;
+
+  ApiGenerateNotificationRequestApplicationJsonBuilder() {
+    ApiGenerateNotificationRequestApplicationJson._defaults(this);
+  }
+
+  ApiGenerateNotificationRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _shortMessage = $v.shortMessage;
+      _longMessage = $v.longMessage;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ApiGenerateNotificationRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ApiGenerateNotificationRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ApiGenerateNotificationRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ApiGenerateNotificationRequestApplicationJson build() => _build();
+
+  _$ApiGenerateNotificationRequestApplicationJson _build() {
+    ApiGenerateNotificationRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ApiGenerateNotificationRequestApplicationJson._(
+            shortMessage: BuiltValueNullFieldError.checkNotNull(
+                shortMessage, r'ApiGenerateNotificationRequestApplicationJson', 'shortMessage'),
+            longMessage: BuiltValueNullFieldError.checkNotNull(
+                longMessage, r'ApiGenerateNotificationRequestApplicationJson', 'longMessage'));
+    replace(_$result);
+    return _$result;
   }
 }
 
@@ -3535,6 +3903,114 @@ class EndpointDeleteNotificationResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $EndpointConfirmIdsForUserRequestApplicationJsonInterfaceBuilder {
+  void replace($EndpointConfirmIdsForUserRequestApplicationJsonInterface other);
+  void update(void Function($EndpointConfirmIdsForUserRequestApplicationJsonInterfaceBuilder) updates);
+  ListBuilder<int> get ids;
+  set ids(ListBuilder<int>? ids);
+}
+
+class _$EndpointConfirmIdsForUserRequestApplicationJson extends EndpointConfirmIdsForUserRequestApplicationJson {
+  @override
+  final BuiltList<int> ids;
+
+  factory _$EndpointConfirmIdsForUserRequestApplicationJson(
+          [void Function(EndpointConfirmIdsForUserRequestApplicationJsonBuilder)? updates]) =>
+      (EndpointConfirmIdsForUserRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$EndpointConfirmIdsForUserRequestApplicationJson._({required this.ids}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(ids, r'EndpointConfirmIdsForUserRequestApplicationJson', 'ids');
+  }
+
+  @override
+  EndpointConfirmIdsForUserRequestApplicationJson rebuild(
+          void Function(EndpointConfirmIdsForUserRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  EndpointConfirmIdsForUserRequestApplicationJsonBuilder toBuilder() =>
+      EndpointConfirmIdsForUserRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is EndpointConfirmIdsForUserRequestApplicationJson && ids == other.ids;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, ids.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'EndpointConfirmIdsForUserRequestApplicationJson')..add('ids', ids))
+        .toString();
+  }
+}
+
+class EndpointConfirmIdsForUserRequestApplicationJsonBuilder
+    implements
+        Builder<EndpointConfirmIdsForUserRequestApplicationJson,
+            EndpointConfirmIdsForUserRequestApplicationJsonBuilder>,
+        $EndpointConfirmIdsForUserRequestApplicationJsonInterfaceBuilder {
+  _$EndpointConfirmIdsForUserRequestApplicationJson? _$v;
+
+  ListBuilder<int>? _ids;
+  ListBuilder<int> get ids => _$this._ids ??= ListBuilder<int>();
+  set ids(covariant ListBuilder<int>? ids) => _$this._ids = ids;
+
+  EndpointConfirmIdsForUserRequestApplicationJsonBuilder() {
+    EndpointConfirmIdsForUserRequestApplicationJson._defaults(this);
+  }
+
+  EndpointConfirmIdsForUserRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _ids = $v.ids.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant EndpointConfirmIdsForUserRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$EndpointConfirmIdsForUserRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(EndpointConfirmIdsForUserRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  EndpointConfirmIdsForUserRequestApplicationJson build() => _build();
+
+  _$EndpointConfirmIdsForUserRequestApplicationJson _build() {
+    EndpointConfirmIdsForUserRequestApplicationJson._validate(this);
+    _$EndpointConfirmIdsForUserRequestApplicationJson _$result;
+    try {
+      _$result = _$v ?? _$EndpointConfirmIdsForUserRequestApplicationJson._(ids: ids.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'ids';
+        ids.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'EndpointConfirmIdsForUserRequestApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $EndpointConfirmIdsForUserResponseApplicationJson_OcsInterfaceBuilder {
   void replace($EndpointConfirmIdsForUserResponseApplicationJson_OcsInterface other);
   void update(void Function($EndpointConfirmIdsForUserResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -3765,6 +4241,140 @@ class EndpointConfirmIdsForUserResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $PushRegisterDeviceRequestApplicationJsonInterfaceBuilder {
+  void replace($PushRegisterDeviceRequestApplicationJsonInterface other);
+  void update(void Function($PushRegisterDeviceRequestApplicationJsonInterfaceBuilder) updates);
+  String? get pushTokenHash;
+  set pushTokenHash(String? pushTokenHash);
+
+  String? get devicePublicKey;
+  set devicePublicKey(String? devicePublicKey);
+
+  String? get proxyServer;
+  set proxyServer(String? proxyServer);
+}
+
+class _$PushRegisterDeviceRequestApplicationJson extends PushRegisterDeviceRequestApplicationJson {
+  @override
+  final String pushTokenHash;
+  @override
+  final String devicePublicKey;
+  @override
+  final String proxyServer;
+
+  factory _$PushRegisterDeviceRequestApplicationJson(
+          [void Function(PushRegisterDeviceRequestApplicationJsonBuilder)? updates]) =>
+      (PushRegisterDeviceRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PushRegisterDeviceRequestApplicationJson._(
+      {required this.pushTokenHash, required this.devicePublicKey, required this.proxyServer})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(pushTokenHash, r'PushRegisterDeviceRequestApplicationJson', 'pushTokenHash');
+    BuiltValueNullFieldError.checkNotNull(
+        devicePublicKey, r'PushRegisterDeviceRequestApplicationJson', 'devicePublicKey');
+    BuiltValueNullFieldError.checkNotNull(proxyServer, r'PushRegisterDeviceRequestApplicationJson', 'proxyServer');
+  }
+
+  @override
+  PushRegisterDeviceRequestApplicationJson rebuild(
+          void Function(PushRegisterDeviceRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PushRegisterDeviceRequestApplicationJsonBuilder toBuilder() =>
+      PushRegisterDeviceRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PushRegisterDeviceRequestApplicationJson &&
+        pushTokenHash == other.pushTokenHash &&
+        devicePublicKey == other.devicePublicKey &&
+        proxyServer == other.proxyServer;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, pushTokenHash.hashCode);
+    _$hash = $jc(_$hash, devicePublicKey.hashCode);
+    _$hash = $jc(_$hash, proxyServer.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PushRegisterDeviceRequestApplicationJson')
+          ..add('pushTokenHash', pushTokenHash)
+          ..add('devicePublicKey', devicePublicKey)
+          ..add('proxyServer', proxyServer))
+        .toString();
+  }
+}
+
+class PushRegisterDeviceRequestApplicationJsonBuilder
+    implements
+        Builder<PushRegisterDeviceRequestApplicationJson, PushRegisterDeviceRequestApplicationJsonBuilder>,
+        $PushRegisterDeviceRequestApplicationJsonInterfaceBuilder {
+  _$PushRegisterDeviceRequestApplicationJson? _$v;
+
+  String? _pushTokenHash;
+  String? get pushTokenHash => _$this._pushTokenHash;
+  set pushTokenHash(covariant String? pushTokenHash) => _$this._pushTokenHash = pushTokenHash;
+
+  String? _devicePublicKey;
+  String? get devicePublicKey => _$this._devicePublicKey;
+  set devicePublicKey(covariant String? devicePublicKey) => _$this._devicePublicKey = devicePublicKey;
+
+  String? _proxyServer;
+  String? get proxyServer => _$this._proxyServer;
+  set proxyServer(covariant String? proxyServer) => _$this._proxyServer = proxyServer;
+
+  PushRegisterDeviceRequestApplicationJsonBuilder() {
+    PushRegisterDeviceRequestApplicationJson._defaults(this);
+  }
+
+  PushRegisterDeviceRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _pushTokenHash = $v.pushTokenHash;
+      _devicePublicKey = $v.devicePublicKey;
+      _proxyServer = $v.proxyServer;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PushRegisterDeviceRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PushRegisterDeviceRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PushRegisterDeviceRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PushRegisterDeviceRequestApplicationJson build() => _build();
+
+  _$PushRegisterDeviceRequestApplicationJson _build() {
+    PushRegisterDeviceRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$PushRegisterDeviceRequestApplicationJson._(
+            pushTokenHash: BuiltValueNullFieldError.checkNotNull(
+                pushTokenHash, r'PushRegisterDeviceRequestApplicationJson', 'pushTokenHash'),
+            devicePublicKey: BuiltValueNullFieldError.checkNotNull(
+                devicePublicKey, r'PushRegisterDeviceRequestApplicationJson', 'devicePublicKey'),
+            proxyServer: BuiltValueNullFieldError.checkNotNull(
+                proxyServer, r'PushRegisterDeviceRequestApplicationJson', 'proxyServer'));
     replace(_$result);
     return _$result;
   }
@@ -4349,6 +4959,140 @@ class PushRemoveDeviceResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $SettingsPersonalRequestApplicationJsonInterfaceBuilder {
+  void replace($SettingsPersonalRequestApplicationJsonInterface other);
+  void update(void Function($SettingsPersonalRequestApplicationJsonInterfaceBuilder) updates);
+  int? get batchSetting;
+  set batchSetting(int? batchSetting);
+
+  String? get soundNotification;
+  set soundNotification(String? soundNotification);
+
+  String? get soundTalk;
+  set soundTalk(String? soundTalk);
+}
+
+class _$SettingsPersonalRequestApplicationJson extends SettingsPersonalRequestApplicationJson {
+  @override
+  final int batchSetting;
+  @override
+  final String soundNotification;
+  @override
+  final String soundTalk;
+
+  factory _$SettingsPersonalRequestApplicationJson(
+          [void Function(SettingsPersonalRequestApplicationJsonBuilder)? updates]) =>
+      (SettingsPersonalRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$SettingsPersonalRequestApplicationJson._(
+      {required this.batchSetting, required this.soundNotification, required this.soundTalk})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(batchSetting, r'SettingsPersonalRequestApplicationJson', 'batchSetting');
+    BuiltValueNullFieldError.checkNotNull(
+        soundNotification, r'SettingsPersonalRequestApplicationJson', 'soundNotification');
+    BuiltValueNullFieldError.checkNotNull(soundTalk, r'SettingsPersonalRequestApplicationJson', 'soundTalk');
+  }
+
+  @override
+  SettingsPersonalRequestApplicationJson rebuild(
+          void Function(SettingsPersonalRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SettingsPersonalRequestApplicationJsonBuilder toBuilder() =>
+      SettingsPersonalRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SettingsPersonalRequestApplicationJson &&
+        batchSetting == other.batchSetting &&
+        soundNotification == other.soundNotification &&
+        soundTalk == other.soundTalk;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, batchSetting.hashCode);
+    _$hash = $jc(_$hash, soundNotification.hashCode);
+    _$hash = $jc(_$hash, soundTalk.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SettingsPersonalRequestApplicationJson')
+          ..add('batchSetting', batchSetting)
+          ..add('soundNotification', soundNotification)
+          ..add('soundTalk', soundTalk))
+        .toString();
+  }
+}
+
+class SettingsPersonalRequestApplicationJsonBuilder
+    implements
+        Builder<SettingsPersonalRequestApplicationJson, SettingsPersonalRequestApplicationJsonBuilder>,
+        $SettingsPersonalRequestApplicationJsonInterfaceBuilder {
+  _$SettingsPersonalRequestApplicationJson? _$v;
+
+  int? _batchSetting;
+  int? get batchSetting => _$this._batchSetting;
+  set batchSetting(covariant int? batchSetting) => _$this._batchSetting = batchSetting;
+
+  String? _soundNotification;
+  String? get soundNotification => _$this._soundNotification;
+  set soundNotification(covariant String? soundNotification) => _$this._soundNotification = soundNotification;
+
+  String? _soundTalk;
+  String? get soundTalk => _$this._soundTalk;
+  set soundTalk(covariant String? soundTalk) => _$this._soundTalk = soundTalk;
+
+  SettingsPersonalRequestApplicationJsonBuilder() {
+    SettingsPersonalRequestApplicationJson._defaults(this);
+  }
+
+  SettingsPersonalRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _batchSetting = $v.batchSetting;
+      _soundNotification = $v.soundNotification;
+      _soundTalk = $v.soundTalk;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant SettingsPersonalRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$SettingsPersonalRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(SettingsPersonalRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SettingsPersonalRequestApplicationJson build() => _build();
+
+  _$SettingsPersonalRequestApplicationJson _build() {
+    SettingsPersonalRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$SettingsPersonalRequestApplicationJson._(
+            batchSetting: BuiltValueNullFieldError.checkNotNull(
+                batchSetting, r'SettingsPersonalRequestApplicationJson', 'batchSetting'),
+            soundNotification: BuiltValueNullFieldError.checkNotNull(
+                soundNotification, r'SettingsPersonalRequestApplicationJson', 'soundNotification'),
+            soundTalk: BuiltValueNullFieldError.checkNotNull(
+                soundTalk, r'SettingsPersonalRequestApplicationJson', 'soundTalk'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $SettingsPersonalResponseApplicationJson_OcsInterfaceBuilder {
   void replace($SettingsPersonalResponseApplicationJson_OcsInterface other);
   void update(void Function($SettingsPersonalResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -4574,6 +5318,137 @@ class SettingsPersonalResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $SettingsAdminRequestApplicationJsonInterfaceBuilder {
+  void replace($SettingsAdminRequestApplicationJsonInterface other);
+  void update(void Function($SettingsAdminRequestApplicationJsonInterfaceBuilder) updates);
+  int? get batchSetting;
+  set batchSetting(int? batchSetting);
+
+  String? get soundNotification;
+  set soundNotification(String? soundNotification);
+
+  String? get soundTalk;
+  set soundTalk(String? soundTalk);
+}
+
+class _$SettingsAdminRequestApplicationJson extends SettingsAdminRequestApplicationJson {
+  @override
+  final int batchSetting;
+  @override
+  final String soundNotification;
+  @override
+  final String soundTalk;
+
+  factory _$SettingsAdminRequestApplicationJson([void Function(SettingsAdminRequestApplicationJsonBuilder)? updates]) =>
+      (SettingsAdminRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$SettingsAdminRequestApplicationJson._(
+      {required this.batchSetting, required this.soundNotification, required this.soundTalk})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(batchSetting, r'SettingsAdminRequestApplicationJson', 'batchSetting');
+    BuiltValueNullFieldError.checkNotNull(
+        soundNotification, r'SettingsAdminRequestApplicationJson', 'soundNotification');
+    BuiltValueNullFieldError.checkNotNull(soundTalk, r'SettingsAdminRequestApplicationJson', 'soundTalk');
+  }
+
+  @override
+  SettingsAdminRequestApplicationJson rebuild(void Function(SettingsAdminRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SettingsAdminRequestApplicationJsonBuilder toBuilder() => SettingsAdminRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SettingsAdminRequestApplicationJson &&
+        batchSetting == other.batchSetting &&
+        soundNotification == other.soundNotification &&
+        soundTalk == other.soundTalk;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, batchSetting.hashCode);
+    _$hash = $jc(_$hash, soundNotification.hashCode);
+    _$hash = $jc(_$hash, soundTalk.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SettingsAdminRequestApplicationJson')
+          ..add('batchSetting', batchSetting)
+          ..add('soundNotification', soundNotification)
+          ..add('soundTalk', soundTalk))
+        .toString();
+  }
+}
+
+class SettingsAdminRequestApplicationJsonBuilder
+    implements
+        Builder<SettingsAdminRequestApplicationJson, SettingsAdminRequestApplicationJsonBuilder>,
+        $SettingsAdminRequestApplicationJsonInterfaceBuilder {
+  _$SettingsAdminRequestApplicationJson? _$v;
+
+  int? _batchSetting;
+  int? get batchSetting => _$this._batchSetting;
+  set batchSetting(covariant int? batchSetting) => _$this._batchSetting = batchSetting;
+
+  String? _soundNotification;
+  String? get soundNotification => _$this._soundNotification;
+  set soundNotification(covariant String? soundNotification) => _$this._soundNotification = soundNotification;
+
+  String? _soundTalk;
+  String? get soundTalk => _$this._soundTalk;
+  set soundTalk(covariant String? soundTalk) => _$this._soundTalk = soundTalk;
+
+  SettingsAdminRequestApplicationJsonBuilder() {
+    SettingsAdminRequestApplicationJson._defaults(this);
+  }
+
+  SettingsAdminRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _batchSetting = $v.batchSetting;
+      _soundNotification = $v.soundNotification;
+      _soundTalk = $v.soundTalk;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant SettingsAdminRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$SettingsAdminRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(SettingsAdminRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SettingsAdminRequestApplicationJson build() => _build();
+
+  _$SettingsAdminRequestApplicationJson _build() {
+    SettingsAdminRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$SettingsAdminRequestApplicationJson._(
+            batchSetting: BuiltValueNullFieldError.checkNotNull(
+                batchSetting, r'SettingsAdminRequestApplicationJson', 'batchSetting'),
+            soundNotification: BuiltValueNullFieldError.checkNotNull(
+                soundNotification, r'SettingsAdminRequestApplicationJson', 'soundNotification'),
+            soundTalk:
+                BuiltValueNullFieldError.checkNotNull(soundTalk, r'SettingsAdminRequestApplicationJson', 'soundTalk'));
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/notifications.openapi.json
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.json
@@ -666,20 +666,30 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "ids[]",
-                        "in": "query",
-                        "description": "IDs of the notifications to check",
-                        "required": true,
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "integer",
-                                "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "ids"
+                                ],
+                                "properties": {
+                                    "ids": {
+                                        "type": "array",
+                                        "description": "IDs of the notifications to check",
+                                        "items": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -792,35 +802,37 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "batchSetting",
+                                    "soundNotification",
+                                    "soundTalk"
+                                ],
+                                "properties": {
+                                    "batchSetting": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4)"
+                                    },
+                                    "soundNotification": {
+                                        "type": "string",
+                                        "description": "Enable sound for notifications ('yes' or 'no')"
+                                    },
+                                    "soundTalk": {
+                                        "type": "string",
+                                        "description": "Enable sound for Talk notifications ('yes' or 'no')"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "batchSetting",
-                        "in": "query",
-                        "description": "How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4)",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "soundNotification",
-                        "in": "query",
-                        "description": "Enable sound for notifications ('yes' or 'no')",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "soundTalk",
-                        "in": "query",
-                        "description": "Enable sound for Talk notifications ('yes' or 'no')",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -892,25 +904,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "shortMessage"
+                                ],
+                                "properties": {
+                                    "shortMessage": {
+                                        "type": "string",
+                                        "description": "Subject of the notification"
+                                    },
+                                    "longMessage": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Message of the notification"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "shortMessage",
-                        "in": "query",
-                        "description": "Subject of the notification",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "longMessage",
-                        "in": "query",
-                        "description": "Message of the notification",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1082,35 +1100,37 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "batchSetting",
+                                    "soundNotification",
+                                    "soundTalk"
+                                ],
+                                "properties": {
+                                    "batchSetting": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4)"
+                                    },
+                                    "soundNotification": {
+                                        "type": "string",
+                                        "description": "Enable sound for notifications ('yes' or 'no')"
+                                    },
+                                    "soundTalk": {
+                                        "type": "string",
+                                        "description": "Enable sound for Talk notifications ('yes' or 'no')"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "batchSetting",
-                        "in": "query",
-                        "description": "How often E-mails about missed notifications should be sent (hourly: 1; every three hours: 2; daily: 3; weekly: 4)",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "soundNotification",
-                        "in": "query",
-                        "description": "Enable sound for notifications ('yes' or 'no')",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "soundTalk",
-                        "in": "query",
-                        "description": "Enable sound for Talk notifications ('yes' or 'no')",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1181,34 +1201,36 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "pushTokenHash",
+                                    "devicePublicKey",
+                                    "proxyServer"
+                                ],
+                                "properties": {
+                                    "pushTokenHash": {
+                                        "type": "string",
+                                        "description": "Hash of the push token"
+                                    },
+                                    "devicePublicKey": {
+                                        "type": "string",
+                                        "description": "Public key of the device"
+                                    },
+                                    "proxyServer": {
+                                        "type": "string",
+                                        "description": "Proxy server to be used"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "pushTokenHash",
-                        "in": "query",
-                        "description": "Hash of the push token",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "devicePublicKey",
-                        "in": "query",
-                        "description": "Public key of the device",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "proxyServer",
-                        "in": "query",
-                        "description": "Proxy server to be used",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -113,9 +113,9 @@ class $AppConfigClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -182,8 +182,8 @@ class $AppConfigClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
-    _parameters['app'] = $app;
+    final __app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
+    _parameters['app'] = __app;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -206,9 +206,9 @@ class $AppConfigClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -286,14 +286,14 @@ class $AppConfigClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $value = _$jsonSerializers.serialize(value, specifiedType: const FullType(String));
-    _parameters['value'] = $value;
+    final __value = _$jsonSerializers.serialize(value, specifiedType: const FullType(String));
+    _parameters['value'] = __value;
 
-    final $app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
-    _parameters['app'] = $app;
+    final __app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
+    _parameters['app'] = __app;
 
-    final $key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
-    _parameters['key'] = $key;
+    final __key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
+    _parameters['key'] = __key;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}/{key}{?value*}')
         .expand(_parameters);
@@ -317,9 +317,9 @@ class $AppConfigClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -404,8 +404,8 @@ class $AppsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $filter = _$jsonSerializers.serialize(filter, specifiedType: const FullType(String));
-    _parameters['filter'] = $filter;
+    final __filter = _$jsonSerializers.serialize(filter, specifiedType: const FullType(String));
+    _parameters['filter'] = __filter;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/apps{?filter*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -428,9 +428,9 @@ class $AppsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -502,8 +502,8 @@ class $AppsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
-    _parameters['app'] = $app;
+    final __app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
+    _parameters['app'] = __app;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/apps/{app}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -526,9 +526,9 @@ class $AppsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -600,8 +600,8 @@ class $AppsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
-    _parameters['app'] = $app;
+    final __app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
+    _parameters['app'] = __app;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/apps/{app}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -624,9 +624,9 @@ class $AppsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -698,8 +698,8 @@ class $AppsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
-    _parameters['app'] = $app;
+    final __app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
+    _parameters['app'] = __app;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/apps/{app}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -722,9 +722,9 @@ class $AppsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -804,13 +804,13 @@ class $GroupsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
+    final __groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
     _i5.checkString(
-      $groupId,
+      __groupId,
       'groupId',
       pattern: RegExp(r'^.+$'),
     );
-    _parameters['groupId'] = $groupId;
+    _parameters['groupId'] = __groupId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/subadmins').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -833,9 +833,9 @@ class $GroupsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -909,16 +909,16 @@ class $GroupsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    $search ??= '';
-    _parameters['search'] = $search;
+    var __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
+    __search ??= '';
+    _parameters['search'] = __search;
 
-    final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = $limit;
+    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    _parameters['limit'] = __limit;
 
-    var $offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    $offset ??= 0;
-    _parameters['offset'] = $offset;
+    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
+    __offset ??= 0;
+    _parameters['offset'] = __offset;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/groups{?search*,limit*,offset*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -941,9 +941,9 @@ class $GroupsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1018,13 +1018,13 @@ class $GroupsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
+    final __groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
     _i5.checkString(
-      $groupId,
+      __groupId,
       'groupId',
       pattern: RegExp(r'^.+$'),
     );
-    _parameters['groupId'] = $groupId;
+    _parameters['groupId'] = __groupId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1047,9 +1047,9 @@ class $GroupsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1122,16 +1122,16 @@ class $GroupsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    $search ??= '';
-    _parameters['search'] = $search;
+    var __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
+    __search ??= '';
+    _parameters['search'] = __search;
 
-    final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = $limit;
+    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    _parameters['limit'] = __limit;
 
-    var $offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    $offset ??= 0;
-    _parameters['offset'] = $offset;
+    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
+    __offset ??= 0;
+    _parameters['offset'] = __offset;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/groups/details{?search*,limit*,offset*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1154,9 +1154,9 @@ class $GroupsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1232,13 +1232,13 @@ class $GroupsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
+    final __groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
     _i5.checkString(
-      $groupId,
+      __groupId,
       'groupId',
       pattern: RegExp(r'^.+$'),
     );
-    _parameters['groupId'] = $groupId;
+    _parameters['groupId'] = __groupId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/users').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1261,9 +1261,9 @@ class $GroupsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1339,24 +1339,24 @@ class $GroupsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
+    final __groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
     _i5.checkString(
-      $groupId,
+      __groupId,
       'groupId',
       pattern: RegExp(r'^.+$'),
     );
-    _parameters['groupId'] = $groupId;
+    _parameters['groupId'] = __groupId;
 
-    var $search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    $search ??= '';
-    _parameters['search'] = $search;
+    var __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
+    __search ??= '';
+    _parameters['search'] = __search;
 
-    final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = $limit;
+    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    _parameters['limit'] = __limit;
 
-    var $offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    $offset ??= 0;
-    _parameters['offset'] = $offset;
+    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
+    __offset ??= 0;
+    _parameters['offset'] = __offset;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/users/details{?search*,limit*,offset*}')
         .expand(_parameters);
@@ -1380,9 +1380,9 @@ class $GroupsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1471,14 +1471,14 @@ class $PreferencesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $configValue = _$jsonSerializers.serialize(configValue, specifiedType: const FullType(String));
-    _parameters['configValue'] = $configValue;
+    final __configValue = _$jsonSerializers.serialize(configValue, specifiedType: const FullType(String));
+    _parameters['configValue'] = __configValue;
 
-    final $appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
-    _parameters['appId'] = $appId;
+    final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
+    _parameters['appId'] = __appId;
 
-    final $configKey = _$jsonSerializers.serialize(configKey, specifiedType: const FullType(String));
-    _parameters['configKey'] = $configKey;
+    final __configKey = _$jsonSerializers.serialize(configKey, specifiedType: const FullType(String));
+    _parameters['configKey'] = __configKey;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}{?configValue*}')
@@ -1503,9 +1503,9 @@ class $PreferencesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1583,11 +1583,11 @@ class $PreferencesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
-    _parameters['appId'] = $appId;
+    final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
+    _parameters['appId'] = __appId;
 
-    final $configKey = _$jsonSerializers.serialize(configKey, specifiedType: const FullType(String));
-    _parameters['configKey'] = $configKey;
+    final __configKey = _$jsonSerializers.serialize(configKey, specifiedType: const FullType(String));
+    _parameters['configKey'] = __configKey;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}')
         .expand(_parameters);
@@ -1611,9 +1611,9 @@ class $PreferencesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1688,16 +1688,16 @@ class $PreferencesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $configs = _$jsonSerializers.serialize(
+    final __configs = _$jsonSerializers.serialize(
       configs,
       specifiedType: const FullType(ContentString, [
         FullType(BuiltMap, [FullType(String), FullType(String)]),
       ]),
     );
-    _parameters['configs'] = $configs;
+    _parameters['configs'] = __configs;
 
-    final $appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
-    _parameters['appId'] = $appId;
+    final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
+    _parameters['appId'] = __appId;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}{?configs*}').expand(_parameters);
@@ -1721,9 +1721,9 @@ class $PreferencesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1799,12 +1799,12 @@ class $PreferencesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $configKeys =
+    final __configKeys =
         _$jsonSerializers.serialize(configKeys, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    _parameters['configKeys%5B%5D'] = $configKeys;
+    _parameters['configKeys%5B%5D'] = __configKeys;
 
-    final $appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
-    _parameters['appId'] = $appId;
+    final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
+    _parameters['appId'] = __appId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}{?configKeys%5B%5D*}')
         .expand(_parameters);
@@ -1828,9 +1828,9 @@ class $PreferencesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1913,8 +1913,8 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1937,9 +1937,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2014,11 +2014,11 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $groupid = _$jsonSerializers.serialize(groupid, specifiedType: const FullType(String));
-    _parameters['groupid'] = $groupid;
+    final __groupid = _$jsonSerializers.serialize(groupid, specifiedType: const FullType(String));
+    _parameters['groupid'] = __groupid;
 
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins{?groupid*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2041,9 +2041,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2122,11 +2122,11 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $groupid = _$jsonSerializers.serialize(groupid, specifiedType: const FullType(String));
-    _parameters['groupid'] = $groupid;
+    final __groupid = _$jsonSerializers.serialize(groupid, specifiedType: const FullType(String));
+    _parameters['groupid'] = __groupid;
 
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins{?groupid*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2149,9 +2149,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2228,16 +2228,16 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    $search ??= '';
-    _parameters['search'] = $search;
+    var __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
+    __search ??= '';
+    _parameters['search'] = __search;
 
-    final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = $limit;
+    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    _parameters['limit'] = __limit;
 
-    var $offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    $offset ??= 0;
-    _parameters['offset'] = $offset;
+    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
+    __offset ??= 0;
+    _parameters['offset'] = __offset;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users{?search*,limit*,offset*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2260,9 +2260,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2354,39 +2354,40 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userid = _$jsonSerializers.serialize(userid, specifiedType: const FullType(String));
-    _parameters['userid'] = $userid;
+    final __userid = _$jsonSerializers.serialize(userid, specifiedType: const FullType(String));
+    _parameters['userid'] = __userid;
 
-    var $password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    $password ??= '';
-    _parameters['password'] = $password;
+    var __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
+    __password ??= '';
+    _parameters['password'] = __password;
 
-    var $displayName = _$jsonSerializers.serialize(displayName, specifiedType: const FullType(String));
-    $displayName ??= '';
-    _parameters['displayName'] = $displayName;
+    var __displayName = _$jsonSerializers.serialize(displayName, specifiedType: const FullType(String));
+    __displayName ??= '';
+    _parameters['displayName'] = __displayName;
 
-    var $email = _$jsonSerializers.serialize(email, specifiedType: const FullType(String));
-    $email ??= '';
-    _parameters['email'] = $email;
+    var __email = _$jsonSerializers.serialize(email, specifiedType: const FullType(String));
+    __email ??= '';
+    _parameters['email'] = __email;
 
-    var $groups = _$jsonSerializers.serialize(groups, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    $groups ??= const [];
-    _parameters['groups%5B%5D'] = $groups;
+    var __groups = _$jsonSerializers.serialize(groups, specifiedType: const FullType(BuiltList, [FullType(String)]));
+    __groups ??= const [];
+    _parameters['groups%5B%5D'] = __groups;
 
-    var $subadmin = _$jsonSerializers.serialize(subadmin, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    $subadmin ??= const [];
-    _parameters['subadmin%5B%5D'] = $subadmin;
+    var __subadmin =
+        _$jsonSerializers.serialize(subadmin, specifiedType: const FullType(BuiltList, [FullType(String)]));
+    __subadmin ??= const [];
+    _parameters['subadmin%5B%5D'] = __subadmin;
 
-    var $quota = _$jsonSerializers.serialize(quota, specifiedType: const FullType(String));
-    $quota ??= '';
-    _parameters['quota'] = $quota;
+    var __quota = _$jsonSerializers.serialize(quota, specifiedType: const FullType(String));
+    __quota ??= '';
+    _parameters['quota'] = __quota;
 
-    var $language = _$jsonSerializers.serialize(language, specifiedType: const FullType(String));
-    $language ??= '';
-    _parameters['language'] = $language;
+    var __language = _$jsonSerializers.serialize(language, specifiedType: const FullType(String));
+    __language ??= '';
+    _parameters['language'] = __language;
 
-    final $manager = _$jsonSerializers.serialize(manager, specifiedType: const FullType(String));
-    _parameters['manager'] = $manager;
+    final __manager = _$jsonSerializers.serialize(manager, specifiedType: const FullType(String));
+    _parameters['manager'] = __manager;
 
     final _path = _i6.UriTemplate(
       '/ocs/v2.php/cloud/users{?userid*,password*,displayName*,email*,groups%5B%5D*,subadmin%5B%5D*,quota*,language*,manager*}',
@@ -2411,9 +2412,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2512,16 +2513,16 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    $search ??= '';
-    _parameters['search'] = $search;
+    var __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
+    __search ??= '';
+    _parameters['search'] = __search;
 
-    final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = $limit;
+    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    _parameters['limit'] = __limit;
 
-    var $offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    $offset ??= 0;
-    _parameters['offset'] = $offset;
+    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
+    __offset ??= 0;
+    _parameters['offset'] = __offset;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/details{?search*,limit*,offset*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2544,9 +2545,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2622,12 +2623,12 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = $limit;
+    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    _parameters['limit'] = __limit;
 
-    var $offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    $offset ??= 0;
-    _parameters['offset'] = $offset;
+    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
+    __offset ??= 0;
+    _parameters['offset'] = __offset;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/disabled{?limit*,offset*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2650,9 +2651,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2726,10 +2727,10 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $location = _$jsonSerializers.serialize(location, specifiedType: const FullType(String));
-    _parameters['location'] = $location;
+    final __location = _$jsonSerializers.serialize(location, specifiedType: const FullType(String));
+    _parameters['location'] = __location;
 
-    final $search = _$jsonSerializers.serialize(
+    final __search = _$jsonSerializers.serialize(
       search,
       specifiedType: const FullType(ContentString, [
         FullType(BuiltMap, [
@@ -2738,7 +2739,7 @@ class $UsersClient {
         ]),
       ]),
     );
-    _parameters['search'] = $search;
+    _parameters['search'] = __search;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/search/by-phone{?location*,search*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2761,9 +2762,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2834,8 +2835,8 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2858,9 +2859,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2933,14 +2934,14 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
-    _parameters['key'] = $key;
+    final __key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
+    _parameters['key'] = __key;
 
-    final $value = _$jsonSerializers.serialize(value, specifiedType: const FullType(String));
-    _parameters['value'] = $value;
+    final __value = _$jsonSerializers.serialize(value, specifiedType: const FullType(String));
+    _parameters['value'] = __value;
 
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}{?key*,value*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -2963,9 +2964,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3043,8 +3044,8 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3067,9 +3068,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3155,9 +3156,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3238,9 +3239,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3305,8 +3306,8 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/user/fields/{userId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3329,9 +3330,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3407,22 +3408,22 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
-    _parameters['key'] = $key;
+    final __key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
+    _parameters['key'] = __key;
 
-    final $value = _$jsonSerializers.serialize(value, specifiedType: const FullType(String));
-    _parameters['value'] = $value;
+    final __value = _$jsonSerializers.serialize(value, specifiedType: const FullType(String));
+    _parameters['value'] = __value;
 
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
-    final $collectionName = _$jsonSerializers.serialize(collectionName, specifiedType: const FullType(String));
+    final __collectionName = _$jsonSerializers.serialize(collectionName, specifiedType: const FullType(String));
     _i5.checkString(
-      $collectionName,
+      __collectionName,
       'collectionName',
       pattern: RegExp(r'^(?!enable$|disable$)[a-zA-Z0-9_]*$'),
     );
-    _parameters['collectionName'] = $collectionName;
+    _parameters['collectionName'] = __collectionName;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/{collectionName}{?key*,value*}').expand(_parameters);
@@ -3446,9 +3447,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3529,8 +3530,8 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/wipe').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3553,9 +3554,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3627,8 +3628,8 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/enable').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3651,9 +3652,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3725,8 +3726,8 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/disable').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3749,9 +3750,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3821,8 +3822,8 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3845,9 +3846,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3919,12 +3920,12 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
-    var $groupid = _$jsonSerializers.serialize(groupid, specifiedType: const FullType(String));
-    $groupid ??= '';
-    _parameters['groupid'] = $groupid;
+    var __groupid = _$jsonSerializers.serialize(groupid, specifiedType: const FullType(String));
+    __groupid ??= '';
+    _parameters['groupid'] = __groupid;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups{?groupid*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3947,9 +3948,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4026,11 +4027,11 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $groupid = _$jsonSerializers.serialize(groupid, specifiedType: const FullType(String));
-    _parameters['groupid'] = $groupid;
+    final __groupid = _$jsonSerializers.serialize(groupid, specifiedType: const FullType(String));
+    _parameters['groupid'] = __groupid;
 
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups{?groupid*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -4053,9 +4054,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4130,8 +4131,8 @@ class $UsersClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/welcome').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -4154,9 +4155,9 @@ class $UsersClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -16,6 +16,8 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
+
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/json_object.dart';
@@ -24,7 +26,6 @@ import 'package:built_value/standard_json_plugin.dart' as _i8;
 import 'package:collection/collection.dart' as _i4;
 import 'package:dynamite_runtime/built_value.dart' as _i7;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/models.dart';
 import 'package:dynamite_runtime/utils.dart' as _i5;
 import 'package:http/http.dart' as _i3;
 import 'package:meta/meta.dart' as _i2;
@@ -266,7 +267,6 @@ class $AppConfigClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [value] New value for the key.
   ///   * [app] ID of the app.
   ///   * [key] Key to update.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -280,23 +280,20 @@ class $AppConfigClient {
   ///  * [$setValue_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setValue_Request({
-    required String value,
     required String app,
     required String key,
+    required AppConfigSetValueRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __value = _$jsonSerializers.serialize(value, specifiedType: const FullType(String));
-    _parameters['value'] = __value;
-
     final __app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
     _parameters['app'] = __app;
 
     final __key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
     _parameters['key'] = __key;
 
-    final _path = _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}/{key}{?value*}')
-        .expand(_parameters);
+    final _path =
+        _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/apps/{app}/{key}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -321,6 +318,10 @@ class $AppConfigClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(AppConfigSetValueRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -332,7 +333,6 @@ class $AppConfigClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [value] New value for the key.
   ///   * [app] ID of the app.
   ///   * [key] Key to update.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -345,16 +345,16 @@ class $AppConfigClient {
   ///  * [$setValue_Request] for the request send by this method.
   ///  * [$setValue_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<AppConfigSetValueResponseApplicationJson, void>> setValue({
-    required String value,
     required String app,
     required String key,
+    required AppConfigSetValueRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setValue_Request(
-      value: value,
       app: app,
       key: key,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -389,7 +389,6 @@ class $AppsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [filter] Filter for enabled or disabled apps.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -400,14 +399,10 @@ class $AppsClient {
   ///  * [$getApps_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getApps_Request({
-    String? filter,
     bool? oCSAPIRequest,
+    AppsGetAppsRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    final __filter = _$jsonSerializers.serialize(filter, specifiedType: const FullType(String));
-    _parameters['filter'] = __filter;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/apps{?filter*}').expand(_parameters);
+    const _path = '/ocs/v2.php/cloud/apps';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -432,6 +427,17 @@ class $AppsClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(AppsGetAppsRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              AppsGetAppsRequestApplicationJson(),
+              specifiedType: const FullType(AppsGetAppsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -443,7 +449,6 @@ class $AppsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [filter] Filter for enabled or disabled apps.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -453,12 +458,12 @@ class $AppsClient {
   ///  * [$getApps_Request] for the request send by this method.
   ///  * [$getApps_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<AppsGetAppsResponseApplicationJson, void>> getApps({
-    String? filter,
     bool? oCSAPIRequest,
+    AppsGetAppsRequestApplicationJson? $body,
   }) async {
     final _request = $getApps_Request(
-      filter: filter,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -890,9 +895,6 @@ class $GroupsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for. Defaults to `""`.
-  ///   * [limit] Limit the amount of groups returned.
-  ///   * [offset] Offset for searching for groups. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -903,24 +905,10 @@ class $GroupsClient {
   ///  * [$getGroups_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getGroups_Request({
-    String? search,
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    GroupsGetGroupsRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    var __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    __search ??= '';
-    _parameters['search'] = __search;
-
-    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = __limit;
-
-    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    __offset ??= 0;
-    _parameters['offset'] = __offset;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/groups{?search*,limit*,offset*}').expand(_parameters);
+    const _path = '/ocs/v2.php/cloud/groups';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -945,6 +933,17 @@ class $GroupsClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(GroupsGetGroupsRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              GroupsGetGroupsRequestApplicationJson(),
+              specifiedType: const FullType(GroupsGetGroupsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -954,9 +953,6 @@ class $GroupsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for. Defaults to `""`.
-  ///   * [limit] Limit the amount of groups returned.
-  ///   * [offset] Offset for searching for groups. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -966,16 +962,12 @@ class $GroupsClient {
   ///  * [$getGroups_Request] for the request send by this method.
   ///  * [$getGroups_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<GroupsGetGroupsResponseApplicationJson, void>> getGroups({
-    String? search,
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    GroupsGetGroupsRequestApplicationJson? $body,
   }) async {
     final _request = $getGroups_Request(
-      search: search,
-      limit: limit,
-      offset: offset,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1103,9 +1095,6 @@ class $GroupsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for. Defaults to `""`.
-  ///   * [limit] Limit the amount of groups returned.
-  ///   * [offset] Offset for searching for groups. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -1116,24 +1105,10 @@ class $GroupsClient {
   ///  * [$getGroupsDetails_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getGroupsDetails_Request({
-    String? search,
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    GroupsGetGroupsDetailsRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    var __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    __search ??= '';
-    _parameters['search'] = __search;
-
-    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = __limit;
-
-    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    __offset ??= 0;
-    _parameters['offset'] = __offset;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/groups/details{?search*,limit*,offset*}').expand(_parameters);
+    const _path = '/ocs/v2.php/cloud/groups/details';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1158,6 +1133,20 @@ class $GroupsClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(GroupsGetGroupsDetailsRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              GroupsGetGroupsDetailsRequestApplicationJson(),
+              specifiedType: const FullType(GroupsGetGroupsDetailsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -1167,9 +1156,6 @@ class $GroupsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for. Defaults to `""`.
-  ///   * [limit] Limit the amount of groups returned.
-  ///   * [offset] Offset for searching for groups. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -1179,16 +1165,12 @@ class $GroupsClient {
   ///  * [$getGroupsDetails_Request] for the request send by this method.
   ///  * [$getGroupsDetails_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<GroupsGetGroupsDetailsResponseApplicationJson, void>> getGroupsDetails({
-    String? search,
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    GroupsGetGroupsDetailsRequestApplicationJson? $body,
   }) async {
     final _request = $getGroupsDetails_Request(
-      search: search,
-      limit: limit,
-      offset: offset,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1318,9 +1300,6 @@ class $GroupsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for. Defaults to `""`.
-  ///   * [limit] Limit the amount of groups returned.
-  ///   * [offset] Offset for searching for groups. Defaults to `0`.
   ///   * [groupId] ID of the group.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1333,10 +1312,8 @@ class $GroupsClient {
   @_i2.experimental
   _i3.Request $getGroupUsersDetails_Request({
     required String groupId,
-    String? search,
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    GroupsGetGroupUsersDetailsRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __groupId = _$jsonSerializers.serialize(groupId, specifiedType: const FullType(String));
@@ -1347,19 +1324,7 @@ class $GroupsClient {
     );
     _parameters['groupId'] = __groupId;
 
-    var __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    __search ??= '';
-    _parameters['search'] = __search;
-
-    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = __limit;
-
-    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    __offset ??= 0;
-    _parameters['offset'] = __offset;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/users/details{?search*,limit*,offset*}')
-        .expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/groups/{groupId}/users/details').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1384,6 +1349,20 @@ class $GroupsClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(GroupsGetGroupUsersDetailsRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              GroupsGetGroupUsersDetailsRequestApplicationJson(),
+              specifiedType: const FullType(GroupsGetGroupUsersDetailsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -1393,9 +1372,6 @@ class $GroupsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for. Defaults to `""`.
-  ///   * [limit] Limit the amount of groups returned.
-  ///   * [offset] Offset for searching for groups. Defaults to `0`.
   ///   * [groupId] ID of the group.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1407,17 +1383,13 @@ class $GroupsClient {
   ///  * [$getGroupUsersDetails_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<GroupsGetGroupUsersDetailsResponseApplicationJson, void>> getGroupUsersDetails({
     required String groupId,
-    String? search,
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    GroupsGetGroupUsersDetailsRequestApplicationJson? $body,
   }) async {
     final _request = $getGroupUsersDetails_Request(
       groupId: groupId,
-      search: search,
-      limit: limit,
-      offset: offset,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1451,7 +1423,6 @@ class $PreferencesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [configValue] New value.
   ///   * [appId] ID of the app.
   ///   * [configKey] Key of the preference.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -1465,24 +1436,20 @@ class $PreferencesClient {
   ///  * [$setPreference_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setPreference_Request({
-    required String configValue,
     required String appId,
     required String configKey,
+    required PreferencesSetPreferenceRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __configValue = _$jsonSerializers.serialize(configValue, specifiedType: const FullType(String));
-    _parameters['configValue'] = __configValue;
-
     final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
     _parameters['appId'] = __appId;
 
     final __configKey = _$jsonSerializers.serialize(configKey, specifiedType: const FullType(String));
     _parameters['configKey'] = __configKey;
 
-    final _path =
-        _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}{?configValue*}')
-            .expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}/{configKey}')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1507,6 +1474,13 @@ class $PreferencesClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(PreferencesSetPreferenceRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -1516,7 +1490,6 @@ class $PreferencesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [configValue] New value.
   ///   * [appId] ID of the app.
   ///   * [configKey] Key of the preference.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -1529,16 +1502,16 @@ class $PreferencesClient {
   ///  * [$setPreference_Request] for the request send by this method.
   ///  * [$setPreference_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<PreferencesSetPreferenceResponseApplicationJson, void>> setPreference({
-    required String configValue,
     required String appId,
     required String configKey,
+    required PreferencesSetPreferenceRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setPreference_Request(
-      configValue: configValue,
       appId: appId,
       configKey: configKey,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1670,7 +1643,6 @@ class $PreferencesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [configs] Key-value pairs of the preferences.
   ///   * [appId] ID of the app.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1683,24 +1655,15 @@ class $PreferencesClient {
   ///  * [$setMultiplePreferences_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setMultiplePreferences_Request({
-    required ContentString<BuiltMap<String, String>> configs,
     required String appId,
+    required PreferencesSetMultiplePreferencesRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __configs = _$jsonSerializers.serialize(
-      configs,
-      specifiedType: const FullType(ContentString, [
-        FullType(BuiltMap, [FullType(String), FullType(String)]),
-      ]),
-    );
-    _parameters['configs'] = __configs;
-
     final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
     _parameters['appId'] = __appId;
 
-    final _path =
-        _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}{?configs*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1725,6 +1688,13 @@ class $PreferencesClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(PreferencesSetMultiplePreferencesRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -1734,7 +1704,6 @@ class $PreferencesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [configs] Key-value pairs of the preferences.
   ///   * [appId] ID of the app.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1746,14 +1715,14 @@ class $PreferencesClient {
   ///  * [$setMultiplePreferences_Request] for the request send by this method.
   ///  * [$setMultiplePreferences_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<PreferencesSetMultiplePreferencesResponseApplicationJson, void>> setMultiplePreferences({
-    required ContentString<BuiltMap<String, String>> configs,
     required String appId,
+    required PreferencesSetMultiplePreferencesRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setMultiplePreferences_Request(
-      configs: configs,
       appId: appId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1781,7 +1750,6 @@ class $PreferencesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [configKeys] Keys to delete.
   ///   * [appId] ID of the app.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1794,20 +1762,15 @@ class $PreferencesClient {
   ///  * [$deleteMultiplePreference_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $deleteMultiplePreference_Request({
-    required BuiltList<String> configKeys,
     required String appId,
+    required PreferencesDeleteMultiplePreferenceRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __configKeys =
-        _$jsonSerializers.serialize(configKeys, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    _parameters['configKeys%5B%5D'] = __configKeys;
-
     final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
     _parameters['appId'] = __appId;
 
-    final _path = _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}{?configKeys%5B%5D*}')
-        .expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/apps/provisioning_api/api/v1/config/users/{appId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1832,6 +1795,13 @@ class $PreferencesClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(PreferencesDeleteMultiplePreferenceRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -1841,7 +1811,6 @@ class $PreferencesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [configKeys] Keys to delete.
   ///   * [appId] ID of the app.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -1854,14 +1823,14 @@ class $PreferencesClient {
   ///  * [$deleteMultiplePreference_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<PreferencesDeleteMultiplePreferenceResponseApplicationJson, void>>
       deleteMultiplePreference({
-    required BuiltList<String> configKeys,
     required String appId,
+    required PreferencesDeleteMultiplePreferenceRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $deleteMultiplePreference_Request(
-      configKeys: configKeys,
       appId: appId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1997,7 +1966,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [groupid] ID of the group.
   ///   * [userId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -2009,18 +1977,15 @@ class $UsersClient {
   ///  * [$addSubAdmin_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $addSubAdmin_Request({
-    required String groupid,
     required String userId,
+    required UsersAddSubAdminRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __groupid = _$jsonSerializers.serialize(groupid, specifiedType: const FullType(String));
-    _parameters['groupid'] = __groupid;
-
     final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
     _parameters['userId'] = __userId;
 
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins{?groupid*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2045,6 +2010,10 @@ class $UsersClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(UsersAddSubAdminRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -2057,7 +2026,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [groupid] ID of the group.
   ///   * [userId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -2068,14 +2036,14 @@ class $UsersClient {
   ///  * [$addSubAdmin_Request] for the request send by this method.
   ///  * [$addSubAdmin_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UsersAddSubAdminResponseApplicationJson, void>> addSubAdmin({
-    required String groupid,
     required String userId,
+    required UsersAddSubAdminRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $addSubAdmin_Request(
-      groupid: groupid,
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2105,7 +2073,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [groupid] ID of the group.
   ///   * [userId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -2117,18 +2084,15 @@ class $UsersClient {
   ///  * [$removeSubAdmin_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $removeSubAdmin_Request({
-    required String groupid,
     required String userId,
+    required UsersRemoveSubAdminRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __groupid = _$jsonSerializers.serialize(groupid, specifiedType: const FullType(String));
-    _parameters['groupid'] = __groupid;
-
     final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
     _parameters['userId'] = __userId;
 
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins{?groupid*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/subadmins').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2153,6 +2117,10 @@ class $UsersClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(UsersRemoveSubAdminRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -2165,7 +2133,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [groupid] ID of the group.
   ///   * [userId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -2176,14 +2143,14 @@ class $UsersClient {
   ///  * [$removeSubAdmin_Request] for the request send by this method.
   ///  * [$removeSubAdmin_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UsersRemoveSubAdminResponseApplicationJson, void>> removeSubAdmin({
-    required String groupid,
     required String userId,
+    required UsersRemoveSubAdminRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $removeSubAdmin_Request(
-      groupid: groupid,
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2209,9 +2176,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for. Defaults to `""`.
-  ///   * [limit] Limit the amount of groups returned.
-  ///   * [offset] Offset for searching for groups. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2222,24 +2186,10 @@ class $UsersClient {
   ///  * [$getUsers_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getUsers_Request({
-    String? search,
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    UsersGetUsersRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    var __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    __search ??= '';
-    _parameters['search'] = __search;
-
-    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = __limit;
-
-    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    __offset ??= 0;
-    _parameters['offset'] = __offset;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users{?search*,limit*,offset*}').expand(_parameters);
+    const _path = '/ocs/v2.php/cloud/users';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2264,6 +2214,17 @@ class $UsersClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(UsersGetUsersRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              UsersGetUsersRequestApplicationJson(),
+              specifiedType: const FullType(UsersGetUsersRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -2273,9 +2234,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for. Defaults to `""`.
-  ///   * [limit] Limit the amount of groups returned.
-  ///   * [offset] Offset for searching for groups. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2285,16 +2243,12 @@ class $UsersClient {
   ///  * [$getUsers_Request] for the request send by this method.
   ///  * [$getUsers_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UsersGetUsersResponseApplicationJson, void>> getUsers({
-    String? search,
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    UsersGetUsersRequestApplicationJson? $body,
   }) async {
     final _request = $getUsers_Request(
-      search: search,
-      limit: limit,
-      offset: offset,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2322,15 +2276,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [userid] ID of the user.
-  ///   * [password] Password of the user. Defaults to `""`.
-  ///   * [displayName] Display name of the user. Defaults to `""`.
-  ///   * [email] Email of the user. Defaults to `""`.
-  ///   * [groups] Groups of the user. Defaults to `[]`.
-  ///   * [subadmin] Groups where the user is subadmin. Defaults to `[]`.
-  ///   * [quota] Quota of the user. Defaults to `""`.
-  ///   * [language] Language of the user. Defaults to `""`.
-  ///   * [manager] Manager of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2342,56 +2287,10 @@ class $UsersClient {
   ///  * [$addUser_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $addUser_Request({
-    required String userid,
-    String? password,
-    String? displayName,
-    String? email,
-    BuiltList<String>? groups,
-    BuiltList<String>? subadmin,
-    String? quota,
-    String? language,
-    String? manager,
+    required UsersAddUserRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __userid = _$jsonSerializers.serialize(userid, specifiedType: const FullType(String));
-    _parameters['userid'] = __userid;
-
-    var __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    __password ??= '';
-    _parameters['password'] = __password;
-
-    var __displayName = _$jsonSerializers.serialize(displayName, specifiedType: const FullType(String));
-    __displayName ??= '';
-    _parameters['displayName'] = __displayName;
-
-    var __email = _$jsonSerializers.serialize(email, specifiedType: const FullType(String));
-    __email ??= '';
-    _parameters['email'] = __email;
-
-    var __groups = _$jsonSerializers.serialize(groups, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    __groups ??= const [];
-    _parameters['groups%5B%5D'] = __groups;
-
-    var __subadmin =
-        _$jsonSerializers.serialize(subadmin, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    __subadmin ??= const [];
-    _parameters['subadmin%5B%5D'] = __subadmin;
-
-    var __quota = _$jsonSerializers.serialize(quota, specifiedType: const FullType(String));
-    __quota ??= '';
-    _parameters['quota'] = __quota;
-
-    var __language = _$jsonSerializers.serialize(language, specifiedType: const FullType(String));
-    __language ??= '';
-    _parameters['language'] = __language;
-
-    final __manager = _$jsonSerializers.serialize(manager, specifiedType: const FullType(String));
-    _parameters['manager'] = __manager;
-
-    final _path = _i6.UriTemplate(
-      '/ocs/v2.php/cloud/users{?userid*,password*,displayName*,email*,groups%5B%5D*,subadmin%5B%5D*,quota*,language*,manager*}',
-    ).expand(_parameters);
+    const _path = '/ocs/v2.php/cloud/users';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2416,6 +2315,9 @@ class $UsersClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json
+        .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(UsersAddUserRequestApplicationJson)));
     return _request;
   }
 
@@ -2427,15 +2329,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [userid] ID of the user.
-  ///   * [password] Password of the user. Defaults to `""`.
-  ///   * [displayName] Display name of the user. Defaults to `""`.
-  ///   * [email] Email of the user. Defaults to `""`.
-  ///   * [groups] Groups of the user. Defaults to `[]`.
-  ///   * [subadmin] Groups where the user is subadmin. Defaults to `[]`.
-  ///   * [quota] Quota of the user. Defaults to `""`.
-  ///   * [language] Language of the user. Defaults to `""`.
-  ///   * [manager] Manager of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2446,28 +2339,12 @@ class $UsersClient {
   ///  * [$addUser_Request] for the request send by this method.
   ///  * [$addUser_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UsersAddUserResponseApplicationJson, void>> addUser({
-    required String userid,
-    String? password,
-    String? displayName,
-    String? email,
-    BuiltList<String>? groups,
-    BuiltList<String>? subadmin,
-    String? quota,
-    String? language,
-    String? manager,
+    required UsersAddUserRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $addUser_Request(
-      userid: userid,
-      password: password,
-      displayName: displayName,
-      email: email,
-      groups: groups,
-      subadmin: subadmin,
-      quota: quota,
-      language: language,
-      manager: manager,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2494,9 +2371,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for. Defaults to `""`.
-  ///   * [limit] Limit the amount of groups returned.
-  ///   * [offset] Offset for searching for groups. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2507,24 +2381,10 @@ class $UsersClient {
   ///  * [$getUsersDetails_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getUsersDetails_Request({
-    String? search,
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    UsersGetUsersDetailsRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    var __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    __search ??= '';
-    _parameters['search'] = __search;
-
-    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = __limit;
-
-    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    __offset ??= 0;
-    _parameters['offset'] = __offset;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/details{?search*,limit*,offset*}').expand(_parameters);
+    const _path = '/ocs/v2.php/cloud/users/details';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2549,6 +2409,20 @@ class $UsersClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(UsersGetUsersDetailsRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              UsersGetUsersDetailsRequestApplicationJson(),
+              specifiedType: const FullType(UsersGetUsersDetailsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -2558,9 +2432,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for. Defaults to `""`.
-  ///   * [limit] Limit the amount of groups returned.
-  ///   * [offset] Offset for searching for groups. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2570,16 +2441,12 @@ class $UsersClient {
   ///  * [$getUsersDetails_Request] for the request send by this method.
   ///  * [$getUsersDetails_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UsersGetUsersDetailsResponseApplicationJson, void>> getUsersDetails({
-    String? search,
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    UsersGetUsersDetailsRequestApplicationJson? $body,
   }) async {
     final _request = $getUsersDetails_Request(
-      search: search,
-      limit: limit,
-      offset: offset,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2606,8 +2473,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [limit] Limit the amount of users returned.
-  ///   * [offset] Offset. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2618,19 +2483,10 @@ class $UsersClient {
   ///  * [$getDisabledUsersDetails_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getDisabledUsersDetails_Request({
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    UsersGetDisabledUsersDetailsRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = __limit;
-
-    var __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    __offset ??= 0;
-    _parameters['offset'] = __offset;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/disabled{?limit*,offset*}').expand(_parameters);
+    const _path = '/ocs/v2.php/cloud/users/disabled';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2655,6 +2511,20 @@ class $UsersClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(UsersGetDisabledUsersDetailsRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              UsersGetDisabledUsersDetailsRequestApplicationJson(),
+              specifiedType: const FullType(UsersGetDisabledUsersDetailsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -2664,8 +2534,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [limit] Limit the amount of users returned.
-  ///   * [offset] Offset. Defaults to `0`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2675,14 +2543,12 @@ class $UsersClient {
   ///  * [$getDisabledUsersDetails_Request] for the request send by this method.
   ///  * [$getDisabledUsersDetails_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UsersGetDisabledUsersDetailsResponseApplicationJson, void>> getDisabledUsersDetails({
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    UsersGetDisabledUsersDetailsRequestApplicationJson? $body,
   }) async {
     final _request = $getDisabledUsersDetails_Request(
-      limit: limit,
-      offset: offset,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2709,8 +2575,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [location] Location of the phone number (for country code).
-  ///   * [search] Phone numbers to search for.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2722,26 +2586,10 @@ class $UsersClient {
   ///  * [$searchByPhoneNumbers_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $searchByPhoneNumbers_Request({
-    required String location,
-    required ContentString<BuiltMap<String, BuiltList<String>>> search,
+    required UsersSearchByPhoneNumbersRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __location = _$jsonSerializers.serialize(location, specifiedType: const FullType(String));
-    _parameters['location'] = __location;
-
-    final __search = _$jsonSerializers.serialize(
-      search,
-      specifiedType: const FullType(ContentString, [
-        FullType(BuiltMap, [
-          FullType(String),
-          FullType(BuiltList, [FullType(String)]),
-        ]),
-      ]),
-    );
-    _parameters['search'] = __search;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/search/by-phone{?location*,search*}').expand(_parameters);
+    const _path = '/ocs/v2.php/cloud/users/search/by-phone';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2766,6 +2614,13 @@ class $UsersClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(UsersSearchByPhoneNumbersRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -2775,8 +2630,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [location] Location of the phone number (for country code).
-  ///   * [search] Phone numbers to search for.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -2787,14 +2640,12 @@ class $UsersClient {
   ///  * [$searchByPhoneNumbers_Request] for the request send by this method.
   ///  * [$searchByPhoneNumbers_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UsersSearchByPhoneNumbersResponseApplicationJson, void>> searchByPhoneNumbers({
-    required String location,
-    required ContentString<BuiltMap<String, BuiltList<String>>> search,
+    required UsersSearchByPhoneNumbersRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $searchByPhoneNumbers_Request(
-      location: location,
-      search: search,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2915,8 +2766,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [key] Key that will be updated.
-  ///   * [value] New value for the key.
   ///   * [userId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -2928,22 +2777,15 @@ class $UsersClient {
   ///  * [$editUser_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $editUser_Request({
-    required String key,
-    required String value,
     required String userId,
+    required UsersEditUserRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
-    _parameters['key'] = __key;
-
-    final __value = _$jsonSerializers.serialize(value, specifiedType: const FullType(String));
-    _parameters['value'] = __value;
-
     final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
     _parameters['userId'] = __userId;
 
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}{?key*,value*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2968,6 +2810,9 @@ class $UsersClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json
+        .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(UsersEditUserRequestApplicationJson)));
     return _request;
   }
 
@@ -2979,8 +2824,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [key] Key that will be updated.
-  ///   * [value] New value for the key.
   ///   * [userId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -2991,16 +2834,14 @@ class $UsersClient {
   ///  * [$editUser_Request] for the request send by this method.
   ///  * [$editUser_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UsersEditUserResponseApplicationJson, void>> editUser({
-    required String key,
-    required String value,
     required String userId,
+    required UsersEditUserRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $editUser_Request(
-      key: key,
-      value: value,
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -3387,8 +3228,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [key] Key that will be updated.
-  ///   * [value] New value for the key.
   ///   * [userId] ID of the user.
   ///   * [collectionName] Collection to update.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -3401,19 +3240,12 @@ class $UsersClient {
   ///  * [$editUserMultiValue_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $editUserMultiValue_Request({
-    required String key,
-    required String value,
     required String userId,
     required String collectionName,
+    required UsersEditUserMultiValueRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
-    _parameters['key'] = __key;
-
-    final __value = _$jsonSerializers.serialize(value, specifiedType: const FullType(String));
-    _parameters['value'] = __value;
-
     final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
     _parameters['userId'] = __userId;
 
@@ -3425,8 +3257,7 @@ class $UsersClient {
     );
     _parameters['collectionName'] = __collectionName;
 
-    final _path =
-        _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/{collectionName}{?key*,value*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/{collectionName}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -3451,6 +3282,13 @@ class $UsersClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(UsersEditUserMultiValueRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -3462,8 +3300,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [key] Key that will be updated.
-  ///   * [value] New value for the key.
   ///   * [userId] ID of the user.
   ///   * [collectionName] Collection to update.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -3475,18 +3311,16 @@ class $UsersClient {
   ///  * [$editUserMultiValue_Request] for the request send by this method.
   ///  * [$editUserMultiValue_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UsersEditUserMultiValueResponseApplicationJson, void>> editUserMultiValue({
-    required String key,
-    required String value,
     required String userId,
     required String collectionName,
+    required UsersEditUserMultiValueRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $editUserMultiValue_Request(
-      key: key,
-      value: value,
       userId: userId,
       collectionName: collectionName,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -3903,7 +3737,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [groupid] ID of the group. Defaults to `""`.
   ///   * [userId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -3916,18 +3749,14 @@ class $UsersClient {
   @_i2.experimental
   _i3.Request $addToGroup_Request({
     required String userId,
-    String? groupid,
     bool? oCSAPIRequest,
+    UsersAddToGroupRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
     _parameters['userId'] = __userId;
 
-    var __groupid = _$jsonSerializers.serialize(groupid, specifiedType: const FullType(String));
-    __groupid ??= '';
-    _parameters['groupid'] = __groupid;
-
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups{?groupid*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -3952,6 +3781,17 @@ class $UsersClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(UsersAddToGroupRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              UsersAddToGroupRequestApplicationJson(),
+              specifiedType: const FullType(UsersAddToGroupRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -3963,7 +3803,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [groupid] ID of the group. Defaults to `""`.
   ///   * [userId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -3975,13 +3814,13 @@ class $UsersClient {
   ///  * [$addToGroup_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UsersAddToGroupResponseApplicationJson, void>> addToGroup({
     required String userId,
-    String? groupid,
     bool? oCSAPIRequest,
+    UsersAddToGroupRequestApplicationJson? $body,
   }) async {
     final _request = $addToGroup_Request(
       userId: userId,
-      groupid: groupid,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -4010,7 +3849,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [groupid] ID of the group.
   ///   * [userId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -4022,18 +3860,15 @@ class $UsersClient {
   ///  * [$removeFromGroup_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $removeFromGroup_Request({
-    required String groupid,
     required String userId,
+    required UsersRemoveFromGroupRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __groupid = _$jsonSerializers.serialize(groupid, specifiedType: const FullType(String));
-    _parameters['groupid'] = __groupid;
-
     final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
     _parameters['userId'] = __userId;
 
-    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups{?groupid*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/cloud/users/{userId}/groups').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -4058,6 +3893,10 @@ class $UsersClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(UsersRemoveFromGroupRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -4069,7 +3908,6 @@ class $UsersClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [groupid] ID of the group.
   ///   * [userId] ID of the user.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -4080,14 +3918,14 @@ class $UsersClient {
   ///  * [$removeFromGroup_Request] for the request send by this method.
   ///  * [$removeFromGroup_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UsersRemoveFromGroupResponseApplicationJson, void>> removeFromGroup({
-    required String groupid,
     required String userId,
+    required UsersRemoveFromGroupRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $removeFromGroup_Request(
-      groupid: groupid,
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -4636,6 +4474,69 @@ abstract class AppConfigGetKeysResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $AppConfigSetValueRequestApplicationJsonInterface {
+  /// New value for the key.
+  String get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppConfigSetValueRequestApplicationJsonInterfaceBuilder].
+  $AppConfigSetValueRequestApplicationJsonInterface rebuild(
+    void Function($AppConfigSetValueRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppConfigSetValueRequestApplicationJsonInterfaceBuilder].
+  $AppConfigSetValueRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppConfigSetValueRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppConfigSetValueRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class AppConfigSetValueRequestApplicationJson
+    implements
+        $AppConfigSetValueRequestApplicationJsonInterface,
+        Built<AppConfigSetValueRequestApplicationJson, AppConfigSetValueRequestApplicationJsonBuilder> {
+  /// Creates a new AppConfigSetValueRequestApplicationJson object using the builder pattern.
+  factory AppConfigSetValueRequestApplicationJson([void Function(AppConfigSetValueRequestApplicationJsonBuilder)? b]) =
+      _$AppConfigSetValueRequestApplicationJson;
+
+  // coverage:ignore-start
+  const AppConfigSetValueRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory AppConfigSetValueRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for AppConfigSetValueRequestApplicationJson.
+  static Serializer<AppConfigSetValueRequestApplicationJson> get serializer =>
+      _$appConfigSetValueRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppConfigSetValueRequestApplicationJsonBuilder b) {
+    $AppConfigSetValueRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppConfigSetValueRequestApplicationJsonBuilder b) {
+    $AppConfigSetValueRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $AppConfigSetValueResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -4759,6 +4660,68 @@ abstract class AppConfigSetValueResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(AppConfigSetValueResponseApplicationJsonBuilder b) {
     $AppConfigSetValueResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $AppsGetAppsRequestApplicationJsonInterface {
+  /// Filter for enabled or disabled apps.
+  String? get filter;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AppsGetAppsRequestApplicationJsonInterfaceBuilder].
+  $AppsGetAppsRequestApplicationJsonInterface rebuild(
+    void Function($AppsGetAppsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AppsGetAppsRequestApplicationJsonInterfaceBuilder].
+  $AppsGetAppsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AppsGetAppsRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AppsGetAppsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class AppsGetAppsRequestApplicationJson
+    implements
+        $AppsGetAppsRequestApplicationJsonInterface,
+        Built<AppsGetAppsRequestApplicationJson, AppsGetAppsRequestApplicationJsonBuilder> {
+  /// Creates a new AppsGetAppsRequestApplicationJson object using the builder pattern.
+  factory AppsGetAppsRequestApplicationJson([void Function(AppsGetAppsRequestApplicationJsonBuilder)? b]) =
+      _$AppsGetAppsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const AppsGetAppsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory AppsGetAppsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for AppsGetAppsRequestApplicationJson.
+  static Serializer<AppsGetAppsRequestApplicationJson> get serializer => _$appsGetAppsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AppsGetAppsRequestApplicationJsonBuilder b) {
+    $AppsGetAppsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AppsGetAppsRequestApplicationJsonBuilder b) {
+    $AppsGetAppsRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -5455,6 +5418,89 @@ abstract class GroupsGetSubAdminsOfGroupResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $GroupsGetGroupsRequestApplicationJsonInterface {
+  static final _$search = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$offset = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// Text to search for.
+  String get search;
+
+  /// Limit the amount of groups returned.
+  int? get limit;
+
+  /// Offset for searching for groups.
+  int get offset;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupsRequestApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupsRequestApplicationJsonInterface rebuild(
+    void Function($GroupsGetGroupsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupsRequestApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupsRequestApplicationJsonInterfaceBuilder b) {
+    b.search = _$search;
+    b.offset = _$offset;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class GroupsGetGroupsRequestApplicationJson
+    implements
+        $GroupsGetGroupsRequestApplicationJsonInterface,
+        Built<GroupsGetGroupsRequestApplicationJson, GroupsGetGroupsRequestApplicationJsonBuilder> {
+  /// Creates a new GroupsGetGroupsRequestApplicationJson object using the builder pattern.
+  factory GroupsGetGroupsRequestApplicationJson([void Function(GroupsGetGroupsRequestApplicationJsonBuilder)? b]) =
+      _$GroupsGetGroupsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const GroupsGetGroupsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory GroupsGetGroupsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for GroupsGetGroupsRequestApplicationJson.
+  static Serializer<GroupsGetGroupsRequestApplicationJson> get serializer =>
+      _$groupsGetGroupsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupsRequestApplicationJsonBuilder b) {
+    $GroupsGetGroupsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupsRequestApplicationJsonBuilder b) {
+    $GroupsGetGroupsRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $GroupsGetGroupsResponseApplicationJson_Ocs_DataInterface {
   BuiltList<String> get groups;
 
@@ -5829,6 +5875,90 @@ abstract class GroupsGetGroupResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(GroupsGetGroupResponseApplicationJsonBuilder b) {
     $GroupsGetGroupResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $GroupsGetGroupsDetailsRequestApplicationJsonInterface {
+  static final _$search = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$offset = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// Text to search for.
+  String get search;
+
+  /// Limit the amount of groups returned.
+  int? get limit;
+
+  /// Offset for searching for groups.
+  int get offset;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupsDetailsRequestApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupsDetailsRequestApplicationJsonInterface rebuild(
+    void Function($GroupsGetGroupsDetailsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupsDetailsRequestApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupsDetailsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupsDetailsRequestApplicationJsonInterfaceBuilder b) {
+    b.search = _$search;
+    b.offset = _$offset;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupsDetailsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class GroupsGetGroupsDetailsRequestApplicationJson
+    implements
+        $GroupsGetGroupsDetailsRequestApplicationJsonInterface,
+        Built<GroupsGetGroupsDetailsRequestApplicationJson, GroupsGetGroupsDetailsRequestApplicationJsonBuilder> {
+  /// Creates a new GroupsGetGroupsDetailsRequestApplicationJson object using the builder pattern.
+  factory GroupsGetGroupsDetailsRequestApplicationJson([
+    void Function(GroupsGetGroupsDetailsRequestApplicationJsonBuilder)? b,
+  ]) = _$GroupsGetGroupsDetailsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const GroupsGetGroupsDetailsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory GroupsGetGroupsDetailsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for GroupsGetGroupsDetailsRequestApplicationJson.
+  static Serializer<GroupsGetGroupsDetailsRequestApplicationJson> get serializer =>
+      _$groupsGetGroupsDetailsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupsDetailsRequestApplicationJsonBuilder b) {
+    $GroupsGetGroupsDetailsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupsDetailsRequestApplicationJsonBuilder b) {
+    $GroupsGetGroupsDetailsRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -6277,6 +6407,91 @@ abstract class GroupsGetGroupUsersResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(GroupsGetGroupUsersResponseApplicationJsonBuilder b) {
     $GroupsGetGroupUsersResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $GroupsGetGroupUsersDetailsRequestApplicationJsonInterface {
+  static final _$search = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$offset = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// Text to search for.
+  String get search;
+
+  /// Limit the amount of groups returned.
+  int? get limit;
+
+  /// Offset for searching for groups.
+  int get offset;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GroupsGetGroupUsersDetailsRequestApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupUsersDetailsRequestApplicationJsonInterface rebuild(
+    void Function($GroupsGetGroupUsersDetailsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GroupsGetGroupUsersDetailsRequestApplicationJsonInterfaceBuilder].
+  $GroupsGetGroupUsersDetailsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GroupsGetGroupUsersDetailsRequestApplicationJsonInterfaceBuilder b) {
+    b.search = _$search;
+    b.offset = _$offset;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GroupsGetGroupUsersDetailsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class GroupsGetGroupUsersDetailsRequestApplicationJson
+    implements
+        $GroupsGetGroupUsersDetailsRequestApplicationJsonInterface,
+        Built<GroupsGetGroupUsersDetailsRequestApplicationJson,
+            GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder> {
+  /// Creates a new GroupsGetGroupUsersDetailsRequestApplicationJson object using the builder pattern.
+  factory GroupsGetGroupUsersDetailsRequestApplicationJson([
+    void Function(GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder)? b,
+  ]) = _$GroupsGetGroupUsersDetailsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const GroupsGetGroupUsersDetailsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory GroupsGetGroupUsersDetailsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for GroupsGetGroupUsersDetailsRequestApplicationJson.
+  static Serializer<GroupsGetGroupUsersDetailsRequestApplicationJson> get serializer =>
+      _$groupsGetGroupUsersDetailsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder b) {
+    $GroupsGetGroupUsersDetailsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder b) {
+    $GroupsGetGroupUsersDetailsRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -6768,6 +6983,70 @@ abstract class GroupsGetGroupUsersDetailsResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $PreferencesSetPreferenceRequestApplicationJsonInterface {
+  /// New value.
+  String get configValue;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreferencesSetPreferenceRequestApplicationJsonInterfaceBuilder].
+  $PreferencesSetPreferenceRequestApplicationJsonInterface rebuild(
+    void Function($PreferencesSetPreferenceRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreferencesSetPreferenceRequestApplicationJsonInterfaceBuilder].
+  $PreferencesSetPreferenceRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreferencesSetPreferenceRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreferencesSetPreferenceRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class PreferencesSetPreferenceRequestApplicationJson
+    implements
+        $PreferencesSetPreferenceRequestApplicationJsonInterface,
+        Built<PreferencesSetPreferenceRequestApplicationJson, PreferencesSetPreferenceRequestApplicationJsonBuilder> {
+  /// Creates a new PreferencesSetPreferenceRequestApplicationJson object using the builder pattern.
+  factory PreferencesSetPreferenceRequestApplicationJson([
+    void Function(PreferencesSetPreferenceRequestApplicationJsonBuilder)? b,
+  ]) = _$PreferencesSetPreferenceRequestApplicationJson;
+
+  // coverage:ignore-start
+  const PreferencesSetPreferenceRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory PreferencesSetPreferenceRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for PreferencesSetPreferenceRequestApplicationJson.
+  static Serializer<PreferencesSetPreferenceRequestApplicationJson> get serializer =>
+      _$preferencesSetPreferenceRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreferencesSetPreferenceRequestApplicationJsonBuilder b) {
+    $PreferencesSetPreferenceRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreferencesSetPreferenceRequestApplicationJsonBuilder b) {
+    $PreferencesSetPreferenceRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $PreferencesSetPreferenceResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -7025,6 +7304,71 @@ abstract class PreferencesDeletePreferenceResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $PreferencesSetMultiplePreferencesRequestApplicationJsonInterface {
+  /// Key-value pairs of the preferences.
+  BuiltMap<String, String> get configs;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreferencesSetMultiplePreferencesRequestApplicationJsonInterfaceBuilder].
+  $PreferencesSetMultiplePreferencesRequestApplicationJsonInterface rebuild(
+    void Function($PreferencesSetMultiplePreferencesRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreferencesSetMultiplePreferencesRequestApplicationJsonInterfaceBuilder].
+  $PreferencesSetMultiplePreferencesRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreferencesSetMultiplePreferencesRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreferencesSetMultiplePreferencesRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class PreferencesSetMultiplePreferencesRequestApplicationJson
+    implements
+        $PreferencesSetMultiplePreferencesRequestApplicationJsonInterface,
+        Built<PreferencesSetMultiplePreferencesRequestApplicationJson,
+            PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder> {
+  /// Creates a new PreferencesSetMultiplePreferencesRequestApplicationJson object using the builder pattern.
+  factory PreferencesSetMultiplePreferencesRequestApplicationJson([
+    void Function(PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder)? b,
+  ]) = _$PreferencesSetMultiplePreferencesRequestApplicationJson;
+
+  // coverage:ignore-start
+  const PreferencesSetMultiplePreferencesRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory PreferencesSetMultiplePreferencesRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for PreferencesSetMultiplePreferencesRequestApplicationJson.
+  static Serializer<PreferencesSetMultiplePreferencesRequestApplicationJson> get serializer =>
+      _$preferencesSetMultiplePreferencesRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder b) {
+    $PreferencesSetMultiplePreferencesRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder b) {
+    $PreferencesSetMultiplePreferencesRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -7150,6 +7494,71 @@ abstract class PreferencesSetMultiplePreferencesResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder b) {
     $PreferencesSetMultiplePreferencesResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterface {
+  /// Keys to delete.
+  BuiltList<String> get configKeys;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterfaceBuilder].
+  $PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterface rebuild(
+    void Function($PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterfaceBuilder].
+  $PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class PreferencesDeleteMultiplePreferenceRequestApplicationJson
+    implements
+        $PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterface,
+        Built<PreferencesDeleteMultiplePreferenceRequestApplicationJson,
+            PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder> {
+  /// Creates a new PreferencesDeleteMultiplePreferenceRequestApplicationJson object using the builder pattern.
+  factory PreferencesDeleteMultiplePreferenceRequestApplicationJson([
+    void Function(PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder)? b,
+  ]) = _$PreferencesDeleteMultiplePreferenceRequestApplicationJson;
+
+  // coverage:ignore-start
+  const PreferencesDeleteMultiplePreferenceRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory PreferencesDeleteMultiplePreferenceRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for PreferencesDeleteMultiplePreferenceRequestApplicationJson.
+  static Serializer<PreferencesDeleteMultiplePreferenceRequestApplicationJson> get serializer =>
+      _$preferencesDeleteMultiplePreferenceRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder b) {
+    $PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder b) {
+    $PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -7412,6 +7821,69 @@ abstract class UsersGetUserSubAdminGroupsResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $UsersAddSubAdminRequestApplicationJsonInterface {
+  /// ID of the group.
+  String get groupid;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersAddSubAdminRequestApplicationJsonInterfaceBuilder].
+  $UsersAddSubAdminRequestApplicationJsonInterface rebuild(
+    void Function($UsersAddSubAdminRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersAddSubAdminRequestApplicationJsonInterfaceBuilder].
+  $UsersAddSubAdminRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersAddSubAdminRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersAddSubAdminRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UsersAddSubAdminRequestApplicationJson
+    implements
+        $UsersAddSubAdminRequestApplicationJsonInterface,
+        Built<UsersAddSubAdminRequestApplicationJson, UsersAddSubAdminRequestApplicationJsonBuilder> {
+  /// Creates a new UsersAddSubAdminRequestApplicationJson object using the builder pattern.
+  factory UsersAddSubAdminRequestApplicationJson([void Function(UsersAddSubAdminRequestApplicationJsonBuilder)? b]) =
+      _$UsersAddSubAdminRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UsersAddSubAdminRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UsersAddSubAdminRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UsersAddSubAdminRequestApplicationJson.
+  static Serializer<UsersAddSubAdminRequestApplicationJson> get serializer =>
+      _$usersAddSubAdminRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersAddSubAdminRequestApplicationJsonBuilder b) {
+    $UsersAddSubAdminRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersAddSubAdminRequestApplicationJsonBuilder b) {
+    $UsersAddSubAdminRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $UsersAddSubAdminResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -7534,6 +8006,70 @@ abstract class UsersAddSubAdminResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(UsersAddSubAdminResponseApplicationJsonBuilder b) {
     $UsersAddSubAdminResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $UsersRemoveSubAdminRequestApplicationJsonInterface {
+  /// ID of the group.
+  String get groupid;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersRemoveSubAdminRequestApplicationJsonInterfaceBuilder].
+  $UsersRemoveSubAdminRequestApplicationJsonInterface rebuild(
+    void Function($UsersRemoveSubAdminRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersRemoveSubAdminRequestApplicationJsonInterfaceBuilder].
+  $UsersRemoveSubAdminRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersRemoveSubAdminRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersRemoveSubAdminRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UsersRemoveSubAdminRequestApplicationJson
+    implements
+        $UsersRemoveSubAdminRequestApplicationJsonInterface,
+        Built<UsersRemoveSubAdminRequestApplicationJson, UsersRemoveSubAdminRequestApplicationJsonBuilder> {
+  /// Creates a new UsersRemoveSubAdminRequestApplicationJson object using the builder pattern.
+  factory UsersRemoveSubAdminRequestApplicationJson([
+    void Function(UsersRemoveSubAdminRequestApplicationJsonBuilder)? b,
+  ]) = _$UsersRemoveSubAdminRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UsersRemoveSubAdminRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UsersRemoveSubAdminRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UsersRemoveSubAdminRequestApplicationJson.
+  static Serializer<UsersRemoveSubAdminRequestApplicationJson> get serializer =>
+      _$usersRemoveSubAdminRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersRemoveSubAdminRequestApplicationJsonBuilder b) {
+    $UsersRemoveSubAdminRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersRemoveSubAdminRequestApplicationJsonBuilder b) {
+    $UsersRemoveSubAdminRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -7661,6 +8197,89 @@ abstract class UsersRemoveSubAdminResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(UsersRemoveSubAdminResponseApplicationJsonBuilder b) {
     $UsersRemoveSubAdminResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $UsersGetUsersRequestApplicationJsonInterface {
+  static final _$search = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$offset = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// Text to search for.
+  String get search;
+
+  /// Limit the amount of groups returned.
+  int? get limit;
+
+  /// Offset for searching for groups.
+  int get offset;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUsersRequestApplicationJsonInterfaceBuilder].
+  $UsersGetUsersRequestApplicationJsonInterface rebuild(
+    void Function($UsersGetUsersRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUsersRequestApplicationJsonInterfaceBuilder].
+  $UsersGetUsersRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUsersRequestApplicationJsonInterfaceBuilder b) {
+    b.search = _$search;
+    b.offset = _$offset;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUsersRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UsersGetUsersRequestApplicationJson
+    implements
+        $UsersGetUsersRequestApplicationJsonInterface,
+        Built<UsersGetUsersRequestApplicationJson, UsersGetUsersRequestApplicationJsonBuilder> {
+  /// Creates a new UsersGetUsersRequestApplicationJson object using the builder pattern.
+  factory UsersGetUsersRequestApplicationJson([void Function(UsersGetUsersRequestApplicationJsonBuilder)? b]) =
+      _$UsersGetUsersRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UsersGetUsersRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UsersGetUsersRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UsersGetUsersRequestApplicationJson.
+  static Serializer<UsersGetUsersRequestApplicationJson> get serializer =>
+      _$usersGetUsersRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUsersRequestApplicationJsonBuilder b) {
+    $UsersGetUsersRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUsersRequestApplicationJsonBuilder b) {
+    $UsersGetUsersRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -7854,6 +8473,137 @@ abstract class UsersGetUsersResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $UsersAddUserRequestApplicationJsonInterface {
+  static final _$password = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$displayName = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$email = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$groups = _$jsonSerializers.deserialize(
+    const [],
+    specifiedType: const FullType(BuiltList, [FullType(String)]),
+  )! as BuiltList<String>;
+
+  static final _$subadmin = _$jsonSerializers.deserialize(
+    const [],
+    specifiedType: const FullType(BuiltList, [FullType(String)]),
+  )! as BuiltList<String>;
+
+  static final _$quota = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$language = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// ID of the user.
+  String get userid;
+
+  /// Password of the user.
+  String get password;
+
+  /// Display name of the user.
+  String get displayName;
+
+  /// Email of the user.
+  String get email;
+
+  /// Groups of the user.
+  BuiltList<String> get groups;
+
+  /// Groups where the user is subadmin.
+  BuiltList<String> get subadmin;
+
+  /// Quota of the user.
+  String get quota;
+
+  /// Language of the user.
+  String get language;
+
+  /// Manager of the user.
+  String? get manager;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersAddUserRequestApplicationJsonInterfaceBuilder].
+  $UsersAddUserRequestApplicationJsonInterface rebuild(
+    void Function($UsersAddUserRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersAddUserRequestApplicationJsonInterfaceBuilder].
+  $UsersAddUserRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersAddUserRequestApplicationJsonInterfaceBuilder b) {
+    b.password = _$password;
+    b.displayName = _$displayName;
+    b.email = _$email;
+    b.groups.replace(_$groups);
+    b.subadmin.replace(_$subadmin);
+    b.quota = _$quota;
+    b.language = _$language;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersAddUserRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UsersAddUserRequestApplicationJson
+    implements
+        $UsersAddUserRequestApplicationJsonInterface,
+        Built<UsersAddUserRequestApplicationJson, UsersAddUserRequestApplicationJsonBuilder> {
+  /// Creates a new UsersAddUserRequestApplicationJson object using the builder pattern.
+  factory UsersAddUserRequestApplicationJson([void Function(UsersAddUserRequestApplicationJsonBuilder)? b]) =
+      _$UsersAddUserRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UsersAddUserRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UsersAddUserRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UsersAddUserRequestApplicationJson.
+  static Serializer<UsersAddUserRequestApplicationJson> get serializer =>
+      _$usersAddUserRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersAddUserRequestApplicationJsonBuilder b) {
+    $UsersAddUserRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersAddUserRequestApplicationJsonBuilder b) {
+    $UsersAddUserRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $UsersAddUserResponseApplicationJson_Ocs_DataInterface {
   String get id;
 
@@ -8038,6 +8788,90 @@ abstract class UsersAddUserResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(UsersAddUserResponseApplicationJsonBuilder b) {
     $UsersAddUserResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $UsersGetUsersDetailsRequestApplicationJsonInterface {
+  static final _$search = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$offset = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// Text to search for.
+  String get search;
+
+  /// Limit the amount of groups returned.
+  int? get limit;
+
+  /// Offset for searching for groups.
+  int get offset;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetUsersDetailsRequestApplicationJsonInterfaceBuilder].
+  $UsersGetUsersDetailsRequestApplicationJsonInterface rebuild(
+    void Function($UsersGetUsersDetailsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetUsersDetailsRequestApplicationJsonInterfaceBuilder].
+  $UsersGetUsersDetailsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetUsersDetailsRequestApplicationJsonInterfaceBuilder b) {
+    b.search = _$search;
+    b.offset = _$offset;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetUsersDetailsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UsersGetUsersDetailsRequestApplicationJson
+    implements
+        $UsersGetUsersDetailsRequestApplicationJsonInterface,
+        Built<UsersGetUsersDetailsRequestApplicationJson, UsersGetUsersDetailsRequestApplicationJsonBuilder> {
+  /// Creates a new UsersGetUsersDetailsRequestApplicationJson object using the builder pattern.
+  factory UsersGetUsersDetailsRequestApplicationJson([
+    void Function(UsersGetUsersDetailsRequestApplicationJsonBuilder)? b,
+  ]) = _$UsersGetUsersDetailsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UsersGetUsersDetailsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UsersGetUsersDetailsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UsersGetUsersDetailsRequestApplicationJson.
+  static Serializer<UsersGetUsersDetailsRequestApplicationJson> get serializer =>
+      _$usersGetUsersDetailsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetUsersDetailsRequestApplicationJsonBuilder b) {
+    $UsersGetUsersDetailsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetUsersDetailsRequestApplicationJsonBuilder b) {
+    $UsersGetUsersDetailsRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -8298,6 +9132,82 @@ abstract class UsersGetUsersDetailsResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(UsersGetUsersDetailsResponseApplicationJsonBuilder b) {
     $UsersGetUsersDetailsResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $UsersGetDisabledUsersDetailsRequestApplicationJsonInterface {
+  static final _$offset = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// Limit the amount of users returned.
+  int? get limit;
+
+  /// Offset.
+  int get offset;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersGetDisabledUsersDetailsRequestApplicationJsonInterfaceBuilder].
+  $UsersGetDisabledUsersDetailsRequestApplicationJsonInterface rebuild(
+    void Function($UsersGetDisabledUsersDetailsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersGetDisabledUsersDetailsRequestApplicationJsonInterfaceBuilder].
+  $UsersGetDisabledUsersDetailsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersGetDisabledUsersDetailsRequestApplicationJsonInterfaceBuilder b) {
+    b.offset = _$offset;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersGetDisabledUsersDetailsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UsersGetDisabledUsersDetailsRequestApplicationJson
+    implements
+        $UsersGetDisabledUsersDetailsRequestApplicationJsonInterface,
+        Built<UsersGetDisabledUsersDetailsRequestApplicationJson,
+            UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder> {
+  /// Creates a new UsersGetDisabledUsersDetailsRequestApplicationJson object using the builder pattern.
+  factory UsersGetDisabledUsersDetailsRequestApplicationJson([
+    void Function(UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder)? b,
+  ]) = _$UsersGetDisabledUsersDetailsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UsersGetDisabledUsersDetailsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UsersGetDisabledUsersDetailsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UsersGetDisabledUsersDetailsRequestApplicationJson.
+  static Serializer<UsersGetDisabledUsersDetailsRequestApplicationJson> get serializer =>
+      _$usersGetDisabledUsersDetailsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder b) {
+    $UsersGetDisabledUsersDetailsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder b) {
+    $UsersGetDisabledUsersDetailsRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -8564,6 +9474,73 @@ abstract class UsersGetDisabledUsersDetailsResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $UsersSearchByPhoneNumbersRequestApplicationJsonInterface {
+  /// Location of the phone number (for country code).
+  String get location;
+
+  /// Phone numbers to search for.
+  BuiltMap<String, BuiltList<String>> get search;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersSearchByPhoneNumbersRequestApplicationJsonInterfaceBuilder].
+  $UsersSearchByPhoneNumbersRequestApplicationJsonInterface rebuild(
+    void Function($UsersSearchByPhoneNumbersRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersSearchByPhoneNumbersRequestApplicationJsonInterfaceBuilder].
+  $UsersSearchByPhoneNumbersRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersSearchByPhoneNumbersRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersSearchByPhoneNumbersRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UsersSearchByPhoneNumbersRequestApplicationJson
+    implements
+        $UsersSearchByPhoneNumbersRequestApplicationJsonInterface,
+        Built<UsersSearchByPhoneNumbersRequestApplicationJson, UsersSearchByPhoneNumbersRequestApplicationJsonBuilder> {
+  /// Creates a new UsersSearchByPhoneNumbersRequestApplicationJson object using the builder pattern.
+  factory UsersSearchByPhoneNumbersRequestApplicationJson([
+    void Function(UsersSearchByPhoneNumbersRequestApplicationJsonBuilder)? b,
+  ]) = _$UsersSearchByPhoneNumbersRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UsersSearchByPhoneNumbersRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UsersSearchByPhoneNumbersRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UsersSearchByPhoneNumbersRequestApplicationJson.
+  static Serializer<UsersSearchByPhoneNumbersRequestApplicationJson> get serializer =>
+      _$usersSearchByPhoneNumbersRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersSearchByPhoneNumbersRequestApplicationJsonBuilder b) {
+    $UsersSearchByPhoneNumbersRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersSearchByPhoneNumbersRequestApplicationJsonBuilder b) {
+    $UsersSearchByPhoneNumbersRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $UsersSearchByPhoneNumbersResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, String> get data;
@@ -8814,6 +9791,72 @@ abstract class UsersGetUserResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(UsersGetUserResponseApplicationJsonBuilder b) {
     $UsersGetUserResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $UsersEditUserRequestApplicationJsonInterface {
+  /// Key that will be updated.
+  String get key;
+
+  /// New value for the key.
+  String get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersEditUserRequestApplicationJsonInterfaceBuilder].
+  $UsersEditUserRequestApplicationJsonInterface rebuild(
+    void Function($UsersEditUserRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersEditUserRequestApplicationJsonInterfaceBuilder].
+  $UsersEditUserRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersEditUserRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersEditUserRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UsersEditUserRequestApplicationJson
+    implements
+        $UsersEditUserRequestApplicationJsonInterface,
+        Built<UsersEditUserRequestApplicationJson, UsersEditUserRequestApplicationJsonBuilder> {
+  /// Creates a new UsersEditUserRequestApplicationJson object using the builder pattern.
+  factory UsersEditUserRequestApplicationJson([void Function(UsersEditUserRequestApplicationJsonBuilder)? b]) =
+      _$UsersEditUserRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UsersEditUserRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UsersEditUserRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UsersEditUserRequestApplicationJson.
+  static Serializer<UsersEditUserRequestApplicationJson> get serializer =>
+      _$usersEditUserRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersEditUserRequestApplicationJsonBuilder b) {
+    $UsersEditUserRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersEditUserRequestApplicationJsonBuilder b) {
+    $UsersEditUserRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -9450,6 +10493,73 @@ abstract class UsersGetEditableFieldsForUserResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(UsersGetEditableFieldsForUserResponseApplicationJsonBuilder b) {
     $UsersGetEditableFieldsForUserResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $UsersEditUserMultiValueRequestApplicationJsonInterface {
+  /// Key that will be updated.
+  String get key;
+
+  /// New value for the key.
+  String get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersEditUserMultiValueRequestApplicationJsonInterfaceBuilder].
+  $UsersEditUserMultiValueRequestApplicationJsonInterface rebuild(
+    void Function($UsersEditUserMultiValueRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersEditUserMultiValueRequestApplicationJsonInterfaceBuilder].
+  $UsersEditUserMultiValueRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersEditUserMultiValueRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersEditUserMultiValueRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UsersEditUserMultiValueRequestApplicationJson
+    implements
+        $UsersEditUserMultiValueRequestApplicationJsonInterface,
+        Built<UsersEditUserMultiValueRequestApplicationJson, UsersEditUserMultiValueRequestApplicationJsonBuilder> {
+  /// Creates a new UsersEditUserMultiValueRequestApplicationJson object using the builder pattern.
+  factory UsersEditUserMultiValueRequestApplicationJson([
+    void Function(UsersEditUserMultiValueRequestApplicationJsonBuilder)? b,
+  ]) = _$UsersEditUserMultiValueRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UsersEditUserMultiValueRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UsersEditUserMultiValueRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UsersEditUserMultiValueRequestApplicationJson.
+  static Serializer<UsersEditUserMultiValueRequestApplicationJson> get serializer =>
+      _$usersEditUserMultiValueRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersEditUserMultiValueRequestApplicationJsonBuilder b) {
+    $UsersEditUserMultiValueRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersEditUserMultiValueRequestApplicationJsonBuilder b) {
+    $UsersEditUserMultiValueRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -10152,6 +11262,77 @@ abstract class UsersGetUsersGroupsResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $UsersAddToGroupRequestApplicationJsonInterface {
+  static final _$groupid = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// ID of the group.
+  String get groupid;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersAddToGroupRequestApplicationJsonInterfaceBuilder].
+  $UsersAddToGroupRequestApplicationJsonInterface rebuild(
+    void Function($UsersAddToGroupRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersAddToGroupRequestApplicationJsonInterfaceBuilder].
+  $UsersAddToGroupRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersAddToGroupRequestApplicationJsonInterfaceBuilder b) {
+    b.groupid = _$groupid;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersAddToGroupRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UsersAddToGroupRequestApplicationJson
+    implements
+        $UsersAddToGroupRequestApplicationJsonInterface,
+        Built<UsersAddToGroupRequestApplicationJson, UsersAddToGroupRequestApplicationJsonBuilder> {
+  /// Creates a new UsersAddToGroupRequestApplicationJson object using the builder pattern.
+  factory UsersAddToGroupRequestApplicationJson([void Function(UsersAddToGroupRequestApplicationJsonBuilder)? b]) =
+      _$UsersAddToGroupRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UsersAddToGroupRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UsersAddToGroupRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UsersAddToGroupRequestApplicationJson.
+  static Serializer<UsersAddToGroupRequestApplicationJson> get serializer =>
+      _$usersAddToGroupRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersAddToGroupRequestApplicationJsonBuilder b) {
+    $UsersAddToGroupRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersAddToGroupRequestApplicationJsonBuilder b) {
+    $UsersAddToGroupRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $UsersAddToGroupResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -10274,6 +11455,70 @@ abstract class UsersAddToGroupResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(UsersAddToGroupResponseApplicationJsonBuilder b) {
     $UsersAddToGroupResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $UsersRemoveFromGroupRequestApplicationJsonInterface {
+  /// ID of the group.
+  String get groupid;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UsersRemoveFromGroupRequestApplicationJsonInterfaceBuilder].
+  $UsersRemoveFromGroupRequestApplicationJsonInterface rebuild(
+    void Function($UsersRemoveFromGroupRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UsersRemoveFromGroupRequestApplicationJsonInterfaceBuilder].
+  $UsersRemoveFromGroupRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UsersRemoveFromGroupRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UsersRemoveFromGroupRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UsersRemoveFromGroupRequestApplicationJson
+    implements
+        $UsersRemoveFromGroupRequestApplicationJsonInterface,
+        Built<UsersRemoveFromGroupRequestApplicationJson, UsersRemoveFromGroupRequestApplicationJsonBuilder> {
+  /// Creates a new UsersRemoveFromGroupRequestApplicationJson object using the builder pattern.
+  factory UsersRemoveFromGroupRequestApplicationJson([
+    void Function(UsersRemoveFromGroupRequestApplicationJsonBuilder)? b,
+  ]) = _$UsersRemoveFromGroupRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UsersRemoveFromGroupRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UsersRemoveFromGroupRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UsersRemoveFromGroupRequestApplicationJson.
+  static Serializer<UsersRemoveFromGroupRequestApplicationJson> get serializer =>
+      _$usersRemoveFromGroupRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UsersRemoveFromGroupRequestApplicationJsonBuilder b) {
+    $UsersRemoveFromGroupRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UsersRemoveFromGroupRequestApplicationJsonBuilder b) {
+    $UsersRemoveFromGroupRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -11218,6 +12463,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(AppConfigGetKeysResponseApplicationJson_Ocs_Data.serializer)
       ..addBuilderFactory(
+        const FullType(AppConfigSetValueRequestApplicationJson),
+        AppConfigSetValueRequestApplicationJsonBuilder.new,
+      )
+      ..add(AppConfigSetValueRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(AppConfigSetValueResponseApplicationJson),
         AppConfigSetValueResponseApplicationJsonBuilder.new,
       )
@@ -11227,6 +12477,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         AppConfigSetValueResponseApplicationJson_OcsBuilder.new,
       )
       ..add(AppConfigSetValueResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(AppsGetAppsRequestApplicationJson),
+        AppsGetAppsRequestApplicationJsonBuilder.new,
+      )
+      ..add(AppsGetAppsRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(AppsGetAppsResponseApplicationJson),
         AppsGetAppsResponseApplicationJsonBuilder.new,
@@ -11287,6 +12542,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(
+        const FullType(GroupsGetGroupsRequestApplicationJson),
+        GroupsGetGroupsRequestApplicationJsonBuilder.new,
+      )
+      ..add(GroupsGetGroupsRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(GroupsGetGroupsResponseApplicationJson),
         GroupsGetGroupsResponseApplicationJsonBuilder.new,
       )
@@ -11316,6 +12576,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         GroupsGetGroupResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(GroupsGetGroupResponseApplicationJson_Ocs_Data.serializer)
+      ..addBuilderFactory(
+        const FullType(GroupsGetGroupsDetailsRequestApplicationJson),
+        GroupsGetGroupsDetailsRequestApplicationJsonBuilder.new,
+      )
+      ..add(GroupsGetGroupsDetailsRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(GroupsGetGroupsDetailsResponseApplicationJson),
         GroupsGetGroupsDetailsResponseApplicationJsonBuilder.new,
@@ -11350,6 +12615,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         GroupsGetGroupUsersResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(GroupsGetGroupUsersResponseApplicationJson_Ocs_Data.serializer)
+      ..addBuilderFactory(
+        const FullType(GroupsGetGroupUsersDetailsRequestApplicationJson),
+        GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder.new,
+      )
+      ..add(GroupsGetGroupUsersDetailsRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(GroupsGetGroupUsersDetailsResponseApplicationJson),
         GroupsGetGroupUsersDetailsResponseApplicationJsonBuilder.new,
@@ -11386,6 +12656,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         MapBuilder<String, GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs_Data_Users>.new,
       )
       ..addBuilderFactory(
+        const FullType(PreferencesSetPreferenceRequestApplicationJson),
+        PreferencesSetPreferenceRequestApplicationJsonBuilder.new,
+      )
+      ..add(PreferencesSetPreferenceRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(PreferencesSetPreferenceResponseApplicationJson),
         PreferencesSetPreferenceResponseApplicationJsonBuilder.new,
       )
@@ -11406,16 +12681,14 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(PreferencesDeletePreferenceResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(
+        const FullType(PreferencesSetMultiplePreferencesRequestApplicationJson),
+        PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder.new,
+      )
+      ..add(PreferencesSetMultiplePreferencesRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(BuiltMap, [FullType(String), FullType(String)]),
         MapBuilder<String, String>.new,
       )
-      ..addBuilderFactory(
-        const FullType(ContentString, [
-          FullType(BuiltMap, [FullType(String), FullType(String)]),
-        ]),
-        ContentStringBuilder<BuiltMap<String, String>>.new,
-      )
-      ..add(ContentString.serializer)
       ..addBuilderFactory(
         const FullType(PreferencesSetMultiplePreferencesResponseApplicationJson),
         PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder.new,
@@ -11426,6 +12699,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         PreferencesSetMultiplePreferencesResponseApplicationJson_OcsBuilder.new,
       )
       ..add(PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(PreferencesDeleteMultiplePreferenceRequestApplicationJson),
+        PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder.new,
+      )
+      ..add(PreferencesDeleteMultiplePreferenceRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(PreferencesDeleteMultiplePreferenceResponseApplicationJson),
         PreferencesDeleteMultiplePreferenceResponseApplicationJsonBuilder.new,
@@ -11447,6 +12725,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(
+        const FullType(UsersAddSubAdminRequestApplicationJson),
+        UsersAddSubAdminRequestApplicationJsonBuilder.new,
+      )
+      ..add(UsersAddSubAdminRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(UsersAddSubAdminResponseApplicationJson),
         UsersAddSubAdminResponseApplicationJsonBuilder.new,
       )
@@ -11457,6 +12740,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(UsersAddSubAdminResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(
+        const FullType(UsersRemoveSubAdminRequestApplicationJson),
+        UsersRemoveSubAdminRequestApplicationJsonBuilder.new,
+      )
+      ..add(UsersRemoveSubAdminRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(UsersRemoveSubAdminResponseApplicationJson),
         UsersRemoveSubAdminResponseApplicationJsonBuilder.new,
       )
@@ -11466,6 +12754,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         UsersRemoveSubAdminResponseApplicationJson_OcsBuilder.new,
       )
       ..add(UsersRemoveSubAdminResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(UsersGetUsersRequestApplicationJson),
+        UsersGetUsersRequestApplicationJsonBuilder.new,
+      )
+      ..add(UsersGetUsersRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(UsersGetUsersResponseApplicationJson),
         UsersGetUsersResponseApplicationJsonBuilder.new,
@@ -11482,6 +12775,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(UsersGetUsersResponseApplicationJson_Ocs_Data.serializer)
       ..addBuilderFactory(
+        const FullType(UsersAddUserRequestApplicationJson),
+        UsersAddUserRequestApplicationJsonBuilder.new,
+      )
+      ..add(UsersAddUserRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(UsersAddUserResponseApplicationJson),
         UsersAddUserResponseApplicationJsonBuilder.new,
       )
@@ -11496,6 +12794,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         UsersAddUserResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(UsersAddUserResponseApplicationJson_Ocs_Data.serializer)
+      ..addBuilderFactory(
+        const FullType(UsersGetUsersDetailsRequestApplicationJson),
+        UsersGetUsersDetailsRequestApplicationJsonBuilder.new,
+      )
+      ..add(UsersGetUsersDetailsRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(UsersGetUsersDetailsResponseApplicationJson),
         UsersGetUsersDetailsResponseApplicationJsonBuilder.new,
@@ -11525,6 +12828,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         MapBuilder<String, UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users>.new,
       )
       ..addBuilderFactory(
+        const FullType(UsersGetDisabledUsersDetailsRequestApplicationJson),
+        UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder.new,
+      )
+      ..add(UsersGetDisabledUsersDetailsRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(UsersGetDisabledUsersDetailsResponseApplicationJson),
         UsersGetDisabledUsersDetailsResponseApplicationJsonBuilder.new,
       )
@@ -11553,20 +12861,16 @@ final Serializers _$serializers = (Serializers().toBuilder()
         MapBuilder<String, UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users>.new,
       )
       ..addBuilderFactory(
+        const FullType(UsersSearchByPhoneNumbersRequestApplicationJson),
+        UsersSearchByPhoneNumbersRequestApplicationJsonBuilder.new,
+      )
+      ..add(UsersSearchByPhoneNumbersRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(BuiltMap, [
           FullType(String),
           FullType(BuiltList, [FullType(String)]),
         ]),
         MapBuilder<String, BuiltList<String>>.new,
-      )
-      ..addBuilderFactory(
-        const FullType(ContentString, [
-          FullType(BuiltMap, [
-            FullType(String),
-            FullType(BuiltList, [FullType(String)]),
-          ]),
-        ]),
-        ContentStringBuilder<BuiltMap<String, BuiltList<String>>>.new,
       )
       ..addBuilderFactory(
         const FullType(UsersSearchByPhoneNumbersResponseApplicationJson),
@@ -11588,6 +12892,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         UsersGetUserResponseApplicationJson_OcsBuilder.new,
       )
       ..add(UsersGetUserResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(UsersEditUserRequestApplicationJson),
+        UsersEditUserRequestApplicationJsonBuilder.new,
+      )
+      ..add(UsersEditUserRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(UsersEditUserResponseApplicationJson),
         UsersEditUserResponseApplicationJsonBuilder.new,
@@ -11638,6 +12947,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         UsersGetEditableFieldsForUserResponseApplicationJson_OcsBuilder.new,
       )
       ..add(UsersGetEditableFieldsForUserResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(UsersEditUserMultiValueRequestApplicationJson),
+        UsersEditUserMultiValueRequestApplicationJsonBuilder.new,
+      )
+      ..add(UsersEditUserMultiValueRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(UsersEditUserMultiValueResponseApplicationJson),
         UsersEditUserMultiValueResponseApplicationJsonBuilder.new,
@@ -11694,6 +13008,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(UsersGetUsersGroupsResponseApplicationJson_Ocs_Data.serializer)
       ..addBuilderFactory(
+        const FullType(UsersAddToGroupRequestApplicationJson),
+        UsersAddToGroupRequestApplicationJsonBuilder.new,
+      )
+      ..add(UsersAddToGroupRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(UsersAddToGroupResponseApplicationJson),
         UsersAddToGroupResponseApplicationJsonBuilder.new,
       )
@@ -11703,6 +13022,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         UsersAddToGroupResponseApplicationJson_OcsBuilder.new,
       )
       ..add(UsersAddToGroupResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(UsersRemoveFromGroupRequestApplicationJson),
+        UsersRemoveFromGroupRequestApplicationJsonBuilder.new,
+      )
+      ..add(UsersRemoveFromGroupRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(UsersRemoveFromGroupResponseApplicationJson),
         UsersRemoveFromGroupResponseApplicationJsonBuilder.new,

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.g.dart
@@ -21,10 +21,14 @@ Serializer<AppConfigGetKeysResponseApplicationJson_Ocs> _$appConfigGetKeysRespon
     _$AppConfigGetKeysResponseApplicationJson_OcsSerializer();
 Serializer<AppConfigGetKeysResponseApplicationJson> _$appConfigGetKeysResponseApplicationJsonSerializer =
     _$AppConfigGetKeysResponseApplicationJsonSerializer();
+Serializer<AppConfigSetValueRequestApplicationJson> _$appConfigSetValueRequestApplicationJsonSerializer =
+    _$AppConfigSetValueRequestApplicationJsonSerializer();
 Serializer<AppConfigSetValueResponseApplicationJson_Ocs> _$appConfigSetValueResponseApplicationJsonOcsSerializer =
     _$AppConfigSetValueResponseApplicationJson_OcsSerializer();
 Serializer<AppConfigSetValueResponseApplicationJson> _$appConfigSetValueResponseApplicationJsonSerializer =
     _$AppConfigSetValueResponseApplicationJsonSerializer();
+Serializer<AppsGetAppsRequestApplicationJson> _$appsGetAppsRequestApplicationJsonSerializer =
+    _$AppsGetAppsRequestApplicationJsonSerializer();
 Serializer<AppsGetAppsResponseApplicationJson_Ocs_Data> _$appsGetAppsResponseApplicationJsonOcsDataSerializer =
     _$AppsGetAppsResponseApplicationJson_Ocs_DataSerializer();
 Serializer<AppsGetAppsResponseApplicationJson_Ocs> _$appsGetAppsResponseApplicationJsonOcsSerializer =
@@ -49,6 +53,8 @@ Serializer<GroupsGetSubAdminsOfGroupResponseApplicationJson_Ocs>
 Serializer<GroupsGetSubAdminsOfGroupResponseApplicationJson>
     _$groupsGetSubAdminsOfGroupResponseApplicationJsonSerializer =
     _$GroupsGetSubAdminsOfGroupResponseApplicationJsonSerializer();
+Serializer<GroupsGetGroupsRequestApplicationJson> _$groupsGetGroupsRequestApplicationJsonSerializer =
+    _$GroupsGetGroupsRequestApplicationJsonSerializer();
 Serializer<GroupsGetGroupsResponseApplicationJson_Ocs_Data> _$groupsGetGroupsResponseApplicationJsonOcsDataSerializer =
     _$GroupsGetGroupsResponseApplicationJson_Ocs_DataSerializer();
 Serializer<GroupsGetGroupsResponseApplicationJson_Ocs> _$groupsGetGroupsResponseApplicationJsonOcsSerializer =
@@ -61,6 +67,8 @@ Serializer<GroupsGetGroupResponseApplicationJson_Ocs> _$groupsGetGroupResponseAp
     _$GroupsGetGroupResponseApplicationJson_OcsSerializer();
 Serializer<GroupsGetGroupResponseApplicationJson> _$groupsGetGroupResponseApplicationJsonSerializer =
     _$GroupsGetGroupResponseApplicationJsonSerializer();
+Serializer<GroupsGetGroupsDetailsRequestApplicationJson> _$groupsGetGroupsDetailsRequestApplicationJsonSerializer =
+    _$GroupsGetGroupsDetailsRequestApplicationJsonSerializer();
 Serializer<GroupDetails> _$groupDetailsSerializer = _$GroupDetailsSerializer();
 Serializer<GroupsGetGroupsDetailsResponseApplicationJson_Ocs_Data>
     _$groupsGetGroupsDetailsResponseApplicationJsonOcsDataSerializer =
@@ -77,6 +85,9 @@ Serializer<GroupsGetGroupUsersResponseApplicationJson_Ocs> _$groupsGetGroupUsers
     _$GroupsGetGroupUsersResponseApplicationJson_OcsSerializer();
 Serializer<GroupsGetGroupUsersResponseApplicationJson> _$groupsGetGroupUsersResponseApplicationJsonSerializer =
     _$GroupsGetGroupUsersResponseApplicationJsonSerializer();
+Serializer<GroupsGetGroupUsersDetailsRequestApplicationJson>
+    _$groupsGetGroupUsersDetailsRequestApplicationJsonSerializer =
+    _$GroupsGetGroupUsersDetailsRequestApplicationJsonSerializer();
 Serializer<UserDetails_BackendCapabilities> _$userDetailsBackendCapabilitiesSerializer =
     _$UserDetails_BackendCapabilitiesSerializer();
 Serializer<UserDetailsQuota> _$userDetailsQuotaSerializer = _$UserDetailsQuotaSerializer();
@@ -93,6 +104,8 @@ Serializer<GroupsGetGroupUsersDetailsResponseApplicationJson_Ocs>
 Serializer<GroupsGetGroupUsersDetailsResponseApplicationJson>
     _$groupsGetGroupUsersDetailsResponseApplicationJsonSerializer =
     _$GroupsGetGroupUsersDetailsResponseApplicationJsonSerializer();
+Serializer<PreferencesSetPreferenceRequestApplicationJson> _$preferencesSetPreferenceRequestApplicationJsonSerializer =
+    _$PreferencesSetPreferenceRequestApplicationJsonSerializer();
 Serializer<PreferencesSetPreferenceResponseApplicationJson_Ocs>
     _$preferencesSetPreferenceResponseApplicationJsonOcsSerializer =
     _$PreferencesSetPreferenceResponseApplicationJson_OcsSerializer();
@@ -105,12 +118,18 @@ Serializer<PreferencesDeletePreferenceResponseApplicationJson_Ocs>
 Serializer<PreferencesDeletePreferenceResponseApplicationJson>
     _$preferencesDeletePreferenceResponseApplicationJsonSerializer =
     _$PreferencesDeletePreferenceResponseApplicationJsonSerializer();
+Serializer<PreferencesSetMultiplePreferencesRequestApplicationJson>
+    _$preferencesSetMultiplePreferencesRequestApplicationJsonSerializer =
+    _$PreferencesSetMultiplePreferencesRequestApplicationJsonSerializer();
 Serializer<PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs>
     _$preferencesSetMultiplePreferencesResponseApplicationJsonOcsSerializer =
     _$PreferencesSetMultiplePreferencesResponseApplicationJson_OcsSerializer();
 Serializer<PreferencesSetMultiplePreferencesResponseApplicationJson>
     _$preferencesSetMultiplePreferencesResponseApplicationJsonSerializer =
     _$PreferencesSetMultiplePreferencesResponseApplicationJsonSerializer();
+Serializer<PreferencesDeleteMultiplePreferenceRequestApplicationJson>
+    _$preferencesDeleteMultiplePreferenceRequestApplicationJsonSerializer =
+    _$PreferencesDeleteMultiplePreferenceRequestApplicationJsonSerializer();
 Serializer<PreferencesDeleteMultiplePreferenceResponseApplicationJson_Ocs>
     _$preferencesDeleteMultiplePreferenceResponseApplicationJsonOcsSerializer =
     _$PreferencesDeleteMultiplePreferenceResponseApplicationJson_OcsSerializer();
@@ -123,26 +142,36 @@ Serializer<UsersGetUserSubAdminGroupsResponseApplicationJson_Ocs>
 Serializer<UsersGetUserSubAdminGroupsResponseApplicationJson>
     _$usersGetUserSubAdminGroupsResponseApplicationJsonSerializer =
     _$UsersGetUserSubAdminGroupsResponseApplicationJsonSerializer();
+Serializer<UsersAddSubAdminRequestApplicationJson> _$usersAddSubAdminRequestApplicationJsonSerializer =
+    _$UsersAddSubAdminRequestApplicationJsonSerializer();
 Serializer<UsersAddSubAdminResponseApplicationJson_Ocs> _$usersAddSubAdminResponseApplicationJsonOcsSerializer =
     _$UsersAddSubAdminResponseApplicationJson_OcsSerializer();
 Serializer<UsersAddSubAdminResponseApplicationJson> _$usersAddSubAdminResponseApplicationJsonSerializer =
     _$UsersAddSubAdminResponseApplicationJsonSerializer();
+Serializer<UsersRemoveSubAdminRequestApplicationJson> _$usersRemoveSubAdminRequestApplicationJsonSerializer =
+    _$UsersRemoveSubAdminRequestApplicationJsonSerializer();
 Serializer<UsersRemoveSubAdminResponseApplicationJson_Ocs> _$usersRemoveSubAdminResponseApplicationJsonOcsSerializer =
     _$UsersRemoveSubAdminResponseApplicationJson_OcsSerializer();
 Serializer<UsersRemoveSubAdminResponseApplicationJson> _$usersRemoveSubAdminResponseApplicationJsonSerializer =
     _$UsersRemoveSubAdminResponseApplicationJsonSerializer();
+Serializer<UsersGetUsersRequestApplicationJson> _$usersGetUsersRequestApplicationJsonSerializer =
+    _$UsersGetUsersRequestApplicationJsonSerializer();
 Serializer<UsersGetUsersResponseApplicationJson_Ocs_Data> _$usersGetUsersResponseApplicationJsonOcsDataSerializer =
     _$UsersGetUsersResponseApplicationJson_Ocs_DataSerializer();
 Serializer<UsersGetUsersResponseApplicationJson_Ocs> _$usersGetUsersResponseApplicationJsonOcsSerializer =
     _$UsersGetUsersResponseApplicationJson_OcsSerializer();
 Serializer<UsersGetUsersResponseApplicationJson> _$usersGetUsersResponseApplicationJsonSerializer =
     _$UsersGetUsersResponseApplicationJsonSerializer();
+Serializer<UsersAddUserRequestApplicationJson> _$usersAddUserRequestApplicationJsonSerializer =
+    _$UsersAddUserRequestApplicationJsonSerializer();
 Serializer<UsersAddUserResponseApplicationJson_Ocs_Data> _$usersAddUserResponseApplicationJsonOcsDataSerializer =
     _$UsersAddUserResponseApplicationJson_Ocs_DataSerializer();
 Serializer<UsersAddUserResponseApplicationJson_Ocs> _$usersAddUserResponseApplicationJsonOcsSerializer =
     _$UsersAddUserResponseApplicationJson_OcsSerializer();
 Serializer<UsersAddUserResponseApplicationJson> _$usersAddUserResponseApplicationJsonSerializer =
     _$UsersAddUserResponseApplicationJsonSerializer();
+Serializer<UsersGetUsersDetailsRequestApplicationJson> _$usersGetUsersDetailsRequestApplicationJsonSerializer =
+    _$UsersGetUsersDetailsRequestApplicationJsonSerializer();
 Serializer<UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1>
     _$usersGetUsersDetailsResponseApplicationJsonOcsDataUsers1Serializer =
     _$UsersGetUsersDetailsResponseApplicationJson_Ocs_Data_Users1Serializer();
@@ -153,6 +182,9 @@ Serializer<UsersGetUsersDetailsResponseApplicationJson_Ocs> _$usersGetUsersDetai
     _$UsersGetUsersDetailsResponseApplicationJson_OcsSerializer();
 Serializer<UsersGetUsersDetailsResponseApplicationJson> _$usersGetUsersDetailsResponseApplicationJsonSerializer =
     _$UsersGetUsersDetailsResponseApplicationJsonSerializer();
+Serializer<UsersGetDisabledUsersDetailsRequestApplicationJson>
+    _$usersGetDisabledUsersDetailsRequestApplicationJsonSerializer =
+    _$UsersGetDisabledUsersDetailsRequestApplicationJsonSerializer();
 Serializer<UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1>
     _$usersGetDisabledUsersDetailsResponseApplicationJsonOcsDataUsers1Serializer =
     _$UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs_Data_Users1Serializer();
@@ -165,6 +197,9 @@ Serializer<UsersGetDisabledUsersDetailsResponseApplicationJson_Ocs>
 Serializer<UsersGetDisabledUsersDetailsResponseApplicationJson>
     _$usersGetDisabledUsersDetailsResponseApplicationJsonSerializer =
     _$UsersGetDisabledUsersDetailsResponseApplicationJsonSerializer();
+Serializer<UsersSearchByPhoneNumbersRequestApplicationJson>
+    _$usersSearchByPhoneNumbersRequestApplicationJsonSerializer =
+    _$UsersSearchByPhoneNumbersRequestApplicationJsonSerializer();
 Serializer<UsersSearchByPhoneNumbersResponseApplicationJson_Ocs>
     _$usersSearchByPhoneNumbersResponseApplicationJsonOcsSerializer =
     _$UsersSearchByPhoneNumbersResponseApplicationJson_OcsSerializer();
@@ -175,6 +210,8 @@ Serializer<UsersGetUserResponseApplicationJson_Ocs> _$usersGetUserResponseApplic
     _$UsersGetUserResponseApplicationJson_OcsSerializer();
 Serializer<UsersGetUserResponseApplicationJson> _$usersGetUserResponseApplicationJsonSerializer =
     _$UsersGetUserResponseApplicationJsonSerializer();
+Serializer<UsersEditUserRequestApplicationJson> _$usersEditUserRequestApplicationJsonSerializer =
+    _$UsersEditUserRequestApplicationJsonSerializer();
 Serializer<UsersEditUserResponseApplicationJson_Ocs> _$usersEditUserResponseApplicationJsonOcsSerializer =
     _$UsersEditUserResponseApplicationJson_OcsSerializer();
 Serializer<UsersEditUserResponseApplicationJson> _$usersEditUserResponseApplicationJsonSerializer =
@@ -198,6 +235,8 @@ Serializer<UsersGetEditableFieldsForUserResponseApplicationJson_Ocs>
 Serializer<UsersGetEditableFieldsForUserResponseApplicationJson>
     _$usersGetEditableFieldsForUserResponseApplicationJsonSerializer =
     _$UsersGetEditableFieldsForUserResponseApplicationJsonSerializer();
+Serializer<UsersEditUserMultiValueRequestApplicationJson> _$usersEditUserMultiValueRequestApplicationJsonSerializer =
+    _$UsersEditUserMultiValueRequestApplicationJsonSerializer();
 Serializer<UsersEditUserMultiValueResponseApplicationJson_Ocs>
     _$usersEditUserMultiValueResponseApplicationJsonOcsSerializer =
     _$UsersEditUserMultiValueResponseApplicationJson_OcsSerializer();
@@ -222,10 +261,14 @@ Serializer<UsersGetUsersGroupsResponseApplicationJson_Ocs> _$usersGetUsersGroups
     _$UsersGetUsersGroupsResponseApplicationJson_OcsSerializer();
 Serializer<UsersGetUsersGroupsResponseApplicationJson> _$usersGetUsersGroupsResponseApplicationJsonSerializer =
     _$UsersGetUsersGroupsResponseApplicationJsonSerializer();
+Serializer<UsersAddToGroupRequestApplicationJson> _$usersAddToGroupRequestApplicationJsonSerializer =
+    _$UsersAddToGroupRequestApplicationJsonSerializer();
 Serializer<UsersAddToGroupResponseApplicationJson_Ocs> _$usersAddToGroupResponseApplicationJsonOcsSerializer =
     _$UsersAddToGroupResponseApplicationJson_OcsSerializer();
 Serializer<UsersAddToGroupResponseApplicationJson> _$usersAddToGroupResponseApplicationJsonSerializer =
     _$UsersAddToGroupResponseApplicationJsonSerializer();
+Serializer<UsersRemoveFromGroupRequestApplicationJson> _$usersRemoveFromGroupRequestApplicationJsonSerializer =
+    _$UsersRemoveFromGroupRequestApplicationJsonSerializer();
 Serializer<UsersRemoveFromGroupResponseApplicationJson_Ocs> _$usersRemoveFromGroupResponseApplicationJsonOcsSerializer =
     _$UsersRemoveFromGroupResponseApplicationJson_OcsSerializer();
 Serializer<UsersRemoveFromGroupResponseApplicationJson> _$usersRemoveFromGroupResponseApplicationJsonSerializer =
@@ -584,6 +627,48 @@ class _$AppConfigGetKeysResponseApplicationJsonSerializer
   }
 }
 
+class _$AppConfigSetValueRequestApplicationJsonSerializer
+    implements StructuredSerializer<AppConfigSetValueRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    AppConfigSetValueRequestApplicationJson,
+    _$AppConfigSetValueRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'AppConfigSetValueRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, AppConfigSetValueRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  AppConfigSetValueRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = AppConfigSetValueRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'value':
+          result.value = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$AppConfigSetValueResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<AppConfigSetValueResponseApplicationJson_Ocs> {
   @override
@@ -667,6 +752,47 @@ class _$AppConfigSetValueResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(AppConfigSetValueResponseApplicationJson_Ocs))!
               as AppConfigSetValueResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$AppsGetAppsRequestApplicationJsonSerializer implements StructuredSerializer<AppsGetAppsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [AppsGetAppsRequestApplicationJson, _$AppsGetAppsRequestApplicationJson];
+  @override
+  final String wireName = 'AppsGetAppsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, AppsGetAppsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.filter;
+    if (value != null) {
+      result
+        ..add('filter')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  AppsGetAppsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = AppsGetAppsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'filter':
+          result.filter = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -1158,6 +1284,59 @@ class _$GroupsGetSubAdminsOfGroupResponseApplicationJsonSerializer
   }
 }
 
+class _$GroupsGetGroupsRequestApplicationJsonSerializer
+    implements StructuredSerializer<GroupsGetGroupsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [GroupsGetGroupsRequestApplicationJson, _$GroupsGetGroupsRequestApplicationJson];
+  @override
+  final String wireName = 'GroupsGetGroupsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GroupsGetGroupsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'search',
+      serializers.serialize(object.search, specifiedType: const FullType(String)),
+      'offset',
+      serializers.serialize(object.offset, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.limit;
+    if (value != null) {
+      result
+        ..add('limit')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  GroupsGetGroupsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GroupsGetGroupsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'search':
+          result.search = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'offset':
+          result.offset = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$GroupsGetGroupsResponseApplicationJson_Ocs_DataSerializer
     implements StructuredSerializer<GroupsGetGroupsResponseApplicationJson_Ocs_Data> {
   @override
@@ -1417,6 +1596,62 @@ class _$GroupsGetGroupResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(GroupsGetGroupResponseApplicationJson_Ocs))!
                   as GroupsGetGroupResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GroupsGetGroupsDetailsRequestApplicationJsonSerializer
+    implements StructuredSerializer<GroupsGetGroupsDetailsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    GroupsGetGroupsDetailsRequestApplicationJson,
+    _$GroupsGetGroupsDetailsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'GroupsGetGroupsDetailsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GroupsGetGroupsDetailsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'search',
+      serializers.serialize(object.search, specifiedType: const FullType(String)),
+      'offset',
+      serializers.serialize(object.offset, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.limit;
+    if (value != null) {
+      result
+        ..add('limit')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  GroupsGetGroupsDetailsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GroupsGetGroupsDetailsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'search':
+          result.search = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'offset':
+          result.offset = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -1758,6 +1993,62 @@ class _$GroupsGetGroupUsersResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(GroupsGetGroupUsersResponseApplicationJson_Ocs))!
               as GroupsGetGroupUsersResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GroupsGetGroupUsersDetailsRequestApplicationJsonSerializer
+    implements StructuredSerializer<GroupsGetGroupUsersDetailsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    GroupsGetGroupUsersDetailsRequestApplicationJson,
+    _$GroupsGetGroupUsersDetailsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'GroupsGetGroupUsersDetailsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GroupsGetGroupUsersDetailsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'search',
+      serializers.serialize(object.search, specifiedType: const FullType(String)),
+      'offset',
+      serializers.serialize(object.offset, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.limit;
+    if (value != null) {
+      result
+        ..add('limit')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  GroupsGetGroupUsersDetailsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'search':
+          result.search = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'offset':
+          result.offset = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -2376,6 +2667,48 @@ class _$GroupsGetGroupUsersDetailsResponseApplicationJsonSerializer
   }
 }
 
+class _$PreferencesSetPreferenceRequestApplicationJsonSerializer
+    implements StructuredSerializer<PreferencesSetPreferenceRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    PreferencesSetPreferenceRequestApplicationJson,
+    _$PreferencesSetPreferenceRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'PreferencesSetPreferenceRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PreferencesSetPreferenceRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'configValue',
+      serializers.serialize(object.configValue, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  PreferencesSetPreferenceRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PreferencesSetPreferenceRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'configValue':
+          result.configValue = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$PreferencesSetPreferenceResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<PreferencesSetPreferenceResponseApplicationJson_Ocs> {
   @override
@@ -2561,6 +2894,51 @@ class _$PreferencesDeletePreferenceResponseApplicationJsonSerializer
   }
 }
 
+class _$PreferencesSetMultiplePreferencesRequestApplicationJsonSerializer
+    implements StructuredSerializer<PreferencesSetMultiplePreferencesRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    PreferencesSetMultiplePreferencesRequestApplicationJson,
+    _$PreferencesSetMultiplePreferencesRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'PreferencesSetMultiplePreferencesRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PreferencesSetMultiplePreferencesRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'configs',
+      serializers.serialize(object.configs,
+          specifiedType: const FullType(BuiltMap, [FullType(String), FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  PreferencesSetMultiplePreferencesRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'configs':
+          result.configs.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, [FullType(String), FullType(String)]))!);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$PreferencesSetMultiplePreferencesResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs> {
   @override
@@ -2648,6 +3026,50 @@ class _$PreferencesSetMultiplePreferencesResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs))!
               as PreferencesSetMultiplePreferencesResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$PreferencesDeleteMultiplePreferenceRequestApplicationJsonSerializer
+    implements StructuredSerializer<PreferencesDeleteMultiplePreferenceRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    PreferencesDeleteMultiplePreferenceRequestApplicationJson,
+    _$PreferencesDeleteMultiplePreferenceRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'PreferencesDeleteMultiplePreferenceRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PreferencesDeleteMultiplePreferenceRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'configKeys',
+      serializers.serialize(object.configKeys, specifiedType: const FullType(BuiltList, [FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  PreferencesDeleteMultiplePreferenceRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'configKeys':
+          result.configKeys.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, [FullType(String)]))! as BuiltList<Object?>);
           break;
       }
     }
@@ -2846,6 +3268,45 @@ class _$UsersGetUserSubAdminGroupsResponseApplicationJsonSerializer
   }
 }
 
+class _$UsersAddSubAdminRequestApplicationJsonSerializer
+    implements StructuredSerializer<UsersAddSubAdminRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [UsersAddSubAdminRequestApplicationJson, _$UsersAddSubAdminRequestApplicationJson];
+  @override
+  final String wireName = 'UsersAddSubAdminRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsersAddSubAdminRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'groupid',
+      serializers.serialize(object.groupid, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  UsersAddSubAdminRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UsersAddSubAdminRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'groupid':
+          result.groupid = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$UsersAddSubAdminResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<UsersAddSubAdminResponseApplicationJson_Ocs> {
   @override
@@ -2937,6 +3398,48 @@ class _$UsersAddSubAdminResponseApplicationJsonSerializer
   }
 }
 
+class _$UsersRemoveSubAdminRequestApplicationJsonSerializer
+    implements StructuredSerializer<UsersRemoveSubAdminRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    UsersRemoveSubAdminRequestApplicationJson,
+    _$UsersRemoveSubAdminRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'UsersRemoveSubAdminRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsersRemoveSubAdminRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'groupid',
+      serializers.serialize(object.groupid, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  UsersRemoveSubAdminRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UsersRemoveSubAdminRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'groupid':
+          result.groupid = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$UsersRemoveSubAdminResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<UsersRemoveSubAdminResponseApplicationJson_Ocs> {
   @override
@@ -3020,6 +3523,59 @@ class _$UsersRemoveSubAdminResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(UsersRemoveSubAdminResponseApplicationJson_Ocs))!
               as UsersRemoveSubAdminResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UsersGetUsersRequestApplicationJsonSerializer
+    implements StructuredSerializer<UsersGetUsersRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [UsersGetUsersRequestApplicationJson, _$UsersGetUsersRequestApplicationJson];
+  @override
+  final String wireName = 'UsersGetUsersRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsersGetUsersRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'search',
+      serializers.serialize(object.search, specifiedType: const FullType(String)),
+      'offset',
+      serializers.serialize(object.offset, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.limit;
+    if (value != null) {
+      result
+        ..add('limit')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  UsersGetUsersRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UsersGetUsersRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'search':
+          result.search = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'offset':
+          result.offset = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -3161,6 +3717,91 @@ class _$UsersGetUsersResponseApplicationJsonSerializer
   }
 }
 
+class _$UsersAddUserRequestApplicationJsonSerializer
+    implements StructuredSerializer<UsersAddUserRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [UsersAddUserRequestApplicationJson, _$UsersAddUserRequestApplicationJson];
+  @override
+  final String wireName = 'UsersAddUserRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsersAddUserRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'userid',
+      serializers.serialize(object.userid, specifiedType: const FullType(String)),
+      'password',
+      serializers.serialize(object.password, specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName, specifiedType: const FullType(String)),
+      'email',
+      serializers.serialize(object.email, specifiedType: const FullType(String)),
+      'groups',
+      serializers.serialize(object.groups, specifiedType: const FullType(BuiltList, [FullType(String)])),
+      'subadmin',
+      serializers.serialize(object.subadmin, specifiedType: const FullType(BuiltList, [FullType(String)])),
+      'quota',
+      serializers.serialize(object.quota, specifiedType: const FullType(String)),
+      'language',
+      serializers.serialize(object.language, specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.manager;
+    if (value != null) {
+      result
+        ..add('manager')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  UsersAddUserRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UsersAddUserRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'userid':
+          result.userid = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'password':
+          result.password = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'email':
+          result.email = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'groups':
+          result.groups.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, [FullType(String)]))! as BuiltList<Object?>);
+          break;
+        case 'subadmin':
+          result.subadmin.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, [FullType(String)]))! as BuiltList<Object?>);
+          break;
+        case 'quota':
+          result.quota = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'language':
+          result.language = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'manager':
+          result.manager = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$UsersAddUserResponseApplicationJson_Ocs_DataSerializer
     implements StructuredSerializer<UsersAddUserResponseApplicationJson_Ocs_Data> {
   @override
@@ -3285,6 +3926,62 @@ class _$UsersAddUserResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(UsersAddUserResponseApplicationJson_Ocs))!
                   as UsersAddUserResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UsersGetUsersDetailsRequestApplicationJsonSerializer
+    implements StructuredSerializer<UsersGetUsersDetailsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    UsersGetUsersDetailsRequestApplicationJson,
+    _$UsersGetUsersDetailsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'UsersGetUsersDetailsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsersGetUsersDetailsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'search',
+      serializers.serialize(object.search, specifiedType: const FullType(String)),
+      'offset',
+      serializers.serialize(object.offset, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.limit;
+    if (value != null) {
+      result
+        ..add('limit')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  UsersGetUsersDetailsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UsersGetUsersDetailsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'search':
+          result.search = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'offset':
+          result.offset = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -3470,6 +4167,57 @@ class _$UsersGetUsersDetailsResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(UsersGetUsersDetailsResponseApplicationJson_Ocs))!
               as UsersGetUsersDetailsResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UsersGetDisabledUsersDetailsRequestApplicationJsonSerializer
+    implements StructuredSerializer<UsersGetDisabledUsersDetailsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    UsersGetDisabledUsersDetailsRequestApplicationJson,
+    _$UsersGetDisabledUsersDetailsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'UsersGetDisabledUsersDetailsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsersGetDisabledUsersDetailsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'offset',
+      serializers.serialize(object.offset, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.limit;
+    if (value != null) {
+      result
+        ..add('limit')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  UsersGetDisabledUsersDetailsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'offset':
+          result.offset = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -3666,6 +4414,61 @@ class _$UsersGetDisabledUsersDetailsResponseApplicationJsonSerializer
   }
 }
 
+class _$UsersSearchByPhoneNumbersRequestApplicationJsonSerializer
+    implements StructuredSerializer<UsersSearchByPhoneNumbersRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    UsersSearchByPhoneNumbersRequestApplicationJson,
+    _$UsersSearchByPhoneNumbersRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'UsersSearchByPhoneNumbersRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsersSearchByPhoneNumbersRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'location',
+      serializers.serialize(object.location, specifiedType: const FullType(String)),
+      'search',
+      serializers.serialize(object.search,
+          specifiedType: const FullType(BuiltMap, [
+            FullType(String),
+            FullType(BuiltList, [FullType(String)])
+          ])),
+    ];
+
+    return result;
+  }
+
+  @override
+  UsersSearchByPhoneNumbersRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UsersSearchByPhoneNumbersRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'location':
+          result.location = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'search':
+          result.search.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, [
+                FullType(String),
+                FullType(BuiltList, [FullType(String)])
+              ]))!);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$UsersSearchByPhoneNumbersResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<UsersSearchByPhoneNumbersResponseApplicationJson_Ocs> {
   @override
@@ -3841,6 +4644,50 @@ class _$UsersGetUserResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(UsersGetUserResponseApplicationJson_Ocs))!
                   as UsersGetUserResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UsersEditUserRequestApplicationJsonSerializer
+    implements StructuredSerializer<UsersEditUserRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [UsersEditUserRequestApplicationJson, _$UsersEditUserRequestApplicationJson];
+  @override
+  final String wireName = 'UsersEditUserRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsersEditUserRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'key',
+      serializers.serialize(object.key, specifiedType: const FullType(String)),
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  UsersEditUserRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UsersEditUserRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'key':
+          result.key = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'value':
+          result.value = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -4297,6 +5144,53 @@ class _$UsersGetEditableFieldsForUserResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(UsersGetEditableFieldsForUserResponseApplicationJson_Ocs))!
               as UsersGetEditableFieldsForUserResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UsersEditUserMultiValueRequestApplicationJsonSerializer
+    implements StructuredSerializer<UsersEditUserMultiValueRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    UsersEditUserMultiValueRequestApplicationJson,
+    _$UsersEditUserMultiValueRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'UsersEditUserMultiValueRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsersEditUserMultiValueRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'key',
+      serializers.serialize(object.key, specifiedType: const FullType(String)),
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  UsersEditUserMultiValueRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UsersEditUserMultiValueRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'key':
+          result.key = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'value':
+          result.value = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -4804,6 +5698,45 @@ class _$UsersGetUsersGroupsResponseApplicationJsonSerializer
   }
 }
 
+class _$UsersAddToGroupRequestApplicationJsonSerializer
+    implements StructuredSerializer<UsersAddToGroupRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [UsersAddToGroupRequestApplicationJson, _$UsersAddToGroupRequestApplicationJson];
+  @override
+  final String wireName = 'UsersAddToGroupRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsersAddToGroupRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'groupid',
+      serializers.serialize(object.groupid, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  UsersAddToGroupRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UsersAddToGroupRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'groupid':
+          result.groupid = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$UsersAddToGroupResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<UsersAddToGroupResponseApplicationJson_Ocs> {
   @override
@@ -4884,6 +5817,48 @@ class _$UsersAddToGroupResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(UsersAddToGroupResponseApplicationJson_Ocs))!
                   as UsersAddToGroupResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UsersRemoveFromGroupRequestApplicationJsonSerializer
+    implements StructuredSerializer<UsersRemoveFromGroupRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    UsersRemoveFromGroupRequestApplicationJson,
+    _$UsersRemoveFromGroupRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'UsersRemoveFromGroupRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UsersRemoveFromGroupRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'groupid',
+      serializers.serialize(object.groupid, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  UsersRemoveFromGroupRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UsersRemoveFromGroupRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'groupid':
+          result.groupid = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -5993,6 +6968,101 @@ class AppConfigGetKeysResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $AppConfigSetValueRequestApplicationJsonInterfaceBuilder {
+  void replace($AppConfigSetValueRequestApplicationJsonInterface other);
+  void update(void Function($AppConfigSetValueRequestApplicationJsonInterfaceBuilder) updates);
+  String? get value;
+  set value(String? value);
+}
+
+class _$AppConfigSetValueRequestApplicationJson extends AppConfigSetValueRequestApplicationJson {
+  @override
+  final String value;
+
+  factory _$AppConfigSetValueRequestApplicationJson(
+          [void Function(AppConfigSetValueRequestApplicationJsonBuilder)? updates]) =>
+      (AppConfigSetValueRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$AppConfigSetValueRequestApplicationJson._({required this.value}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(value, r'AppConfigSetValueRequestApplicationJson', 'value');
+  }
+
+  @override
+  AppConfigSetValueRequestApplicationJson rebuild(
+          void Function(AppConfigSetValueRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AppConfigSetValueRequestApplicationJsonBuilder toBuilder() =>
+      AppConfigSetValueRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AppConfigSetValueRequestApplicationJson && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'AppConfigSetValueRequestApplicationJson')..add('value', value)).toString();
+  }
+}
+
+class AppConfigSetValueRequestApplicationJsonBuilder
+    implements
+        Builder<AppConfigSetValueRequestApplicationJson, AppConfigSetValueRequestApplicationJsonBuilder>,
+        $AppConfigSetValueRequestApplicationJsonInterfaceBuilder {
+  _$AppConfigSetValueRequestApplicationJson? _$v;
+
+  String? _value;
+  String? get value => _$this._value;
+  set value(covariant String? value) => _$this._value = value;
+
+  AppConfigSetValueRequestApplicationJsonBuilder() {
+    AppConfigSetValueRequestApplicationJson._defaults(this);
+  }
+
+  AppConfigSetValueRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant AppConfigSetValueRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$AppConfigSetValueRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(AppConfigSetValueRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  AppConfigSetValueRequestApplicationJson build() => _build();
+
+  _$AppConfigSetValueRequestApplicationJson _build() {
+    AppConfigSetValueRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$AppConfigSetValueRequestApplicationJson._(
+            value: BuiltValueNullFieldError.checkNotNull(value, r'AppConfigSetValueRequestApplicationJson', 'value'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $AppConfigSetValueResponseApplicationJson_OcsInterfaceBuilder {
   void replace($AppConfigSetValueResponseApplicationJson_OcsInterface other);
   void update(void Function($AppConfigSetValueResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -6218,6 +7288,94 @@ class AppConfigSetValueResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $AppsGetAppsRequestApplicationJsonInterfaceBuilder {
+  void replace($AppsGetAppsRequestApplicationJsonInterface other);
+  void update(void Function($AppsGetAppsRequestApplicationJsonInterfaceBuilder) updates);
+  String? get filter;
+  set filter(String? filter);
+}
+
+class _$AppsGetAppsRequestApplicationJson extends AppsGetAppsRequestApplicationJson {
+  @override
+  final String? filter;
+
+  factory _$AppsGetAppsRequestApplicationJson([void Function(AppsGetAppsRequestApplicationJsonBuilder)? updates]) =>
+      (AppsGetAppsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$AppsGetAppsRequestApplicationJson._({this.filter}) : super._();
+
+  @override
+  AppsGetAppsRequestApplicationJson rebuild(void Function(AppsGetAppsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AppsGetAppsRequestApplicationJsonBuilder toBuilder() => AppsGetAppsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AppsGetAppsRequestApplicationJson && filter == other.filter;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, filter.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'AppsGetAppsRequestApplicationJson')..add('filter', filter)).toString();
+  }
+}
+
+class AppsGetAppsRequestApplicationJsonBuilder
+    implements
+        Builder<AppsGetAppsRequestApplicationJson, AppsGetAppsRequestApplicationJsonBuilder>,
+        $AppsGetAppsRequestApplicationJsonInterfaceBuilder {
+  _$AppsGetAppsRequestApplicationJson? _$v;
+
+  String? _filter;
+  String? get filter => _$this._filter;
+  set filter(covariant String? filter) => _$this._filter = filter;
+
+  AppsGetAppsRequestApplicationJsonBuilder() {
+    AppsGetAppsRequestApplicationJson._defaults(this);
+  }
+
+  AppsGetAppsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _filter = $v.filter;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant AppsGetAppsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$AppsGetAppsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(AppsGetAppsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  AppsGetAppsRequestApplicationJson build() => _build();
+
+  _$AppsGetAppsRequestApplicationJson _build() {
+    AppsGetAppsRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$AppsGetAppsRequestApplicationJson._(filter: filter);
     replace(_$result);
     return _$result;
   }
@@ -7467,6 +8625,132 @@ class GroupsGetSubAdminsOfGroupResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $GroupsGetGroupsRequestApplicationJsonInterfaceBuilder {
+  void replace($GroupsGetGroupsRequestApplicationJsonInterface other);
+  void update(void Function($GroupsGetGroupsRequestApplicationJsonInterfaceBuilder) updates);
+  String? get search;
+  set search(String? search);
+
+  int? get limit;
+  set limit(int? limit);
+
+  int? get offset;
+  set offset(int? offset);
+}
+
+class _$GroupsGetGroupsRequestApplicationJson extends GroupsGetGroupsRequestApplicationJson {
+  @override
+  final String search;
+  @override
+  final int? limit;
+  @override
+  final int offset;
+
+  factory _$GroupsGetGroupsRequestApplicationJson(
+          [void Function(GroupsGetGroupsRequestApplicationJsonBuilder)? updates]) =>
+      (GroupsGetGroupsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$GroupsGetGroupsRequestApplicationJson._({required this.search, this.limit, required this.offset}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(search, r'GroupsGetGroupsRequestApplicationJson', 'search');
+    BuiltValueNullFieldError.checkNotNull(offset, r'GroupsGetGroupsRequestApplicationJson', 'offset');
+  }
+
+  @override
+  GroupsGetGroupsRequestApplicationJson rebuild(void Function(GroupsGetGroupsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GroupsGetGroupsRequestApplicationJsonBuilder toBuilder() =>
+      GroupsGetGroupsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GroupsGetGroupsRequestApplicationJson &&
+        search == other.search &&
+        limit == other.limit &&
+        offset == other.offset;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, search.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jc(_$hash, offset.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GroupsGetGroupsRequestApplicationJson')
+          ..add('search', search)
+          ..add('limit', limit)
+          ..add('offset', offset))
+        .toString();
+  }
+}
+
+class GroupsGetGroupsRequestApplicationJsonBuilder
+    implements
+        Builder<GroupsGetGroupsRequestApplicationJson, GroupsGetGroupsRequestApplicationJsonBuilder>,
+        $GroupsGetGroupsRequestApplicationJsonInterfaceBuilder {
+  _$GroupsGetGroupsRequestApplicationJson? _$v;
+
+  String? _search;
+  String? get search => _$this._search;
+  set search(covariant String? search) => _$this._search = search;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  int? _offset;
+  int? get offset => _$this._offset;
+  set offset(covariant int? offset) => _$this._offset = offset;
+
+  GroupsGetGroupsRequestApplicationJsonBuilder() {
+    GroupsGetGroupsRequestApplicationJson._defaults(this);
+  }
+
+  GroupsGetGroupsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _search = $v.search;
+      _limit = $v.limit;
+      _offset = $v.offset;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant GroupsGetGroupsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GroupsGetGroupsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(GroupsGetGroupsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GroupsGetGroupsRequestApplicationJson build() => _build();
+
+  _$GroupsGetGroupsRequestApplicationJson _build() {
+    GroupsGetGroupsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$GroupsGetGroupsRequestApplicationJson._(
+            search: BuiltValueNullFieldError.checkNotNull(search, r'GroupsGetGroupsRequestApplicationJson', 'search'),
+            limit: limit,
+            offset: BuiltValueNullFieldError.checkNotNull(offset, r'GroupsGetGroupsRequestApplicationJson', 'offset'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $GroupsGetGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($GroupsGetGroupsResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($GroupsGetGroupsResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
@@ -8134,6 +9418,136 @@ class GroupsGetGroupResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $GroupsGetGroupsDetailsRequestApplicationJsonInterfaceBuilder {
+  void replace($GroupsGetGroupsDetailsRequestApplicationJsonInterface other);
+  void update(void Function($GroupsGetGroupsDetailsRequestApplicationJsonInterfaceBuilder) updates);
+  String? get search;
+  set search(String? search);
+
+  int? get limit;
+  set limit(int? limit);
+
+  int? get offset;
+  set offset(int? offset);
+}
+
+class _$GroupsGetGroupsDetailsRequestApplicationJson extends GroupsGetGroupsDetailsRequestApplicationJson {
+  @override
+  final String search;
+  @override
+  final int? limit;
+  @override
+  final int offset;
+
+  factory _$GroupsGetGroupsDetailsRequestApplicationJson(
+          [void Function(GroupsGetGroupsDetailsRequestApplicationJsonBuilder)? updates]) =>
+      (GroupsGetGroupsDetailsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$GroupsGetGroupsDetailsRequestApplicationJson._({required this.search, this.limit, required this.offset})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(search, r'GroupsGetGroupsDetailsRequestApplicationJson', 'search');
+    BuiltValueNullFieldError.checkNotNull(offset, r'GroupsGetGroupsDetailsRequestApplicationJson', 'offset');
+  }
+
+  @override
+  GroupsGetGroupsDetailsRequestApplicationJson rebuild(
+          void Function(GroupsGetGroupsDetailsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GroupsGetGroupsDetailsRequestApplicationJsonBuilder toBuilder() =>
+      GroupsGetGroupsDetailsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GroupsGetGroupsDetailsRequestApplicationJson &&
+        search == other.search &&
+        limit == other.limit &&
+        offset == other.offset;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, search.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jc(_$hash, offset.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GroupsGetGroupsDetailsRequestApplicationJson')
+          ..add('search', search)
+          ..add('limit', limit)
+          ..add('offset', offset))
+        .toString();
+  }
+}
+
+class GroupsGetGroupsDetailsRequestApplicationJsonBuilder
+    implements
+        Builder<GroupsGetGroupsDetailsRequestApplicationJson, GroupsGetGroupsDetailsRequestApplicationJsonBuilder>,
+        $GroupsGetGroupsDetailsRequestApplicationJsonInterfaceBuilder {
+  _$GroupsGetGroupsDetailsRequestApplicationJson? _$v;
+
+  String? _search;
+  String? get search => _$this._search;
+  set search(covariant String? search) => _$this._search = search;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  int? _offset;
+  int? get offset => _$this._offset;
+  set offset(covariant int? offset) => _$this._offset = offset;
+
+  GroupsGetGroupsDetailsRequestApplicationJsonBuilder() {
+    GroupsGetGroupsDetailsRequestApplicationJson._defaults(this);
+  }
+
+  GroupsGetGroupsDetailsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _search = $v.search;
+      _limit = $v.limit;
+      _offset = $v.offset;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant GroupsGetGroupsDetailsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GroupsGetGroupsDetailsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(GroupsGetGroupsDetailsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GroupsGetGroupsDetailsRequestApplicationJson build() => _build();
+
+  _$GroupsGetGroupsDetailsRequestApplicationJson _build() {
+    GroupsGetGroupsDetailsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$GroupsGetGroupsDetailsRequestApplicationJson._(
+            search: BuiltValueNullFieldError.checkNotNull(
+                search, r'GroupsGetGroupsDetailsRequestApplicationJson', 'search'),
+            limit: limit,
+            offset: BuiltValueNullFieldError.checkNotNull(
+                offset, r'GroupsGetGroupsDetailsRequestApplicationJson', 'offset'));
     replace(_$result);
     return _$result;
   }
@@ -8988,6 +10402,137 @@ class GroupsGetGroupUsersResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $GroupsGetGroupUsersDetailsRequestApplicationJsonInterfaceBuilder {
+  void replace($GroupsGetGroupUsersDetailsRequestApplicationJsonInterface other);
+  void update(void Function($GroupsGetGroupUsersDetailsRequestApplicationJsonInterfaceBuilder) updates);
+  String? get search;
+  set search(String? search);
+
+  int? get limit;
+  set limit(int? limit);
+
+  int? get offset;
+  set offset(int? offset);
+}
+
+class _$GroupsGetGroupUsersDetailsRequestApplicationJson extends GroupsGetGroupUsersDetailsRequestApplicationJson {
+  @override
+  final String search;
+  @override
+  final int? limit;
+  @override
+  final int offset;
+
+  factory _$GroupsGetGroupUsersDetailsRequestApplicationJson(
+          [void Function(GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder)? updates]) =>
+      (GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$GroupsGetGroupUsersDetailsRequestApplicationJson._({required this.search, this.limit, required this.offset})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(search, r'GroupsGetGroupUsersDetailsRequestApplicationJson', 'search');
+    BuiltValueNullFieldError.checkNotNull(offset, r'GroupsGetGroupUsersDetailsRequestApplicationJson', 'offset');
+  }
+
+  @override
+  GroupsGetGroupUsersDetailsRequestApplicationJson rebuild(
+          void Function(GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder toBuilder() =>
+      GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GroupsGetGroupUsersDetailsRequestApplicationJson &&
+        search == other.search &&
+        limit == other.limit &&
+        offset == other.offset;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, search.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jc(_$hash, offset.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GroupsGetGroupUsersDetailsRequestApplicationJson')
+          ..add('search', search)
+          ..add('limit', limit)
+          ..add('offset', offset))
+        .toString();
+  }
+}
+
+class GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder
+    implements
+        Builder<GroupsGetGroupUsersDetailsRequestApplicationJson,
+            GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder>,
+        $GroupsGetGroupUsersDetailsRequestApplicationJsonInterfaceBuilder {
+  _$GroupsGetGroupUsersDetailsRequestApplicationJson? _$v;
+
+  String? _search;
+  String? get search => _$this._search;
+  set search(covariant String? search) => _$this._search = search;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  int? _offset;
+  int? get offset => _$this._offset;
+  set offset(covariant int? offset) => _$this._offset = offset;
+
+  GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder() {
+    GroupsGetGroupUsersDetailsRequestApplicationJson._defaults(this);
+  }
+
+  GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _search = $v.search;
+      _limit = $v.limit;
+      _offset = $v.offset;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant GroupsGetGroupUsersDetailsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GroupsGetGroupUsersDetailsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(GroupsGetGroupUsersDetailsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GroupsGetGroupUsersDetailsRequestApplicationJson build() => _build();
+
+  _$GroupsGetGroupUsersDetailsRequestApplicationJson _build() {
+    GroupsGetGroupUsersDetailsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$GroupsGetGroupUsersDetailsRequestApplicationJson._(
+            search: BuiltValueNullFieldError.checkNotNull(
+                search, r'GroupsGetGroupUsersDetailsRequestApplicationJson', 'search'),
+            limit: limit,
+            offset: BuiltValueNullFieldError.checkNotNull(
+                offset, r'GroupsGetGroupUsersDetailsRequestApplicationJson', 'offset'));
     replace(_$result);
     return _$result;
   }
@@ -10455,6 +12000,105 @@ class GroupsGetGroupUsersDetailsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $PreferencesSetPreferenceRequestApplicationJsonInterfaceBuilder {
+  void replace($PreferencesSetPreferenceRequestApplicationJsonInterface other);
+  void update(void Function($PreferencesSetPreferenceRequestApplicationJsonInterfaceBuilder) updates);
+  String? get configValue;
+  set configValue(String? configValue);
+}
+
+class _$PreferencesSetPreferenceRequestApplicationJson extends PreferencesSetPreferenceRequestApplicationJson {
+  @override
+  final String configValue;
+
+  factory _$PreferencesSetPreferenceRequestApplicationJson(
+          [void Function(PreferencesSetPreferenceRequestApplicationJsonBuilder)? updates]) =>
+      (PreferencesSetPreferenceRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PreferencesSetPreferenceRequestApplicationJson._({required this.configValue}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        configValue, r'PreferencesSetPreferenceRequestApplicationJson', 'configValue');
+  }
+
+  @override
+  PreferencesSetPreferenceRequestApplicationJson rebuild(
+          void Function(PreferencesSetPreferenceRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PreferencesSetPreferenceRequestApplicationJsonBuilder toBuilder() =>
+      PreferencesSetPreferenceRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PreferencesSetPreferenceRequestApplicationJson && configValue == other.configValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, configValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PreferencesSetPreferenceRequestApplicationJson')
+          ..add('configValue', configValue))
+        .toString();
+  }
+}
+
+class PreferencesSetPreferenceRequestApplicationJsonBuilder
+    implements
+        Builder<PreferencesSetPreferenceRequestApplicationJson, PreferencesSetPreferenceRequestApplicationJsonBuilder>,
+        $PreferencesSetPreferenceRequestApplicationJsonInterfaceBuilder {
+  _$PreferencesSetPreferenceRequestApplicationJson? _$v;
+
+  String? _configValue;
+  String? get configValue => _$this._configValue;
+  set configValue(covariant String? configValue) => _$this._configValue = configValue;
+
+  PreferencesSetPreferenceRequestApplicationJsonBuilder() {
+    PreferencesSetPreferenceRequestApplicationJson._defaults(this);
+  }
+
+  PreferencesSetPreferenceRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _configValue = $v.configValue;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PreferencesSetPreferenceRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PreferencesSetPreferenceRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PreferencesSetPreferenceRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PreferencesSetPreferenceRequestApplicationJson build() => _build();
+
+  _$PreferencesSetPreferenceRequestApplicationJson _build() {
+    PreferencesSetPreferenceRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$PreferencesSetPreferenceRequestApplicationJson._(
+            configValue: BuiltValueNullFieldError.checkNotNull(
+                configValue, r'PreferencesSetPreferenceRequestApplicationJson', 'configValue'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $PreferencesSetPreferenceResponseApplicationJson_OcsInterfaceBuilder {
   void replace($PreferencesSetPreferenceResponseApplicationJson_OcsInterface other);
   void update(void Function($PreferencesSetPreferenceResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -10927,6 +12571,117 @@ class PreferencesDeletePreferenceResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $PreferencesSetMultiplePreferencesRequestApplicationJsonInterfaceBuilder {
+  void replace($PreferencesSetMultiplePreferencesRequestApplicationJsonInterface other);
+  void update(void Function($PreferencesSetMultiplePreferencesRequestApplicationJsonInterfaceBuilder) updates);
+  MapBuilder<String, String> get configs;
+  set configs(MapBuilder<String, String>? configs);
+}
+
+class _$PreferencesSetMultiplePreferencesRequestApplicationJson
+    extends PreferencesSetMultiplePreferencesRequestApplicationJson {
+  @override
+  final BuiltMap<String, String> configs;
+
+  factory _$PreferencesSetMultiplePreferencesRequestApplicationJson(
+          [void Function(PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder)? updates]) =>
+      (PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PreferencesSetMultiplePreferencesRequestApplicationJson._({required this.configs}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        configs, r'PreferencesSetMultiplePreferencesRequestApplicationJson', 'configs');
+  }
+
+  @override
+  PreferencesSetMultiplePreferencesRequestApplicationJson rebuild(
+          void Function(PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder toBuilder() =>
+      PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PreferencesSetMultiplePreferencesRequestApplicationJson && configs == other.configs;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, configs.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PreferencesSetMultiplePreferencesRequestApplicationJson')
+          ..add('configs', configs))
+        .toString();
+  }
+}
+
+class PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder
+    implements
+        Builder<PreferencesSetMultiplePreferencesRequestApplicationJson,
+            PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder>,
+        $PreferencesSetMultiplePreferencesRequestApplicationJsonInterfaceBuilder {
+  _$PreferencesSetMultiplePreferencesRequestApplicationJson? _$v;
+
+  MapBuilder<String, String>? _configs;
+  MapBuilder<String, String> get configs => _$this._configs ??= MapBuilder<String, String>();
+  set configs(covariant MapBuilder<String, String>? configs) => _$this._configs = configs;
+
+  PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder() {
+    PreferencesSetMultiplePreferencesRequestApplicationJson._defaults(this);
+  }
+
+  PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _configs = $v.configs.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PreferencesSetMultiplePreferencesRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PreferencesSetMultiplePreferencesRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PreferencesSetMultiplePreferencesRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PreferencesSetMultiplePreferencesRequestApplicationJson build() => _build();
+
+  _$PreferencesSetMultiplePreferencesRequestApplicationJson _build() {
+    PreferencesSetMultiplePreferencesRequestApplicationJson._validate(this);
+    _$PreferencesSetMultiplePreferencesRequestApplicationJson _$result;
+    try {
+      _$result = _$v ?? _$PreferencesSetMultiplePreferencesRequestApplicationJson._(configs: configs.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'configs';
+        configs.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'PreferencesSetMultiplePreferencesRequestApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterfaceBuilder {
   void replace($PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterface other);
   void update(void Function($PreferencesSetMultiplePreferencesResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -11161,6 +12916,117 @@ class PreferencesSetMultiplePreferencesResponseApplicationJsonBuilder
       } catch (e) {
         throw BuiltValueNestedFieldError(
             r'PreferencesSetMultiplePreferencesResponseApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterfaceBuilder {
+  void replace($PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterface other);
+  void update(void Function($PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterfaceBuilder) updates);
+  ListBuilder<String> get configKeys;
+  set configKeys(ListBuilder<String>? configKeys);
+}
+
+class _$PreferencesDeleteMultiplePreferenceRequestApplicationJson
+    extends PreferencesDeleteMultiplePreferenceRequestApplicationJson {
+  @override
+  final BuiltList<String> configKeys;
+
+  factory _$PreferencesDeleteMultiplePreferenceRequestApplicationJson(
+          [void Function(PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder)? updates]) =>
+      (PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PreferencesDeleteMultiplePreferenceRequestApplicationJson._({required this.configKeys}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        configKeys, r'PreferencesDeleteMultiplePreferenceRequestApplicationJson', 'configKeys');
+  }
+
+  @override
+  PreferencesDeleteMultiplePreferenceRequestApplicationJson rebuild(
+          void Function(PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder toBuilder() =>
+      PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PreferencesDeleteMultiplePreferenceRequestApplicationJson && configKeys == other.configKeys;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, configKeys.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PreferencesDeleteMultiplePreferenceRequestApplicationJson')
+          ..add('configKeys', configKeys))
+        .toString();
+  }
+}
+
+class PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder
+    implements
+        Builder<PreferencesDeleteMultiplePreferenceRequestApplicationJson,
+            PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder>,
+        $PreferencesDeleteMultiplePreferenceRequestApplicationJsonInterfaceBuilder {
+  _$PreferencesDeleteMultiplePreferenceRequestApplicationJson? _$v;
+
+  ListBuilder<String>? _configKeys;
+  ListBuilder<String> get configKeys => _$this._configKeys ??= ListBuilder<String>();
+  set configKeys(covariant ListBuilder<String>? configKeys) => _$this._configKeys = configKeys;
+
+  PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder() {
+    PreferencesDeleteMultiplePreferenceRequestApplicationJson._defaults(this);
+  }
+
+  PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _configKeys = $v.configKeys.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PreferencesDeleteMultiplePreferenceRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PreferencesDeleteMultiplePreferenceRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PreferencesDeleteMultiplePreferenceRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PreferencesDeleteMultiplePreferenceRequestApplicationJson build() => _build();
+
+  _$PreferencesDeleteMultiplePreferenceRequestApplicationJson _build() {
+    PreferencesDeleteMultiplePreferenceRequestApplicationJson._validate(this);
+    _$PreferencesDeleteMultiplePreferenceRequestApplicationJson _$result;
+    try {
+      _$result = _$v ?? _$PreferencesDeleteMultiplePreferenceRequestApplicationJson._(configKeys: configKeys.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'configKeys';
+        configKeys.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'PreferencesDeleteMultiplePreferenceRequestApplicationJson', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -11646,6 +13512,102 @@ class UsersGetUserSubAdminGroupsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $UsersAddSubAdminRequestApplicationJsonInterfaceBuilder {
+  void replace($UsersAddSubAdminRequestApplicationJsonInterface other);
+  void update(void Function($UsersAddSubAdminRequestApplicationJsonInterfaceBuilder) updates);
+  String? get groupid;
+  set groupid(String? groupid);
+}
+
+class _$UsersAddSubAdminRequestApplicationJson extends UsersAddSubAdminRequestApplicationJson {
+  @override
+  final String groupid;
+
+  factory _$UsersAddSubAdminRequestApplicationJson(
+          [void Function(UsersAddSubAdminRequestApplicationJsonBuilder)? updates]) =>
+      (UsersAddSubAdminRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UsersAddSubAdminRequestApplicationJson._({required this.groupid}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(groupid, r'UsersAddSubAdminRequestApplicationJson', 'groupid');
+  }
+
+  @override
+  UsersAddSubAdminRequestApplicationJson rebuild(
+          void Function(UsersAddSubAdminRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsersAddSubAdminRequestApplicationJsonBuilder toBuilder() =>
+      UsersAddSubAdminRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsersAddSubAdminRequestApplicationJson && groupid == other.groupid;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, groupid.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsersAddSubAdminRequestApplicationJson')..add('groupid', groupid)).toString();
+  }
+}
+
+class UsersAddSubAdminRequestApplicationJsonBuilder
+    implements
+        Builder<UsersAddSubAdminRequestApplicationJson, UsersAddSubAdminRequestApplicationJsonBuilder>,
+        $UsersAddSubAdminRequestApplicationJsonInterfaceBuilder {
+  _$UsersAddSubAdminRequestApplicationJson? _$v;
+
+  String? _groupid;
+  String? get groupid => _$this._groupid;
+  set groupid(covariant String? groupid) => _$this._groupid = groupid;
+
+  UsersAddSubAdminRequestApplicationJsonBuilder() {
+    UsersAddSubAdminRequestApplicationJson._defaults(this);
+  }
+
+  UsersAddSubAdminRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _groupid = $v.groupid;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UsersAddSubAdminRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UsersAddSubAdminRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UsersAddSubAdminRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsersAddSubAdminRequestApplicationJson build() => _build();
+
+  _$UsersAddSubAdminRequestApplicationJson _build() {
+    UsersAddSubAdminRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UsersAddSubAdminRequestApplicationJson._(
+            groupid:
+                BuiltValueNullFieldError.checkNotNull(groupid, r'UsersAddSubAdminRequestApplicationJson', 'groupid'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $UsersAddSubAdminResponseApplicationJson_OcsInterfaceBuilder {
   void replace($UsersAddSubAdminResponseApplicationJson_OcsInterface other);
   void update(void Function($UsersAddSubAdminResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -11871,6 +13833,103 @@ class UsersAddSubAdminResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $UsersRemoveSubAdminRequestApplicationJsonInterfaceBuilder {
+  void replace($UsersRemoveSubAdminRequestApplicationJsonInterface other);
+  void update(void Function($UsersRemoveSubAdminRequestApplicationJsonInterfaceBuilder) updates);
+  String? get groupid;
+  set groupid(String? groupid);
+}
+
+class _$UsersRemoveSubAdminRequestApplicationJson extends UsersRemoveSubAdminRequestApplicationJson {
+  @override
+  final String groupid;
+
+  factory _$UsersRemoveSubAdminRequestApplicationJson(
+          [void Function(UsersRemoveSubAdminRequestApplicationJsonBuilder)? updates]) =>
+      (UsersRemoveSubAdminRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UsersRemoveSubAdminRequestApplicationJson._({required this.groupid}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(groupid, r'UsersRemoveSubAdminRequestApplicationJson', 'groupid');
+  }
+
+  @override
+  UsersRemoveSubAdminRequestApplicationJson rebuild(
+          void Function(UsersRemoveSubAdminRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsersRemoveSubAdminRequestApplicationJsonBuilder toBuilder() =>
+      UsersRemoveSubAdminRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsersRemoveSubAdminRequestApplicationJson && groupid == other.groupid;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, groupid.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsersRemoveSubAdminRequestApplicationJson')..add('groupid', groupid))
+        .toString();
+  }
+}
+
+class UsersRemoveSubAdminRequestApplicationJsonBuilder
+    implements
+        Builder<UsersRemoveSubAdminRequestApplicationJson, UsersRemoveSubAdminRequestApplicationJsonBuilder>,
+        $UsersRemoveSubAdminRequestApplicationJsonInterfaceBuilder {
+  _$UsersRemoveSubAdminRequestApplicationJson? _$v;
+
+  String? _groupid;
+  String? get groupid => _$this._groupid;
+  set groupid(covariant String? groupid) => _$this._groupid = groupid;
+
+  UsersRemoveSubAdminRequestApplicationJsonBuilder() {
+    UsersRemoveSubAdminRequestApplicationJson._defaults(this);
+  }
+
+  UsersRemoveSubAdminRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _groupid = $v.groupid;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UsersRemoveSubAdminRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UsersRemoveSubAdminRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UsersRemoveSubAdminRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsersRemoveSubAdminRequestApplicationJson build() => _build();
+
+  _$UsersRemoveSubAdminRequestApplicationJson _build() {
+    UsersRemoveSubAdminRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UsersRemoveSubAdminRequestApplicationJson._(
+            groupid: BuiltValueNullFieldError.checkNotNull(
+                groupid, r'UsersRemoveSubAdminRequestApplicationJson', 'groupid'));
     replace(_$result);
     return _$result;
   }
@@ -12102,6 +14161,130 @@ class UsersRemoveSubAdminResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $UsersGetUsersRequestApplicationJsonInterfaceBuilder {
+  void replace($UsersGetUsersRequestApplicationJsonInterface other);
+  void update(void Function($UsersGetUsersRequestApplicationJsonInterfaceBuilder) updates);
+  String? get search;
+  set search(String? search);
+
+  int? get limit;
+  set limit(int? limit);
+
+  int? get offset;
+  set offset(int? offset);
+}
+
+class _$UsersGetUsersRequestApplicationJson extends UsersGetUsersRequestApplicationJson {
+  @override
+  final String search;
+  @override
+  final int? limit;
+  @override
+  final int offset;
+
+  factory _$UsersGetUsersRequestApplicationJson([void Function(UsersGetUsersRequestApplicationJsonBuilder)? updates]) =>
+      (UsersGetUsersRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UsersGetUsersRequestApplicationJson._({required this.search, this.limit, required this.offset}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(search, r'UsersGetUsersRequestApplicationJson', 'search');
+    BuiltValueNullFieldError.checkNotNull(offset, r'UsersGetUsersRequestApplicationJson', 'offset');
+  }
+
+  @override
+  UsersGetUsersRequestApplicationJson rebuild(void Function(UsersGetUsersRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsersGetUsersRequestApplicationJsonBuilder toBuilder() => UsersGetUsersRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsersGetUsersRequestApplicationJson &&
+        search == other.search &&
+        limit == other.limit &&
+        offset == other.offset;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, search.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jc(_$hash, offset.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsersGetUsersRequestApplicationJson')
+          ..add('search', search)
+          ..add('limit', limit)
+          ..add('offset', offset))
+        .toString();
+  }
+}
+
+class UsersGetUsersRequestApplicationJsonBuilder
+    implements
+        Builder<UsersGetUsersRequestApplicationJson, UsersGetUsersRequestApplicationJsonBuilder>,
+        $UsersGetUsersRequestApplicationJsonInterfaceBuilder {
+  _$UsersGetUsersRequestApplicationJson? _$v;
+
+  String? _search;
+  String? get search => _$this._search;
+  set search(covariant String? search) => _$this._search = search;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  int? _offset;
+  int? get offset => _$this._offset;
+  set offset(covariant int? offset) => _$this._offset = offset;
+
+  UsersGetUsersRequestApplicationJsonBuilder() {
+    UsersGetUsersRequestApplicationJson._defaults(this);
+  }
+
+  UsersGetUsersRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _search = $v.search;
+      _limit = $v.limit;
+      _offset = $v.offset;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UsersGetUsersRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UsersGetUsersRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UsersGetUsersRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsersGetUsersRequestApplicationJson build() => _build();
+
+  _$UsersGetUsersRequestApplicationJson _build() {
+    UsersGetUsersRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UsersGetUsersRequestApplicationJson._(
+            search: BuiltValueNullFieldError.checkNotNull(search, r'UsersGetUsersRequestApplicationJson', 'search'),
+            limit: limit,
+            offset: BuiltValueNullFieldError.checkNotNull(offset, r'UsersGetUsersRequestApplicationJson', 'offset'));
     replace(_$result);
     return _$result;
   }
@@ -12441,6 +14624,247 @@ class UsersGetUsersResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $UsersAddUserRequestApplicationJsonInterfaceBuilder {
+  void replace($UsersAddUserRequestApplicationJsonInterface other);
+  void update(void Function($UsersAddUserRequestApplicationJsonInterfaceBuilder) updates);
+  String? get userid;
+  set userid(String? userid);
+
+  String? get password;
+  set password(String? password);
+
+  String? get displayName;
+  set displayName(String? displayName);
+
+  String? get email;
+  set email(String? email);
+
+  ListBuilder<String> get groups;
+  set groups(ListBuilder<String>? groups);
+
+  ListBuilder<String> get subadmin;
+  set subadmin(ListBuilder<String>? subadmin);
+
+  String? get quota;
+  set quota(String? quota);
+
+  String? get language;
+  set language(String? language);
+
+  String? get manager;
+  set manager(String? manager);
+}
+
+class _$UsersAddUserRequestApplicationJson extends UsersAddUserRequestApplicationJson {
+  @override
+  final String userid;
+  @override
+  final String password;
+  @override
+  final String displayName;
+  @override
+  final String email;
+  @override
+  final BuiltList<String> groups;
+  @override
+  final BuiltList<String> subadmin;
+  @override
+  final String quota;
+  @override
+  final String language;
+  @override
+  final String? manager;
+
+  factory _$UsersAddUserRequestApplicationJson([void Function(UsersAddUserRequestApplicationJsonBuilder)? updates]) =>
+      (UsersAddUserRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UsersAddUserRequestApplicationJson._(
+      {required this.userid,
+      required this.password,
+      required this.displayName,
+      required this.email,
+      required this.groups,
+      required this.subadmin,
+      required this.quota,
+      required this.language,
+      this.manager})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(userid, r'UsersAddUserRequestApplicationJson', 'userid');
+    BuiltValueNullFieldError.checkNotNull(password, r'UsersAddUserRequestApplicationJson', 'password');
+    BuiltValueNullFieldError.checkNotNull(displayName, r'UsersAddUserRequestApplicationJson', 'displayName');
+    BuiltValueNullFieldError.checkNotNull(email, r'UsersAddUserRequestApplicationJson', 'email');
+    BuiltValueNullFieldError.checkNotNull(groups, r'UsersAddUserRequestApplicationJson', 'groups');
+    BuiltValueNullFieldError.checkNotNull(subadmin, r'UsersAddUserRequestApplicationJson', 'subadmin');
+    BuiltValueNullFieldError.checkNotNull(quota, r'UsersAddUserRequestApplicationJson', 'quota');
+    BuiltValueNullFieldError.checkNotNull(language, r'UsersAddUserRequestApplicationJson', 'language');
+  }
+
+  @override
+  UsersAddUserRequestApplicationJson rebuild(void Function(UsersAddUserRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsersAddUserRequestApplicationJsonBuilder toBuilder() => UsersAddUserRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsersAddUserRequestApplicationJson &&
+        userid == other.userid &&
+        password == other.password &&
+        displayName == other.displayName &&
+        email == other.email &&
+        groups == other.groups &&
+        subadmin == other.subadmin &&
+        quota == other.quota &&
+        language == other.language &&
+        manager == other.manager;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, userid.hashCode);
+    _$hash = $jc(_$hash, password.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, email.hashCode);
+    _$hash = $jc(_$hash, groups.hashCode);
+    _$hash = $jc(_$hash, subadmin.hashCode);
+    _$hash = $jc(_$hash, quota.hashCode);
+    _$hash = $jc(_$hash, language.hashCode);
+    _$hash = $jc(_$hash, manager.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsersAddUserRequestApplicationJson')
+          ..add('userid', userid)
+          ..add('password', password)
+          ..add('displayName', displayName)
+          ..add('email', email)
+          ..add('groups', groups)
+          ..add('subadmin', subadmin)
+          ..add('quota', quota)
+          ..add('language', language)
+          ..add('manager', manager))
+        .toString();
+  }
+}
+
+class UsersAddUserRequestApplicationJsonBuilder
+    implements
+        Builder<UsersAddUserRequestApplicationJson, UsersAddUserRequestApplicationJsonBuilder>,
+        $UsersAddUserRequestApplicationJsonInterfaceBuilder {
+  _$UsersAddUserRequestApplicationJson? _$v;
+
+  String? _userid;
+  String? get userid => _$this._userid;
+  set userid(covariant String? userid) => _$this._userid = userid;
+
+  String? _password;
+  String? get password => _$this._password;
+  set password(covariant String? password) => _$this._password = password;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(covariant String? displayName) => _$this._displayName = displayName;
+
+  String? _email;
+  String? get email => _$this._email;
+  set email(covariant String? email) => _$this._email = email;
+
+  ListBuilder<String>? _groups;
+  ListBuilder<String> get groups => _$this._groups ??= ListBuilder<String>();
+  set groups(covariant ListBuilder<String>? groups) => _$this._groups = groups;
+
+  ListBuilder<String>? _subadmin;
+  ListBuilder<String> get subadmin => _$this._subadmin ??= ListBuilder<String>();
+  set subadmin(covariant ListBuilder<String>? subadmin) => _$this._subadmin = subadmin;
+
+  String? _quota;
+  String? get quota => _$this._quota;
+  set quota(covariant String? quota) => _$this._quota = quota;
+
+  String? _language;
+  String? get language => _$this._language;
+  set language(covariant String? language) => _$this._language = language;
+
+  String? _manager;
+  String? get manager => _$this._manager;
+  set manager(covariant String? manager) => _$this._manager = manager;
+
+  UsersAddUserRequestApplicationJsonBuilder() {
+    UsersAddUserRequestApplicationJson._defaults(this);
+  }
+
+  UsersAddUserRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _userid = $v.userid;
+      _password = $v.password;
+      _displayName = $v.displayName;
+      _email = $v.email;
+      _groups = $v.groups.toBuilder();
+      _subadmin = $v.subadmin.toBuilder();
+      _quota = $v.quota;
+      _language = $v.language;
+      _manager = $v.manager;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UsersAddUserRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UsersAddUserRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UsersAddUserRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsersAddUserRequestApplicationJson build() => _build();
+
+  _$UsersAddUserRequestApplicationJson _build() {
+    UsersAddUserRequestApplicationJson._validate(this);
+    _$UsersAddUserRequestApplicationJson _$result;
+    try {
+      _$result = _$v ??
+          _$UsersAddUserRequestApplicationJson._(
+              userid: BuiltValueNullFieldError.checkNotNull(userid, r'UsersAddUserRequestApplicationJson', 'userid'),
+              password:
+                  BuiltValueNullFieldError.checkNotNull(password, r'UsersAddUserRequestApplicationJson', 'password'),
+              displayName: BuiltValueNullFieldError.checkNotNull(
+                  displayName, r'UsersAddUserRequestApplicationJson', 'displayName'),
+              email: BuiltValueNullFieldError.checkNotNull(email, r'UsersAddUserRequestApplicationJson', 'email'),
+              groups: groups.build(),
+              subadmin: subadmin.build(),
+              quota: BuiltValueNullFieldError.checkNotNull(quota, r'UsersAddUserRequestApplicationJson', 'quota'),
+              language:
+                  BuiltValueNullFieldError.checkNotNull(language, r'UsersAddUserRequestApplicationJson', 'language'),
+              manager: manager);
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'groups';
+        groups.build();
+        _$failedField = 'subadmin';
+        subadmin.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'UsersAddUserRequestApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $UsersAddUserResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($UsersAddUserResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($UsersAddUserResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
@@ -12757,6 +15181,135 @@ class UsersAddUserResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $UsersGetUsersDetailsRequestApplicationJsonInterfaceBuilder {
+  void replace($UsersGetUsersDetailsRequestApplicationJsonInterface other);
+  void update(void Function($UsersGetUsersDetailsRequestApplicationJsonInterfaceBuilder) updates);
+  String? get search;
+  set search(String? search);
+
+  int? get limit;
+  set limit(int? limit);
+
+  int? get offset;
+  set offset(int? offset);
+}
+
+class _$UsersGetUsersDetailsRequestApplicationJson extends UsersGetUsersDetailsRequestApplicationJson {
+  @override
+  final String search;
+  @override
+  final int? limit;
+  @override
+  final int offset;
+
+  factory _$UsersGetUsersDetailsRequestApplicationJson(
+          [void Function(UsersGetUsersDetailsRequestApplicationJsonBuilder)? updates]) =>
+      (UsersGetUsersDetailsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UsersGetUsersDetailsRequestApplicationJson._({required this.search, this.limit, required this.offset}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(search, r'UsersGetUsersDetailsRequestApplicationJson', 'search');
+    BuiltValueNullFieldError.checkNotNull(offset, r'UsersGetUsersDetailsRequestApplicationJson', 'offset');
+  }
+
+  @override
+  UsersGetUsersDetailsRequestApplicationJson rebuild(
+          void Function(UsersGetUsersDetailsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsersGetUsersDetailsRequestApplicationJsonBuilder toBuilder() =>
+      UsersGetUsersDetailsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsersGetUsersDetailsRequestApplicationJson &&
+        search == other.search &&
+        limit == other.limit &&
+        offset == other.offset;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, search.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jc(_$hash, offset.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsersGetUsersDetailsRequestApplicationJson')
+          ..add('search', search)
+          ..add('limit', limit)
+          ..add('offset', offset))
+        .toString();
+  }
+}
+
+class UsersGetUsersDetailsRequestApplicationJsonBuilder
+    implements
+        Builder<UsersGetUsersDetailsRequestApplicationJson, UsersGetUsersDetailsRequestApplicationJsonBuilder>,
+        $UsersGetUsersDetailsRequestApplicationJsonInterfaceBuilder {
+  _$UsersGetUsersDetailsRequestApplicationJson? _$v;
+
+  String? _search;
+  String? get search => _$this._search;
+  set search(covariant String? search) => _$this._search = search;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  int? _offset;
+  int? get offset => _$this._offset;
+  set offset(covariant int? offset) => _$this._offset = offset;
+
+  UsersGetUsersDetailsRequestApplicationJsonBuilder() {
+    UsersGetUsersDetailsRequestApplicationJson._defaults(this);
+  }
+
+  UsersGetUsersDetailsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _search = $v.search;
+      _limit = $v.limit;
+      _offset = $v.offset;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UsersGetUsersDetailsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UsersGetUsersDetailsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UsersGetUsersDetailsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsersGetUsersDetailsRequestApplicationJson build() => _build();
+
+  _$UsersGetUsersDetailsRequestApplicationJson _build() {
+    UsersGetUsersDetailsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UsersGetUsersDetailsRequestApplicationJson._(
+            search:
+                BuiltValueNullFieldError.checkNotNull(search, r'UsersGetUsersDetailsRequestApplicationJson', 'search'),
+            limit: limit,
+            offset:
+                BuiltValueNullFieldError.checkNotNull(offset, r'UsersGetUsersDetailsRequestApplicationJson', 'offset'));
     replace(_$result);
     return _$result;
   }
@@ -13199,6 +15752,120 @@ class UsersGetUsersDetailsResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $UsersGetDisabledUsersDetailsRequestApplicationJsonInterfaceBuilder {
+  void replace($UsersGetDisabledUsersDetailsRequestApplicationJsonInterface other);
+  void update(void Function($UsersGetDisabledUsersDetailsRequestApplicationJsonInterfaceBuilder) updates);
+  int? get limit;
+  set limit(int? limit);
+
+  int? get offset;
+  set offset(int? offset);
+}
+
+class _$UsersGetDisabledUsersDetailsRequestApplicationJson extends UsersGetDisabledUsersDetailsRequestApplicationJson {
+  @override
+  final int? limit;
+  @override
+  final int offset;
+
+  factory _$UsersGetDisabledUsersDetailsRequestApplicationJson(
+          [void Function(UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder)? updates]) =>
+      (UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UsersGetDisabledUsersDetailsRequestApplicationJson._({this.limit, required this.offset}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(offset, r'UsersGetDisabledUsersDetailsRequestApplicationJson', 'offset');
+  }
+
+  @override
+  UsersGetDisabledUsersDetailsRequestApplicationJson rebuild(
+          void Function(UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder toBuilder() =>
+      UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsersGetDisabledUsersDetailsRequestApplicationJson &&
+        limit == other.limit &&
+        offset == other.offset;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jc(_$hash, offset.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsersGetDisabledUsersDetailsRequestApplicationJson')
+          ..add('limit', limit)
+          ..add('offset', offset))
+        .toString();
+  }
+}
+
+class UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder
+    implements
+        Builder<UsersGetDisabledUsersDetailsRequestApplicationJson,
+            UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder>,
+        $UsersGetDisabledUsersDetailsRequestApplicationJsonInterfaceBuilder {
+  _$UsersGetDisabledUsersDetailsRequestApplicationJson? _$v;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  int? _offset;
+  int? get offset => _$this._offset;
+  set offset(covariant int? offset) => _$this._offset = offset;
+
+  UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder() {
+    UsersGetDisabledUsersDetailsRequestApplicationJson._defaults(this);
+  }
+
+  UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _limit = $v.limit;
+      _offset = $v.offset;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UsersGetDisabledUsersDetailsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UsersGetDisabledUsersDetailsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UsersGetDisabledUsersDetailsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsersGetDisabledUsersDetailsRequestApplicationJson build() => _build();
+
+  _$UsersGetDisabledUsersDetailsRequestApplicationJson _build() {
+    UsersGetDisabledUsersDetailsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UsersGetDisabledUsersDetailsRequestApplicationJson._(
+            limit: limit,
+            offset: BuiltValueNullFieldError.checkNotNull(
+                offset, r'UsersGetDisabledUsersDetailsRequestApplicationJson', 'offset'));
     replace(_$result);
     return _$result;
   }
@@ -13649,6 +16316,134 @@ class UsersGetDisabledUsersDetailsResponseApplicationJsonBuilder
       } catch (e) {
         throw BuiltValueNestedFieldError(
             r'UsersGetDisabledUsersDetailsResponseApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $UsersSearchByPhoneNumbersRequestApplicationJsonInterfaceBuilder {
+  void replace($UsersSearchByPhoneNumbersRequestApplicationJsonInterface other);
+  void update(void Function($UsersSearchByPhoneNumbersRequestApplicationJsonInterfaceBuilder) updates);
+  String? get location;
+  set location(String? location);
+
+  MapBuilder<String, BuiltList<String>> get search;
+  set search(MapBuilder<String, BuiltList<String>>? search);
+}
+
+class _$UsersSearchByPhoneNumbersRequestApplicationJson extends UsersSearchByPhoneNumbersRequestApplicationJson {
+  @override
+  final String location;
+  @override
+  final BuiltMap<String, BuiltList<String>> search;
+
+  factory _$UsersSearchByPhoneNumbersRequestApplicationJson(
+          [void Function(UsersSearchByPhoneNumbersRequestApplicationJsonBuilder)? updates]) =>
+      (UsersSearchByPhoneNumbersRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UsersSearchByPhoneNumbersRequestApplicationJson._({required this.location, required this.search}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(location, r'UsersSearchByPhoneNumbersRequestApplicationJson', 'location');
+    BuiltValueNullFieldError.checkNotNull(search, r'UsersSearchByPhoneNumbersRequestApplicationJson', 'search');
+  }
+
+  @override
+  UsersSearchByPhoneNumbersRequestApplicationJson rebuild(
+          void Function(UsersSearchByPhoneNumbersRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsersSearchByPhoneNumbersRequestApplicationJsonBuilder toBuilder() =>
+      UsersSearchByPhoneNumbersRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsersSearchByPhoneNumbersRequestApplicationJson &&
+        location == other.location &&
+        search == other.search;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, location.hashCode);
+    _$hash = $jc(_$hash, search.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsersSearchByPhoneNumbersRequestApplicationJson')
+          ..add('location', location)
+          ..add('search', search))
+        .toString();
+  }
+}
+
+class UsersSearchByPhoneNumbersRequestApplicationJsonBuilder
+    implements
+        Builder<UsersSearchByPhoneNumbersRequestApplicationJson,
+            UsersSearchByPhoneNumbersRequestApplicationJsonBuilder>,
+        $UsersSearchByPhoneNumbersRequestApplicationJsonInterfaceBuilder {
+  _$UsersSearchByPhoneNumbersRequestApplicationJson? _$v;
+
+  String? _location;
+  String? get location => _$this._location;
+  set location(covariant String? location) => _$this._location = location;
+
+  MapBuilder<String, BuiltList<String>>? _search;
+  MapBuilder<String, BuiltList<String>> get search => _$this._search ??= MapBuilder<String, BuiltList<String>>();
+  set search(covariant MapBuilder<String, BuiltList<String>>? search) => _$this._search = search;
+
+  UsersSearchByPhoneNumbersRequestApplicationJsonBuilder() {
+    UsersSearchByPhoneNumbersRequestApplicationJson._defaults(this);
+  }
+
+  UsersSearchByPhoneNumbersRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _location = $v.location;
+      _search = $v.search.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UsersSearchByPhoneNumbersRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UsersSearchByPhoneNumbersRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UsersSearchByPhoneNumbersRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsersSearchByPhoneNumbersRequestApplicationJson build() => _build();
+
+  _$UsersSearchByPhoneNumbersRequestApplicationJson _build() {
+    UsersSearchByPhoneNumbersRequestApplicationJson._validate(this);
+    _$UsersSearchByPhoneNumbersRequestApplicationJson _$result;
+    try {
+      _$result = _$v ??
+          _$UsersSearchByPhoneNumbersRequestApplicationJson._(
+              location: BuiltValueNullFieldError.checkNotNull(
+                  location, r'UsersSearchByPhoneNumbersRequestApplicationJson', 'location'),
+              search: search.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'search';
+        search.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'UsersSearchByPhoneNumbersRequestApplicationJson', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -14112,6 +16907,114 @@ class UsersGetUserResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $UsersEditUserRequestApplicationJsonInterfaceBuilder {
+  void replace($UsersEditUserRequestApplicationJsonInterface other);
+  void update(void Function($UsersEditUserRequestApplicationJsonInterfaceBuilder) updates);
+  String? get key;
+  set key(String? key);
+
+  String? get value;
+  set value(String? value);
+}
+
+class _$UsersEditUserRequestApplicationJson extends UsersEditUserRequestApplicationJson {
+  @override
+  final String key;
+  @override
+  final String value;
+
+  factory _$UsersEditUserRequestApplicationJson([void Function(UsersEditUserRequestApplicationJsonBuilder)? updates]) =>
+      (UsersEditUserRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UsersEditUserRequestApplicationJson._({required this.key, required this.value}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(key, r'UsersEditUserRequestApplicationJson', 'key');
+    BuiltValueNullFieldError.checkNotNull(value, r'UsersEditUserRequestApplicationJson', 'value');
+  }
+
+  @override
+  UsersEditUserRequestApplicationJson rebuild(void Function(UsersEditUserRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsersEditUserRequestApplicationJsonBuilder toBuilder() => UsersEditUserRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsersEditUserRequestApplicationJson && key == other.key && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, key.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsersEditUserRequestApplicationJson')
+          ..add('key', key)
+          ..add('value', value))
+        .toString();
+  }
+}
+
+class UsersEditUserRequestApplicationJsonBuilder
+    implements
+        Builder<UsersEditUserRequestApplicationJson, UsersEditUserRequestApplicationJsonBuilder>,
+        $UsersEditUserRequestApplicationJsonInterfaceBuilder {
+  _$UsersEditUserRequestApplicationJson? _$v;
+
+  String? _key;
+  String? get key => _$this._key;
+  set key(covariant String? key) => _$this._key = key;
+
+  String? _value;
+  String? get value => _$this._value;
+  set value(covariant String? value) => _$this._value = value;
+
+  UsersEditUserRequestApplicationJsonBuilder() {
+    UsersEditUserRequestApplicationJson._defaults(this);
+  }
+
+  UsersEditUserRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _key = $v.key;
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UsersEditUserRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UsersEditUserRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UsersEditUserRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsersEditUserRequestApplicationJson build() => _build();
+
+  _$UsersEditUserRequestApplicationJson _build() {
+    UsersEditUserRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UsersEditUserRequestApplicationJson._(
+            key: BuiltValueNullFieldError.checkNotNull(key, r'UsersEditUserRequestApplicationJson', 'key'),
+            value: BuiltValueNullFieldError.checkNotNull(value, r'UsersEditUserRequestApplicationJson', 'value'));
     replace(_$result);
     return _$result;
   }
@@ -15266,6 +18169,118 @@ class UsersGetEditableFieldsForUserResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $UsersEditUserMultiValueRequestApplicationJsonInterfaceBuilder {
+  void replace($UsersEditUserMultiValueRequestApplicationJsonInterface other);
+  void update(void Function($UsersEditUserMultiValueRequestApplicationJsonInterfaceBuilder) updates);
+  String? get key;
+  set key(String? key);
+
+  String? get value;
+  set value(String? value);
+}
+
+class _$UsersEditUserMultiValueRequestApplicationJson extends UsersEditUserMultiValueRequestApplicationJson {
+  @override
+  final String key;
+  @override
+  final String value;
+
+  factory _$UsersEditUserMultiValueRequestApplicationJson(
+          [void Function(UsersEditUserMultiValueRequestApplicationJsonBuilder)? updates]) =>
+      (UsersEditUserMultiValueRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UsersEditUserMultiValueRequestApplicationJson._({required this.key, required this.value}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(key, r'UsersEditUserMultiValueRequestApplicationJson', 'key');
+    BuiltValueNullFieldError.checkNotNull(value, r'UsersEditUserMultiValueRequestApplicationJson', 'value');
+  }
+
+  @override
+  UsersEditUserMultiValueRequestApplicationJson rebuild(
+          void Function(UsersEditUserMultiValueRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsersEditUserMultiValueRequestApplicationJsonBuilder toBuilder() =>
+      UsersEditUserMultiValueRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsersEditUserMultiValueRequestApplicationJson && key == other.key && value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, key.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsersEditUserMultiValueRequestApplicationJson')
+          ..add('key', key)
+          ..add('value', value))
+        .toString();
+  }
+}
+
+class UsersEditUserMultiValueRequestApplicationJsonBuilder
+    implements
+        Builder<UsersEditUserMultiValueRequestApplicationJson, UsersEditUserMultiValueRequestApplicationJsonBuilder>,
+        $UsersEditUserMultiValueRequestApplicationJsonInterfaceBuilder {
+  _$UsersEditUserMultiValueRequestApplicationJson? _$v;
+
+  String? _key;
+  String? get key => _$this._key;
+  set key(covariant String? key) => _$this._key = key;
+
+  String? _value;
+  String? get value => _$this._value;
+  set value(covariant String? value) => _$this._value = value;
+
+  UsersEditUserMultiValueRequestApplicationJsonBuilder() {
+    UsersEditUserMultiValueRequestApplicationJson._defaults(this);
+  }
+
+  UsersEditUserMultiValueRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _key = $v.key;
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UsersEditUserMultiValueRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UsersEditUserMultiValueRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UsersEditUserMultiValueRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsersEditUserMultiValueRequestApplicationJson build() => _build();
+
+  _$UsersEditUserMultiValueRequestApplicationJson _build() {
+    UsersEditUserMultiValueRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UsersEditUserMultiValueRequestApplicationJson._(
+            key: BuiltValueNullFieldError.checkNotNull(key, r'UsersEditUserMultiValueRequestApplicationJson', 'key'),
+            value: BuiltValueNullFieldError.checkNotNull(
+                value, r'UsersEditUserMultiValueRequestApplicationJson', 'value'));
     replace(_$result);
     return _$result;
   }
@@ -16534,6 +19549,101 @@ class UsersGetUsersGroupsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $UsersAddToGroupRequestApplicationJsonInterfaceBuilder {
+  void replace($UsersAddToGroupRequestApplicationJsonInterface other);
+  void update(void Function($UsersAddToGroupRequestApplicationJsonInterfaceBuilder) updates);
+  String? get groupid;
+  set groupid(String? groupid);
+}
+
+class _$UsersAddToGroupRequestApplicationJson extends UsersAddToGroupRequestApplicationJson {
+  @override
+  final String groupid;
+
+  factory _$UsersAddToGroupRequestApplicationJson(
+          [void Function(UsersAddToGroupRequestApplicationJsonBuilder)? updates]) =>
+      (UsersAddToGroupRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UsersAddToGroupRequestApplicationJson._({required this.groupid}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(groupid, r'UsersAddToGroupRequestApplicationJson', 'groupid');
+  }
+
+  @override
+  UsersAddToGroupRequestApplicationJson rebuild(void Function(UsersAddToGroupRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsersAddToGroupRequestApplicationJsonBuilder toBuilder() =>
+      UsersAddToGroupRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsersAddToGroupRequestApplicationJson && groupid == other.groupid;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, groupid.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsersAddToGroupRequestApplicationJson')..add('groupid', groupid)).toString();
+  }
+}
+
+class UsersAddToGroupRequestApplicationJsonBuilder
+    implements
+        Builder<UsersAddToGroupRequestApplicationJson, UsersAddToGroupRequestApplicationJsonBuilder>,
+        $UsersAddToGroupRequestApplicationJsonInterfaceBuilder {
+  _$UsersAddToGroupRequestApplicationJson? _$v;
+
+  String? _groupid;
+  String? get groupid => _$this._groupid;
+  set groupid(covariant String? groupid) => _$this._groupid = groupid;
+
+  UsersAddToGroupRequestApplicationJsonBuilder() {
+    UsersAddToGroupRequestApplicationJson._defaults(this);
+  }
+
+  UsersAddToGroupRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _groupid = $v.groupid;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UsersAddToGroupRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UsersAddToGroupRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UsersAddToGroupRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsersAddToGroupRequestApplicationJson build() => _build();
+
+  _$UsersAddToGroupRequestApplicationJson _build() {
+    UsersAddToGroupRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UsersAddToGroupRequestApplicationJson._(
+            groupid:
+                BuiltValueNullFieldError.checkNotNull(groupid, r'UsersAddToGroupRequestApplicationJson', 'groupid'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $UsersAddToGroupResponseApplicationJson_OcsInterfaceBuilder {
   void replace($UsersAddToGroupResponseApplicationJson_OcsInterface other);
   void update(void Function($UsersAddToGroupResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -16758,6 +19868,103 @@ class UsersAddToGroupResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $UsersRemoveFromGroupRequestApplicationJsonInterfaceBuilder {
+  void replace($UsersRemoveFromGroupRequestApplicationJsonInterface other);
+  void update(void Function($UsersRemoveFromGroupRequestApplicationJsonInterfaceBuilder) updates);
+  String? get groupid;
+  set groupid(String? groupid);
+}
+
+class _$UsersRemoveFromGroupRequestApplicationJson extends UsersRemoveFromGroupRequestApplicationJson {
+  @override
+  final String groupid;
+
+  factory _$UsersRemoveFromGroupRequestApplicationJson(
+          [void Function(UsersRemoveFromGroupRequestApplicationJsonBuilder)? updates]) =>
+      (UsersRemoveFromGroupRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UsersRemoveFromGroupRequestApplicationJson._({required this.groupid}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(groupid, r'UsersRemoveFromGroupRequestApplicationJson', 'groupid');
+  }
+
+  @override
+  UsersRemoveFromGroupRequestApplicationJson rebuild(
+          void Function(UsersRemoveFromGroupRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UsersRemoveFromGroupRequestApplicationJsonBuilder toBuilder() =>
+      UsersRemoveFromGroupRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UsersRemoveFromGroupRequestApplicationJson && groupid == other.groupid;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, groupid.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UsersRemoveFromGroupRequestApplicationJson')..add('groupid', groupid))
+        .toString();
+  }
+}
+
+class UsersRemoveFromGroupRequestApplicationJsonBuilder
+    implements
+        Builder<UsersRemoveFromGroupRequestApplicationJson, UsersRemoveFromGroupRequestApplicationJsonBuilder>,
+        $UsersRemoveFromGroupRequestApplicationJsonInterfaceBuilder {
+  _$UsersRemoveFromGroupRequestApplicationJson? _$v;
+
+  String? _groupid;
+  String? get groupid => _$this._groupid;
+  set groupid(covariant String? groupid) => _$this._groupid = groupid;
+
+  UsersRemoveFromGroupRequestApplicationJsonBuilder() {
+    UsersRemoveFromGroupRequestApplicationJson._defaults(this);
+  }
+
+  UsersRemoveFromGroupRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _groupid = $v.groupid;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UsersRemoveFromGroupRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UsersRemoveFromGroupRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UsersRemoveFromGroupRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UsersRemoveFromGroupRequestApplicationJson build() => _build();
+
+  _$UsersRemoveFromGroupRequestApplicationJson _build() {
+    UsersRemoveFromGroupRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UsersRemoveFromGroupRequestApplicationJson._(
+            groupid: BuiltValueNullFieldError.checkNotNull(
+                groupid, r'UsersRemoveFromGroupRequestApplicationJson', 'groupid'));
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.json
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.json
@@ -393,16 +393,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "filter",
-                        "in": "query",
-                        "description": "Filter for enabled or disabled apps",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "filter": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Filter for enabled or disabled apps"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -758,36 +766,36 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "search": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Text to search for"
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Limit the amount of groups returned"
+                                    },
+                                    "offset": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "description": "Offset for searching for groups"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "search",
-                        "in": "query",
-                        "description": "Text to search for",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Limit the amount of groups returned",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "description": "Offset for searching for groups",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -1015,16 +1023,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "groupid",
-                        "in": "query",
-                        "description": "ID of the group",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "groupid"
+                                ],
+                                "properties": {
+                                    "groupid": {
+                                        "type": "string",
+                                        "description": "ID of the group"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "userId",
                         "in": "path",
@@ -1091,16 +1109,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "groupid",
-                        "in": "query",
-                        "description": "ID of the group",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "groupid"
+                                ],
+                                "properties": {
+                                    "groupid": {
+                                        "type": "string",
+                                        "description": "ID of the group"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "userId",
                         "in": "path",
@@ -1370,16 +1398,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "New value for the key",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "value"
+                                ],
+                                "properties": {
+                                    "value": {
+                                        "type": "string",
+                                        "description": "New value for the key"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "app",
                         "in": "path",
@@ -1502,36 +1540,36 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "search": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Text to search for"
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Limit the amount of groups returned"
+                                    },
+                                    "offset": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "description": "Offset for searching for groups"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "search",
-                        "in": "query",
-                        "description": "Text to search for",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Limit the amount of groups returned",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "description": "Offset for searching for groups",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -1741,36 +1779,36 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "search": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Text to search for"
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Limit the amount of groups returned"
+                                    },
+                                    "offset": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "description": "Offset for searching for groups"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "search",
-                        "in": "query",
-                        "description": "Text to search for",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Limit the amount of groups returned",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "description": "Offset for searching for groups",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0
-                        }
-                    },
                     {
                         "name": "groupId",
                         "in": "path",
@@ -1867,36 +1905,36 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "search": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Text to search for"
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Limit the amount of groups returned"
+                                    },
+                                    "offset": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "description": "Offset for searching for groups"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "search",
-                        "in": "query",
-                        "description": "Text to search for",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Limit the amount of groups returned",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "description": "Offset for searching for groups",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -1967,94 +2005,72 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "userid"
+                                ],
+                                "properties": {
+                                    "userid": {
+                                        "type": "string",
+                                        "description": "ID of the user"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Password of the user"
+                                    },
+                                    "displayName": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Display name of the user"
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Email of the user"
+                                    },
+                                    "groups": {
+                                        "type": "array",
+                                        "default": [],
+                                        "description": "Groups of the user",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "subadmin": {
+                                        "type": "array",
+                                        "default": [],
+                                        "description": "Groups where the user is subadmin",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "quota": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Quota of the user"
+                                    },
+                                    "language": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Language of the user"
+                                    },
+                                    "manager": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Manager of the user"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "userid",
-                        "in": "query",
-                        "description": "ID of the user",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "password",
-                        "in": "query",
-                        "description": "Password of the user",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "displayName",
-                        "in": "query",
-                        "description": "Display name of the user",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "email",
-                        "in": "query",
-                        "description": "Email of the user",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "groups[]",
-                        "in": "query",
-                        "description": "Groups of the user",
-                        "schema": {
-                            "type": "array",
-                            "default": [],
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    {
-                        "name": "subadmin[]",
-                        "in": "query",
-                        "description": "Groups where the user is subadmin",
-                        "schema": {
-                            "type": "array",
-                            "default": [],
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    {
-                        "name": "quota",
-                        "in": "query",
-                        "description": "Quota of the user",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "language",
-                        "in": "query",
-                        "description": "Language of the user",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "manager",
-                        "in": "query",
-                        "description": "Manager of the user",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -2151,36 +2167,36 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "search": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Text to search for"
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Limit the amount of groups returned"
+                                    },
+                                    "offset": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "description": "Offset for searching for groups"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "search",
-                        "in": "query",
-                        "description": "Text to search for",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Limit the amount of groups returned",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "description": "Offset for searching for groups",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -2267,27 +2283,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Limit the amount of users returned"
+                                    },
+                                    "offset": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "description": "Offset"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Limit the amount of users returned",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "description": "Offset",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -2374,36 +2394,37 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "location",
-                        "in": "query",
-                        "description": "Location of the phone number (for country code)",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "search",
-                        "in": "query",
-                        "description": "Phone numbers to search for",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "contentMediaType": "application/json",
-                            "contentSchema": {
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
                                 "type": "object",
-                                "description": "Phone numbers to search for",
-                                "additionalProperties": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
+                                "required": [
+                                    "location",
+                                    "search"
+                                ],
+                                "properties": {
+                                    "location": {
+                                        "type": "string",
+                                        "description": "Location of the phone number (for country code)"
+                                    },
+                                    "search": {
+                                        "type": "object",
+                                        "description": "Phone numbers to search for",
+                                        "additionalProperties": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -2564,25 +2585,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "key",
+                                    "value"
+                                ],
+                                "properties": {
+                                    "key": {
+                                        "type": "string",
+                                        "description": "Key that will be updated"
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": "New value for the key"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "key",
-                        "in": "query",
-                        "description": "Key that will be updated",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "New value for the key",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "userId",
                         "in": "path",
@@ -2916,25 +2943,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "key",
+                                    "value"
+                                ],
+                                "properties": {
+                                    "key": {
+                                        "type": "string",
+                                        "description": "Key that will be updated"
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": "New value for the key"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "key",
-                        "in": "query",
-                        "description": "Key that will be updated",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "New value for the key",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "userId",
                         "in": "path",
@@ -3299,16 +3332,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "groupid",
-                        "in": "query",
-                        "description": "ID of the group",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "groupid": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "ID of the group"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "userId",
                         "in": "path",
@@ -3375,16 +3416,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "groupid",
-                        "in": "query",
-                        "description": "ID of the group",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "groupid"
+                                ],
+                                "properties": {
+                                    "groupid": {
+                                        "type": "string",
+                                        "description": "ID of the group"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "userId",
                         "in": "path",
@@ -3521,16 +3572,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "configValue",
-                        "in": "query",
-                        "description": "New value",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "configValue"
+                                ],
+                                "properties": {
+                                    "configValue": {
+                                        "type": "string",
+                                        "description": "New value"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "appId",
                         "in": "path",
@@ -3738,24 +3799,29 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "configs",
-                        "in": "query",
-                        "description": "Key-value pairs of the preferences",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "contentMediaType": "application/json",
-                            "contentSchema": {
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
                                 "type": "object",
-                                "description": "Key-value pairs of the preferences",
-                                "additionalProperties": {
-                                    "type": "string"
+                                "required": [
+                                    "configs"
+                                ],
+                                "properties": {
+                                    "configs": {
+                                        "type": "object",
+                                        "description": "Key-value pairs of the preferences",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "appId",
                         "in": "path",
@@ -3849,19 +3915,29 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "configKeys[]",
-                        "in": "query",
-                        "description": "Keys to delete",
-                        "required": true,
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "configKeys"
+                                ],
+                                "properties": {
+                                    "configKeys": {
+                                        "type": "array",
+                                        "description": "Keys to delete",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "appId",
                         "in": "path",

--- a/packages/nextcloud/lib/src/api/settings.openapi.dart
+++ b/packages/nextcloud/lib/src/api/settings.openapi.dart
@@ -16,21 +16,20 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
-import 'package:built_value/standard_json_plugin.dart' as _i8;
-import 'package:collection/collection.dart' as _i5;
-import 'package:dynamite_runtime/built_value.dart' as _i7;
+import 'package:built_value/standard_json_plugin.dart' as _i7;
+import 'package:collection/collection.dart' as _i4;
+import 'package:dynamite_runtime/built_value.dart' as _i6;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/models.dart';
-import 'package:dynamite_runtime/utils.dart' as _i6;
+import 'package:dynamite_runtime/utils.dart' as _i5;
 import 'package:http/http.dart' as _i3;
 import 'package:meta/meta.dart' as _i2;
-import 'package:uri/uri.dart' as _i4;
 
 part 'settings.openapi.g.dart';
 
@@ -77,10 +76,6 @@ class $DeclarativeSettingsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [app] ID of the app.
-  ///   * [formId] ID of the form.
-  ///   * [fieldId] ID of the field.
-  ///   * [value] Value to be saved.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -93,33 +88,15 @@ class $DeclarativeSettingsClient {
   ///  * [$setValue_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setValue_Request({
-    required String app,
-    required String formId,
-    required String fieldId,
-    required ContentString<JsonObject> value,
+    required DeclarativeSettingsSetValueRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
-    _parameters['app'] = __app;
-
-    final __formId = _$jsonSerializers.serialize(formId, specifiedType: const FullType(String));
-    _parameters['formId'] = __formId;
-
-    final __fieldId = _$jsonSerializers.serialize(fieldId, specifiedType: const FullType(String));
-    _parameters['fieldId'] = __fieldId;
-
-    final __value =
-        _$jsonSerializers.serialize(value, specifiedType: const FullType(ContentString, [FullType(JsonObject)]));
-    _parameters['value'] = __value;
-
-    final _path = _i4.UriTemplate('/ocs/v2.php/settings/api/declarative/value{?app*,formId*,fieldId*,value*}')
-        .expand(_parameters);
+    const _path = '/ocs/v2.php/settings/api/declarative/value';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -137,8 +114,15 @@ class $DeclarativeSettingsClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(DeclarativeSettingsSetValueRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -148,10 +132,6 @@ class $DeclarativeSettingsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [app] ID of the app.
-  ///   * [formId] ID of the form.
-  ///   * [fieldId] ID of the field.
-  ///   * [value] Value to be saved.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -163,18 +143,12 @@ class $DeclarativeSettingsClient {
   ///  * [$setValue_Request] for the request send by this method.
   ///  * [$setValue_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<DeclarativeSettingsSetValueResponseApplicationJson, void>> setValue({
-    required String app,
-    required String formId,
-    required String fieldId,
-    required ContentString<JsonObject> value,
+    required DeclarativeSettingsSetValueRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setValue_Request(
-      app: app,
-      formId: formId,
-      fieldId: fieldId,
-      value: value,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -217,7 +191,7 @@ class $DeclarativeSettingsClient {
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -235,7 +209,7 @@ class $DeclarativeSettingsClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -307,7 +281,7 @@ class $LogSettingsClient {
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/octet-stream';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -348,6 +322,80 @@ class $LogSettingsClient {
     final _rawResponse =
         _i1.ResponseConverter<Uint8List, LogSettingsLogSettingsDownloadHeaders>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $DeclarativeSettingsSetValueRequestApplicationJsonInterface {
+  /// ID of the app.
+  String get app;
+
+  /// ID of the form.
+  String get formId;
+
+  /// ID of the field.
+  String get fieldId;
+
+  /// Value to be saved.
+  JsonObject get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$DeclarativeSettingsSetValueRequestApplicationJsonInterfaceBuilder].
+  $DeclarativeSettingsSetValueRequestApplicationJsonInterface rebuild(
+    void Function($DeclarativeSettingsSetValueRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$DeclarativeSettingsSetValueRequestApplicationJsonInterfaceBuilder].
+  $DeclarativeSettingsSetValueRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($DeclarativeSettingsSetValueRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($DeclarativeSettingsSetValueRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class DeclarativeSettingsSetValueRequestApplicationJson
+    implements
+        $DeclarativeSettingsSetValueRequestApplicationJsonInterface,
+        Built<DeclarativeSettingsSetValueRequestApplicationJson,
+            DeclarativeSettingsSetValueRequestApplicationJsonBuilder> {
+  /// Creates a new DeclarativeSettingsSetValueRequestApplicationJson object using the builder pattern.
+  factory DeclarativeSettingsSetValueRequestApplicationJson([
+    void Function(DeclarativeSettingsSetValueRequestApplicationJsonBuilder)? b,
+  ]) = _$DeclarativeSettingsSetValueRequestApplicationJson;
+
+  // coverage:ignore-start
+  const DeclarativeSettingsSetValueRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory DeclarativeSettingsSetValueRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for DeclarativeSettingsSetValueRequestApplicationJson.
+  static Serializer<DeclarativeSettingsSetValueRequestApplicationJson> get serializer =>
+      _$declarativeSettingsSetValueRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(DeclarativeSettingsSetValueRequestApplicationJsonBuilder b) {
+    $DeclarativeSettingsSetValueRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(DeclarativeSettingsSetValueRequestApplicationJsonBuilder b) {
+    $DeclarativeSettingsSetValueRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -1200,13 +1248,13 @@ extension $ecd8d9fe35935410da9dc2662cd86d27Extension on _$ecd8d9fe35935410da9dc2
   List<String> get _names => const ['declarativeFormFieldOptions1', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i6.validateOneOf(
+  void validateOneOf() => _i5.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i6.validateAnyOf(
+  void validateAnyOf() => _i5.validateAnyOf(
         _values,
         _names,
       );
@@ -1287,13 +1335,13 @@ extension $bb4e9af94b69347c125c27e03a648d24Extension on _$bb4e9af94b69347c125c27
   List<String> get _names => const [r'$bool', 'builtListString', r'$num', 'string'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i6.validateOneOf(
+  void validateOneOf() => _i5.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i6.validateAnyOf(
+  void validateAnyOf() => _i5.validateAnyOf(
         _values,
         _names,
       );
@@ -1390,8 +1438,11 @@ class _$bb4e9af94b69347c125c27e03a648d24Serializer implements PrimitiveSerialize
 @_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
-      ..addBuilderFactory(const FullType(ContentString, [FullType(JsonObject)]), ContentStringBuilder<JsonObject>.new)
-      ..add(ContentString.serializer)
+      ..addBuilderFactory(
+        const FullType(DeclarativeSettingsSetValueRequestApplicationJson),
+        DeclarativeSettingsSetValueRequestApplicationJsonBuilder.new,
+      )
+      ..add(DeclarativeSettingsSetValueRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(DeclarativeSettingsSetValueResponseApplicationJson),
         DeclarativeSettingsSetValueResponseApplicationJsonBuilder.new,
@@ -1449,16 +1500,16 @@ final Serializers _$serializers = (Serializers().toBuilder()
 @_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
-      ..add(_i7.DynamiteDoubleSerializer())
+      ..add(_i6.DynamiteDoubleSerializer())
       ..addPlugin(
-        _i8.StandardJsonPlugin(
+        _i7.StandardJsonPlugin(
           typesToLeaveAsList: const {
             _$ecd8d9fe35935410da9dc2662cd86d27,
             _$bb4e9af94b69347c125c27e03a648d24,
           },
         ),
       )
-      ..addPlugin(const _i7.HeaderPlugin())
-      ..addPlugin(const _i7.ContentStringPlugin()))
+      ..addPlugin(const _i6.HeaderPlugin())
+      ..addPlugin(const _i6.ContentStringPlugin()))
     .build();
 // coverage:ignore-end

--- a/packages/nextcloud/lib/src/api/settings.openapi.dart
+++ b/packages/nextcloud/lib/src/api/settings.openapi.dart
@@ -100,18 +100,18 @@ class $DeclarativeSettingsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
-    _parameters['app'] = $app;
+    final __app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
+    _parameters['app'] = __app;
 
-    final $formId = _$jsonSerializers.serialize(formId, specifiedType: const FullType(String));
-    _parameters['formId'] = $formId;
+    final __formId = _$jsonSerializers.serialize(formId, specifiedType: const FullType(String));
+    _parameters['formId'] = __formId;
 
-    final $fieldId = _$jsonSerializers.serialize(fieldId, specifiedType: const FullType(String));
-    _parameters['fieldId'] = $fieldId;
+    final __fieldId = _$jsonSerializers.serialize(fieldId, specifiedType: const FullType(String));
+    _parameters['fieldId'] = __fieldId;
 
-    final $value =
+    final __value =
         _$jsonSerializers.serialize(value, specifiedType: const FullType(ContentString, [FullType(JsonObject)]));
-    _parameters['value'] = $value;
+    _parameters['value'] = __value;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/settings/api/declarative/value{?app*,formId*,fieldId*,value*}')
         .expand(_parameters);
@@ -135,9 +135,9 @@ class $DeclarativeSettingsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -233,9 +233,9 @@ class $DeclarativeSettingsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/settings.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/settings.openapi.g.dart
@@ -102,6 +102,9 @@ final BuiltSet<DeclarativeFormField_Type> _$declarativeFormFieldTypeValues =
   _$declarativeFormFieldTypeMultiSelect,
 ]);
 
+Serializer<DeclarativeSettingsSetValueRequestApplicationJson>
+    _$declarativeSettingsSetValueRequestApplicationJsonSerializer =
+    _$DeclarativeSettingsSetValueRequestApplicationJsonSerializer();
 Serializer<OCSMeta> _$oCSMetaSerializer = _$OCSMetaSerializer();
 Serializer<DeclarativeSettingsSetValueResponseApplicationJson_Ocs>
     _$declarativeSettingsSetValueResponseApplicationJsonOcsSerializer =
@@ -121,6 +124,63 @@ Serializer<DeclarativeSettingsGetFormsResponseApplicationJson>
     _$DeclarativeSettingsGetFormsResponseApplicationJsonSerializer();
 Serializer<LogSettingsLogSettingsDownloadHeaders> _$logSettingsLogSettingsDownloadHeadersSerializer =
     _$LogSettingsLogSettingsDownloadHeadersSerializer();
+
+class _$DeclarativeSettingsSetValueRequestApplicationJsonSerializer
+    implements StructuredSerializer<DeclarativeSettingsSetValueRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    DeclarativeSettingsSetValueRequestApplicationJson,
+    _$DeclarativeSettingsSetValueRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'DeclarativeSettingsSetValueRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, DeclarativeSettingsSetValueRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'app',
+      serializers.serialize(object.app, specifiedType: const FullType(String)),
+      'formId',
+      serializers.serialize(object.formId, specifiedType: const FullType(String)),
+      'fieldId',
+      serializers.serialize(object.fieldId, specifiedType: const FullType(String)),
+      'value',
+      serializers.serialize(object.value, specifiedType: const FullType(JsonObject)),
+    ];
+
+    return result;
+  }
+
+  @override
+  DeclarativeSettingsSetValueRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = DeclarativeSettingsSetValueRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'app':
+          result.app = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'formId':
+          result.formId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'fieldId':
+          result.fieldId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'value':
+          result.value = serializers.deserialize(value, specifiedType: const FullType(JsonObject))! as JsonObject;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
 
 class _$OCSMetaSerializer implements StructuredSerializer<OCSMeta> {
   @override
@@ -658,6 +718,156 @@ class _$LogSettingsLogSettingsDownloadHeadersSerializer
     }
 
     return result.build();
+  }
+}
+
+abstract mixin class $DeclarativeSettingsSetValueRequestApplicationJsonInterfaceBuilder {
+  void replace($DeclarativeSettingsSetValueRequestApplicationJsonInterface other);
+  void update(void Function($DeclarativeSettingsSetValueRequestApplicationJsonInterfaceBuilder) updates);
+  String? get app;
+  set app(String? app);
+
+  String? get formId;
+  set formId(String? formId);
+
+  String? get fieldId;
+  set fieldId(String? fieldId);
+
+  JsonObject? get value;
+  set value(JsonObject? value);
+}
+
+class _$DeclarativeSettingsSetValueRequestApplicationJson extends DeclarativeSettingsSetValueRequestApplicationJson {
+  @override
+  final String app;
+  @override
+  final String formId;
+  @override
+  final String fieldId;
+  @override
+  final JsonObject value;
+
+  factory _$DeclarativeSettingsSetValueRequestApplicationJson(
+          [void Function(DeclarativeSettingsSetValueRequestApplicationJsonBuilder)? updates]) =>
+      (DeclarativeSettingsSetValueRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$DeclarativeSettingsSetValueRequestApplicationJson._(
+      {required this.app, required this.formId, required this.fieldId, required this.value})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(app, r'DeclarativeSettingsSetValueRequestApplicationJson', 'app');
+    BuiltValueNullFieldError.checkNotNull(formId, r'DeclarativeSettingsSetValueRequestApplicationJson', 'formId');
+    BuiltValueNullFieldError.checkNotNull(fieldId, r'DeclarativeSettingsSetValueRequestApplicationJson', 'fieldId');
+    BuiltValueNullFieldError.checkNotNull(value, r'DeclarativeSettingsSetValueRequestApplicationJson', 'value');
+  }
+
+  @override
+  DeclarativeSettingsSetValueRequestApplicationJson rebuild(
+          void Function(DeclarativeSettingsSetValueRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DeclarativeSettingsSetValueRequestApplicationJsonBuilder toBuilder() =>
+      DeclarativeSettingsSetValueRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DeclarativeSettingsSetValueRequestApplicationJson &&
+        app == other.app &&
+        formId == other.formId &&
+        fieldId == other.fieldId &&
+        value == other.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, app.hashCode);
+    _$hash = $jc(_$hash, formId.hashCode);
+    _$hash = $jc(_$hash, fieldId.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'DeclarativeSettingsSetValueRequestApplicationJson')
+          ..add('app', app)
+          ..add('formId', formId)
+          ..add('fieldId', fieldId)
+          ..add('value', value))
+        .toString();
+  }
+}
+
+class DeclarativeSettingsSetValueRequestApplicationJsonBuilder
+    implements
+        Builder<DeclarativeSettingsSetValueRequestApplicationJson,
+            DeclarativeSettingsSetValueRequestApplicationJsonBuilder>,
+        $DeclarativeSettingsSetValueRequestApplicationJsonInterfaceBuilder {
+  _$DeclarativeSettingsSetValueRequestApplicationJson? _$v;
+
+  String? _app;
+  String? get app => _$this._app;
+  set app(covariant String? app) => _$this._app = app;
+
+  String? _formId;
+  String? get formId => _$this._formId;
+  set formId(covariant String? formId) => _$this._formId = formId;
+
+  String? _fieldId;
+  String? get fieldId => _$this._fieldId;
+  set fieldId(covariant String? fieldId) => _$this._fieldId = fieldId;
+
+  JsonObject? _value;
+  JsonObject? get value => _$this._value;
+  set value(covariant JsonObject? value) => _$this._value = value;
+
+  DeclarativeSettingsSetValueRequestApplicationJsonBuilder() {
+    DeclarativeSettingsSetValueRequestApplicationJson._defaults(this);
+  }
+
+  DeclarativeSettingsSetValueRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _app = $v.app;
+      _formId = $v.formId;
+      _fieldId = $v.fieldId;
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant DeclarativeSettingsSetValueRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$DeclarativeSettingsSetValueRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(DeclarativeSettingsSetValueRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DeclarativeSettingsSetValueRequestApplicationJson build() => _build();
+
+  _$DeclarativeSettingsSetValueRequestApplicationJson _build() {
+    DeclarativeSettingsSetValueRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$DeclarativeSettingsSetValueRequestApplicationJson._(
+            app:
+                BuiltValueNullFieldError.checkNotNull(app, r'DeclarativeSettingsSetValueRequestApplicationJson', 'app'),
+            formId: BuiltValueNullFieldError.checkNotNull(
+                formId, r'DeclarativeSettingsSetValueRequestApplicationJson', 'formId'),
+            fieldId: BuiltValueNullFieldError.checkNotNull(
+                fieldId, r'DeclarativeSettingsSetValueRequestApplicationJson', 'fieldId'),
+            value: BuiltValueNullFieldError.checkNotNull(
+                value, r'DeclarativeSettingsSetValueRequestApplicationJson', 'value'));
+    replace(_$result);
+    return _$result;
   }
 }
 

--- a/packages/nextcloud/lib/src/api/settings.openapi.json
+++ b/packages/nextcloud/lib/src/api/settings.openapi.json
@@ -253,48 +253,41 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "app",
-                        "in": "query",
-                        "description": "ID of the app",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "formId",
-                        "in": "query",
-                        "description": "ID of the form",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "fieldId",
-                        "in": "query",
-                        "description": "ID of the field",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "Value to be saved",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "contentMediaType": "application/json",
-                            "contentSchema": {
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
                                 "type": "object",
-                                "description": "Value to be saved"
+                                "required": [
+                                    "app",
+                                    "formId",
+                                    "fieldId",
+                                    "value"
+                                ],
+                                "properties": {
+                                    "app": {
+                                        "type": "string",
+                                        "description": "ID of the app"
+                                    },
+                                    "formId": {
+                                        "type": "string",
+                                        "description": "ID of the form"
+                                    },
+                                    "fieldId": {
+                                        "type": "string",
+                                        "description": "ID of the field"
+                                    },
+                                    "value": {
+                                        "type": "object",
+                                        "description": "Value to be saved"
+                                    }
+                                }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -129,21 +129,22 @@ class $AvatarClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $darkTheme = _$jsonSerializers.serialize(darkTheme, specifiedType: const FullType(AvatarGetAvatarDarkTheme));
-    $darkTheme ??= 0;
-    _parameters['darkTheme'] = $darkTheme;
+    var __darkTheme = _$jsonSerializers.serialize(darkTheme, specifiedType: const FullType(AvatarGetAvatarDarkTheme));
+    __darkTheme ??= 0;
+    _parameters['darkTheme'] = __darkTheme;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(AvatarGetAvatarApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion =
+        _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(AvatarGetAvatarApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar{?darkTheme*}')
         .expand(_parameters);
@@ -165,9 +166,9 @@ class $AvatarClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -243,18 +244,18 @@ class $AvatarClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(AvatarUploadAvatarApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -275,9 +276,9 @@ class $AvatarClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -351,18 +352,18 @@ class $AvatarClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(AvatarDeleteAvatarApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -383,9 +384,9 @@ class $AvatarClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -463,24 +464,24 @@ class $AvatarClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $emoji = _$jsonSerializers.serialize(emoji, specifiedType: const FullType(String));
-    _parameters['emoji'] = $emoji;
+    final __emoji = _$jsonSerializers.serialize(emoji, specifiedType: const FullType(String));
+    _parameters['emoji'] = __emoji;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $color = _$jsonSerializers.serialize(color, specifiedType: const FullType(String));
-    _parameters['color'] = $color;
+    final __color = _$jsonSerializers.serialize(color, specifiedType: const FullType(String));
+    _parameters['color'] = __color;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(AvatarEmojiAvatarApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar/emoji{?emoji*,color*}')
         .expand(_parameters);
@@ -502,9 +503,9 @@ class $AvatarClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -583,18 +584,18 @@ class $AvatarClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(AvatarGetAvatarDarkApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar/dark').expand(_parameters);
@@ -616,9 +617,9 @@ class $AvatarClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -693,26 +694,26 @@ class $AvatarClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $cloudId = _$jsonSerializers.serialize(cloudId, specifiedType: const FullType(String));
-    _parameters['cloudId'] = $cloudId;
+    final __cloudId = _$jsonSerializers.serialize(cloudId, specifiedType: const FullType(String));
+    _parameters['cloudId'] = __cloudId;
 
-    final $size =
+    final __size =
         _$jsonSerializers.serialize(size, specifiedType: const FullType(AvatarGetUserProxyAvatarWithoutRoomSize));
-    _parameters['size'] = $size;
+    _parameters['size'] = __size;
 
-    var $darkTheme = _$jsonSerializers.serialize(
+    var __darkTheme = _$jsonSerializers.serialize(
       darkTheme,
       specifiedType: const FullType(AvatarGetUserProxyAvatarWithoutRoomDarkTheme),
     );
-    $darkTheme ??= 0;
-    _parameters['darkTheme'] = $darkTheme;
+    __darkTheme ??= 0;
+    _parameters['darkTheme'] = __darkTheme;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(AvatarGetUserProxyAvatarWithoutRoomApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}{?cloudId*,darkTheme*}')
@@ -737,9 +738,9 @@ class $AvatarClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -818,19 +819,19 @@ class $AvatarClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $cloudId = _$jsonSerializers.serialize(cloudId, specifiedType: const FullType(String));
-    _parameters['cloudId'] = $cloudId;
+    final __cloudId = _$jsonSerializers.serialize(cloudId, specifiedType: const FullType(String));
+    _parameters['cloudId'] = __cloudId;
 
-    final $size =
+    final __size =
         _$jsonSerializers.serialize(size, specifiedType: const FullType(AvatarGetUserProxyAvatarDarkWithoutRoomSize));
-    _parameters['size'] = $size;
+    _parameters['size'] = __size;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(AvatarGetUserProxyAvatarDarkWithoutRoomApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}/dark{?cloudId*}')
@@ -855,9 +856,9 @@ class $AvatarClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -937,29 +938,29 @@ class $AvatarClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $cloudId = _$jsonSerializers.serialize(cloudId, specifiedType: const FullType(String));
-    _parameters['cloudId'] = $cloudId;
+    final __cloudId = _$jsonSerializers.serialize(cloudId, specifiedType: const FullType(String));
+    _parameters['cloudId'] = __cloudId;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $size = _$jsonSerializers.serialize(size, specifiedType: const FullType(AvatarGetUserProxyAvatarSize));
-    _parameters['size'] = $size;
+    final __size = _$jsonSerializers.serialize(size, specifiedType: const FullType(AvatarGetUserProxyAvatarSize));
+    _parameters['size'] = __size;
 
-    var $darkTheme =
+    var __darkTheme =
         _$jsonSerializers.serialize(darkTheme, specifiedType: const FullType(AvatarGetUserProxyAvatarDarkTheme));
-    $darkTheme ??= 0;
-    _parameters['darkTheme'] = $darkTheme;
+    __darkTheme ??= 0;
+    _parameters['darkTheme'] = __darkTheme;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(AvatarGetUserProxyAvatarApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/{token}/user-avatar/{size}{?cloudId*,darkTheme*}',
@@ -982,9 +983,9 @@ class $AvatarClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1068,24 +1069,24 @@ class $AvatarClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $cloudId = _$jsonSerializers.serialize(cloudId, specifiedType: const FullType(String));
-    _parameters['cloudId'] = $cloudId;
+    final __cloudId = _$jsonSerializers.serialize(cloudId, specifiedType: const FullType(String));
+    _parameters['cloudId'] = __cloudId;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $size = _$jsonSerializers.serialize(size, specifiedType: const FullType(AvatarGetUserProxyAvatarDarkSize));
-    _parameters['size'] = $size;
+    final __size = _$jsonSerializers.serialize(size, specifiedType: const FullType(AvatarGetUserProxyAvatarDarkSize));
+    _parameters['size'] = __size;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(AvatarGetUserProxyAvatarDarkApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/{token}/user-avatar/{size}/dark{?cloudId*}')
@@ -1108,9 +1109,9 @@ class $AvatarClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1194,17 +1195,17 @@ class $BotClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotListBotsApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotListBotsApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1227,9 +1228,9 @@ class $BotClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1305,20 +1306,20 @@ class $BotClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $botId = _$jsonSerializers.serialize(botId, specifiedType: const FullType(int));
-    _parameters['botId'] = $botId;
+    final __botId = _$jsonSerializers.serialize(botId, specifiedType: const FullType(int));
+    _parameters['botId'] = __botId;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotEnableBotApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotEnableBotApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/{botId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1341,9 +1342,9 @@ class $BotClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1423,20 +1424,20 @@ class $BotClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $botId = _$jsonSerializers.serialize(botId, specifiedType: const FullType(int));
-    _parameters['botId'] = $botId;
+    final __botId = _$jsonSerializers.serialize(botId, specifiedType: const FullType(int));
+    _parameters['botId'] = __botId;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotDisableBotApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotDisableBotApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/{botId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -1459,9 +1460,9 @@ class $BotClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1551,32 +1552,32 @@ class $BotClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
-    _parameters['message'] = $message;
+    final __message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
+    _parameters['message'] = __message;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $referenceId = _$jsonSerializers.serialize(referenceId, specifiedType: const FullType(String));
-    $referenceId ??= '';
-    _parameters['referenceId'] = $referenceId;
+    var __referenceId = _$jsonSerializers.serialize(referenceId, specifiedType: const FullType(String));
+    __referenceId ??= '';
+    _parameters['referenceId'] = __referenceId;
 
-    var $replyTo = _$jsonSerializers.serialize(replyTo, specifiedType: const FullType(int));
-    $replyTo ??= 0;
-    _parameters['replyTo'] = $replyTo;
+    var __replyTo = _$jsonSerializers.serialize(replyTo, specifiedType: const FullType(int));
+    __replyTo ??= 0;
+    _parameters['replyTo'] = __replyTo;
 
-    var $silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(BotSendMessageSilent));
-    $silent ??= 0;
-    _parameters['silent'] = $silent;
+    var __silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(BotSendMessageSilent));
+    __silent ??= 0;
+    _parameters['silent'] = __silent;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotSendMessageApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotSendMessageApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/message{?message*,referenceId*,replyTo*,silent*}',
@@ -1599,9 +1600,9 @@ class $BotClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1698,23 +1699,23 @@ class $BotClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
-    _parameters['reaction'] = $reaction;
+    final __reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
+    _parameters['reaction'] = __reaction;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
-    _parameters['messageId'] = $messageId;
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
+    _parameters['messageId'] = __messageId;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotReactApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotReactApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/reaction/{messageId}{?reaction*}')
@@ -1737,9 +1738,9 @@ class $BotClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1828,24 +1829,24 @@ class $BotClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
-    _parameters['reaction'] = $reaction;
+    final __reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
+    _parameters['reaction'] = __reaction;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
-    _parameters['messageId'] = $messageId;
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
+    _parameters['messageId'] = __messageId;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotDeleteReactionApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/reaction/{messageId}{?reaction*}')
@@ -1868,9 +1869,9 @@ class $BotClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1966,37 +1967,37 @@ class $BreakoutRoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $mode =
+    final __mode =
         _$jsonSerializers.serialize(mode, specifiedType: const FullType(BreakoutRoomConfigureBreakoutRoomsMode));
-    _parameters['mode'] = $mode;
+    _parameters['mode'] = __mode;
 
-    final $amount = _$jsonSerializers.serialize(amount, specifiedType: const FullType(int));
+    final __amount = _$jsonSerializers.serialize(amount, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $amount,
+      __amount,
       'amount',
       maximum: 20,
       minimum: 1,
     );
-    _parameters['amount'] = $amount;
+    _parameters['amount'] = __amount;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $attendeeMap = _$jsonSerializers.serialize(attendeeMap, specifiedType: const FullType(String));
-    $attendeeMap ??= '[]';
-    _parameters['attendeeMap'] = $attendeeMap;
+    var __attendeeMap = _$jsonSerializers.serialize(attendeeMap, specifiedType: const FullType(String));
+    __attendeeMap ??= '[]';
+    _parameters['attendeeMap'] = __attendeeMap;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(BreakoutRoomConfigureBreakoutRoomsApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}{?mode*,amount*,attendeeMap*}')
@@ -2021,9 +2022,9 @@ class $BreakoutRoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2107,20 +2108,20 @@ class $BreakoutRoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(BreakoutRoomRemoveBreakoutRoomsApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}').expand(_parameters);
@@ -2144,9 +2145,9 @@ class $BreakoutRoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2224,23 +2225,23 @@ class $BreakoutRoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
-    _parameters['message'] = $message;
+    final __message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
+    _parameters['message'] = __message;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(BreakoutRoomBroadcastChatMessageApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/broadcast{?message*}')
@@ -2265,9 +2266,9 @@ class $BreakoutRoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2349,21 +2350,21 @@ class $BreakoutRoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $attendeeMap = _$jsonSerializers.serialize(attendeeMap, specifiedType: const FullType(String));
-    _parameters['attendeeMap'] = $attendeeMap;
+    final __attendeeMap = _$jsonSerializers.serialize(attendeeMap, specifiedType: const FullType(String));
+    _parameters['attendeeMap'] = __attendeeMap;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BreakoutRoomApplyAttendeeMapApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/attendees{?attendeeMap*}')
@@ -2388,9 +2389,9 @@ class $BreakoutRoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2468,18 +2469,18 @@ class $BreakoutRoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BreakoutRoomRequestAssistanceApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/request-assistance')
         .expand(_parameters);
@@ -2503,9 +2504,9 @@ class $BreakoutRoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2580,20 +2581,20 @@ class $BreakoutRoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(BreakoutRoomResetRequestForAssistanceApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/request-assistance')
         .expand(_parameters);
@@ -2617,9 +2618,9 @@ class $BreakoutRoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2696,20 +2697,20 @@ class $BreakoutRoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(BreakoutRoomStartBreakoutRoomsApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/rooms').expand(_parameters);
@@ -2733,9 +2734,9 @@ class $BreakoutRoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2810,18 +2811,18 @@ class $BreakoutRoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BreakoutRoomStopBreakoutRoomsApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/rooms').expand(_parameters);
@@ -2845,9 +2846,9 @@ class $BreakoutRoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -2924,23 +2925,23 @@ class $BreakoutRoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $target = _$jsonSerializers.serialize(target, specifiedType: const FullType(String));
-    _parameters['target'] = $target;
+    final __target = _$jsonSerializers.serialize(target, specifiedType: const FullType(String));
+    _parameters['target'] = __target;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(BreakoutRoomSwitchBreakoutRoomApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/switch{?target*}')
         .expand(_parameters);
@@ -2964,9 +2965,9 @@ class $BreakoutRoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3050,18 +3051,18 @@ class $CallClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(CallGetPeersForCallApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3082,9 +3083,9 @@ class $CallClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3161,27 +3162,27 @@ class $CallClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $flags = _$jsonSerializers.serialize(flags, specifiedType: const FullType(int));
+    final __flags = _$jsonSerializers.serialize(flags, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $flags,
+      __flags,
       'flags',
       maximum: 15,
       minimum: 0,
     );
-    _parameters['flags'] = $flags;
+    _parameters['flags'] = __flags;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(CallUpdateCallFlagsApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}{?flags*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3202,9 +3203,9 @@ class $CallClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3291,44 +3292,44 @@ class $CallClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $flags = _$jsonSerializers.serialize(flags, specifiedType: const FullType(int));
+    final __flags = _$jsonSerializers.serialize(flags, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $flags,
+      __flags,
       'flags',
       maximum: 15,
       minimum: 0,
     );
-    _parameters['flags'] = $flags;
+    _parameters['flags'] = __flags;
 
-    final $forcePermissions = _$jsonSerializers.serialize(forcePermissions, specifiedType: const FullType(int));
+    final __forcePermissions = _$jsonSerializers.serialize(forcePermissions, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $forcePermissions,
+      __forcePermissions,
       'forcePermissions',
       maximum: 255,
       minimum: 0,
     );
-    _parameters['forcePermissions'] = $forcePermissions;
+    _parameters['forcePermissions'] = __forcePermissions;
 
-    var $silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(CallJoinCallSilent));
-    $silent ??= 0;
-    _parameters['silent'] = $silent;
+    var __silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(CallJoinCallSilent));
+    __silent ??= 0;
+    _parameters['silent'] = __silent;
 
-    var $recordingConsent =
+    var __recordingConsent =
         _$jsonSerializers.serialize(recordingConsent, specifiedType: const FullType(CallJoinCallRecordingConsent));
-    $recordingConsent ??= 0;
-    _parameters['recordingConsent'] = $recordingConsent;
+    __recordingConsent ??= 0;
+    _parameters['recordingConsent'] = __recordingConsent;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(CallJoinCallApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(CallJoinCallApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}{?flags*,forcePermissions*,silent*,recordingConsent*}',
@@ -3351,9 +3352,9 @@ class $CallClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3442,21 +3443,21 @@ class $CallClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $all = _$jsonSerializers.serialize(all, specifiedType: const FullType(CallLeaveCallAll));
-    $all ??= 0;
-    _parameters['all'] = $all;
+    var __all = _$jsonSerializers.serialize(all, specifiedType: const FullType(CallLeaveCallAll));
+    __all ??= 0;
+    _parameters['all'] = __all;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(CallLeaveCallApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(CallLeaveCallApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}{?all*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -3477,9 +3478,9 @@ class $CallClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3560,21 +3561,21 @@ class $CallClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
-    _parameters['attendeeId'] = $attendeeId;
+    final __attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
+    _parameters['attendeeId'] = __attendeeId;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(CallRingAttendeeApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/ring/{attendeeId}').expand(_parameters);
@@ -3596,9 +3597,9 @@ class $CallClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3681,20 +3682,20 @@ class $CallClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
-    _parameters['attendeeId'] = $attendeeId;
+    final __attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
+    _parameters['attendeeId'] = __attendeeId;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(CallSipDialOutApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(CallSipDialOutApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}/dialout/{attendeeId}')
         .expand(_parameters);
@@ -3716,9 +3717,9 @@ class $CallClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -3827,78 +3828,78 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $lookIntoFuture =
+    final __lookIntoFuture =
         _$jsonSerializers.serialize(lookIntoFuture, specifiedType: const FullType(ChatReceiveMessagesLookIntoFuture));
-    _parameters['lookIntoFuture'] = $lookIntoFuture;
+    _parameters['lookIntoFuture'] = __lookIntoFuture;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    $limit ??= 100;
-    _parameters['limit'] = $limit;
+    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    __limit ??= 100;
+    _parameters['limit'] = __limit;
 
-    var $lastKnownMessageId = _$jsonSerializers.serialize(lastKnownMessageId, specifiedType: const FullType(int));
-    $lastKnownMessageId ??= 0;
+    var __lastKnownMessageId = _$jsonSerializers.serialize(lastKnownMessageId, specifiedType: const FullType(int));
+    __lastKnownMessageId ??= 0;
     _i4.checkNumber(
-      $lastKnownMessageId,
+      __lastKnownMessageId,
       'lastKnownMessageId',
       minimum: 0,
     );
-    _parameters['lastKnownMessageId'] = $lastKnownMessageId;
+    _parameters['lastKnownMessageId'] = __lastKnownMessageId;
 
-    var $lastCommonReadId = _$jsonSerializers.serialize(lastCommonReadId, specifiedType: const FullType(int));
-    $lastCommonReadId ??= 0;
+    var __lastCommonReadId = _$jsonSerializers.serialize(lastCommonReadId, specifiedType: const FullType(int));
+    __lastCommonReadId ??= 0;
     _i4.checkNumber(
-      $lastCommonReadId,
+      __lastCommonReadId,
       'lastCommonReadId',
       minimum: 0,
     );
-    _parameters['lastCommonReadId'] = $lastCommonReadId;
+    _parameters['lastCommonReadId'] = __lastCommonReadId;
 
-    var $timeout = _$jsonSerializers.serialize(timeout, specifiedType: const FullType(int));
-    $timeout ??= 30;
+    var __timeout = _$jsonSerializers.serialize(timeout, specifiedType: const FullType(int));
+    __timeout ??= 30;
     _i4.checkNumber(
-      $timeout,
+      __timeout,
       'timeout',
       maximum: 30,
       minimum: 0,
     );
-    _parameters['timeout'] = $timeout;
+    _parameters['timeout'] = __timeout;
 
-    var $setReadMarker =
+    var __setReadMarker =
         _$jsonSerializers.serialize(setReadMarker, specifiedType: const FullType(ChatReceiveMessagesSetReadMarker));
-    $setReadMarker ??= 1;
-    _parameters['setReadMarker'] = $setReadMarker;
+    __setReadMarker ??= 1;
+    _parameters['setReadMarker'] = __setReadMarker;
 
-    var $includeLastKnown = _$jsonSerializers.serialize(
+    var __includeLastKnown = _$jsonSerializers.serialize(
       includeLastKnown,
       specifiedType: const FullType(ChatReceiveMessagesIncludeLastKnown),
     );
-    $includeLastKnown ??= 0;
-    _parameters['includeLastKnown'] = $includeLastKnown;
+    __includeLastKnown ??= 0;
+    _parameters['includeLastKnown'] = __includeLastKnown;
 
-    var $noStatusUpdate =
+    var __noStatusUpdate =
         _$jsonSerializers.serialize(noStatusUpdate, specifiedType: const FullType(ChatReceiveMessagesNoStatusUpdate));
-    $noStatusUpdate ??= 0;
-    _parameters['noStatusUpdate'] = $noStatusUpdate;
+    __noStatusUpdate ??= 0;
+    _parameters['noStatusUpdate'] = __noStatusUpdate;
 
-    var $markNotificationsAsRead = _$jsonSerializers.serialize(
+    var __markNotificationsAsRead = _$jsonSerializers.serialize(
       markNotificationsAsRead,
       specifiedType: const FullType(ChatReceiveMessagesMarkNotificationsAsRead),
     );
-    $markNotificationsAsRead ??= 1;
-    _parameters['markNotificationsAsRead'] = $markNotificationsAsRead;
+    __markNotificationsAsRead ??= 1;
+    _parameters['markNotificationsAsRead'] = __markNotificationsAsRead;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatReceiveMessagesApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}{?lookIntoFuture*,limit*,lastKnownMessageId*,lastCommonReadId*,timeout*,setReadMarker*,includeLastKnown*,noStatusUpdate*,markNotificationsAsRead*}',
@@ -3921,9 +3922,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4047,41 +4048,42 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
-    _parameters['message'] = $message;
+    final __message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
+    _parameters['message'] = __message;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $actorDisplayName = _$jsonSerializers.serialize(actorDisplayName, specifiedType: const FullType(String));
-    $actorDisplayName ??= '';
-    _parameters['actorDisplayName'] = $actorDisplayName;
+    var __actorDisplayName = _$jsonSerializers.serialize(actorDisplayName, specifiedType: const FullType(String));
+    __actorDisplayName ??= '';
+    _parameters['actorDisplayName'] = __actorDisplayName;
 
-    var $referenceId = _$jsonSerializers.serialize(referenceId, specifiedType: const FullType(String));
-    $referenceId ??= '';
-    _parameters['referenceId'] = $referenceId;
+    var __referenceId = _$jsonSerializers.serialize(referenceId, specifiedType: const FullType(String));
+    __referenceId ??= '';
+    _parameters['referenceId'] = __referenceId;
 
-    var $replyTo = _$jsonSerializers.serialize(replyTo, specifiedType: const FullType(int));
-    $replyTo ??= 0;
+    var __replyTo = _$jsonSerializers.serialize(replyTo, specifiedType: const FullType(int));
+    __replyTo ??= 0;
     _i4.checkNumber(
-      $replyTo,
+      __replyTo,
       'replyTo',
       minimum: 0,
     );
-    _parameters['replyTo'] = $replyTo;
+    _parameters['replyTo'] = __replyTo;
 
-    var $silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(ChatSendMessageSilent));
-    $silent ??= 0;
-    _parameters['silent'] = $silent;
+    var __silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(ChatSendMessageSilent));
+    __silent ??= 0;
+    _parameters['silent'] = __silent;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatSendMessageApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion =
+        _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatSendMessageApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}{?message*,actorDisplayName*,referenceId*,replyTo*,silent*}',
@@ -4104,9 +4106,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4203,18 +4205,18 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatClearHistoryApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -4237,9 +4239,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4325,28 +4327,29 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
-    _parameters['message'] = $message;
+    final __message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
+    _parameters['message'] = __message;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $messageId,
+      __messageId,
       'messageId',
       minimum: 0,
     );
-    _parameters['messageId'] = $messageId;
+    _parameters['messageId'] = __messageId;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatEditMessageApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion =
+        _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatEditMessageApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}{?message*}')
         .expand(_parameters);
@@ -4368,9 +4371,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4463,26 +4466,26 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $messageId,
+      __messageId,
       'messageId',
       minimum: 0,
     );
-    _parameters['messageId'] = $messageId;
+    _parameters['messageId'] = __messageId;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatDeleteMessageApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}').expand(_parameters);
@@ -4504,9 +4507,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4593,36 +4596,36 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $messageId,
+      __messageId,
       'messageId',
       minimum: 0,
     );
-    _parameters['messageId'] = $messageId;
+    _parameters['messageId'] = __messageId;
 
-    var $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    $limit ??= 50;
+    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    __limit ??= 50;
     _i4.checkNumber(
-      $limit,
+      __limit,
       'limit',
       maximum: 100,
       minimum: 1,
     );
-    _parameters['limit'] = $limit;
+    _parameters['limit'] = __limit;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatGetMessageContextApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/context{?limit*}')
         .expand(_parameters);
@@ -4644,9 +4647,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4732,25 +4735,26 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $messageId,
+      __messageId,
       'messageId',
       minimum: 0,
     );
-    _parameters['messageId'] = $messageId;
+    _parameters['messageId'] = __messageId;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatGetReminderApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion =
+        _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatGetReminderApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder')
         .expand(_parameters);
@@ -4774,9 +4778,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4858,33 +4862,34 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $timestamp = _$jsonSerializers.serialize(timestamp, specifiedType: const FullType(int));
+    final __timestamp = _$jsonSerializers.serialize(timestamp, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $timestamp,
+      __timestamp,
       'timestamp',
       minimum: 0,
     );
-    _parameters['timestamp'] = $timestamp;
+    _parameters['timestamp'] = __timestamp;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $messageId,
+      __messageId,
       'messageId',
       minimum: 0,
     );
-    _parameters['messageId'] = $messageId;
+    _parameters['messageId'] = __messageId;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatSetReminderApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion =
+        _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatSetReminderApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder{?timestamp*}')
@@ -4909,9 +4914,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -4994,26 +4999,26 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $messageId,
+      __messageId,
       'messageId',
       minimum: 0,
     );
-    _parameters['messageId'] = $messageId;
+    _parameters['messageId'] = __messageId;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatDeleteReminderApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder')
         .expand(_parameters);
@@ -5037,9 +5042,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5118,26 +5123,26 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $lastReadMessage = _$jsonSerializers.serialize(lastReadMessage, specifiedType: const FullType(int));
+    final __lastReadMessage = _$jsonSerializers.serialize(lastReadMessage, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $lastReadMessage,
+      __lastReadMessage,
       'lastReadMessage',
       minimum: 0,
     );
-    _parameters['lastReadMessage'] = $lastReadMessage;
+    _parameters['lastReadMessage'] = __lastReadMessage;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatSetReadMarkerApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/read{?lastReadMessage*}')
         .expand(_parameters);
@@ -5159,9 +5164,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5238,17 +5243,17 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatMarkUnreadApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatMarkUnreadApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/read').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -5269,9 +5274,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5350,29 +5355,29 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    _parameters['search'] = $search;
+    final __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
+    _parameters['search'] = __search;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    $limit ??= 20;
-    _parameters['limit'] = $limit;
+    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    __limit ??= 20;
+    _parameters['limit'] = __limit;
 
-    var $includeStatus =
+    var __includeStatus =
         _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(ChatMentionsIncludeStatus));
-    $includeStatus ??= 0;
-    _parameters['includeStatus'] = $includeStatus;
+    __includeStatus ??= 0;
+    _parameters['includeStatus'] = __includeStatus;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatMentionsApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatMentionsApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/mentions{?search*,limit*,includeStatus*}',
@@ -5395,9 +5400,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5485,40 +5490,40 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $objectType = _$jsonSerializers.serialize(objectType, specifiedType: const FullType(String));
-    _parameters['objectType'] = $objectType;
+    final __objectType = _$jsonSerializers.serialize(objectType, specifiedType: const FullType(String));
+    _parameters['objectType'] = __objectType;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $lastKnownMessageId = _$jsonSerializers.serialize(lastKnownMessageId, specifiedType: const FullType(int));
-    $lastKnownMessageId ??= 0;
+    var __lastKnownMessageId = _$jsonSerializers.serialize(lastKnownMessageId, specifiedType: const FullType(int));
+    __lastKnownMessageId ??= 0;
     _i4.checkNumber(
-      $lastKnownMessageId,
+      __lastKnownMessageId,
       'lastKnownMessageId',
       minimum: 0,
     );
-    _parameters['lastKnownMessageId'] = $lastKnownMessageId;
+    _parameters['lastKnownMessageId'] = __lastKnownMessageId;
 
-    var $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    $limit ??= 100;
+    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    __limit ??= 100;
     _i4.checkNumber(
-      $limit,
+      __limit,
       'limit',
       maximum: 200,
       minimum: 1,
     );
-    _parameters['limit'] = $limit;
+    _parameters['limit'] = __limit;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatGetObjectsSharedInRoomApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share{?objectType*,lastKnownMessageId*,limit*}',
@@ -5541,9 +5546,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5643,36 +5648,36 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $objectType = _$jsonSerializers.serialize(objectType, specifiedType: const FullType(String));
-    _parameters['objectType'] = $objectType;
+    final __objectType = _$jsonSerializers.serialize(objectType, specifiedType: const FullType(String));
+    _parameters['objectType'] = __objectType;
 
-    final $objectId = _$jsonSerializers.serialize(objectId, specifiedType: const FullType(String));
-    _parameters['objectId'] = $objectId;
+    final __objectId = _$jsonSerializers.serialize(objectId, specifiedType: const FullType(String));
+    _parameters['objectId'] = __objectId;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $metaData = _$jsonSerializers.serialize(metaData, specifiedType: const FullType(String));
-    $metaData ??= '';
-    _parameters['metaData'] = $metaData;
+    var __metaData = _$jsonSerializers.serialize(metaData, specifiedType: const FullType(String));
+    __metaData ??= '';
+    _parameters['metaData'] = __metaData;
 
-    var $actorDisplayName = _$jsonSerializers.serialize(actorDisplayName, specifiedType: const FullType(String));
-    $actorDisplayName ??= '';
-    _parameters['actorDisplayName'] = $actorDisplayName;
+    var __actorDisplayName = _$jsonSerializers.serialize(actorDisplayName, specifiedType: const FullType(String));
+    __actorDisplayName ??= '';
+    _parameters['actorDisplayName'] = __actorDisplayName;
 
-    var $referenceId = _$jsonSerializers.serialize(referenceId, specifiedType: const FullType(String));
-    $referenceId ??= '';
-    _parameters['referenceId'] = $referenceId;
+    var __referenceId = _$jsonSerializers.serialize(referenceId, specifiedType: const FullType(String));
+    __referenceId ??= '';
+    _parameters['referenceId'] = __referenceId;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatShareObjectToChatApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share{?objectType*,objectId*,metaData*,actorDisplayName*,referenceId*}',
@@ -5695,9 +5700,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5795,30 +5800,30 @@ class $ChatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    $limit ??= 7;
+    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    __limit ??= 7;
     _i4.checkNumber(
-      $limit,
+      __limit,
       'limit',
       maximum: 20,
       minimum: 1,
     );
-    _parameters['limit'] = $limit;
+    _parameters['limit'] = __limit;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(ChatGetObjectsSharedInRoomOverviewApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share/overview{?limit*}')
         .expand(_parameters);
@@ -5840,9 +5845,9 @@ class $ChatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -5929,14 +5934,14 @@ class $ExternalSignalingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    $token ??= '';
-    _parameters['token'] = $token;
+    var __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    __token ??= '';
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SignalingGetSettingsApiVersion));
-    $apiVersion ??= 'v3';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v3';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/settings{?token*}').expand(_parameters);
@@ -5958,9 +5963,9 @@ class $ExternalSignalingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -6047,18 +6052,18 @@ class $FederationClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $id,
+      __id,
       'id',
       minimum: 0,
     );
-    _parameters['id'] = $id;
+    _parameters['id'] = __id;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(FederationAcceptShareApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/federation/invitation/{id}').expand(_parameters);
@@ -6082,9 +6087,9 @@ class $FederationClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -6166,18 +6171,18 @@ class $FederationClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
+    final __id = _$jsonSerializers.serialize(id, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $id,
+      __id,
       'id',
       minimum: 0,
     );
-    _parameters['id'] = $id;
+    _parameters['id'] = __id;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(FederationRejectShareApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/federation/invitation/{id}').expand(_parameters);
@@ -6201,9 +6206,9 @@ class $FederationClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -6280,10 +6285,10 @@ class $FederationClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(FederationGetSharesApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/federation/invitation').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -6306,9 +6311,9 @@ class $FederationClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -6393,20 +6398,20 @@ class $FilesIntegrationClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(String));
+    final __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(String));
     _i4.checkString(
-      $fileId,
+      __fileId,
       'fileId',
       pattern: RegExp(r'^.+$'),
     );
-    _parameters['fileId'] = $fileId;
+    _parameters['fileId'] = __fileId;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(FilesIntegrationGetRoomByFileIdApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/file/{fileId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -6429,9 +6434,9 @@ class $FilesIntegrationClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -6518,20 +6523,20 @@ class $FilesIntegrationClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $shareToken = _$jsonSerializers.serialize(shareToken, specifiedType: const FullType(String));
+    final __shareToken = _$jsonSerializers.serialize(shareToken, specifiedType: const FullType(String));
     _i4.checkString(
-      $shareToken,
+      __shareToken,
       'shareToken',
       pattern: RegExp(r'^.+$'),
     );
-    _parameters['shareToken'] = $shareToken;
+    _parameters['shareToken'] = __shareToken;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(FilesIntegrationGetRoomByShareTokenApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/publicshare/{shareToken}').expand(_parameters);
@@ -6553,9 +6558,9 @@ class $FilesIntegrationClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -6640,13 +6645,13 @@ class $FilesIntegrationClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $shareToken = _$jsonSerializers.serialize(shareToken, specifiedType: const FullType(String));
-    _parameters['shareToken'] = $shareToken;
+    final __shareToken = _$jsonSerializers.serialize(shareToken, specifiedType: const FullType(String));
+    _parameters['shareToken'] = __shareToken;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PublicShareAuthCreateRoomApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/publicshareauth{?shareToken*}').expand(_parameters);
@@ -6668,9 +6673,9 @@ class $FilesIntegrationClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -6758,21 +6763,21 @@ class $GuestClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $displayName = _$jsonSerializers.serialize(displayName, specifiedType: const FullType(String));
-    _parameters['displayName'] = $displayName;
+    final __displayName = _$jsonSerializers.serialize(displayName, specifiedType: const FullType(String));
+    _parameters['displayName'] = __displayName;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(GuestSetDisplayNameApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/guest/{token}/name{?displayName*}')
         .expand(_parameters);
@@ -6794,9 +6799,9 @@ class $GuestClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -6893,27 +6898,27 @@ class $HostedSignalingServerClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $url = _$jsonSerializers.serialize(url, specifiedType: const FullType(String));
-    _parameters['url'] = $url;
+    final __url = _$jsonSerializers.serialize(url, specifiedType: const FullType(String));
+    _parameters['url'] = __url;
 
-    final $name = _$jsonSerializers.serialize(name, specifiedType: const FullType(String));
-    _parameters['name'] = $name;
+    final __name = _$jsonSerializers.serialize(name, specifiedType: const FullType(String));
+    _parameters['name'] = __name;
 
-    final $email = _$jsonSerializers.serialize(email, specifiedType: const FullType(String));
-    _parameters['email'] = $email;
+    final __email = _$jsonSerializers.serialize(email, specifiedType: const FullType(String));
+    _parameters['email'] = __email;
 
-    final $language = _$jsonSerializers.serialize(language, specifiedType: const FullType(String));
-    _parameters['language'] = $language;
+    final __language = _$jsonSerializers.serialize(language, specifiedType: const FullType(String));
+    _parameters['language'] = __language;
 
-    final $country = _$jsonSerializers.serialize(country, specifiedType: const FullType(String));
-    _parameters['country'] = $country;
+    final __country = _$jsonSerializers.serialize(country, specifiedType: const FullType(String));
+    _parameters['country'] = __country;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(HostedSignalingServerRequestTrialApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/hostedsignalingserver/requesttrial{?url*,name*,email*,language*,country*}',
@@ -6938,9 +6943,9 @@ class $HostedSignalingServerClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -7031,12 +7036,12 @@ class $HostedSignalingServerClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(HostedSignalingServerDeleteAccountApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/hostedsignalingserver/delete').expand(_parameters);
@@ -7059,9 +7064,9 @@ class $HostedSignalingServerClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -7143,14 +7148,14 @@ class $InternalSignalingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    $token ??= '';
-    _parameters['token'] = $token;
+    var __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    __token ??= '';
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SignalingGetSettingsApiVersion));
-    $apiVersion ??= 'v3';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v3';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/settings{?token*}').expand(_parameters);
@@ -7172,9 +7177,9 @@ class $InternalSignalingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -7252,18 +7257,18 @@ class $InternalSignalingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SignalingPullMessagesApiVersion));
-    $apiVersion ??= 'v3';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v3';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -7284,9 +7289,9 @@ class $InternalSignalingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -7365,21 +7370,21 @@ class $InternalSignalingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $messages = _$jsonSerializers.serialize(messages, specifiedType: const FullType(String));
-    _parameters['messages'] = $messages;
+    final __messages = _$jsonSerializers.serialize(messages, specifiedType: const FullType(String));
+    _parameters['messages'] = __messages;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SignalingSendMessagesApiVersion));
-    $apiVersion ??= 'v3';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v3';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/{token}{?messages*}').expand(_parameters);
@@ -7401,9 +7406,9 @@ class $InternalSignalingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -7487,18 +7492,18 @@ class $MatterbridgeClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(MatterbridgeGetBridgeOfRoomApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -7521,9 +7526,9 @@ class $MatterbridgeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -7601,19 +7606,19 @@ class $MatterbridgeClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $enabled =
+    final __enabled =
         _$jsonSerializers.serialize(enabled, specifiedType: const FullType(MatterbridgeEditBridgeOfRoomEnabled));
-    _parameters['enabled'] = $enabled;
+    _parameters['enabled'] = __enabled;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $parts = _$jsonSerializers.serialize(
+    final __parts = _$jsonSerializers.serialize(
       parts,
       specifiedType: const FullType(ContentString, [
         FullType(BuiltList, [
@@ -7621,12 +7626,12 @@ class $MatterbridgeClient {
         ]),
       ]),
     );
-    _parameters['parts'] = $parts;
+    _parameters['parts'] = __parts;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(MatterbridgeEditBridgeOfRoomApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}{?enabled*,parts*}')
         .expand(_parameters);
@@ -7650,9 +7655,9 @@ class $MatterbridgeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -7733,20 +7738,20 @@ class $MatterbridgeClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(MatterbridgeDeleteBridgeOfRoomApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -7769,9 +7774,9 @@ class $MatterbridgeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -7845,20 +7850,20 @@ class $MatterbridgeClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(MatterbridgeGetBridgeProcessStateApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}/process').expand(_parameters);
@@ -7882,9 +7887,9 @@ class $MatterbridgeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -7959,12 +7964,12 @@ class $MatterbridgeClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(MatterbridgeSettingsStopAllBridgesApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -7987,9 +7992,9 @@ class $MatterbridgeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -8065,12 +8070,12 @@ class $MatterbridgeClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(MatterbridgeSettingsGetMatterbridgeVersionApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/version').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -8093,9 +8098,9 @@ class $MatterbridgeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -8186,30 +8191,31 @@ class $PollClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $question = _$jsonSerializers.serialize(question, specifiedType: const FullType(String));
-    _parameters['question'] = $question;
+    final __question = _$jsonSerializers.serialize(question, specifiedType: const FullType(String));
+    _parameters['question'] = __question;
 
-    final $options = _$jsonSerializers.serialize(options, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    _parameters['options%5B%5D'] = $options;
+    final __options =
+        _$jsonSerializers.serialize(options, specifiedType: const FullType(BuiltList, [FullType(String)]));
+    _parameters['options%5B%5D'] = __options;
 
-    final $resultMode =
+    final __resultMode =
         _$jsonSerializers.serialize(resultMode, specifiedType: const FullType(PollCreatePollResultMode));
-    _parameters['resultMode'] = $resultMode;
+    _parameters['resultMode'] = __resultMode;
 
-    final $maxVotes = _$jsonSerializers.serialize(maxVotes, specifiedType: const FullType(int));
-    _parameters['maxVotes'] = $maxVotes;
+    final __maxVotes = _$jsonSerializers.serialize(maxVotes, specifiedType: const FullType(int));
+    _parameters['maxVotes'] = __maxVotes;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PollCreatePollApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PollCreatePollApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}{?question*,options%5B%5D*,resultMode*,maxVotes*}',
@@ -8232,9 +8238,9 @@ class $PollClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -8322,25 +8328,25 @@ class $PollClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $pollId = _$jsonSerializers.serialize(pollId, specifiedType: const FullType(int));
+    final __pollId = _$jsonSerializers.serialize(pollId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $pollId,
+      __pollId,
       'pollId',
       minimum: 0,
     );
-    _parameters['pollId'] = $pollId;
+    _parameters['pollId'] = __pollId;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PollShowPollApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PollShowPollApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -8361,9 +8367,9 @@ class $PollClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -8445,29 +8451,29 @@ class $PollClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $pollId = _$jsonSerializers.serialize(pollId, specifiedType: const FullType(int));
+    final __pollId = _$jsonSerializers.serialize(pollId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $pollId,
+      __pollId,
       'pollId',
       minimum: 0,
     );
-    _parameters['pollId'] = $pollId;
+    _parameters['pollId'] = __pollId;
 
-    var $optionIds = _$jsonSerializers.serialize(optionIds, specifiedType: const FullType(BuiltList, [FullType(int)]));
-    $optionIds ??= const [];
-    _parameters['optionIds%5B%5D'] = $optionIds;
+    var __optionIds = _$jsonSerializers.serialize(optionIds, specifiedType: const FullType(BuiltList, [FullType(int)]));
+    __optionIds ??= const [];
+    _parameters['optionIds%5B%5D'] = __optionIds;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PollVotePollApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PollVotePollApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}{?optionIds%5B%5D*}')
         .expand(_parameters);
@@ -8489,9 +8495,9 @@ class $PollClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -8577,25 +8583,25 @@ class $PollClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $pollId = _$jsonSerializers.serialize(pollId, specifiedType: const FullType(int));
+    final __pollId = _$jsonSerializers.serialize(pollId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $pollId,
+      __pollId,
       'pollId',
       minimum: 0,
     );
-    _parameters['pollId'] = $pollId;
+    _parameters['pollId'] = __pollId;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PollClosePollApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PollClosePollApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -8616,9 +8622,9 @@ class $PollClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -8710,29 +8716,29 @@ class $ReactionClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $messageId,
+      __messageId,
       'messageId',
       minimum: 0,
     );
-    _parameters['messageId'] = $messageId;
+    _parameters['messageId'] = __messageId;
 
-    final $reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
-    _parameters['reaction'] = $reaction;
+    final __reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
+    _parameters['reaction'] = __reaction;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ReactionGetReactionsApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}{?reaction*}')
         .expand(_parameters);
@@ -8754,9 +8760,9 @@ class $ReactionClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -8842,28 +8848,28 @@ class $ReactionClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
-    _parameters['reaction'] = $reaction;
+    final __reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
+    _parameters['reaction'] = __reaction;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $messageId,
+      __messageId,
       'messageId',
       minimum: 0,
     );
-    _parameters['messageId'] = $messageId;
+    _parameters['messageId'] = __messageId;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ReactionReactApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ReactionReactApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}{?reaction*}')
         .expand(_parameters);
@@ -8885,9 +8891,9 @@ class $ReactionClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -8974,28 +8980,28 @@ class $ReactionClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
-    _parameters['reaction'] = $reaction;
+    final __reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
+    _parameters['reaction'] = __reaction;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $messageId,
+      __messageId,
       'messageId',
       minimum: 0,
     );
-    _parameters['messageId'] = $messageId;
+    _parameters['messageId'] = __messageId;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ReactionDeleteApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ReactionDeleteApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}{?reaction*}')
         .expand(_parameters);
@@ -9017,9 +9023,9 @@ class $ReactionClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -9109,20 +9115,20 @@ class $RecordingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $status = _$jsonSerializers.serialize(status, specifiedType: const FullType(int));
-    _parameters['status'] = $status;
+    final __status = _$jsonSerializers.serialize(status, specifiedType: const FullType(int));
+    _parameters['status'] = __status;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RecordingStartApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RecordingStartApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}{?status*}').expand(_parameters);
@@ -9146,9 +9152,9 @@ class $RecordingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -9225,17 +9231,17 @@ class $RecordingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RecordingStopApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RecordingStopApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -9258,9 +9264,9 @@ class $RecordingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -9337,26 +9343,26 @@ class $RecordingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $timestamp = _$jsonSerializers.serialize(timestamp, specifiedType: const FullType(int));
+    final __timestamp = _$jsonSerializers.serialize(timestamp, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $timestamp,
+      __timestamp,
       'timestamp',
       minimum: 0,
     );
-    _parameters['timestamp'] = $timestamp;
+    _parameters['timestamp'] = __timestamp;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RecordingNotificationDismissApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/notification{?timestamp*}')
@@ -9381,9 +9387,9 @@ class $RecordingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -9465,34 +9471,34 @@ class $RecordingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
+    final __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $fileId,
+      __fileId,
       'fileId',
       minimum: 0,
     );
-    _parameters['fileId'] = $fileId;
+    _parameters['fileId'] = __fileId;
 
-    final $timestamp = _$jsonSerializers.serialize(timestamp, specifiedType: const FullType(int));
+    final __timestamp = _$jsonSerializers.serialize(timestamp, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $timestamp,
+      __timestamp,
       'timestamp',
       minimum: 0,
     );
-    _parameters['timestamp'] = $timestamp;
+    _parameters['timestamp'] = __timestamp;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RecordingShareToChatApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/share-chat{?fileId*,timestamp*}')
@@ -9517,9 +9523,9 @@ class $RecordingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -9599,10 +9605,10 @@ class $RecordingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RecordingBackendApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/backend').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -9623,9 +9629,9 @@ class $RecordingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -9701,20 +9707,20 @@ class $RecordingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $owner = _$jsonSerializers.serialize(owner, specifiedType: const FullType(String));
-    _parameters['owner'] = $owner;
+    final __owner = _$jsonSerializers.serialize(owner, specifiedType: const FullType(String));
+    _parameters['owner'] = __owner;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RecordingStoreApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RecordingStoreApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/store{?owner*}')
         .expand(_parameters);
@@ -9736,9 +9742,9 @@ class $RecordingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -9827,28 +9833,28 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $noStatusUpdate =
+    var __noStatusUpdate =
         _$jsonSerializers.serialize(noStatusUpdate, specifiedType: const FullType(RoomGetRoomsNoStatusUpdate));
-    $noStatusUpdate ??= 0;
-    _parameters['noStatusUpdate'] = $noStatusUpdate;
+    __noStatusUpdate ??= 0;
+    _parameters['noStatusUpdate'] = __noStatusUpdate;
 
-    var $includeStatus =
+    var __includeStatus =
         _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(RoomGetRoomsIncludeStatus));
-    $includeStatus ??= 0;
-    _parameters['includeStatus'] = $includeStatus;
+    __includeStatus ??= 0;
+    _parameters['includeStatus'] = __includeStatus;
 
-    var $modifiedSince = _$jsonSerializers.serialize(modifiedSince, specifiedType: const FullType(int));
-    $modifiedSince ??= 0;
+    var __modifiedSince = _$jsonSerializers.serialize(modifiedSince, specifiedType: const FullType(int));
+    __modifiedSince ??= 0;
     _i4.checkNumber(
-      $modifiedSince,
+      __modifiedSince,
       'modifiedSince',
       minimum: 0,
     );
-    _parameters['modifiedSince'] = $modifiedSince;
+    _parameters['modifiedSince'] = __modifiedSince;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomGetRoomsApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomGetRoomsApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room{?noStatusUpdate*,includeStatus*,modifiedSince*}')
@@ -9873,9 +9879,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -9969,32 +9975,32 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $roomType = _$jsonSerializers.serialize(roomType, specifiedType: const FullType(int));
-    _parameters['roomType'] = $roomType;
+    final __roomType = _$jsonSerializers.serialize(roomType, specifiedType: const FullType(int));
+    _parameters['roomType'] = __roomType;
 
-    var $invite = _$jsonSerializers.serialize(invite, specifiedType: const FullType(String));
-    $invite ??= '';
-    _parameters['invite'] = $invite;
+    var __invite = _$jsonSerializers.serialize(invite, specifiedType: const FullType(String));
+    __invite ??= '';
+    _parameters['invite'] = __invite;
 
-    var $roomName = _$jsonSerializers.serialize(roomName, specifiedType: const FullType(String));
-    $roomName ??= '';
-    _parameters['roomName'] = $roomName;
+    var __roomName = _$jsonSerializers.serialize(roomName, specifiedType: const FullType(String));
+    __roomName ??= '';
+    _parameters['roomName'] = __roomName;
 
-    var $source = _$jsonSerializers.serialize(source, specifiedType: const FullType(String));
-    $source ??= '';
-    _parameters['source'] = $source;
+    var __source = _$jsonSerializers.serialize(source, specifiedType: const FullType(String));
+    __source ??= '';
+    _parameters['source'] = __source;
 
-    var $objectType = _$jsonSerializers.serialize(objectType, specifiedType: const FullType(String));
-    $objectType ??= '';
-    _parameters['objectType'] = $objectType;
+    var __objectType = _$jsonSerializers.serialize(objectType, specifiedType: const FullType(String));
+    __objectType ??= '';
+    _parameters['objectType'] = __objectType;
 
-    var $objectId = _$jsonSerializers.serialize(objectId, specifiedType: const FullType(String));
-    $objectId ??= '';
-    _parameters['objectId'] = $objectId;
+    var __objectId = _$jsonSerializers.serialize(objectId, specifiedType: const FullType(String));
+    __objectId ??= '';
+    _parameters['objectId'] = __objectId;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomCreateRoomApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomCreateRoomApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/room{?roomType*,invite*,roomName*,source*,objectType*,objectId*}',
@@ -10019,9 +10025,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -10113,14 +10119,14 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $searchTerm = _$jsonSerializers.serialize(searchTerm, specifiedType: const FullType(String));
-    $searchTerm ??= '';
-    _parameters['searchTerm'] = $searchTerm;
+    var __searchTerm = _$jsonSerializers.serialize(searchTerm, specifiedType: const FullType(String));
+    __searchTerm ??= '';
+    _parameters['searchTerm'] = __searchTerm;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomGetListedRoomsApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/listed-room{?searchTerm*}').expand(_parameters);
@@ -10144,9 +10150,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -10219,10 +10225,10 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomGetNoteToSelfConversationApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/note-to-self').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -10245,9 +10251,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -10324,18 +10330,18 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomGetSingleRoomApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -10356,9 +10362,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -10437,18 +10443,18 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomGetBreakoutRoomsApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/breakout-rooms').expand(_parameters);
@@ -10472,9 +10478,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -10551,17 +10557,17 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomMakePublicApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomMakePublicApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/public').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -10584,9 +10590,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -10661,17 +10667,18 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomMakePrivateApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion =
+        _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomMakePrivateApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/public').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -10694,9 +10701,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -10773,21 +10780,21 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $description = _$jsonSerializers.serialize(description, specifiedType: const FullType(String));
-    _parameters['description'] = $description;
+    final __description = _$jsonSerializers.serialize(description, specifiedType: const FullType(String));
+    _parameters['description'] = __description;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetDescriptionApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/description{?description*}')
         .expand(_parameters);
@@ -10809,9 +10816,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -10891,20 +10898,21 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $state = _$jsonSerializers.serialize(state, specifiedType: const FullType(RoomSetReadOnlyState));
-    _parameters['state'] = $state;
+    final __state = _$jsonSerializers.serialize(state, specifiedType: const FullType(RoomSetReadOnlyState));
+    _parameters['state'] = __state;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetReadOnlyApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion =
+        _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetReadOnlyApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/read-only{?state*}').expand(_parameters);
@@ -10928,9 +10936,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -11010,20 +11018,21 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $scope = _$jsonSerializers.serialize(scope, specifiedType: const FullType(RoomSetListableScope));
-    _parameters['scope'] = $scope;
+    final __scope = _$jsonSerializers.serialize(scope, specifiedType: const FullType(RoomSetListableScope));
+    _parameters['scope'] = __scope;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetListableApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion =
+        _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetListableApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/listable{?scope*}').expand(_parameters);
@@ -11047,9 +11056,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -11130,20 +11139,21 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    _parameters['password'] = $password;
+    final __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
+    _parameters['password'] = __password;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetPasswordApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion =
+        _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetPasswordApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/password{?password*}')
         .expand(_parameters);
@@ -11165,9 +11175,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -11250,35 +11260,35 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
+    final __permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $permissions,
+      __permissions,
       'permissions',
       maximum: 255,
       minimum: 0,
     );
-    _parameters['permissions'] = $permissions;
+    _parameters['permissions'] = __permissions;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $mode = _$jsonSerializers.serialize(mode, specifiedType: const FullType(RoomSetPermissionsMode));
+    final __mode = _$jsonSerializers.serialize(mode, specifiedType: const FullType(RoomSetPermissionsMode));
     _i4.checkString(
-      $mode,
+      __mode,
       'mode',
       pattern: RegExp(r'^(call|default)$'),
     );
-    _parameters['mode'] = $mode;
+    _parameters['mode'] = __mode;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetPermissionsApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/permissions/{mode}{?permissions*}')
@@ -11301,9 +11311,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -11386,23 +11396,23 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $includeStatus =
+    var __includeStatus =
         _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(RoomGetParticipantsIncludeStatus));
-    $includeStatus ??= 0;
-    _parameters['includeStatus'] = $includeStatus;
+    __includeStatus ??= 0;
+    _parameters['includeStatus'] = __includeStatus;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomGetParticipantsApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants{?includeStatus*}')
         .expand(_parameters);
@@ -11424,9 +11434,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -11513,25 +11523,25 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $newParticipant = _$jsonSerializers.serialize(newParticipant, specifiedType: const FullType(String));
-    _parameters['newParticipant'] = $newParticipant;
+    final __newParticipant = _$jsonSerializers.serialize(newParticipant, specifiedType: const FullType(String));
+    _parameters['newParticipant'] = __newParticipant;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $source = _$jsonSerializers.serialize(source, specifiedType: const FullType(RoomAddParticipantToRoomSource));
-    $source ??= 'users';
-    _parameters['source'] = $source;
+    var __source = _$jsonSerializers.serialize(source, specifiedType: const FullType(RoomAddParticipantToRoomSource));
+    __source ??= 'users';
+    _parameters['source'] = __source;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomAddParticipantToRoomApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants{?newParticipant*,source*}')
@@ -11556,9 +11566,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -11645,27 +11655,27 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $includeStatus = _$jsonSerializers.serialize(
+    var __includeStatus = _$jsonSerializers.serialize(
       includeStatus,
       specifiedType: const FullType(RoomGetBreakoutRoomParticipantsIncludeStatus),
     );
-    $includeStatus ??= 0;
-    _parameters['includeStatus'] = $includeStatus;
+    __includeStatus ??= 0;
+    _parameters['includeStatus'] = __includeStatus;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(RoomGetBreakoutRoomParticipantsApiVersion),
     );
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/breakout-rooms/participants{?includeStatus*}',
@@ -11688,9 +11698,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -11773,18 +11783,18 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomRemoveSelfFromRoomApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/self').expand(_parameters);
@@ -11808,9 +11818,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -11890,26 +11900,26 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
+    final __attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $attendeeId,
+      __attendeeId,
       'attendeeId',
       minimum: 0,
     );
-    _parameters['attendeeId'] = $attendeeId;
+    _parameters['attendeeId'] = __attendeeId;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomRemoveAttendeeFromRoomApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees{?attendeeId*}')
         .expand(_parameters);
@@ -11931,9 +11941,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -12021,39 +12031,39 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
+    final __attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $attendeeId,
+      __attendeeId,
       'attendeeId',
       minimum: 0,
     );
-    _parameters['attendeeId'] = $attendeeId;
+    _parameters['attendeeId'] = __attendeeId;
 
-    final $method =
+    final __method =
         _$jsonSerializers.serialize(method, specifiedType: const FullType(RoomSetAttendeePermissionsMethod));
-    _parameters['method'] = $method;
+    _parameters['method'] = __method;
 
-    final $permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
+    final __permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $permissions,
+      __permissions,
       'permissions',
       maximum: 255,
       minimum: 0,
     );
-    _parameters['permissions'] = $permissions;
+    _parameters['permissions'] = __permissions;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetAttendeePermissionsApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees/permissions{?attendeeId*,method*,permissions*}',
@@ -12076,9 +12086,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -12168,33 +12178,33 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $method =
+    final __method =
         _$jsonSerializers.serialize(method, specifiedType: const FullType(RoomSetAllAttendeesPermissionsMethod));
-    _parameters['method'] = $method;
+    _parameters['method'] = __method;
 
-    final $permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
+    final __permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $permissions,
+      __permissions,
       'permissions',
       maximum: 255,
       minimum: 0,
     );
-    _parameters['permissions'] = $permissions;
+    _parameters['permissions'] = __permissions;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(RoomSetAllAttendeesPermissionsApiVersion),
     );
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees/permissions/all{?method*,permissions*}',
@@ -12217,9 +12227,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -12306,25 +12316,25 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    $password ??= '';
-    _parameters['password'] = $password;
+    var __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
+    __password ??= '';
+    _parameters['password'] = __password;
 
-    var $force = _$jsonSerializers.serialize(force, specifiedType: const FullType(RoomJoinRoomForce));
-    $force ??= 1;
-    _parameters['force'] = $force;
+    var __force = _$jsonSerializers.serialize(force, specifiedType: const FullType(RoomJoinRoomForce));
+    __force ??= 1;
+    _parameters['force'] = __force;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomJoinRoomApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomJoinRoomApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/active{?password*,force*}')
@@ -12347,9 +12357,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -12431,17 +12441,17 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomLeaveRoomApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomLeaveRoomApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/active')
         .expand(_parameters);
@@ -12463,9 +12473,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -12541,26 +12551,26 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
+    final __attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $attendeeId,
+      __attendeeId,
       'attendeeId',
       minimum: 0,
     );
-    _parameters['attendeeId'] = $attendeeId;
+    _parameters['attendeeId'] = __attendeeId;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomResendInvitationsApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/resend-invitations{?attendeeId*}',
@@ -12585,9 +12595,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -12668,21 +12678,21 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $state = _$jsonSerializers.serialize(state, specifiedType: const FullType(RoomSetSessionStateState));
-    _parameters['state'] = $state;
+    final __state = _$jsonSerializers.serialize(state, specifiedType: const FullType(RoomSetSessionStateState));
+    _parameters['state'] = __state;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetSessionStateApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/state{?state*}')
         .expand(_parameters);
@@ -12704,9 +12714,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -12789,26 +12799,26 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
+    final __attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $attendeeId,
+      __attendeeId,
       'attendeeId',
       minimum: 0,
     );
-    _parameters['attendeeId'] = $attendeeId;
+    _parameters['attendeeId'] = __attendeeId;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomPromoteModeratorApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/moderators{?attendeeId*}')
         .expand(_parameters);
@@ -12830,9 +12840,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -12916,26 +12926,26 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
+    final __attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $attendeeId,
+      __attendeeId,
       'attendeeId',
       minimum: 0,
     );
-    _parameters['attendeeId'] = $attendeeId;
+    _parameters['attendeeId'] = __attendeeId;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomDemoteModeratorApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/moderators{?attendeeId*}')
         .expand(_parameters);
@@ -12957,9 +12967,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -13038,18 +13048,18 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomAddToFavoritesApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/favorite').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -13072,9 +13082,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -13147,18 +13157,18 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomRemoveFromFavoritesApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/favorite').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -13181,9 +13191,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -13259,21 +13269,21 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $level = _$jsonSerializers.serialize(level, specifiedType: const FullType(int));
-    _parameters['level'] = $level;
+    final __level = _$jsonSerializers.serialize(level, specifiedType: const FullType(int));
+    _parameters['level'] = __level;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetNotificationLevelApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/notify{?level*}').expand(_parameters);
@@ -13297,9 +13307,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -13379,21 +13389,21 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $level = _$jsonSerializers.serialize(level, specifiedType: const FullType(int));
-    _parameters['level'] = $level;
+    final __level = _$jsonSerializers.serialize(level, specifiedType: const FullType(int));
+    _parameters['level'] = __level;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetNotificationCallsApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/notify-calls{?level*}')
         .expand(_parameters);
@@ -13417,9 +13427,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -13500,28 +13510,28 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $state = _$jsonSerializers.serialize(state, specifiedType: const FullType(int));
-    _parameters['state'] = $state;
+    final __state = _$jsonSerializers.serialize(state, specifiedType: const FullType(int));
+    _parameters['state'] = __state;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $timer = _$jsonSerializers.serialize(timer, specifiedType: const FullType(int));
+    final __timer = _$jsonSerializers.serialize(timer, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $timer,
+      __timer,
       'timer',
       minimum: 0,
     );
-    _parameters['timer'] = $timer;
+    _parameters['timer'] = __timer;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetLobbyApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetLobbyApiVersion));
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/webinar/lobby{?state*,timer*}')
         .expand(_parameters);
@@ -13545,9 +13555,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -13633,21 +13643,21 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $state = _$jsonSerializers.serialize(state, specifiedType: const FullType(RoomSetsipEnabledState));
-    _parameters['state'] = $state;
+    final __state = _$jsonSerializers.serialize(state, specifiedType: const FullType(RoomSetsipEnabledState));
+    _parameters['state'] = __state;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetsipEnabledApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/webinar/sip{?state*}')
         .expand(_parameters);
@@ -13671,9 +13681,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -13757,21 +13767,21 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $recordingConsent = _$jsonSerializers.serialize(recordingConsent, specifiedType: const FullType(int));
-    _parameters['recordingConsent'] = $recordingConsent;
+    final __recordingConsent = _$jsonSerializers.serialize(recordingConsent, specifiedType: const FullType(int));
+    _parameters['recordingConsent'] = __recordingConsent;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetRecordingConsentApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/recording-consent{?recordingConsent*}')
@@ -13796,9 +13806,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -13879,26 +13889,26 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $seconds = _$jsonSerializers.serialize(seconds, specifiedType: const FullType(int));
+    final __seconds = _$jsonSerializers.serialize(seconds, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $seconds,
+      __seconds,
       'seconds',
       minimum: 0,
     );
-    _parameters['seconds'] = $seconds;
+    _parameters['seconds'] = __seconds;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetMessageExpirationApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/message-expiration{?seconds*}')
         .expand(_parameters);
@@ -13920,9 +13930,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -14001,18 +14011,18 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomGetCapabilitiesApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/capabilities').expand(_parameters);
@@ -14034,9 +14044,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -14115,18 +14125,18 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomJoinFederatedRoomApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/federation/active').expand(_parameters);
@@ -14148,9 +14158,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -14232,26 +14242,26 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $pin = _$jsonSerializers.serialize(pin, specifiedType: const FullType(String));
+    final __pin = _$jsonSerializers.serialize(pin, specifiedType: const FullType(String));
     _i4.checkString(
-      $pin,
+      __pin,
       'pin',
       pattern: RegExp(r'^\d{7,32}$'),
     );
-    _parameters['pin'] = $pin;
+    _parameters['pin'] = __pin;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomVerifyDialInPinDeprecatedApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/pin/{pin}').expand(_parameters);
@@ -14273,9 +14283,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -14359,21 +14369,21 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $pin = _$jsonSerializers.serialize(pin, specifiedType: const FullType(String));
-    _parameters['pin'] = $pin;
+    final __pin = _$jsonSerializers.serialize(pin, specifiedType: const FullType(String));
+    _parameters['pin'] = __pin;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomVerifyDialInPinApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/verify-dialin{?pin*}')
         .expand(_parameters);
@@ -14395,9 +14405,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -14484,27 +14494,27 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $number = _$jsonSerializers.serialize(number, specifiedType: const FullType(String));
-    _parameters['number'] = $number;
+    final __number = _$jsonSerializers.serialize(number, specifiedType: const FullType(String));
+    _parameters['number'] = __number;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $options = _$jsonSerializers.serialize(
+    final __options = _$jsonSerializers.serialize(
       options,
       specifiedType: const FullType(ContentString, [FullType(RoomVerifyDialOutNumberOptions)]),
     );
-    _parameters['options'] = $options;
+    _parameters['options'] = __options;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomVerifyDialOutNumberApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/verify-dialout{?number*,options*}')
@@ -14527,9 +14537,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -14614,18 +14624,18 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomCreateGuestByDialInApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/open-dial-in').expand(_parameters);
@@ -14647,9 +14657,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -14732,27 +14742,27 @@ class $RoomClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $callId = _$jsonSerializers.serialize(callId, specifiedType: const FullType(String));
-    _parameters['callId'] = $callId;
+    final __callId = _$jsonSerializers.serialize(callId, specifiedType: const FullType(String));
+    _parameters['callId'] = __callId;
 
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
-      $token,
+      __token,
       'token',
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
-    _parameters['token'] = $token;
+    _parameters['token'] = __token;
 
-    final $options = _$jsonSerializers.serialize(
+    final __options = _$jsonSerializers.serialize(
       options,
       specifiedType: const FullType(ContentString, [FullType(RoomRejectedDialOutRequestOptions)]),
     );
-    _parameters['options'] = $options;
+    _parameters['options'] = __options;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomRejectedDialOutRequestApiVersion));
-    $apiVersion ??= 'v4';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v4';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/rejected-dialout{?callId*,options*}')
@@ -14775,9 +14785,9 @@ class $RoomClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -14870,16 +14880,16 @@ class $SettingsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $key = _$jsonSerializers.serialize(key, specifiedType: const FullType(SettingsSetUserSettingKey));
-    _parameters['key'] = $key;
+    final __key = _$jsonSerializers.serialize(key, specifiedType: const FullType(SettingsSetUserSettingKey));
+    _parameters['key'] = __key;
 
-    final $value = _$jsonSerializers.serialize(value, specifiedType: const FullType(SettingsSetUserSettingValue));
-    _parameters['value'] = $value;
+    final __value = _$jsonSerializers.serialize(value, specifiedType: const FullType(SettingsSetUserSettingValue));
+    _parameters['value'] = __value;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SettingsSetUserSettingApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/user{?key*,value*}').expand(_parameters);
@@ -14903,9 +14913,9 @@ class $SettingsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -14982,10 +14992,10 @@ class $SettingsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotAdminListBotsApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/admin').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -15008,9 +15018,9 @@ class $SettingsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -15085,15 +15095,15 @@ class $SettingsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $host = _$jsonSerializers.serialize(host, specifiedType: const FullType(String));
-    _parameters['host'] = $host;
+    final __host = _$jsonSerializers.serialize(host, specifiedType: const FullType(String));
+    _parameters['host'] = __host;
 
-    var $apiVersion = _$jsonSerializers.serialize(
+    var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(CertificateGetCertificateExpirationApiVersion),
     );
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/certificate/expiration{?host*}').expand(_parameters);
@@ -15117,9 +15127,9 @@ class $SettingsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -15201,18 +15211,18 @@ class $SettingsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $serverId = _$jsonSerializers.serialize(serverId, specifiedType: const FullType(int));
+    final __serverId = _$jsonSerializers.serialize(serverId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $serverId,
+      __serverId,
       'serverId',
       minimum: 0,
     );
-    _parameters['serverId'] = $serverId;
+    _parameters['serverId'] = __serverId;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RecordingGetWelcomeMessageApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/welcome/{serverId}').expand(_parameters);
@@ -15236,9 +15246,9 @@ class $SettingsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -15321,23 +15331,23 @@ class $SettingsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $sipGroups =
+    var __sipGroups =
         _$jsonSerializers.serialize(sipGroups, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    $sipGroups ??= const [];
-    _parameters['sipGroups%5B%5D'] = $sipGroups;
+    __sipGroups ??= const [];
+    _parameters['sipGroups%5B%5D'] = __sipGroups;
 
-    var $dialInInfo = _$jsonSerializers.serialize(dialInInfo, specifiedType: const FullType(String));
-    $dialInInfo ??= '';
-    _parameters['dialInInfo'] = $dialInInfo;
+    var __dialInInfo = _$jsonSerializers.serialize(dialInInfo, specifiedType: const FullType(String));
+    __dialInInfo ??= '';
+    _parameters['dialInInfo'] = __dialInInfo;
 
-    var $sharedSecret = _$jsonSerializers.serialize(sharedSecret, specifiedType: const FullType(String));
-    $sharedSecret ??= '';
-    _parameters['sharedSecret'] = $sharedSecret;
+    var __sharedSecret = _$jsonSerializers.serialize(sharedSecret, specifiedType: const FullType(String));
+    __sharedSecret ??= '';
+    _parameters['sharedSecret'] = __sharedSecret;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SettingsSetsipSettingsApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate(
       '/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/sip{?sipGroups%5B%5D*,dialInInfo*,sharedSecret*}',
@@ -15362,9 +15372,9 @@ class $SettingsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -15450,18 +15460,18 @@ class $SettingsClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $serverId = _$jsonSerializers.serialize(serverId, specifiedType: const FullType(int));
+    final __serverId = _$jsonSerializers.serialize(serverId, specifiedType: const FullType(int));
     _i4.checkNumber(
-      $serverId,
+      __serverId,
       'serverId',
       minimum: 0,
     );
-    _parameters['serverId'] = $serverId;
+    _parameters['serverId'] = __serverId;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SignalingGetWelcomeMessageApiVersion));
-    $apiVersion ??= 'v3';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v3';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path =
         _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/welcome/{serverId}').expand(_parameters);
@@ -15485,9 +15495,9 @@ class $SettingsClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -15571,10 +15581,10 @@ class $SignalingClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SignalingBackendApiVersion));
-    $apiVersion ??= 'v3';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v3';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/backend').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -15595,9 +15605,9 @@ class $SignalingClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -15691,9 +15701,9 @@ class $UserAvatarClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -15776,9 +15786,9 @@ class $UserAvatarClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -16,6 +16,7 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:built_collection/built_collection.dart';
@@ -110,7 +111,6 @@ class $AvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [darkTheme] Theme used for background. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -124,9 +124,9 @@ class $AvatarClient {
   @_i2.experimental
   _i3.Request $getAvatar_Request({
     required String token,
-    AvatarGetAvatarDarkTheme? darkTheme,
     AvatarGetAvatarApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    AvatarGetAvatarRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -137,17 +137,12 @@ class $AvatarClient {
     );
     _parameters['token'] = __token;
 
-    var __darkTheme = _$jsonSerializers.serialize(darkTheme, specifiedType: const FullType(AvatarGetAvatarDarkTheme));
-    __darkTheme ??= 0;
-    _parameters['darkTheme'] = __darkTheme;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(AvatarGetAvatarApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar{?darkTheme*}')
-        .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = '*/*';
@@ -170,6 +165,17 @@ class $AvatarClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(AvatarGetAvatarRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              AvatarGetAvatarRequestApplicationJson(),
+              specifiedType: const FullType(AvatarGetAvatarRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -179,7 +185,6 @@ class $AvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [darkTheme] Theme used for background. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -192,15 +197,15 @@ class $AvatarClient {
   ///  * [$getAvatar_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Uint8List, void>> getAvatar({
     required String token,
-    AvatarGetAvatarDarkTheme? darkTheme,
     AvatarGetAvatarApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    AvatarGetAvatarRequestApplicationJson? $body,
   }) async {
     final _request = $getAvatar_Request(
       token: token,
-      darkTheme: darkTheme,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -442,8 +447,6 @@ class $AvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [emoji] Emoji.
-  ///   * [color] Color of the emoji.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -457,16 +460,12 @@ class $AvatarClient {
   ///  * [$emojiAvatar_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $emojiAvatar_Request({
-    required String emoji,
     required String token,
-    String? color,
+    required AvatarEmojiAvatarRequestApplicationJson $body,
     AvatarEmojiAvatarApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __emoji = _$jsonSerializers.serialize(emoji, specifiedType: const FullType(String));
-    _parameters['emoji'] = __emoji;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -475,16 +474,13 @@ class $AvatarClient {
     );
     _parameters['token'] = __token;
 
-    final __color = _$jsonSerializers.serialize(color, specifiedType: const FullType(String));
-    _parameters['color'] = __color;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(AvatarEmojiAvatarApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar/emoji{?emoji*,color*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/avatar/emoji').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -507,6 +503,10 @@ class $AvatarClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(AvatarEmojiAvatarRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -516,8 +516,6 @@ class $AvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [emoji] Emoji.
-  ///   * [color] Color of the emoji.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -530,18 +528,16 @@ class $AvatarClient {
   ///  * [$emojiAvatar_Request] for the request send by this method.
   ///  * [$emojiAvatar_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<AvatarEmojiAvatarResponseApplicationJson, void>> emojiAvatar({
-    required String emoji,
     required String token,
-    String? color,
+    required AvatarEmojiAvatarRequestApplicationJson $body,
     AvatarEmojiAvatarApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $emojiAvatar_Request(
-      emoji: emoji,
       token: token,
-      color: color,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -673,8 +669,6 @@ class $AvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [cloudId] Federation CloudID to get the avatar for.
-  ///   * [darkTheme] Theme used for background. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [size] Avatar size.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -687,26 +681,15 @@ class $AvatarClient {
   ///  * [$getUserProxyAvatarWithoutRoom_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getUserProxyAvatarWithoutRoom_Request({
-    required String cloudId,
     required AvatarGetUserProxyAvatarWithoutRoomSize size,
-    AvatarGetUserProxyAvatarWithoutRoomDarkTheme? darkTheme,
+    required AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson $body,
     AvatarGetUserProxyAvatarWithoutRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __cloudId = _$jsonSerializers.serialize(cloudId, specifiedType: const FullType(String));
-    _parameters['cloudId'] = __cloudId;
-
     final __size =
         _$jsonSerializers.serialize(size, specifiedType: const FullType(AvatarGetUserProxyAvatarWithoutRoomSize));
     _parameters['size'] = __size;
-
-    var __darkTheme = _$jsonSerializers.serialize(
-      darkTheme,
-      specifiedType: const FullType(AvatarGetUserProxyAvatarWithoutRoomDarkTheme),
-    );
-    __darkTheme ??= 0;
-    _parameters['darkTheme'] = __darkTheme;
 
     var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
@@ -716,8 +699,7 @@ class $AvatarClient {
     _parameters['apiVersion'] = __apiVersion;
 
     final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}{?cloudId*,darkTheme*}')
-            .expand(_parameters);
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = '*/*';
@@ -742,6 +724,13 @@ class $AvatarClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -751,8 +740,6 @@ class $AvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [cloudId] Federation CloudID to get the avatar for.
-  ///   * [darkTheme] Theme used for background. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [size] Avatar size.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -764,18 +751,16 @@ class $AvatarClient {
   ///  * [$getUserProxyAvatarWithoutRoom_Request] for the request send by this method.
   ///  * [$getUserProxyAvatarWithoutRoom_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Uint8List, void>> getUserProxyAvatarWithoutRoom({
-    required String cloudId,
     required AvatarGetUserProxyAvatarWithoutRoomSize size,
-    AvatarGetUserProxyAvatarWithoutRoomDarkTheme? darkTheme,
+    required AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson $body,
     AvatarGetUserProxyAvatarWithoutRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $getUserProxyAvatarWithoutRoom_Request(
-      cloudId: cloudId,
       size: size,
-      darkTheme: darkTheme,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -800,7 +785,6 @@ class $AvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [cloudId] Federation CloudID to get the avatar for.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [size] Avatar size.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -813,15 +797,12 @@ class $AvatarClient {
   ///  * [$getUserProxyAvatarDarkWithoutRoom_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getUserProxyAvatarDarkWithoutRoom_Request({
-    required String cloudId,
     required AvatarGetUserProxyAvatarDarkWithoutRoomSize size,
+    required AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson $body,
     AvatarGetUserProxyAvatarDarkWithoutRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __cloudId = _$jsonSerializers.serialize(cloudId, specifiedType: const FullType(String));
-    _parameters['cloudId'] = __cloudId;
-
     final __size =
         _$jsonSerializers.serialize(size, specifiedType: const FullType(AvatarGetUserProxyAvatarDarkWithoutRoomSize));
     _parameters['size'] = __size;
@@ -833,9 +814,8 @@ class $AvatarClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}/dark{?cloudId*}')
-            .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/new/user-avatar/{size}/dark')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = '*/*';
@@ -860,6 +840,13 @@ class $AvatarClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -869,7 +856,6 @@ class $AvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [cloudId] Federation CloudID to get the avatar for.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [size] Avatar size.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -881,16 +867,16 @@ class $AvatarClient {
   ///  * [$getUserProxyAvatarDarkWithoutRoom_Request] for the request send by this method.
   ///  * [$getUserProxyAvatarDarkWithoutRoom_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Uint8List, void>> getUserProxyAvatarDarkWithoutRoom({
-    required String cloudId,
     required AvatarGetUserProxyAvatarDarkWithoutRoomSize size,
+    required AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson $body,
     AvatarGetUserProxyAvatarDarkWithoutRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $getUserProxyAvatarDarkWithoutRoom_Request(
-      cloudId: cloudId,
       size: size,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -915,8 +901,6 @@ class $AvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [cloudId] Federation CloudID to get the avatar for.
-  ///   * [darkTheme] Theme used for background. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [size] Avatar size.
@@ -930,17 +914,13 @@ class $AvatarClient {
   ///  * [$getUserProxyAvatar_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getUserProxyAvatar_Request({
-    required String cloudId,
     required String token,
     required AvatarGetUserProxyAvatarSize size,
-    AvatarGetUserProxyAvatarDarkTheme? darkTheme,
+    required AvatarGetUserProxyAvatarRequestApplicationJson $body,
     AvatarGetUserProxyAvatarApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __cloudId = _$jsonSerializers.serialize(cloudId, specifiedType: const FullType(String));
-    _parameters['cloudId'] = __cloudId;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -952,19 +932,13 @@ class $AvatarClient {
     final __size = _$jsonSerializers.serialize(size, specifiedType: const FullType(AvatarGetUserProxyAvatarSize));
     _parameters['size'] = __size;
 
-    var __darkTheme =
-        _$jsonSerializers.serialize(darkTheme, specifiedType: const FullType(AvatarGetUserProxyAvatarDarkTheme));
-    __darkTheme ??= 0;
-    _parameters['darkTheme'] = __darkTheme;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(AvatarGetUserProxyAvatarApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/{token}/user-avatar/{size}{?cloudId*,darkTheme*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/{token}/user-avatar/{size}')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = '*/*';
@@ -987,6 +961,13 @@ class $AvatarClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(AvatarGetUserProxyAvatarRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -996,8 +977,6 @@ class $AvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [cloudId] Federation CloudID to get the avatar for.
-  ///   * [darkTheme] Theme used for background. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [size] Avatar size.
@@ -1010,20 +989,18 @@ class $AvatarClient {
   ///  * [$getUserProxyAvatar_Request] for the request send by this method.
   ///  * [$getUserProxyAvatar_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Uint8List, void>> getUserProxyAvatar({
-    required String cloudId,
     required String token,
     required AvatarGetUserProxyAvatarSize size,
-    AvatarGetUserProxyAvatarDarkTheme? darkTheme,
+    required AvatarGetUserProxyAvatarRequestApplicationJson $body,
     AvatarGetUserProxyAvatarApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $getUserProxyAvatar_Request(
-      cloudId: cloudId,
       token: token,
       size: size,
-      darkTheme: darkTheme,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1048,7 +1025,6 @@ class $AvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [cloudId] Federation CloudID to get the avatar for.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [size] Avatar size.
@@ -1062,16 +1038,13 @@ class $AvatarClient {
   ///  * [$getUserProxyAvatarDark_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getUserProxyAvatarDark_Request({
-    required String cloudId,
     required String token,
     required AvatarGetUserProxyAvatarDarkSize size,
+    required AvatarGetUserProxyAvatarDarkRequestApplicationJson $body,
     AvatarGetUserProxyAvatarDarkApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __cloudId = _$jsonSerializers.serialize(cloudId, specifiedType: const FullType(String));
-    _parameters['cloudId'] = __cloudId;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -1088,9 +1061,8 @@ class $AvatarClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/{token}/user-avatar/{size}/dark{?cloudId*}')
-            .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/proxy/{token}/user-avatar/{size}/dark')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = '*/*';
@@ -1113,6 +1085,13 @@ class $AvatarClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(AvatarGetUserProxyAvatarDarkRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -1122,7 +1101,6 @@ class $AvatarClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [cloudId] Federation CloudID to get the avatar for.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [size] Avatar size.
@@ -1135,18 +1113,18 @@ class $AvatarClient {
   ///  * [$getUserProxyAvatarDark_Request] for the request send by this method.
   ///  * [$getUserProxyAvatarDark_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Uint8List, void>> getUserProxyAvatarDark({
-    required String cloudId,
     required String token,
     required AvatarGetUserProxyAvatarDarkSize size,
+    required AvatarGetUserProxyAvatarDarkRequestApplicationJson $body,
     AvatarGetUserProxyAvatarDarkApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $getUserProxyAvatarDark_Request(
-      cloudId: cloudId,
       token: token,
       size: size,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1524,10 +1502,6 @@ class $BotClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [message] The message to send.
-  ///   * [referenceId] For the message to be able to later identify it again. Defaults to `""`.
-  ///   * [replyTo] Parent id which this message is a reply to. Defaults to `0`.
-  ///   * [silent] If sent silent the chat message will not create any notifications. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token] Conversation token.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -1543,18 +1517,12 @@ class $BotClient {
   ///  * [$sendMessage_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $sendMessage_Request({
-    required String message,
     required String token,
-    String? referenceId,
-    int? replyTo,
-    BotSendMessageSilent? silent,
+    required BotSendMessageRequestApplicationJson $body,
     BotSendMessageApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
-    _parameters['message'] = __message;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -1563,25 +1531,11 @@ class $BotClient {
     );
     _parameters['token'] = __token;
 
-    var __referenceId = _$jsonSerializers.serialize(referenceId, specifiedType: const FullType(String));
-    __referenceId ??= '';
-    _parameters['referenceId'] = __referenceId;
-
-    var __replyTo = _$jsonSerializers.serialize(replyTo, specifiedType: const FullType(int));
-    __replyTo ??= 0;
-    _parameters['replyTo'] = __replyTo;
-
-    var __silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(BotSendMessageSilent));
-    __silent ??= 0;
-    _parameters['silent'] = __silent;
-
     var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(BotSendMessageApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/message{?message*,referenceId*,replyTo*,silent*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/message').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1604,6 +1558,10 @@ class $BotClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(BotSendMessageRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -1615,10 +1573,6 @@ class $BotClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [message] The message to send.
-  ///   * [referenceId] For the message to be able to later identify it again. Defaults to `""`.
-  ///   * [replyTo] Parent id which this message is a reply to. Defaults to `0`.
-  ///   * [silent] If sent silent the chat message will not create any notifications. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token] Conversation token.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -1633,22 +1587,16 @@ class $BotClient {
   ///  * [$sendMessage_Request] for the request send by this method.
   ///  * [$sendMessage_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<BotSendMessageResponseApplicationJson, void>> sendMessage({
-    required String message,
     required String token,
-    String? referenceId,
-    int? replyTo,
-    BotSendMessageSilent? silent,
+    required BotSendMessageRequestApplicationJson $body,
     BotSendMessageApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $sendMessage_Request(
-      message: message,
       token: token,
-      referenceId: referenceId,
-      replyTo: replyTo,
-      silent: silent,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1674,7 +1622,6 @@ class $BotClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [reaction] Reaction to add.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token] Conversation token.
   ///   * [messageId] ID of the message.
@@ -1692,16 +1639,13 @@ class $BotClient {
   ///  * [$react_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $react_Request({
-    required String reaction,
     required String token,
     required int messageId,
+    required BotReactRequestApplicationJson $body,
     BotReactApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
-    _parameters['reaction'] = __reaction;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -1717,9 +1661,8 @@ class $BotClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/reaction/{messageId}{?reaction*}')
-            .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/reaction/{messageId}')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1742,6 +1685,9 @@ class $BotClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body =
+        json.encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(BotReactRequestApplicationJson)));
     return _request;
   }
 
@@ -1751,7 +1697,6 @@ class $BotClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [reaction] Reaction to add.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token] Conversation token.
   ///   * [messageId] ID of the message.
@@ -1768,18 +1713,18 @@ class $BotClient {
   ///  * [$react_Request] for the request send by this method.
   ///  * [$react_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<BotReactResponseApplicationJson, void>> react({
-    required String reaction,
     required String token,
     required int messageId,
+    required BotReactRequestApplicationJson $body,
     BotReactApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $react_Request(
-      reaction: reaction,
       token: token,
       messageId: messageId,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1805,7 +1750,6 @@ class $BotClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [reaction] Reaction to delete.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token] Conversation token.
   ///   * [messageId] ID of the message.
@@ -1822,16 +1766,13 @@ class $BotClient {
   ///  * [$deleteReaction_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $deleteReaction_Request({
-    required String reaction,
     required String token,
     required int messageId,
+    required BotDeleteReactionRequestApplicationJson $body,
     BotDeleteReactionApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
-    _parameters['reaction'] = __reaction;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -1848,9 +1789,8 @@ class $BotClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/reaction/{messageId}{?reaction*}')
-            .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bot/{token}/reaction/{messageId}')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -1873,6 +1813,10 @@ class $BotClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(BotDeleteReactionRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -1882,7 +1826,6 @@ class $BotClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [reaction] Reaction to delete.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token] Conversation token.
   ///   * [messageId] ID of the message.
@@ -1898,18 +1841,18 @@ class $BotClient {
   ///  * [$deleteReaction_Request] for the request send by this method.
   ///  * [$deleteReaction_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<BotDeleteReactionResponseApplicationJson, void>> deleteReaction({
-    required String reaction,
     required String token,
     required int messageId,
+    required BotDeleteReactionRequestApplicationJson $body,
     BotDeleteReactionApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $deleteReaction_Request(
-      reaction: reaction,
       token: token,
       messageId: messageId,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -1943,9 +1886,6 @@ class $BreakoutRoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [mode] Mode of the breakout rooms.
-  ///   * [amount] Number of breakout rooms - Constants {@see BreakoutRoom::MINIMUM_ROOM_AMOUNT} and {@see BreakoutRoom::MAXIMUM_ROOM_AMOUNT}.
-  ///   * [attendeeMap] Mapping of the attendees to breakout rooms. Defaults to `"[]"`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -1959,27 +1899,12 @@ class $BreakoutRoomClient {
   ///  * [$configureBreakoutRooms_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $configureBreakoutRooms_Request({
-    required BreakoutRoomConfigureBreakoutRoomsMode mode,
-    required int amount,
     required String token,
-    String? attendeeMap,
+    required BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson $body,
     BreakoutRoomConfigureBreakoutRoomsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __mode =
-        _$jsonSerializers.serialize(mode, specifiedType: const FullType(BreakoutRoomConfigureBreakoutRoomsMode));
-    _parameters['mode'] = __mode;
-
-    final __amount = _$jsonSerializers.serialize(amount, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __amount,
-      'amount',
-      maximum: 20,
-      minimum: 1,
-    );
-    _parameters['amount'] = __amount;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -1987,10 +1912,6 @@ class $BreakoutRoomClient {
       pattern: RegExp(r'^[a-z0-9]{4,30}$'),
     );
     _parameters['token'] = __token;
-
-    var __attendeeMap = _$jsonSerializers.serialize(attendeeMap, specifiedType: const FullType(String));
-    __attendeeMap ??= '[]';
-    _parameters['attendeeMap'] = __attendeeMap;
 
     var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
@@ -2000,8 +1921,7 @@ class $BreakoutRoomClient {
     _parameters['apiVersion'] = __apiVersion;
 
     final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}{?mode*,amount*,attendeeMap*}')
-            .expand(_parameters);
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2026,6 +1946,13 @@ class $BreakoutRoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -2035,9 +1962,6 @@ class $BreakoutRoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [mode] Mode of the breakout rooms.
-  ///   * [amount] Number of breakout rooms - Constants {@see BreakoutRoom::MINIMUM_ROOM_AMOUNT} and {@see BreakoutRoom::MAXIMUM_ROOM_AMOUNT}.
-  ///   * [attendeeMap] Mapping of the attendees to breakout rooms. Defaults to `"[]"`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -2050,20 +1974,16 @@ class $BreakoutRoomClient {
   ///  * [$configureBreakoutRooms_Request] for the request send by this method.
   ///  * [$configureBreakoutRooms_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson, void>> configureBreakoutRooms({
-    required BreakoutRoomConfigureBreakoutRoomsMode mode,
-    required int amount,
     required String token,
-    String? attendeeMap,
+    required BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson $body,
     BreakoutRoomConfigureBreakoutRoomsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $configureBreakoutRooms_Request(
-      mode: mode,
-      amount: amount,
       token: token,
-      attendeeMap: attendeeMap,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2204,7 +2124,6 @@ class $BreakoutRoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [message] Message to broadcast.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -2219,15 +2138,12 @@ class $BreakoutRoomClient {
   ///  * [$broadcastChatMessage_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $broadcastChatMessage_Request({
-    required String message,
     required String token,
+    required BreakoutRoomBroadcastChatMessageRequestApplicationJson $body,
     BreakoutRoomBroadcastChatMessageApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
-    _parameters['message'] = __message;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -2243,9 +2159,8 @@ class $BreakoutRoomClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/broadcast{?message*}')
-            .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/broadcast')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2270,6 +2185,13 @@ class $BreakoutRoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(BreakoutRoomBroadcastChatMessageRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -2279,7 +2201,6 @@ class $BreakoutRoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [message] Message to broadcast.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -2293,16 +2214,16 @@ class $BreakoutRoomClient {
   ///  * [$broadcastChatMessage_Request] for the request send by this method.
   ///  * [$broadcastChatMessage_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<BreakoutRoomBroadcastChatMessageResponseApplicationJson, void>> broadcastChatMessage({
-    required String message,
     required String token,
+    required BreakoutRoomBroadcastChatMessageRequestApplicationJson $body,
     BreakoutRoomBroadcastChatMessageApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $broadcastChatMessage_Request(
-      message: message,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2330,7 +2251,6 @@ class $BreakoutRoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [attendeeMap] JSON encoded mapping of the attendees to breakout rooms `array<int, int>`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -2344,15 +2264,12 @@ class $BreakoutRoomClient {
   ///  * [$applyAttendeeMap_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $applyAttendeeMap_Request({
-    required String attendeeMap,
     required String token,
+    required BreakoutRoomApplyAttendeeMapRequestApplicationJson $body,
     BreakoutRoomApplyAttendeeMapApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __attendeeMap = _$jsonSerializers.serialize(attendeeMap, specifiedType: const FullType(String));
-    _parameters['attendeeMap'] = __attendeeMap;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -2366,9 +2283,8 @@ class $BreakoutRoomClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/attendees{?attendeeMap*}')
-            .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/attendees')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2393,6 +2309,13 @@ class $BreakoutRoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(BreakoutRoomApplyAttendeeMapRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -2402,7 +2325,6 @@ class $BreakoutRoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [attendeeMap] JSON encoded mapping of the attendees to breakout rooms `array<int, int>`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -2415,16 +2337,16 @@ class $BreakoutRoomClient {
   ///  * [$applyAttendeeMap_Request] for the request send by this method.
   ///  * [$applyAttendeeMap_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<BreakoutRoomApplyAttendeeMapResponseApplicationJson, void>> applyAttendeeMap({
-    required String attendeeMap,
     required String token,
+    required BreakoutRoomApplyAttendeeMapRequestApplicationJson $body,
     BreakoutRoomApplyAttendeeMapApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $applyAttendeeMap_Request(
-      attendeeMap: attendeeMap,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -2905,7 +2827,6 @@ class $BreakoutRoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [target] Target breakout room.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -2919,15 +2840,12 @@ class $BreakoutRoomClient {
   ///  * [$switchBreakoutRoom_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $switchBreakoutRoom_Request({
-    required String target,
     required String token,
+    required BreakoutRoomSwitchBreakoutRoomRequestApplicationJson $body,
     BreakoutRoomSwitchBreakoutRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __target = _$jsonSerializers.serialize(target, specifiedType: const FullType(String));
-    _parameters['target'] = __target;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -2943,8 +2861,8 @@ class $BreakoutRoomClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/switch{?target*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/breakout-rooms/{token}/switch').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -2969,6 +2887,13 @@ class $BreakoutRoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(BreakoutRoomSwitchBreakoutRoomRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -2978,7 +2903,6 @@ class $BreakoutRoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [target] Target breakout room.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -2991,16 +2915,16 @@ class $BreakoutRoomClient {
   ///  * [$switchBreakoutRoom_Request] for the request send by this method.
   ///  * [$switchBreakoutRoom_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson, void>> switchBreakoutRoom({
-    required String target,
     required String token,
+    required BreakoutRoomSwitchBreakoutRoomRequestApplicationJson $body,
     BreakoutRoomSwitchBreakoutRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $switchBreakoutRoom_Request(
-      target: target,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -3141,7 +3065,6 @@ class $CallClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [flags] New flags.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -3156,21 +3079,12 @@ class $CallClient {
   ///  * [$updateCallFlags_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $updateCallFlags_Request({
-    required int flags,
     required String token,
+    required CallUpdateCallFlagsRequestApplicationJson $body,
     CallUpdateCallFlagsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __flags = _$jsonSerializers.serialize(flags, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __flags,
-      'flags',
-      maximum: 15,
-      minimum: 0,
-    );
-    _parameters['flags'] = __flags;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -3184,7 +3098,7 @@ class $CallClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}{?flags*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -3207,6 +3121,10 @@ class $CallClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(CallUpdateCallFlagsRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -3216,7 +3134,6 @@ class $CallClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [flags] New flags.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -3230,16 +3147,16 @@ class $CallClient {
   ///  * [$updateCallFlags_Request] for the request send by this method.
   ///  * [$updateCallFlags_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<CallUpdateCallFlagsResponseApplicationJson, void>> updateCallFlags({
-    required int flags,
     required String token,
+    required CallUpdateCallFlagsRequestApplicationJson $body,
     CallUpdateCallFlagsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $updateCallFlags_Request(
-      flags: flags,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -3265,10 +3182,6 @@ class $CallClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [flags] In-Call flags.
-  ///   * [forcePermissions] In-call permissions.
-  ///   * [silent] Join the call silently. Defaults to `0`.
-  ///   * [recordingConsent] When the user ticked a checkbox and agreed with being recorded (Only needed when the `config => call => recording-consent` capability is set to {@see RecordingService::CONSENT_REQUIRED_YES} or the capability is {@see RecordingService::CONSENT_REQUIRED_OPTIONAL} and the conversation `recordingConsent` value is {@see RecordingService::CONSENT_REQUIRED_YES} ). Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -3284,12 +3197,9 @@ class $CallClient {
   @_i2.experimental
   _i3.Request $joinCall_Request({
     required String token,
-    int? flags,
-    int? forcePermissions,
-    CallJoinCallSilent? silent,
-    CallJoinCallRecordingConsent? recordingConsent,
     CallJoinCallApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    CallJoinCallRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -3300,40 +3210,11 @@ class $CallClient {
     );
     _parameters['token'] = __token;
 
-    final __flags = _$jsonSerializers.serialize(flags, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __flags,
-      'flags',
-      maximum: 15,
-      minimum: 0,
-    );
-    _parameters['flags'] = __flags;
-
-    final __forcePermissions = _$jsonSerializers.serialize(forcePermissions, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __forcePermissions,
-      'forcePermissions',
-      maximum: 255,
-      minimum: 0,
-    );
-    _parameters['forcePermissions'] = __forcePermissions;
-
-    var __silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(CallJoinCallSilent));
-    __silent ??= 0;
-    _parameters['silent'] = __silent;
-
-    var __recordingConsent =
-        _$jsonSerializers.serialize(recordingConsent, specifiedType: const FullType(CallJoinCallRecordingConsent));
-    __recordingConsent ??= 0;
-    _parameters['recordingConsent'] = __recordingConsent;
-
     var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(CallJoinCallApiVersion));
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}{?flags*,forcePermissions*,silent*,recordingConsent*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -3356,6 +3237,17 @@ class $CallClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(CallJoinCallRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              CallJoinCallRequestApplicationJson(),
+              specifiedType: const FullType(CallJoinCallRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -3365,10 +3257,6 @@ class $CallClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [flags] In-Call flags.
-  ///   * [forcePermissions] In-call permissions.
-  ///   * [silent] Join the call silently. Defaults to `0`.
-  ///   * [recordingConsent] When the user ticked a checkbox and agreed with being recorded (Only needed when the `config => call => recording-consent` capability is set to {@see RecordingService::CONSENT_REQUIRED_YES} or the capability is {@see RecordingService::CONSENT_REQUIRED_OPTIONAL} and the conversation `recordingConsent` value is {@see RecordingService::CONSENT_REQUIRED_YES} ). Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -3383,21 +3271,15 @@ class $CallClient {
   ///  * [$joinCall_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<CallJoinCallResponseApplicationJson, void>> joinCall({
     required String token,
-    int? flags,
-    int? forcePermissions,
-    CallJoinCallSilent? silent,
-    CallJoinCallRecordingConsent? recordingConsent,
     CallJoinCallApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    CallJoinCallRequestApplicationJson? $body,
   }) async {
     final _request = $joinCall_Request(
       token: token,
-      flags: flags,
-      forcePermissions: forcePermissions,
-      silent: silent,
-      recordingConsent: recordingConsent,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -3423,7 +3305,6 @@ class $CallClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [all] whether to also terminate the call for all participants. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -3438,9 +3319,9 @@ class $CallClient {
   @_i2.experimental
   _i3.Request $leaveCall_Request({
     required String token,
-    CallLeaveCallAll? all,
     CallLeaveCallApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    CallLeaveCallRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -3451,15 +3332,11 @@ class $CallClient {
     );
     _parameters['token'] = __token;
 
-    var __all = _$jsonSerializers.serialize(all, specifiedType: const FullType(CallLeaveCallAll));
-    __all ??= 0;
-    _parameters['all'] = __all;
-
     var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(CallLeaveCallApiVersion));
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}{?all*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/call/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -3482,6 +3359,17 @@ class $CallClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(CallLeaveCallRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              CallLeaveCallRequestApplicationJson(),
+              specifiedType: const FullType(CallLeaveCallRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -3491,7 +3379,6 @@ class $CallClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [all] whether to also terminate the call for all participants. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -3505,15 +3392,15 @@ class $CallClient {
   ///  * [$leaveCall_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<CallLeaveCallResponseApplicationJson, void>> leaveCall({
     required String token,
-    CallLeaveCallAll? all,
     CallLeaveCallApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    CallLeaveCallRequestApplicationJson? $body,
   }) async {
     final _request = $leaveCall_Request(
       token: token,
-      all: all,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -3792,15 +3679,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [lookIntoFuture] Polling for new messages (1) or getting the history of the chat (0).
-  ///   * [limit] Number of chat messages to receive (100 by default, 200 at most). Defaults to `100`.
-  ///   * [lastKnownMessageId] The last known message (serves as offset). Defaults to `0`.
-  ///   * [lastCommonReadId] The last known common read message (so the response is 200 instead of 304 when it changes even when there are no messages). Defaults to `0`.
-  ///   * [timeout] Number of seconds to wait for new messages (30 by default, 30 at most). Defaults to `30`.
-  ///   * [setReadMarker] Automatically set the last read marker when 1, if your client does this itself via chat/{token}/read set to 0. Defaults to `1`.
-  ///   * [includeLastKnown] Include the $lastKnownMessageId in the messages when 1 (default 0). Defaults to `0`.
-  ///   * [noStatusUpdate] When the user status should not be automatically set to online set to 1 (default 0). Defaults to `0`.
-  ///   * [markNotificationsAsRead] Set to 0 when notifications should not be marked as read (default 1). Defaults to `1`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -3814,24 +3692,12 @@ class $ChatClient {
   ///  * [$receiveMessages_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $receiveMessages_Request({
-    required ChatReceiveMessagesLookIntoFuture lookIntoFuture,
     required String token,
-    int? limit,
-    int? lastKnownMessageId,
-    int? lastCommonReadId,
-    int? timeout,
-    ChatReceiveMessagesSetReadMarker? setReadMarker,
-    ChatReceiveMessagesIncludeLastKnown? includeLastKnown,
-    ChatReceiveMessagesNoStatusUpdate? noStatusUpdate,
-    ChatReceiveMessagesMarkNotificationsAsRead? markNotificationsAsRead,
+    required ChatReceiveMessagesRequestApplicationJson $body,
     ChatReceiveMessagesApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __lookIntoFuture =
-        _$jsonSerializers.serialize(lookIntoFuture, specifiedType: const FullType(ChatReceiveMessagesLookIntoFuture));
-    _parameters['lookIntoFuture'] = __lookIntoFuture;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -3840,70 +3706,12 @@ class $ChatClient {
     );
     _parameters['token'] = __token;
 
-    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    __limit ??= 100;
-    _parameters['limit'] = __limit;
-
-    var __lastKnownMessageId = _$jsonSerializers.serialize(lastKnownMessageId, specifiedType: const FullType(int));
-    __lastKnownMessageId ??= 0;
-    _i4.checkNumber(
-      __lastKnownMessageId,
-      'lastKnownMessageId',
-      minimum: 0,
-    );
-    _parameters['lastKnownMessageId'] = __lastKnownMessageId;
-
-    var __lastCommonReadId = _$jsonSerializers.serialize(lastCommonReadId, specifiedType: const FullType(int));
-    __lastCommonReadId ??= 0;
-    _i4.checkNumber(
-      __lastCommonReadId,
-      'lastCommonReadId',
-      minimum: 0,
-    );
-    _parameters['lastCommonReadId'] = __lastCommonReadId;
-
-    var __timeout = _$jsonSerializers.serialize(timeout, specifiedType: const FullType(int));
-    __timeout ??= 30;
-    _i4.checkNumber(
-      __timeout,
-      'timeout',
-      maximum: 30,
-      minimum: 0,
-    );
-    _parameters['timeout'] = __timeout;
-
-    var __setReadMarker =
-        _$jsonSerializers.serialize(setReadMarker, specifiedType: const FullType(ChatReceiveMessagesSetReadMarker));
-    __setReadMarker ??= 1;
-    _parameters['setReadMarker'] = __setReadMarker;
-
-    var __includeLastKnown = _$jsonSerializers.serialize(
-      includeLastKnown,
-      specifiedType: const FullType(ChatReceiveMessagesIncludeLastKnown),
-    );
-    __includeLastKnown ??= 0;
-    _parameters['includeLastKnown'] = __includeLastKnown;
-
-    var __noStatusUpdate =
-        _$jsonSerializers.serialize(noStatusUpdate, specifiedType: const FullType(ChatReceiveMessagesNoStatusUpdate));
-    __noStatusUpdate ??= 0;
-    _parameters['noStatusUpdate'] = __noStatusUpdate;
-
-    var __markNotificationsAsRead = _$jsonSerializers.serialize(
-      markNotificationsAsRead,
-      specifiedType: const FullType(ChatReceiveMessagesMarkNotificationsAsRead),
-    );
-    __markNotificationsAsRead ??= 1;
-    _parameters['markNotificationsAsRead'] = __markNotificationsAsRead;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatReceiveMessagesApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}{?lookIntoFuture*,limit*,lastKnownMessageId*,lastCommonReadId*,timeout*,setReadMarker*,includeLastKnown*,noStatusUpdate*,markNotificationsAsRead*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -3926,6 +3734,10 @@ class $ChatClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -3939,15 +3751,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [lookIntoFuture] Polling for new messages (1) or getting the history of the chat (0).
-  ///   * [limit] Number of chat messages to receive (100 by default, 200 at most). Defaults to `100`.
-  ///   * [lastKnownMessageId] The last known message (serves as offset). Defaults to `0`.
-  ///   * [lastCommonReadId] The last known common read message (so the response is 200 instead of 304 when it changes even when there are no messages). Defaults to `0`.
-  ///   * [timeout] Number of seconds to wait for new messages (30 by default, 30 at most). Defaults to `30`.
-  ///   * [setReadMarker] Automatically set the last read marker when 1, if your client does this itself via chat/{token}/read set to 0. Defaults to `1`.
-  ///   * [includeLastKnown] Include the $lastKnownMessageId in the messages when 1 (default 0). Defaults to `0`.
-  ///   * [noStatusUpdate] When the user status should not be automatically set to online set to 1 (default 0). Defaults to `0`.
-  ///   * [markNotificationsAsRead] Set to 0 when notifications should not be marked as read (default 1). Defaults to `1`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -3961,32 +3764,16 @@ class $ChatClient {
   ///  * [$receiveMessages_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ChatReceiveMessagesResponseApplicationJson, ChatChatReceiveMessagesHeaders>>
       receiveMessages({
-    required ChatReceiveMessagesLookIntoFuture lookIntoFuture,
     required String token,
-    int? limit,
-    int? lastKnownMessageId,
-    int? lastCommonReadId,
-    int? timeout,
-    ChatReceiveMessagesSetReadMarker? setReadMarker,
-    ChatReceiveMessagesIncludeLastKnown? includeLastKnown,
-    ChatReceiveMessagesNoStatusUpdate? noStatusUpdate,
-    ChatReceiveMessagesMarkNotificationsAsRead? markNotificationsAsRead,
+    required ChatReceiveMessagesRequestApplicationJson $body,
     ChatReceiveMessagesApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $receiveMessages_Request(
-      lookIntoFuture: lookIntoFuture,
       token: token,
-      limit: limit,
-      lastKnownMessageId: lastKnownMessageId,
-      lastCommonReadId: lastCommonReadId,
-      timeout: timeout,
-      setReadMarker: setReadMarker,
-      includeLastKnown: includeLastKnown,
-      noStatusUpdate: noStatusUpdate,
-      markNotificationsAsRead: markNotificationsAsRead,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -4017,11 +3804,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [message] the message to send.
-  ///   * [actorDisplayName] for guests. Defaults to `""`.
-  ///   * [referenceId] for the message to be able to later identify it again. Defaults to `""`.
-  ///   * [replyTo] Parent id which this message is a reply to. Defaults to `0`.
-  ///   * [silent] If sent silent the chat message will not create any notifications. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -4038,19 +3820,12 @@ class $ChatClient {
   ///  * [$sendMessage_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $sendMessage_Request({
-    required String message,
     required String token,
-    String? actorDisplayName,
-    String? referenceId,
-    int? replyTo,
-    ChatSendMessageSilent? silent,
+    required ChatSendMessageRequestApplicationJson $body,
     ChatSendMessageApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
-    _parameters['message'] = __message;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -4059,35 +3834,12 @@ class $ChatClient {
     );
     _parameters['token'] = __token;
 
-    var __actorDisplayName = _$jsonSerializers.serialize(actorDisplayName, specifiedType: const FullType(String));
-    __actorDisplayName ??= '';
-    _parameters['actorDisplayName'] = __actorDisplayName;
-
-    var __referenceId = _$jsonSerializers.serialize(referenceId, specifiedType: const FullType(String));
-    __referenceId ??= '';
-    _parameters['referenceId'] = __referenceId;
-
-    var __replyTo = _$jsonSerializers.serialize(replyTo, specifiedType: const FullType(int));
-    __replyTo ??= 0;
-    _i4.checkNumber(
-      __replyTo,
-      'replyTo',
-      minimum: 0,
-    );
-    _parameters['replyTo'] = __replyTo;
-
-    var __silent = _$jsonSerializers.serialize(silent, specifiedType: const FullType(ChatSendMessageSilent));
-    __silent ??= 0;
-    _parameters['silent'] = __silent;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatSendMessageApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}{?message*,actorDisplayName*,referenceId*,replyTo*,silent*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -4110,6 +3862,10 @@ class $ChatClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(ChatSendMessageRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -4121,11 +3877,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [message] the message to send.
-  ///   * [actorDisplayName] for guests. Defaults to `""`.
-  ///   * [referenceId] for the message to be able to later identify it again. Defaults to `""`.
-  ///   * [replyTo] Parent id which this message is a reply to. Defaults to `0`.
-  ///   * [silent] If sent silent the chat message will not create any notifications. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -4141,24 +3892,16 @@ class $ChatClient {
   ///  * [$sendMessage_Request] for the request send by this method.
   ///  * [$sendMessage_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ChatSendMessageResponseApplicationJson, ChatChatSendMessageHeaders>> sendMessage({
-    required String message,
     required String token,
-    String? actorDisplayName,
-    String? referenceId,
-    int? replyTo,
-    ChatSendMessageSilent? silent,
+    required ChatSendMessageRequestApplicationJson $body,
     ChatSendMessageApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $sendMessage_Request(
-      message: message,
       token: token,
-      actorDisplayName: actorDisplayName,
-      referenceId: referenceId,
-      replyTo: replyTo,
-      silent: silent,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -4300,7 +4043,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [message] the message to send.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [messageId] ID of the message.
@@ -4320,16 +4062,13 @@ class $ChatClient {
   ///  * [$editMessage_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $editMessage_Request({
-    required String message,
     required String token,
     required int messageId,
+    required ChatEditMessageRequestApplicationJson $body,
     ChatEditMessageApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
-    _parameters['message'] = __message;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -4351,8 +4090,8 @@ class $ChatClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}{?message*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -4375,6 +4114,10 @@ class $ChatClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(ChatEditMessageRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -4384,7 +4127,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [message] the message to send.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [messageId] ID of the message.
@@ -4403,18 +4145,18 @@ class $ChatClient {
   ///  * [$editMessage_Request] for the request send by this method.
   ///  * [$editMessage_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ChatEditMessageResponseApplicationJson, ChatChatEditMessageHeaders>> editMessage({
-    required String message,
     required String token,
     required int messageId,
+    required ChatEditMessageRequestApplicationJson $body,
     ChatEditMessageApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $editMessage_Request(
-      message: message,
       token: token,
       messageId: messageId,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -4574,7 +4316,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [limit] Number of chat messages to receive in both directions (50 by default, 100 at most, might return 201 messages). Defaults to `50`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [messageId] The focused message which should be in the "middle" of the returned context.
@@ -4591,9 +4332,9 @@ class $ChatClient {
   _i3.Request $getMessageContext_Request({
     required String token,
     required int messageId,
-    int? limit,
     ChatGetMessageContextApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    ChatGetMessageContextRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -4612,22 +4353,12 @@ class $ChatClient {
     );
     _parameters['messageId'] = __messageId;
 
-    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    __limit ??= 50;
-    _i4.checkNumber(
-      __limit,
-      'limit',
-      maximum: 100,
-      minimum: 1,
-    );
-    _parameters['limit'] = __limit;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatGetMessageContextApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/context{?limit*}')
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/context')
         .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
@@ -4651,6 +4382,20 @@ class $ChatClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(ChatGetMessageContextRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ChatGetMessageContextRequestApplicationJson(),
+              specifiedType: const FullType(ChatGetMessageContextRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -4660,7 +4405,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [limit] Number of chat messages to receive in both directions (50 by default, 100 at most, might return 201 messages). Defaults to `50`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [messageId] The focused message which should be in the "middle" of the returned context.
@@ -4677,16 +4421,16 @@ class $ChatClient {
       getMessageContext({
     required String token,
     required int messageId,
-    int? limit,
     ChatGetMessageContextApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    ChatGetMessageContextRequestApplicationJson? $body,
   }) async {
     final _request = $getMessageContext_Request(
       token: token,
       messageId: messageId,
-      limit: limit,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -4840,7 +4584,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [timestamp] Timestamp of the reminder.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [messageId] ID of the message.
@@ -4855,21 +4598,13 @@ class $ChatClient {
   ///  * [$setReminder_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setReminder_Request({
-    required int timestamp,
     required String token,
     required int messageId,
+    required ChatSetReminderRequestApplicationJson $body,
     ChatSetReminderApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __timestamp = _$jsonSerializers.serialize(timestamp, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __timestamp,
-      'timestamp',
-      minimum: 0,
-    );
-    _parameters['timestamp'] = __timestamp;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -4891,9 +4626,8 @@ class $ChatClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder{?timestamp*}')
-            .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/{messageId}/reminder')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -4918,6 +4652,10 @@ class $ChatClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(ChatSetReminderRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -4927,7 +4665,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [timestamp] Timestamp of the reminder.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [messageId] ID of the message.
@@ -4941,18 +4678,18 @@ class $ChatClient {
   ///  * [$setReminder_Request] for the request send by this method.
   ///  * [$setReminder_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ChatSetReminderResponseApplicationJson, void>> setReminder({
-    required int timestamp,
     required String token,
     required int messageId,
+    required ChatSetReminderRequestApplicationJson $body,
     ChatSetReminderApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setReminder_Request(
-      timestamp: timestamp,
       token: token,
       messageId: messageId,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -5104,7 +4841,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [lastReadMessage] ID if the last read message (Optional only with `chat-read-last` capability).
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -5118,9 +4854,9 @@ class $ChatClient {
   @_i2.experimental
   _i3.Request $setReadMarker_Request({
     required String token,
-    int? lastReadMessage,
     ChatSetReadMarkerApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    ChatSetReadMarkerRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -5131,21 +4867,12 @@ class $ChatClient {
     );
     _parameters['token'] = __token;
 
-    final __lastReadMessage = _$jsonSerializers.serialize(lastReadMessage, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __lastReadMessage,
-      'lastReadMessage',
-      minimum: 0,
-    );
-    _parameters['lastReadMessage'] = __lastReadMessage;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatSetReadMarkerApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/read{?lastReadMessage*}')
-        .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/read').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -5168,6 +4895,17 @@ class $ChatClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(ChatSetReadMarkerRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ChatSetReadMarkerRequestApplicationJson(),
+              specifiedType: const FullType(ChatSetReadMarkerRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -5177,7 +4915,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [lastReadMessage] ID if the last read message (Optional only with `chat-read-last` capability).
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -5190,15 +4927,15 @@ class $ChatClient {
   ///  * [$setReadMarker_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ChatSetReadMarkerResponseApplicationJson, ChatChatSetReadMarkerHeaders>> setReadMarker({
     required String token,
-    int? lastReadMessage,
     ChatSetReadMarkerApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    ChatSetReadMarkerRequestApplicationJson? $body,
   }) async {
     final _request = $setReadMarker_Request(
       token: token,
-      lastReadMessage: lastReadMessage,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -5332,9 +5069,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for.
-  ///   * [limit] Maximum number of results. Defaults to `20`.
-  ///   * [includeStatus] Include the user statuses. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -5347,17 +5081,12 @@ class $ChatClient {
   ///  * [$mentions_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $mentions_Request({
-    required String search,
     required String token,
-    int? limit,
-    ChatMentionsIncludeStatus? includeStatus,
+    required ChatMentionsRequestApplicationJson $body,
     ChatMentionsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __search = _$jsonSerializers.serialize(search, specifiedType: const FullType(String));
-    _parameters['search'] = __search;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -5366,22 +5095,11 @@ class $ChatClient {
     );
     _parameters['token'] = __token;
 
-    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    __limit ??= 20;
-    _parameters['limit'] = __limit;
-
-    var __includeStatus =
-        _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(ChatMentionsIncludeStatus));
-    __includeStatus ??= 0;
-    _parameters['includeStatus'] = __includeStatus;
-
     var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatMentionsApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/mentions{?search*,limit*,includeStatus*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/mentions').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -5404,6 +5122,9 @@ class $ChatClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json
+        .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(ChatMentionsRequestApplicationJson)));
     return _request;
   }
 
@@ -5413,9 +5134,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [search] Text to search for.
-  ///   * [limit] Maximum number of results. Defaults to `20`.
-  ///   * [includeStatus] Include the user statuses. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -5427,20 +5145,16 @@ class $ChatClient {
   ///  * [$mentions_Request] for the request send by this method.
   ///  * [$mentions_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ChatMentionsResponseApplicationJson, void>> mentions({
-    required String search,
     required String token,
-    int? limit,
-    ChatMentionsIncludeStatus? includeStatus,
+    required ChatMentionsRequestApplicationJson $body,
     ChatMentionsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $mentions_Request(
-      search: search,
       token: token,
-      limit: limit,
-      includeStatus: includeStatus,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -5467,9 +5181,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [objectType] Type of the objects.
-  ///   * [lastKnownMessageId] ID of the last known message. Defaults to `0`.
-  ///   * [limit] Maximum number of objects. Defaults to `100`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -5482,17 +5193,12 @@ class $ChatClient {
   ///  * [$getObjectsSharedInRoom_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getObjectsSharedInRoom_Request({
-    required String objectType,
     required String token,
-    int? lastKnownMessageId,
-    int? limit,
+    required ChatGetObjectsSharedInRoomRequestApplicationJson $body,
     ChatGetObjectsSharedInRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __objectType = _$jsonSerializers.serialize(objectType, specifiedType: const FullType(String));
-    _parameters['objectType'] = __objectType;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -5501,33 +5207,12 @@ class $ChatClient {
     );
     _parameters['token'] = __token;
 
-    var __lastKnownMessageId = _$jsonSerializers.serialize(lastKnownMessageId, specifiedType: const FullType(int));
-    __lastKnownMessageId ??= 0;
-    _i4.checkNumber(
-      __lastKnownMessageId,
-      'lastKnownMessageId',
-      minimum: 0,
-    );
-    _parameters['lastKnownMessageId'] = __lastKnownMessageId;
-
-    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    __limit ??= 100;
-    _i4.checkNumber(
-      __limit,
-      'limit',
-      maximum: 200,
-      minimum: 1,
-    );
-    _parameters['limit'] = __limit;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatGetObjectsSharedInRoomApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share{?objectType*,lastKnownMessageId*,limit*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -5550,6 +5235,13 @@ class $ChatClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(ChatGetObjectsSharedInRoomRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -5559,9 +5251,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [objectType] Type of the objects.
-  ///   * [lastKnownMessageId] ID of the last known message. Defaults to `0`.
-  ///   * [limit] Maximum number of objects. Defaults to `100`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -5574,20 +5263,16 @@ class $ChatClient {
   ///  * [$getObjectsSharedInRoom_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ChatGetObjectsSharedInRoomResponseApplicationJson, ChatChatGetObjectsSharedInRoomHeaders>>
       getObjectsSharedInRoom({
-    required String objectType,
     required String token,
-    int? lastKnownMessageId,
-    int? limit,
+    required ChatGetObjectsSharedInRoomRequestApplicationJson $body,
     ChatGetObjectsSharedInRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $getObjectsSharedInRoom_Request(
-      objectType: objectType,
       token: token,
-      lastKnownMessageId: lastKnownMessageId,
-      limit: limit,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -5618,11 +5303,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [objectType] Type of the object.
-  ///   * [objectId] ID of the object.
-  ///   * [metaData] Additional metadata. Defaults to `""`.
-  ///   * [actorDisplayName] Guest name. Defaults to `""`.
-  ///   * [referenceId] Reference ID. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -5638,22 +5318,12 @@ class $ChatClient {
   ///  * [$shareObjectToChat_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $shareObjectToChat_Request({
-    required String objectType,
-    required String objectId,
     required String token,
-    String? metaData,
-    String? actorDisplayName,
-    String? referenceId,
+    required ChatShareObjectToChatRequestApplicationJson $body,
     ChatShareObjectToChatApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __objectType = _$jsonSerializers.serialize(objectType, specifiedType: const FullType(String));
-    _parameters['objectType'] = __objectType;
-
-    final __objectId = _$jsonSerializers.serialize(objectId, specifiedType: const FullType(String));
-    _parameters['objectId'] = __objectId;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -5662,26 +5332,12 @@ class $ChatClient {
     );
     _parameters['token'] = __token;
 
-    var __metaData = _$jsonSerializers.serialize(metaData, specifiedType: const FullType(String));
-    __metaData ??= '';
-    _parameters['metaData'] = __metaData;
-
-    var __actorDisplayName = _$jsonSerializers.serialize(actorDisplayName, specifiedType: const FullType(String));
-    __actorDisplayName ??= '';
-    _parameters['actorDisplayName'] = __actorDisplayName;
-
-    var __referenceId = _$jsonSerializers.serialize(referenceId, specifiedType: const FullType(String));
-    __referenceId ??= '';
-    _parameters['referenceId'] = __referenceId;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ChatShareObjectToChatApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share{?objectType*,objectId*,metaData*,actorDisplayName*,referenceId*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -5704,6 +5360,10 @@ class $ChatClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(ChatShareObjectToChatRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -5715,11 +5375,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [objectType] Type of the object.
-  ///   * [objectId] ID of the object.
-  ///   * [metaData] Additional metadata. Defaults to `""`.
-  ///   * [actorDisplayName] Guest name. Defaults to `""`.
-  ///   * [referenceId] Reference ID. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -5735,24 +5390,16 @@ class $ChatClient {
   ///  * [$shareObjectToChat_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ChatShareObjectToChatResponseApplicationJson, ChatChatShareObjectToChatHeaders>>
       shareObjectToChat({
-    required String objectType,
-    required String objectId,
     required String token,
-    String? metaData,
-    String? actorDisplayName,
-    String? referenceId,
+    required ChatShareObjectToChatRequestApplicationJson $body,
     ChatShareObjectToChatApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $shareObjectToChat_Request(
-      objectType: objectType,
-      objectId: objectId,
       token: token,
-      metaData: metaData,
-      actorDisplayName: actorDisplayName,
-      referenceId: referenceId,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -5781,7 +5428,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [limit] Maximum number of objects. Defaults to `7`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -5795,9 +5441,9 @@ class $ChatClient {
   @_i2.experimental
   _i3.Request $getObjectsSharedInRoomOverview_Request({
     required String token,
-    int? limit,
     ChatGetObjectsSharedInRoomOverviewApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    ChatGetObjectsSharedInRoomOverviewRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -5808,16 +5454,6 @@ class $ChatClient {
     );
     _parameters['token'] = __token;
 
-    var __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    __limit ??= 7;
-    _i4.checkNumber(
-      __limit,
-      'limit',
-      maximum: 20,
-      minimum: 1,
-    );
-    _parameters['limit'] = __limit;
-
     var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(ChatGetObjectsSharedInRoomOverviewApiVersion),
@@ -5825,8 +5461,8 @@ class $ChatClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share/overview{?limit*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/chat/{token}/share/overview').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -5849,6 +5485,20 @@ class $ChatClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(ChatGetObjectsSharedInRoomOverviewRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ChatGetObjectsSharedInRoomOverviewRequestApplicationJson(),
+              specifiedType: const FullType(ChatGetObjectsSharedInRoomOverviewRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -5858,7 +5508,6 @@ class $ChatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [limit] Maximum number of objects. Defaults to `7`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -5872,15 +5521,15 @@ class $ChatClient {
   Future<_i1.DynamiteResponse<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson, void>>
       getObjectsSharedInRoomOverview({
     required String token,
-    int? limit,
     ChatGetObjectsSharedInRoomOverviewApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    ChatGetObjectsSharedInRoomOverviewRequestApplicationJson? $body,
   }) async {
     final _request = $getObjectsSharedInRoomOverview_Request(
       token: token,
-      limit: limit,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -5915,7 +5564,6 @@ class $ExternalSignalingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [token] Token of the room. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v3"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -5929,22 +5577,17 @@ class $ExternalSignalingClient {
   ///  * [$signalingGetSettings_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $signalingGetSettings_Request({
-    String? token,
     SignalingGetSettingsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    SignalingGetSettingsRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
-    var __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    __token ??= '';
-    _parameters['token'] = __token;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SignalingGetSettingsApiVersion));
     __apiVersion ??= 'v3';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/settings{?token*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/settings').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -5967,6 +5610,20 @@ class $ExternalSignalingClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(SignalingGetSettingsRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              SignalingGetSettingsRequestApplicationJson(),
+              specifiedType: const FullType(SignalingGetSettingsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -5976,7 +5633,6 @@ class $ExternalSignalingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [token] Token of the room. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v3"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -5989,14 +5645,14 @@ class $ExternalSignalingClient {
   ///  * [$signalingGetSettings_Request] for the request send by this method.
   ///  * [$signalingGetSettings_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<SignalingGetSettingsResponseApplicationJson, void>> signalingGetSettings({
-    String? token,
     SignalingGetSettingsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    SignalingGetSettingsRequestApplicationJson? $body,
   }) async {
     final _request = $signalingGetSettings_Request(
-      token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -6627,7 +6283,6 @@ class $FilesIntegrationClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [shareToken] Token of the file share.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -6640,21 +6295,17 @@ class $FilesIntegrationClient {
   ///  * [$publicShareAuthCreateRoom_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $publicShareAuthCreateRoom_Request({
-    required String shareToken,
+    required PublicShareAuthCreateRoomRequestApplicationJson $body,
     PublicShareAuthCreateRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __shareToken = _$jsonSerializers.serialize(shareToken, specifiedType: const FullType(String));
-    _parameters['shareToken'] = __shareToken;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PublicShareAuthCreateRoomApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/publicshareauth{?shareToken*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/publicshareauth').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -6677,6 +6328,13 @@ class $FilesIntegrationClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(PublicShareAuthCreateRoomRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -6689,7 +6347,6 @@ class $FilesIntegrationClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [shareToken] Token of the file share.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -6701,14 +6358,14 @@ class $FilesIntegrationClient {
   ///  * [$publicShareAuthCreateRoom_Request] for the request send by this method.
   ///  * [$publicShareAuthCreateRoom_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<PublicShareAuthCreateRoomResponseApplicationJson, void>> publicShareAuthCreateRoom({
-    required String shareToken,
+    required PublicShareAuthCreateRoomRequestApplicationJson $body,
     PublicShareAuthCreateRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $publicShareAuthCreateRoom_Request(
-      shareToken: shareToken,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -6742,7 +6399,6 @@ class $GuestClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [displayName] New display name.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -6757,15 +6413,12 @@ class $GuestClient {
   ///  * [$setDisplayName_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setDisplayName_Request({
-    required String displayName,
     required String token,
+    required GuestSetDisplayNameRequestApplicationJson $body,
     GuestSetDisplayNameApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __displayName = _$jsonSerializers.serialize(displayName, specifiedType: const FullType(String));
-    _parameters['displayName'] = __displayName;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -6779,8 +6432,7 @@ class $GuestClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/guest/{token}/name{?displayName*}')
-        .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/guest/{token}/name').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -6803,6 +6455,10 @@ class $GuestClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(GuestSetDisplayNameRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -6812,7 +6468,6 @@ class $GuestClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [displayName] New display name.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -6826,16 +6481,16 @@ class $GuestClient {
   ///  * [$setDisplayName_Request] for the request send by this method.
   ///  * [$setDisplayName_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<GuestSetDisplayNameResponseApplicationJson, void>> setDisplayName({
-    required String displayName,
     required String token,
+    required GuestSetDisplayNameRequestApplicationJson $body,
     GuestSetDisplayNameApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setDisplayName_Request(
-      displayName: displayName,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -6871,11 +6526,6 @@ class $HostedSignalingServerClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [url] Server URL.
-  ///   * [name] Display name of the user.
-  ///   * [email] Email of the user.
-  ///   * [language] Language of the user.
-  ///   * [country] Country of the user.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -6889,30 +6539,11 @@ class $HostedSignalingServerClient {
   ///  * [$requestTrial_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $requestTrial_Request({
-    required String url,
-    required String name,
-    required String email,
-    required String language,
-    required String country,
+    required HostedSignalingServerRequestTrialRequestApplicationJson $body,
     HostedSignalingServerRequestTrialApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __url = _$jsonSerializers.serialize(url, specifiedType: const FullType(String));
-    _parameters['url'] = __url;
-
-    final __name = _$jsonSerializers.serialize(name, specifiedType: const FullType(String));
-    _parameters['name'] = __name;
-
-    final __email = _$jsonSerializers.serialize(email, specifiedType: const FullType(String));
-    _parameters['email'] = __email;
-
-    final __language = _$jsonSerializers.serialize(language, specifiedType: const FullType(String));
-    _parameters['language'] = __language;
-
-    final __country = _$jsonSerializers.serialize(country, specifiedType: const FullType(String));
-    _parameters['country'] = __country;
-
     var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(HostedSignalingServerRequestTrialApiVersion),
@@ -6920,9 +6551,8 @@ class $HostedSignalingServerClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/hostedsignalingserver/requesttrial{?url*,name*,email*,language*,country*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/hostedsignalingserver/requesttrial')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -6947,6 +6577,13 @@ class $HostedSignalingServerClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(HostedSignalingServerRequestTrialRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -6958,11 +6595,6 @@ class $HostedSignalingServerClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [url] Server URL.
-  ///   * [name] Display name of the user.
-  ///   * [email] Email of the user.
-  ///   * [language] Language of the user.
-  ///   * [country] Country of the user.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -6975,22 +6607,14 @@ class $HostedSignalingServerClient {
   ///  * [$requestTrial_Request] for the request send by this method.
   ///  * [$requestTrial_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<HostedSignalingServerRequestTrialResponseApplicationJson, void>> requestTrial({
-    required String url,
-    required String name,
-    required String email,
-    required String language,
-    required String country,
+    required HostedSignalingServerRequestTrialRequestApplicationJson $body,
     HostedSignalingServerRequestTrialApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $requestTrial_Request(
-      url: url,
-      name: name,
-      email: email,
-      language: language,
-      country: country,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -7129,7 +6753,6 @@ class $InternalSignalingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [token] Token of the room. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v3"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -7143,22 +6766,17 @@ class $InternalSignalingClient {
   ///  * [$signalingGetSettings_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $signalingGetSettings_Request({
-    String? token,
     SignalingGetSettingsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    SignalingGetSettingsRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
-    var __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    __token ??= '';
-    _parameters['token'] = __token;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SignalingGetSettingsApiVersion));
     __apiVersion ??= 'v3';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/settings{?token*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/settings').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -7181,6 +6799,20 @@ class $InternalSignalingClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(SignalingGetSettingsRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              SignalingGetSettingsRequestApplicationJson(),
+              specifiedType: const FullType(SignalingGetSettingsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -7190,7 +6822,6 @@ class $InternalSignalingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [token] Token of the room. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v3"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -7203,14 +6834,14 @@ class $InternalSignalingClient {
   ///  * [$signalingGetSettings_Request] for the request send by this method.
   ///  * [$signalingGetSettings_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<SignalingGetSettingsResponseApplicationJson, void>> signalingGetSettings({
-    String? token,
     SignalingGetSettingsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    SignalingGetSettingsRequestApplicationJson? $body,
   }) async {
     final _request = $signalingGetSettings_Request(
-      token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -7350,7 +6981,6 @@ class $InternalSignalingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [messages] JSON encoded messages.
   ///   * [apiVersion] Defaults to `"v3"`.
   ///   * [token] Token of the room.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -7364,15 +6994,12 @@ class $InternalSignalingClient {
   ///  * [$signalingSendMessages_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $signalingSendMessages_Request({
-    required String messages,
     required String token,
+    required SignalingSendMessagesRequestApplicationJson $body,
     SignalingSendMessagesApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __messages = _$jsonSerializers.serialize(messages, specifiedType: const FullType(String));
-    _parameters['messages'] = __messages;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -7386,8 +7013,7 @@ class $InternalSignalingClient {
     __apiVersion ??= 'v3';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/{token}{?messages*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/signaling/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -7410,6 +7036,10 @@ class $InternalSignalingClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(SignalingSendMessagesRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -7419,7 +7049,6 @@ class $InternalSignalingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [messages] JSON encoded messages.
   ///   * [apiVersion] Defaults to `"v3"`.
   ///   * [token] Token of the room.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -7432,16 +7061,16 @@ class $InternalSignalingClient {
   ///  * [$signalingSendMessages_Request] for the request send by this method.
   ///  * [$signalingSendMessages_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<SignalingSendMessagesResponseApplicationJson, void>> signalingSendMessages({
-    required String messages,
     required String token,
+    required SignalingSendMessagesRequestApplicationJson $body,
     SignalingSendMessagesApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $signalingSendMessages_Request(
-      messages: messages,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -7584,8 +7213,6 @@ class $MatterbridgeClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [enabled] If the bridge should be enabled.
-  ///   * [parts] New parts.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -7599,17 +7226,12 @@ class $MatterbridgeClient {
   ///  * [$editBridgeOfRoom_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $editBridgeOfRoom_Request({
-    required MatterbridgeEditBridgeOfRoomEnabled enabled,
     required String token,
-    ContentString<BuiltList<BuiltMap<String, JsonObject>>>? parts,
+    required MatterbridgeEditBridgeOfRoomRequestApplicationJson $body,
     MatterbridgeEditBridgeOfRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __enabled =
-        _$jsonSerializers.serialize(enabled, specifiedType: const FullType(MatterbridgeEditBridgeOfRoomEnabled));
-    _parameters['enabled'] = __enabled;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -7618,23 +7240,12 @@ class $MatterbridgeClient {
     );
     _parameters['token'] = __token;
 
-    final __parts = _$jsonSerializers.serialize(
-      parts,
-      specifiedType: const FullType(ContentString, [
-        FullType(BuiltList, [
-          FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
-        ]),
-      ]),
-    );
-    _parameters['parts'] = __parts;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(MatterbridgeEditBridgeOfRoomApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}{?enabled*,parts*}')
-        .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/bridge/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -7659,6 +7270,13 @@ class $MatterbridgeClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(MatterbridgeEditBridgeOfRoomRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -7668,8 +7286,6 @@ class $MatterbridgeClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [enabled] If the bridge should be enabled.
-  ///   * [parts] New parts.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -7682,18 +7298,16 @@ class $MatterbridgeClient {
   ///  * [$editBridgeOfRoom_Request] for the request send by this method.
   ///  * [$editBridgeOfRoom_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<MatterbridgeEditBridgeOfRoomResponseApplicationJson, void>> editBridgeOfRoom({
-    required MatterbridgeEditBridgeOfRoomEnabled enabled,
     required String token,
-    ContentString<BuiltList<BuiltMap<String, JsonObject>>>? parts,
+    required MatterbridgeEditBridgeOfRoomRequestApplicationJson $body,
     MatterbridgeEditBridgeOfRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $editBridgeOfRoom_Request(
-      enabled: enabled,
       token: token,
-      parts: parts,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -8165,10 +7779,6 @@ class $PollClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [question] Question of the poll.
-  ///   * [options] Options of the poll.
-  ///   * [resultMode] Mode how the results will be shown.
-  ///   * [maxVotes] Number of maximum votes per voter.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -8182,29 +7792,12 @@ class $PollClient {
   ///  * [$createPoll_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $createPoll_Request({
-    required String question,
-    required BuiltList<String> options,
-    required PollCreatePollResultMode resultMode,
-    required int maxVotes,
     required String token,
+    required PollCreatePollRequestApplicationJson $body,
     PollCreatePollApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __question = _$jsonSerializers.serialize(question, specifiedType: const FullType(String));
-    _parameters['question'] = __question;
-
-    final __options =
-        _$jsonSerializers.serialize(options, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    _parameters['options%5B%5D'] = __options;
-
-    final __resultMode =
-        _$jsonSerializers.serialize(resultMode, specifiedType: const FullType(PollCreatePollResultMode));
-    _parameters['resultMode'] = __resultMode;
-
-    final __maxVotes = _$jsonSerializers.serialize(maxVotes, specifiedType: const FullType(int));
-    _parameters['maxVotes'] = __maxVotes;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -8217,9 +7810,7 @@ class $PollClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}{?question*,options%5B%5D*,resultMode*,maxVotes*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -8242,6 +7833,10 @@ class $PollClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(PollCreatePollRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -8251,10 +7846,6 @@ class $PollClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [question] Question of the poll.
-  ///   * [options] Options of the poll.
-  ///   * [resultMode] Mode how the results will be shown.
-  ///   * [maxVotes] Number of maximum votes per voter.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -8267,22 +7858,16 @@ class $PollClient {
   ///  * [$createPoll_Request] for the request send by this method.
   ///  * [$createPoll_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<PollCreatePollResponseApplicationJson, void>> createPoll({
-    required String question,
-    required BuiltList<String> options,
-    required PollCreatePollResultMode resultMode,
-    required int maxVotes,
     required String token,
+    required PollCreatePollRequestApplicationJson $body,
     PollCreatePollApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $createPoll_Request(
-      question: question,
-      options: options,
-      resultMode: resultMode,
-      maxVotes: maxVotes,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -8428,7 +8013,6 @@ class $PollClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [optionIds] IDs of the selected options. Defaults to `[]`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [pollId] ID of the poll.
@@ -8446,9 +8030,9 @@ class $PollClient {
   _i3.Request $votePoll_Request({
     required String token,
     required int pollId,
-    BuiltList<int>? optionIds,
     PollVotePollApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    PollVotePollRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -8467,16 +8051,11 @@ class $PollClient {
     );
     _parameters['pollId'] = __pollId;
 
-    var __optionIds = _$jsonSerializers.serialize(optionIds, specifiedType: const FullType(BuiltList, [FullType(int)]));
-    __optionIds ??= const [];
-    _parameters['optionIds%5B%5D'] = __optionIds;
-
     var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(PollVotePollApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}{?optionIds%5B%5D*}')
-        .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/poll/{token}/{pollId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -8499,6 +8078,17 @@ class $PollClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(PollVotePollRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              PollVotePollRequestApplicationJson(),
+              specifiedType: const FullType(PollVotePollRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -8508,7 +8098,6 @@ class $PollClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [optionIds] IDs of the selected options. Defaults to `[]`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [pollId] ID of the poll.
@@ -8525,16 +8114,16 @@ class $PollClient {
   Future<_i1.DynamiteResponse<PollVotePollResponseApplicationJson, void>> votePoll({
     required String token,
     required int pollId,
-    BuiltList<int>? optionIds,
     PollVotePollApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    PollVotePollRequestApplicationJson? $body,
   }) async {
     final _request = $votePoll_Request(
       token: token,
       pollId: pollId,
-      optionIds: optionIds,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -8694,7 +8283,6 @@ class $ReactionClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [reaction] Emoji to filter.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [messageId] ID of the message.
@@ -8711,9 +8299,9 @@ class $ReactionClient {
   _i3.Request $getReactions_Request({
     required String token,
     required int messageId,
-    String? reaction,
     ReactionGetReactionsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    ReactionGetReactionsRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -8732,16 +8320,13 @@ class $ReactionClient {
     );
     _parameters['messageId'] = __messageId;
 
-    final __reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
-    _parameters['reaction'] = __reaction;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ReactionGetReactionsApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}{?reaction*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -8764,6 +8349,20 @@ class $ReactionClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(ReactionGetReactionsRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ReactionGetReactionsRequestApplicationJson(),
+              specifiedType: const FullType(ReactionGetReactionsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -8773,7 +8372,6 @@ class $ReactionClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [reaction] Emoji to filter.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [messageId] ID of the message.
@@ -8789,16 +8387,16 @@ class $ReactionClient {
   Future<_i1.DynamiteResponse<ReactionGetReactionsResponseApplicationJson, void>> getReactions({
     required String token,
     required int messageId,
-    String? reaction,
     ReactionGetReactionsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    ReactionGetReactionsRequestApplicationJson? $body,
   }) async {
     final _request = $getReactions_Request(
       token: token,
       messageId: messageId,
-      reaction: reaction,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -8824,7 +8422,6 @@ class $ReactionClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [reaction] Emoji to add.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [messageId] ID of the message.
@@ -8841,16 +8438,13 @@ class $ReactionClient {
   ///  * [$react_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $react_Request({
-    required String reaction,
     required String token,
     required int messageId,
+    required ReactionReactRequestApplicationJson $body,
     ReactionReactApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
-    _parameters['reaction'] = __reaction;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -8871,8 +8465,8 @@ class $ReactionClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}{?reaction*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -8895,6 +8489,9 @@ class $ReactionClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json
+        .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(ReactionReactRequestApplicationJson)));
     return _request;
   }
 
@@ -8904,7 +8501,6 @@ class $ReactionClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [reaction] Emoji to add.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [messageId] ID of the message.
@@ -8920,18 +8516,18 @@ class $ReactionClient {
   ///  * [$react_Request] for the request send by this method.
   ///  * [$react_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ReactionReactResponseApplicationJson, void>> react({
-    required String reaction,
     required String token,
     required int messageId,
+    required ReactionReactRequestApplicationJson $body,
     ReactionReactApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $react_Request(
-      reaction: reaction,
       token: token,
       messageId: messageId,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -8957,7 +8553,6 @@ class $ReactionClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [reaction] Emoji to remove.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [messageId] ID of the message.
@@ -8973,16 +8568,13 @@ class $ReactionClient {
   ///  * [$delete_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $delete_Request({
-    required String reaction,
     required String token,
     required int messageId,
+    required ReactionDeleteRequestApplicationJson $body,
     ReactionDeleteApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __reaction = _$jsonSerializers.serialize(reaction, specifiedType: const FullType(String));
-    _parameters['reaction'] = __reaction;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -9003,8 +8595,8 @@ class $ReactionClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}{?reaction*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/reaction/{token}/{messageId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -9027,6 +8619,10 @@ class $ReactionClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(ReactionDeleteRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -9036,7 +8632,6 @@ class $ReactionClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [reaction] Emoji to remove.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [messageId] ID of the message.
@@ -9051,18 +8646,18 @@ class $ReactionClient {
   ///  * [$delete_Request] for the request send by this method.
   ///  * [$delete_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ReactionDeleteResponseApplicationJson, void>> delete({
-    required String reaction,
     required String token,
     required int messageId,
+    required ReactionDeleteRequestApplicationJson $body,
     ReactionDeleteApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $delete_Request(
-      reaction: reaction,
       token: token,
       messageId: messageId,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -9095,7 +8690,6 @@ class $RecordingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [status] Type of the recording.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -9109,15 +8703,12 @@ class $RecordingClient {
   ///  * [$start_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $start_Request({
-    required int status,
     required String token,
+    required RecordingStartRequestApplicationJson $body,
     RecordingStartApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __status = _$jsonSerializers.serialize(status, specifiedType: const FullType(int));
-    _parameters['status'] = __status;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -9130,8 +8721,7 @@ class $RecordingClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}{?status*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -9156,6 +8746,10 @@ class $RecordingClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RecordingStartRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -9165,7 +8759,6 @@ class $RecordingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [status] Type of the recording.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -9178,16 +8771,16 @@ class $RecordingClient {
   ///  * [$start_Request] for the request send by this method.
   ///  * [$start_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RecordingStartResponseApplicationJson, void>> start({
-    required int status,
     required String token,
+    required RecordingStartRequestApplicationJson $body,
     RecordingStartApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $start_Request(
-      status: status,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -9323,7 +8916,6 @@ class $RecordingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [timestamp] Timestamp of the notification to be dismissed.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -9337,20 +8929,12 @@ class $RecordingClient {
   ///  * [$notificationDismiss_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $notificationDismiss_Request({
-    required int timestamp,
     required String token,
+    required RecordingNotificationDismissRequestApplicationJson $body,
     RecordingNotificationDismissApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __timestamp = _$jsonSerializers.serialize(timestamp, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __timestamp,
-      'timestamp',
-      minimum: 0,
-    );
-    _parameters['timestamp'] = __timestamp;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -9365,8 +8949,7 @@ class $RecordingClient {
     _parameters['apiVersion'] = __apiVersion;
 
     final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/notification{?timestamp*}')
-            .expand(_parameters);
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/notification').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -9391,6 +8974,13 @@ class $RecordingClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(RecordingNotificationDismissRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -9400,7 +8990,6 @@ class $RecordingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [timestamp] Timestamp of the notification to be dismissed.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -9413,16 +9002,16 @@ class $RecordingClient {
   ///  * [$notificationDismiss_Request] for the request send by this method.
   ///  * [$notificationDismiss_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RecordingNotificationDismissResponseApplicationJson, void>> notificationDismiss({
-    required int timestamp,
     required String token,
+    required RecordingNotificationDismissRequestApplicationJson $body,
     RecordingNotificationDismissApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $notificationDismiss_Request(
-      timestamp: timestamp,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -9449,8 +9038,6 @@ class $RecordingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [fileId] ID of the file.
-  ///   * [timestamp] Timestamp of the notification to be dismissed.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -9464,29 +9051,12 @@ class $RecordingClient {
   ///  * [$shareToChat_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $shareToChat_Request({
-    required int fileId,
-    required int timestamp,
     required String token,
+    required RecordingShareToChatRequestApplicationJson $body,
     RecordingShareToChatApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __fileId = _$jsonSerializers.serialize(fileId, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __fileId,
-      'fileId',
-      minimum: 0,
-    );
-    _parameters['fileId'] = __fileId;
-
-    final __timestamp = _$jsonSerializers.serialize(timestamp, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __timestamp,
-      'timestamp',
-      minimum: 0,
-    );
-    _parameters['timestamp'] = __timestamp;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -9501,8 +9071,7 @@ class $RecordingClient {
     _parameters['apiVersion'] = __apiVersion;
 
     final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/share-chat{?fileId*,timestamp*}')
-            .expand(_parameters);
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/share-chat').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -9527,6 +9096,10 @@ class $RecordingClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RecordingShareToChatRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -9536,8 +9109,6 @@ class $RecordingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [fileId] ID of the file.
-  ///   * [timestamp] Timestamp of the notification to be dismissed.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -9550,18 +9121,16 @@ class $RecordingClient {
   ///  * [$shareToChat_Request] for the request send by this method.
   ///  * [$shareToChat_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RecordingShareToChatResponseApplicationJson, void>> shareToChat({
-    required int fileId,
-    required int timestamp,
     required String token,
+    required RecordingShareToChatRequestApplicationJson $body,
     RecordingShareToChatApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $shareToChat_Request(
-      fileId: fileId,
-      timestamp: timestamp,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -9686,7 +9255,6 @@ class $RecordingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [owner] User that will own the recording file.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -9701,15 +9269,12 @@ class $RecordingClient {
   ///  * [$store_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $store_Request({
-    required String owner,
     required String token,
+    required RecordingStoreRequestApplicationJson $body,
     RecordingStoreApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __owner = _$jsonSerializers.serialize(owner, specifiedType: const FullType(String));
-    _parameters['owner'] = __owner;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -9722,8 +9287,8 @@ class $RecordingClient {
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/store{?owner*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/recording/{token}/store').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -9746,6 +9311,10 @@ class $RecordingClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RecordingStoreRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -9755,7 +9324,6 @@ class $RecordingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [owner] User that will own the recording file.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -9769,16 +9337,16 @@ class $RecordingClient {
   ///  * [$store_Request] for the request send by this method.
   ///  * [$store_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RecordingStoreResponseApplicationJson, void>> store({
-    required String owner,
     required String token,
+    required RecordingStoreRequestApplicationJson $body,
     RecordingStoreApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $store_Request(
-      owner: owner,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -9812,9 +9380,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [noStatusUpdate] When the user status should not be automatically set to online set to 1 (default 0). Defaults to `0`.
-  ///   * [includeStatus] Include the user status. Defaults to `0`.
-  ///   * [modifiedSince] Filter rooms modified after a timestamp. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -9826,39 +9391,16 @@ class $RoomClient {
   ///  * [$getRooms_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getRooms_Request({
-    RoomGetRoomsNoStatusUpdate? noStatusUpdate,
-    RoomGetRoomsIncludeStatus? includeStatus,
-    int? modifiedSince,
     RoomGetRoomsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    RoomGetRoomsRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
-    var __noStatusUpdate =
-        _$jsonSerializers.serialize(noStatusUpdate, specifiedType: const FullType(RoomGetRoomsNoStatusUpdate));
-    __noStatusUpdate ??= 0;
-    _parameters['noStatusUpdate'] = __noStatusUpdate;
-
-    var __includeStatus =
-        _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(RoomGetRoomsIncludeStatus));
-    __includeStatus ??= 0;
-    _parameters['includeStatus'] = __includeStatus;
-
-    var __modifiedSince = _$jsonSerializers.serialize(modifiedSince, specifiedType: const FullType(int));
-    __modifiedSince ??= 0;
-    _i4.checkNumber(
-      __modifiedSince,
-      'modifiedSince',
-      minimum: 0,
-    );
-    _parameters['modifiedSince'] = __modifiedSince;
-
     var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomGetRoomsApiVersion));
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room{?noStatusUpdate*,includeStatus*,modifiedSince*}')
-            .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -9883,6 +9425,17 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomGetRoomsRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              RoomGetRoomsRequestApplicationJson(),
+              specifiedType: const FullType(RoomGetRoomsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -9892,9 +9445,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [noStatusUpdate] When the user status should not be automatically set to online set to 1 (default 0). Defaults to `0`.
-  ///   * [includeStatus] Include the user status. Defaults to `0`.
-  ///   * [modifiedSince] Filter rooms modified after a timestamp. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -9905,18 +9455,14 @@ class $RoomClient {
   ///  * [$getRooms_Request] for the request send by this method.
   ///  * [$getRooms_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomGetRoomsResponseApplicationJson, RoomRoomGetRoomsHeaders>> getRooms({
-    RoomGetRoomsNoStatusUpdate? noStatusUpdate,
-    RoomGetRoomsIncludeStatus? includeStatus,
-    int? modifiedSince,
     RoomGetRoomsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    RoomGetRoomsRequestApplicationJson? $body,
   }) async {
     final _request = $getRooms_Request(
-      noStatusUpdate: noStatusUpdate,
-      includeStatus: includeStatus,
-      modifiedSince: modifiedSince,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -9944,12 +9490,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [roomType] Type of the room.
-  ///   * [invite] User, group, … ID to invite. Defaults to `""`.
-  ///   * [roomName] Name of the room. Defaults to `""`.
-  ///   * [source] Source of the invite ID ('circles' to create a room with a circle, etc.). Defaults to `""`.
-  ///   * [objectType] Type of the object. Defaults to `""`.
-  ///   * [objectId] ID of the object. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -9965,46 +9505,16 @@ class $RoomClient {
   ///  * [$createRoom_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $createRoom_Request({
-    required int roomType,
-    String? invite,
-    String? roomName,
-    String? source,
-    String? objectType,
-    String? objectId,
+    required RoomCreateRoomRequestApplicationJson $body,
     RoomCreateRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __roomType = _$jsonSerializers.serialize(roomType, specifiedType: const FullType(int));
-    _parameters['roomType'] = __roomType;
-
-    var __invite = _$jsonSerializers.serialize(invite, specifiedType: const FullType(String));
-    __invite ??= '';
-    _parameters['invite'] = __invite;
-
-    var __roomName = _$jsonSerializers.serialize(roomName, specifiedType: const FullType(String));
-    __roomName ??= '';
-    _parameters['roomName'] = __roomName;
-
-    var __source = _$jsonSerializers.serialize(source, specifiedType: const FullType(String));
-    __source ??= '';
-    _parameters['source'] = __source;
-
-    var __objectType = _$jsonSerializers.serialize(objectType, specifiedType: const FullType(String));
-    __objectType ??= '';
-    _parameters['objectType'] = __objectType;
-
-    var __objectId = _$jsonSerializers.serialize(objectId, specifiedType: const FullType(String));
-    __objectId ??= '';
-    _parameters['objectId'] = __objectId;
-
     var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomCreateRoomApiVersion));
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/room{?roomType*,invite*,roomName*,source*,objectType*,objectId*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -10029,6 +9539,10 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomCreateRoomRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -10038,12 +9552,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [roomType] Type of the room.
-  ///   * [invite] User, group, … ID to invite. Defaults to `""`.
-  ///   * [roomName] Name of the room. Defaults to `""`.
-  ///   * [source] Source of the invite ID ('circles' to create a room with a circle, etc.). Defaults to `""`.
-  ///   * [objectType] Type of the object. Defaults to `""`.
-  ///   * [objectId] ID of the object. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -10058,24 +9566,14 @@ class $RoomClient {
   ///  * [$createRoom_Request] for the request send by this method.
   ///  * [$createRoom_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomCreateRoomResponseApplicationJson, void>> createRoom({
-    required int roomType,
-    String? invite,
-    String? roomName,
-    String? source,
-    String? objectType,
-    String? objectId,
+    required RoomCreateRoomRequestApplicationJson $body,
     RoomCreateRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $createRoom_Request(
-      roomType: roomType,
-      invite: invite,
-      roomName: roomName,
-      source: source,
-      objectType: objectType,
-      objectId: objectId,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -10102,7 +9600,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [searchTerm] search term. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -10114,22 +9611,17 @@ class $RoomClient {
   ///  * [$getListedRooms_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $getListedRooms_Request({
-    String? searchTerm,
     RoomGetListedRoomsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    RoomGetListedRoomsRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
-    var __searchTerm = _$jsonSerializers.serialize(searchTerm, specifiedType: const FullType(String));
-    __searchTerm ??= '';
-    _parameters['searchTerm'] = __searchTerm;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomGetListedRoomsApiVersion));
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/listed-room{?searchTerm*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/listed-room').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -10154,6 +9646,17 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomGetListedRoomsRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              RoomGetListedRoomsRequestApplicationJson(),
+              specifiedType: const FullType(RoomGetListedRoomsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -10163,7 +9666,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [searchTerm] search term. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -10174,14 +9676,14 @@ class $RoomClient {
   ///  * [$getListedRooms_Request] for the request send by this method.
   ///  * [$getListedRooms_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomGetListedRoomsResponseApplicationJson, void>> getListedRooms({
-    String? searchTerm,
     RoomGetListedRoomsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    RoomGetListedRoomsRequestApplicationJson? $body,
   }) async {
     final _request = $getListedRooms_Request(
-      searchTerm: searchTerm,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -10760,7 +10262,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [description] New description.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -10774,15 +10275,12 @@ class $RoomClient {
   ///  * [$setDescription_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setDescription_Request({
-    required String description,
     required String token,
+    required RoomSetDescriptionRequestApplicationJson $body,
     RoomSetDescriptionApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __description = _$jsonSerializers.serialize(description, specifiedType: const FullType(String));
-    _parameters['description'] = __description;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -10796,8 +10294,8 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/description{?description*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/description').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -10820,6 +10318,10 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomSetDescriptionRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -10829,7 +10331,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [description] New description.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -10842,16 +10343,16 @@ class $RoomClient {
   ///  * [$setDescription_Request] for the request send by this method.
   ///  * [$setDescription_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetDescriptionResponseApplicationJson, void>> setDescription({
-    required String description,
     required String token,
+    required RoomSetDescriptionRequestApplicationJson $body,
     RoomSetDescriptionApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setDescription_Request(
-      description: description,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -10878,7 +10379,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [state] New read-only state.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -10892,15 +10392,12 @@ class $RoomClient {
   ///  * [$setReadOnly_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setReadOnly_Request({
-    required RoomSetReadOnlyState state,
     required String token,
+    required RoomSetReadOnlyRequestApplicationJson $body,
     RoomSetReadOnlyApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __state = _$jsonSerializers.serialize(state, specifiedType: const FullType(RoomSetReadOnlyState));
-    _parameters['state'] = __state;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -10915,7 +10412,7 @@ class $RoomClient {
     _parameters['apiVersion'] = __apiVersion;
 
     final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/read-only{?state*}').expand(_parameters);
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/read-only').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -10940,6 +10437,10 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomSetReadOnlyRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -10949,7 +10450,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [state] New read-only state.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -10962,16 +10462,16 @@ class $RoomClient {
   ///  * [$setReadOnly_Request] for the request send by this method.
   ///  * [$setReadOnly_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetReadOnlyResponseApplicationJson, void>> setReadOnly({
-    required RoomSetReadOnlyState state,
     required String token,
+    required RoomSetReadOnlyRequestApplicationJson $body,
     RoomSetReadOnlyApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setReadOnly_Request(
-      state: state,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -10998,7 +10498,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [scope] Scope where the room is listable.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -11012,15 +10511,12 @@ class $RoomClient {
   ///  * [$setListable_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setListable_Request({
-    required RoomSetListableScope scope,
     required String token,
+    required RoomSetListableRequestApplicationJson $body,
     RoomSetListableApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __scope = _$jsonSerializers.serialize(scope, specifiedType: const FullType(RoomSetListableScope));
-    _parameters['scope'] = __scope;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -11034,8 +10530,7 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/listable{?scope*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/listable').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -11060,6 +10555,10 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomSetListableRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -11069,7 +10568,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [scope] Scope where the room is listable.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -11082,16 +10580,16 @@ class $RoomClient {
   ///  * [$setListable_Request] for the request send by this method.
   ///  * [$setListable_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetListableResponseApplicationJson, void>> setListable({
-    required RoomSetListableScope scope,
     required String token,
+    required RoomSetListableRequestApplicationJson $body,
     RoomSetListableApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setListable_Request(
-      scope: scope,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -11118,7 +10616,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [password] New password.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -11133,15 +10630,12 @@ class $RoomClient {
   ///  * [$setPassword_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setPassword_Request({
-    required String password,
     required String token,
+    required RoomSetPasswordRequestApplicationJson $body,
     RoomSetPasswordApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    _parameters['password'] = __password;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -11155,8 +10649,7 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/password{?password*}')
-        .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/password').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -11179,6 +10672,10 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomSetPasswordRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -11188,7 +10685,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [password] New password.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -11202,16 +10698,16 @@ class $RoomClient {
   ///  * [$setPassword_Request] for the request send by this method.
   ///  * [$setPassword_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetPasswordResponseApplicationJson, void>> setPassword({
-    required String password,
     required String token,
+    required RoomSetPasswordRequestApplicationJson $body,
     RoomSetPasswordApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setPassword_Request(
-      password: password,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -11238,7 +10734,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [permissions] New permissions.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [mode] Level of the permissions ('call', 'default').
@@ -11253,22 +10748,13 @@ class $RoomClient {
   ///  * [$setPermissions_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setPermissions_Request({
-    required int permissions,
     required String token,
     required RoomSetPermissionsMode mode,
+    required RoomSetPermissionsRequestApplicationJson $body,
     RoomSetPermissionsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __permissions,
-      'permissions',
-      maximum: 255,
-      minimum: 0,
-    );
-    _parameters['permissions'] = __permissions;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -11291,8 +10777,7 @@ class $RoomClient {
     _parameters['apiVersion'] = __apiVersion;
 
     final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/permissions/{mode}{?permissions*}')
-            .expand(_parameters);
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/permissions/{mode}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -11315,6 +10800,10 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomSetPermissionsRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -11324,7 +10813,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [permissions] New permissions.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [mode] Level of the permissions ('call', 'default').
@@ -11338,18 +10826,18 @@ class $RoomClient {
   ///  * [$setPermissions_Request] for the request send by this method.
   ///  * [$setPermissions_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetPermissionsResponseApplicationJson, void>> setPermissions({
-    required int permissions,
     required String token,
     required RoomSetPermissionsMode mode,
+    required RoomSetPermissionsRequestApplicationJson $body,
     RoomSetPermissionsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setPermissions_Request(
-      permissions: permissions,
       token: token,
       mode: mode,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -11376,7 +10864,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [includeStatus] Include the user statuses. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -11391,9 +10878,9 @@ class $RoomClient {
   @_i2.experimental
   _i3.Request $getParticipants_Request({
     required String token,
-    RoomGetParticipantsIncludeStatus? includeStatus,
     RoomGetParticipantsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    RoomGetParticipantsRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -11404,18 +10891,13 @@ class $RoomClient {
     );
     _parameters['token'] = __token;
 
-    var __includeStatus =
-        _$jsonSerializers.serialize(includeStatus, specifiedType: const FullType(RoomGetParticipantsIncludeStatus));
-    __includeStatus ??= 0;
-    _parameters['includeStatus'] = __includeStatus;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomGetParticipantsApiVersion));
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants{?includeStatus*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -11438,6 +10920,20 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(RoomGetParticipantsRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              RoomGetParticipantsRequestApplicationJson(),
+              specifiedType: const FullType(RoomGetParticipantsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -11447,7 +10943,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [includeStatus] Include the user statuses. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -11462,15 +10957,15 @@ class $RoomClient {
   Future<_i1.DynamiteResponse<RoomGetParticipantsResponseApplicationJson, RoomRoomGetParticipantsHeaders>>
       getParticipants({
     required String token,
-    RoomGetParticipantsIncludeStatus? includeStatus,
     RoomGetParticipantsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    RoomGetParticipantsRequestApplicationJson? $body,
   }) async {
     final _request = $getParticipants_Request(
       token: token,
-      includeStatus: includeStatus,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -11499,8 +10994,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [newParticipant] New participant.
-  ///   * [source] Source of the participant. Defaults to `"users"`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -11516,16 +11009,12 @@ class $RoomClient {
   ///  * [$addParticipantToRoom_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $addParticipantToRoom_Request({
-    required String newParticipant,
     required String token,
-    RoomAddParticipantToRoomSource? source,
+    required RoomAddParticipantToRoomRequestApplicationJson $body,
     RoomAddParticipantToRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __newParticipant = _$jsonSerializers.serialize(newParticipant, specifiedType: const FullType(String));
-    _parameters['newParticipant'] = __newParticipant;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -11534,18 +11023,13 @@ class $RoomClient {
     );
     _parameters['token'] = __token;
 
-    var __source = _$jsonSerializers.serialize(source, specifiedType: const FullType(RoomAddParticipantToRoomSource));
-    __source ??= 'users';
-    _parameters['source'] = __source;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomAddParticipantToRoomApiVersion));
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
     final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants{?newParticipant*,source*}')
-            .expand(_parameters);
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -11570,6 +11054,13 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(RoomAddParticipantToRoomRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -11579,8 +11070,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [newParticipant] New participant.
-  ///   * [source] Source of the participant. Defaults to `"users"`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -11595,18 +11084,16 @@ class $RoomClient {
   ///  * [$addParticipantToRoom_Request] for the request send by this method.
   ///  * [$addParticipantToRoom_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomAddParticipantToRoomResponseApplicationJson, void>> addParticipantToRoom({
-    required String newParticipant,
     required String token,
-    RoomAddParticipantToRoomSource? source,
+    required RoomAddParticipantToRoomRequestApplicationJson $body,
     RoomAddParticipantToRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $addParticipantToRoom_Request(
-      newParticipant: newParticipant,
       token: token,
-      source: source,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -11634,7 +11121,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [includeStatus] Include the user statuses. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -11650,9 +11136,9 @@ class $RoomClient {
   @_i2.experimental
   _i3.Request $getBreakoutRoomParticipants_Request({
     required String token,
-    RoomGetBreakoutRoomParticipantsIncludeStatus? includeStatus,
     RoomGetBreakoutRoomParticipantsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    RoomGetBreakoutRoomParticipantsRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -11663,13 +11149,6 @@ class $RoomClient {
     );
     _parameters['token'] = __token;
 
-    var __includeStatus = _$jsonSerializers.serialize(
-      includeStatus,
-      specifiedType: const FullType(RoomGetBreakoutRoomParticipantsIncludeStatus),
-    );
-    __includeStatus ??= 0;
-    _parameters['includeStatus'] = __includeStatus;
-
     var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(RoomGetBreakoutRoomParticipantsApiVersion),
@@ -11677,9 +11156,8 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/breakout-rooms/participants{?includeStatus*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/breakout-rooms/participants')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -11702,6 +11180,20 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(RoomGetBreakoutRoomParticipantsRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              RoomGetBreakoutRoomParticipantsRequestApplicationJson(),
+              specifiedType: const FullType(RoomGetBreakoutRoomParticipantsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -11711,7 +11203,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [includeStatus] Include the user statuses. Defaults to `0`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -11728,15 +11219,15 @@ class $RoomClient {
       _i1.DynamiteResponse<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
           RoomRoomGetBreakoutRoomParticipantsHeaders>> getBreakoutRoomParticipants({
     required String token,
-    RoomGetBreakoutRoomParticipantsIncludeStatus? includeStatus,
     RoomGetBreakoutRoomParticipantsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    RoomGetBreakoutRoomParticipantsRequestApplicationJson? $body,
   }) async {
     final _request = $getBreakoutRoomParticipants_Request(
       token: token,
-      includeStatus: includeStatus,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -11878,7 +11369,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [attendeeId] ID of the attendee.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -11894,20 +11384,12 @@ class $RoomClient {
   ///  * [$removeAttendeeFromRoom_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $removeAttendeeFromRoom_Request({
-    required int attendeeId,
     required String token,
+    required RoomRemoveAttendeeFromRoomRequestApplicationJson $body,
     RoomRemoveAttendeeFromRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __attendeeId,
-      'attendeeId',
-      minimum: 0,
-    );
-    _parameters['attendeeId'] = __attendeeId;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -11921,8 +11403,8 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees{?attendeeId*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -11945,6 +11427,13 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(RoomRemoveAttendeeFromRoomRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -11954,7 +11443,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [attendeeId] ID of the attendee.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -11969,16 +11457,16 @@ class $RoomClient {
   ///  * [$removeAttendeeFromRoom_Request] for the request send by this method.
   ///  * [$removeAttendeeFromRoom_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomRemoveAttendeeFromRoomResponseApplicationJson, void>> removeAttendeeFromRoom({
-    required int attendeeId,
     required String token,
+    required RoomRemoveAttendeeFromRoomRequestApplicationJson $body,
     RoomRemoveAttendeeFromRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $removeAttendeeFromRoom_Request(
-      attendeeId: attendeeId,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -12005,9 +11493,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [attendeeId] ID of the attendee.
-  ///   * [method] Method of updating permissions ('set', 'remove', 'add').
-  ///   * [permissions] New permissions.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12023,35 +11508,12 @@ class $RoomClient {
   ///  * [$setAttendeePermissions_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setAttendeePermissions_Request({
-    required int attendeeId,
-    required RoomSetAttendeePermissionsMethod method,
-    required int permissions,
     required String token,
+    required RoomSetAttendeePermissionsRequestApplicationJson $body,
     RoomSetAttendeePermissionsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __attendeeId,
-      'attendeeId',
-      minimum: 0,
-    );
-    _parameters['attendeeId'] = __attendeeId;
-
-    final __method =
-        _$jsonSerializers.serialize(method, specifiedType: const FullType(RoomSetAttendeePermissionsMethod));
-    _parameters['method'] = __method;
-
-    final __permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __permissions,
-      'permissions',
-      maximum: 255,
-      minimum: 0,
-    );
-    _parameters['permissions'] = __permissions;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -12065,9 +11527,8 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees/permissions{?attendeeId*,method*,permissions*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees/permissions')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -12090,6 +11551,13 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(RoomSetAttendeePermissionsRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -12099,9 +11567,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [attendeeId] ID of the attendee.
-  ///   * [method] Method of updating permissions ('set', 'remove', 'add').
-  ///   * [permissions] New permissions.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12116,20 +11581,16 @@ class $RoomClient {
   ///  * [$setAttendeePermissions_Request] for the request send by this method.
   ///  * [$setAttendeePermissions_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetAttendeePermissionsResponseApplicationJson, void>> setAttendeePermissions({
-    required int attendeeId,
-    required RoomSetAttendeePermissionsMethod method,
-    required int permissions,
     required String token,
+    required RoomSetAttendeePermissionsRequestApplicationJson $body,
     RoomSetAttendeePermissionsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setAttendeePermissions_Request(
-      attendeeId: attendeeId,
-      method: method,
-      permissions: permissions,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -12156,8 +11617,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [method] Method of updating permissions ('set', 'remove', 'add').
-  ///   * [permissions] New permissions.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12171,26 +11630,12 @@ class $RoomClient {
   ///  * [$setAllAttendeesPermissions_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setAllAttendeesPermissions_Request({
-    required RoomSetAllAttendeesPermissionsMethod method,
-    required int permissions,
     required String token,
+    required RoomSetAllAttendeesPermissionsRequestApplicationJson $body,
     RoomSetAllAttendeesPermissionsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __method =
-        _$jsonSerializers.serialize(method, specifiedType: const FullType(RoomSetAllAttendeesPermissionsMethod));
-    _parameters['method'] = __method;
-
-    final __permissions = _$jsonSerializers.serialize(permissions, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __permissions,
-      'permissions',
-      maximum: 255,
-      minimum: 0,
-    );
-    _parameters['permissions'] = __permissions;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -12206,9 +11651,8 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees/permissions/all{?method*,permissions*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/attendees/permissions/all')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -12231,6 +11675,13 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(RoomSetAllAttendeesPermissionsRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -12240,8 +11691,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [method] Method of updating permissions ('set', 'remove', 'add').
-  ///   * [permissions] New permissions.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12254,18 +11703,16 @@ class $RoomClient {
   ///  * [$setAllAttendeesPermissions_Request] for the request send by this method.
   ///  * [$setAllAttendeesPermissions_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetAllAttendeesPermissionsResponseApplicationJson, void>> setAllAttendeesPermissions({
-    required RoomSetAllAttendeesPermissionsMethod method,
-    required int permissions,
     required String token,
+    required RoomSetAllAttendeesPermissionsRequestApplicationJson $body,
     RoomSetAllAttendeesPermissionsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setAllAttendeesPermissions_Request(
-      method: method,
-      permissions: permissions,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -12292,8 +11739,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [password] Password of the room. Defaults to `""`.
-  ///   * [force] Create a new session if necessary. Defaults to `1`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token] Token of the room.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12310,10 +11755,9 @@ class $RoomClient {
   @_i2.experimental
   _i3.Request $joinRoom_Request({
     required String token,
-    String? password,
-    RoomJoinRoomForce? force,
     RoomJoinRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    RoomJoinRoomRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -12324,21 +11768,12 @@ class $RoomClient {
     );
     _parameters['token'] = __token;
 
-    var __password = _$jsonSerializers.serialize(password, specifiedType: const FullType(String));
-    __password ??= '';
-    _parameters['password'] = __password;
-
-    var __force = _$jsonSerializers.serialize(force, specifiedType: const FullType(RoomJoinRoomForce));
-    __force ??= 1;
-    _parameters['force'] = __force;
-
     var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomJoinRoomApiVersion));
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/active{?password*,force*}')
-            .expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/active')
+        .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -12361,6 +11796,17 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomJoinRoomRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              RoomJoinRoomRequestApplicationJson(),
+              specifiedType: const FullType(RoomJoinRoomRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -12370,8 +11816,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [password] Password of the room. Defaults to `""`.
-  ///   * [force] Create a new session if necessary. Defaults to `1`.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token] Token of the room.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12387,17 +11831,15 @@ class $RoomClient {
   ///  * [$joinRoom_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomJoinRoomResponseApplicationJson, RoomRoomJoinRoomHeaders>> joinRoom({
     required String token,
-    String? password,
-    RoomJoinRoomForce? force,
     RoomJoinRoomApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    RoomJoinRoomRequestApplicationJson? $body,
   }) async {
     final _request = $joinRoom_Request(
       token: token,
-      password: password,
-      force: force,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -12531,7 +11973,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [attendeeId] ID of the attendee.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12546,9 +11987,9 @@ class $RoomClient {
   @_i2.experimental
   _i3.Request $resendInvitations_Request({
     required String token,
-    int? attendeeId,
     RoomResendInvitationsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    RoomResendInvitationsRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
@@ -12559,22 +12000,14 @@ class $RoomClient {
     );
     _parameters['token'] = __token;
 
-    final __attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __attendeeId,
-      'attendeeId',
-      minimum: 0,
-    );
-    _parameters['attendeeId'] = __attendeeId;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomResendInvitationsApiVersion));
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/resend-invitations{?attendeeId*}',
-    ).expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/resend-invitations')
+            .expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -12599,6 +12032,20 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(RoomResendInvitationsRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              RoomResendInvitationsRequestApplicationJson(),
+              specifiedType: const FullType(RoomResendInvitationsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -12608,7 +12055,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [attendeeId] ID of the attendee.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12622,15 +12068,15 @@ class $RoomClient {
   ///  * [$resendInvitations_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomResendInvitationsResponseApplicationJson, void>> resendInvitations({
     required String token,
-    int? attendeeId,
     RoomResendInvitationsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    RoomResendInvitationsRequestApplicationJson? $body,
   }) async {
     final _request = $resendInvitations_Request(
       token: token,
-      attendeeId: attendeeId,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -12657,7 +12103,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [state] of the room.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12672,15 +12117,12 @@ class $RoomClient {
   ///  * [$setSessionState_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setSessionState_Request({
-    required RoomSetSessionStateState state,
     required String token,
+    required RoomSetSessionStateRequestApplicationJson $body,
     RoomSetSessionStateApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __state = _$jsonSerializers.serialize(state, specifiedType: const FullType(RoomSetSessionStateState));
-    _parameters['state'] = __state;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -12694,8 +12136,8 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/state{?state*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/participants/state').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -12718,6 +12160,10 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomSetSessionStateRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -12727,7 +12173,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [state] of the room.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12741,16 +12186,16 @@ class $RoomClient {
   ///  * [$setSessionState_Request] for the request send by this method.
   ///  * [$setSessionState_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetSessionStateResponseApplicationJson, void>> setSessionState({
-    required RoomSetSessionStateState state,
     required String token,
+    required RoomSetSessionStateRequestApplicationJson $body,
     RoomSetSessionStateApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setSessionState_Request(
-      state: state,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -12777,7 +12222,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [attendeeId] ID of the attendee.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12793,20 +12237,12 @@ class $RoomClient {
   ///  * [$promoteModerator_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $promoteModerator_Request({
-    required int attendeeId,
     required String token,
+    required RoomPromoteModeratorRequestApplicationJson $body,
     RoomPromoteModeratorApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __attendeeId,
-      'attendeeId',
-      minimum: 0,
-    );
-    _parameters['attendeeId'] = __attendeeId;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -12820,8 +12256,8 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/moderators{?attendeeId*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/moderators').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -12844,6 +12280,10 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomPromoteModeratorRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -12853,7 +12293,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [attendeeId] ID of the attendee.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12868,16 +12307,16 @@ class $RoomClient {
   ///  * [$promoteModerator_Request] for the request send by this method.
   ///  * [$promoteModerator_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomPromoteModeratorResponseApplicationJson, void>> promoteModerator({
-    required int attendeeId,
     required String token,
+    required RoomPromoteModeratorRequestApplicationJson $body,
     RoomPromoteModeratorApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $promoteModerator_Request(
-      attendeeId: attendeeId,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -12904,7 +12343,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [attendeeId] ID of the attendee.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12920,20 +12358,12 @@ class $RoomClient {
   ///  * [$demoteModerator_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $demoteModerator_Request({
-    required int attendeeId,
     required String token,
+    required RoomDemoteModeratorRequestApplicationJson $body,
     RoomDemoteModeratorApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __attendeeId = _$jsonSerializers.serialize(attendeeId, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __attendeeId,
-      'attendeeId',
-      minimum: 0,
-    );
-    _parameters['attendeeId'] = __attendeeId;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -12947,8 +12377,8 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/moderators{?attendeeId*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/moderators').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -12971,6 +12401,10 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomDemoteModeratorRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -12980,7 +12414,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [attendeeId] ID of the attendee.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -12995,16 +12428,16 @@ class $RoomClient {
   ///  * [$demoteModerator_Request] for the request send by this method.
   ///  * [$demoteModerator_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomDemoteModeratorResponseApplicationJson, void>> demoteModerator({
-    required int attendeeId,
     required String token,
+    required RoomDemoteModeratorRequestApplicationJson $body,
     RoomDemoteModeratorApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $demoteModerator_Request(
-      attendeeId: attendeeId,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -13249,7 +12682,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [level] New level.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -13263,15 +12695,12 @@ class $RoomClient {
   ///  * [$setNotificationLevel_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setNotificationLevel_Request({
-    required int level,
     required String token,
+    required RoomSetNotificationLevelRequestApplicationJson $body,
     RoomSetNotificationLevelApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __level = _$jsonSerializers.serialize(level, specifiedType: const FullType(int));
-    _parameters['level'] = __level;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -13285,8 +12714,7 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/notify{?level*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/notify').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -13311,6 +12739,13 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(RoomSetNotificationLevelRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -13320,7 +12755,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [level] New level.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -13333,16 +12767,16 @@ class $RoomClient {
   ///  * [$setNotificationLevel_Request] for the request send by this method.
   ///  * [$setNotificationLevel_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetNotificationLevelResponseApplicationJson, void>> setNotificationLevel({
-    required int level,
     required String token,
+    required RoomSetNotificationLevelRequestApplicationJson $body,
     RoomSetNotificationLevelApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setNotificationLevel_Request(
-      level: level,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -13369,7 +12803,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [level] New level.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -13383,15 +12816,12 @@ class $RoomClient {
   ///  * [$setNotificationCalls_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setNotificationCalls_Request({
-    required int level,
     required String token,
+    required RoomSetNotificationCallsRequestApplicationJson $body,
     RoomSetNotificationCallsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __level = _$jsonSerializers.serialize(level, specifiedType: const FullType(int));
-    _parameters['level'] = __level;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -13405,8 +12835,8 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/notify-calls{?level*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/notify-calls').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -13431,6 +12861,13 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(RoomSetNotificationCallsRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -13440,7 +12877,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [level] New level.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -13453,16 +12889,16 @@ class $RoomClient {
   ///  * [$setNotificationCalls_Request] for the request send by this method.
   ///  * [$setNotificationCalls_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetNotificationCallsResponseApplicationJson, void>> setNotificationCalls({
-    required int level,
     required String token,
+    required RoomSetNotificationCallsRequestApplicationJson $body,
     RoomSetNotificationCallsApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setNotificationCalls_Request(
-      level: level,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -13488,8 +12924,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [state] New state.
-  ///   * [timer] Timer when the lobby will be removed.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -13503,16 +12937,12 @@ class $RoomClient {
   ///  * [$setLobby_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setLobby_Request({
-    required int state,
     required String token,
-    int? timer,
+    required RoomSetLobbyRequestApplicationJson $body,
     RoomSetLobbyApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __state = _$jsonSerializers.serialize(state, specifiedType: const FullType(int));
-    _parameters['state'] = __state;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -13521,20 +12951,12 @@ class $RoomClient {
     );
     _parameters['token'] = __token;
 
-    final __timer = _$jsonSerializers.serialize(timer, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __timer,
-      'timer',
-      minimum: 0,
-    );
-    _parameters['timer'] = __timer;
-
     var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomSetLobbyApiVersion));
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/webinar/lobby{?state*,timer*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/webinar/lobby').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -13559,6 +12981,9 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json
+        .encode(_$jsonSerializers.serialize($body, specifiedType: const FullType(RoomSetLobbyRequestApplicationJson)));
     return _request;
   }
 
@@ -13568,8 +12993,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [state] New state.
-  ///   * [timer] Timer when the lobby will be removed.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -13582,18 +13005,16 @@ class $RoomClient {
   ///  * [$setLobby_Request] for the request send by this method.
   ///  * [$setLobby_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetLobbyResponseApplicationJson, void>> setLobby({
-    required int state,
     required String token,
-    int? timer,
+    required RoomSetLobbyRequestApplicationJson $body,
     RoomSetLobbyApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setLobby_Request(
-      state: state,
       token: token,
-      timer: timer,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -13620,7 +13041,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [state] New state.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -13637,15 +13057,12 @@ class $RoomClient {
   ///  * [$setsipEnabled_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setsipEnabled_Request({
-    required RoomSetsipEnabledState state,
     required String token,
+    required RoomSetsipEnabledRequestApplicationJson $body,
     RoomSetsipEnabledApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __state = _$jsonSerializers.serialize(state, specifiedType: const FullType(RoomSetsipEnabledState));
-    _parameters['state'] = __state;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -13659,8 +13076,8 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/webinar/sip{?state*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/webinar/sip').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -13685,6 +13102,10 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomSetsipEnabledRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -13694,7 +13115,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [state] New state.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -13710,16 +13130,16 @@ class $RoomClient {
   ///  * [$setsipEnabled_Request] for the request send by this method.
   ///  * [$setsipEnabled_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetsipEnabledResponseApplicationJson, void>> setsipEnabled({
-    required RoomSetsipEnabledState state,
     required String token,
+    required RoomSetsipEnabledRequestApplicationJson $body,
     RoomSetsipEnabledApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setsipEnabled_Request(
-      state: state,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -13746,7 +13166,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [recordingConsent] New consent setting for the conversation (Only {@see RecordingService::CONSENT_REQUIRED_NO} and {@see RecordingService::CONSENT_REQUIRED_YES} are allowed here.).
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -13761,15 +13180,12 @@ class $RoomClient {
   ///  * [$setRecordingConsent_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setRecordingConsent_Request({
-    required int recordingConsent,
     required String token,
+    required RoomSetRecordingConsentRequestApplicationJson $body,
     RoomSetRecordingConsentApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __recordingConsent = _$jsonSerializers.serialize(recordingConsent, specifiedType: const FullType(int));
-    _parameters['recordingConsent'] = __recordingConsent;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -13784,8 +13200,7 @@ class $RoomClient {
     _parameters['apiVersion'] = __apiVersion;
 
     final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/recording-consent{?recordingConsent*}')
-            .expand(_parameters);
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/recording-consent').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -13810,6 +13225,13 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(RoomSetRecordingConsentRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -13819,7 +13241,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [recordingConsent] New consent setting for the conversation (Only {@see RecordingService::CONSENT_REQUIRED_NO} and {@see RecordingService::CONSENT_REQUIRED_YES} are allowed here.).
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -13833,16 +13254,16 @@ class $RoomClient {
   ///  * [$setRecordingConsent_Request] for the request send by this method.
   ///  * [$setRecordingConsent_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetRecordingConsentResponseApplicationJson, void>> setRecordingConsent({
-    required int recordingConsent,
     required String token,
+    required RoomSetRecordingConsentRequestApplicationJson $body,
     RoomSetRecordingConsentApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setRecordingConsent_Request(
-      recordingConsent: recordingConsent,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -13869,7 +13290,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [seconds] New time.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -13883,20 +13303,12 @@ class $RoomClient {
   ///  * [$setMessageExpiration_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setMessageExpiration_Request({
-    required int seconds,
     required String token,
+    required RoomSetMessageExpirationRequestApplicationJson $body,
     RoomSetMessageExpirationApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __seconds = _$jsonSerializers.serialize(seconds, specifiedType: const FullType(int));
-    _i4.checkNumber(
-      __seconds,
-      'seconds',
-      minimum: 0,
-    );
-    _parameters['seconds'] = __seconds;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -13910,8 +13322,8 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/message-expiration{?seconds*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/message-expiration').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -13934,6 +13346,13 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(RoomSetMessageExpirationRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -13943,7 +13362,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [seconds] New time.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -13956,16 +13374,16 @@ class $RoomClient {
   ///  * [$setMessageExpiration_Request] for the request send by this method.
   ///  * [$setMessageExpiration_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomSetMessageExpirationResponseApplicationJson, void>> setMessageExpiration({
-    required int seconds,
     required String token,
+    required RoomSetMessageExpirationRequestApplicationJson $body,
     RoomSetMessageExpirationApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setMessageExpiration_Request(
-      seconds: seconds,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -14347,7 +13765,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [pin] PIN the participant used to dial-in.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -14363,15 +13780,12 @@ class $RoomClient {
   ///  * [$verifyDialInPin_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $verifyDialInPin_Request({
-    required String pin,
     required String token,
+    required RoomVerifyDialInPinRequestApplicationJson $body,
     RoomVerifyDialInPinApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __pin = _$jsonSerializers.serialize(pin, specifiedType: const FullType(String));
-    _parameters['pin'] = __pin;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -14385,8 +13799,8 @@ class $RoomClient {
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/verify-dialin{?pin*}')
-        .expand(_parameters);
+    final _path =
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/verify-dialin').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -14409,6 +13823,10 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(RoomVerifyDialInPinRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -14418,7 +13836,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [pin] PIN the participant used to dial-in.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -14433,16 +13850,16 @@ class $RoomClient {
   ///  * [$verifyDialInPin_Request] for the request send by this method.
   ///  * [$verifyDialInPin_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomVerifyDialInPinResponseApplicationJson, void>> verifyDialInPin({
-    required String pin,
     required String token,
+    required RoomVerifyDialInPinRequestApplicationJson $body,
     RoomVerifyDialInPinApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $verifyDialInPin_Request(
-      pin: pin,
       token: token,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -14469,8 +13886,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [number] E164 formatted phone number.
-  ///   * [options] Additional details to verify the validity of the request.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -14487,16 +13902,12 @@ class $RoomClient {
   ///  * [$verifyDialOutNumber_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $verifyDialOutNumber_Request({
-    required String number,
     required String token,
-    ContentString<RoomVerifyDialOutNumberOptions>? options,
+    required RoomVerifyDialOutNumberRequestApplicationJson $body,
     RoomVerifyDialOutNumberApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __number = _$jsonSerializers.serialize(number, specifiedType: const FullType(String));
-    _parameters['number'] = __number;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -14505,20 +13916,13 @@ class $RoomClient {
     );
     _parameters['token'] = __token;
 
-    final __options = _$jsonSerializers.serialize(
-      options,
-      specifiedType: const FullType(ContentString, [FullType(RoomVerifyDialOutNumberOptions)]),
-    );
-    _parameters['options'] = __options;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomVerifyDialOutNumberApiVersion));
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
     final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/verify-dialout{?number*,options*}')
-            .expand(_parameters);
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/verify-dialout').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -14541,6 +13945,13 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(RoomVerifyDialOutNumberRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -14550,8 +13961,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [number] E164 formatted phone number.
-  ///   * [options] Additional details to verify the validity of the request.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -14567,18 +13976,16 @@ class $RoomClient {
   ///  * [$verifyDialOutNumber_Request] for the request send by this method.
   ///  * [$verifyDialOutNumber_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomVerifyDialOutNumberResponseApplicationJson, void>> verifyDialOutNumber({
-    required String number,
     required String token,
-    ContentString<RoomVerifyDialOutNumberOptions>? options,
+    required RoomVerifyDialOutNumberRequestApplicationJson $body,
     RoomVerifyDialOutNumberApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $verifyDialOutNumber_Request(
-      number: number,
       token: token,
-      options: options,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -14717,8 +14124,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [callId] The call ID provided by the SIP bridge earlier to uniquely identify the call to terminate.
-  ///   * [options] Additional details to verify the validity of the request.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -14735,16 +14140,12 @@ class $RoomClient {
   ///  * [$rejectedDialOutRequest_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $rejectedDialOutRequest_Request({
-    required String callId,
     required String token,
-    ContentString<RoomRejectedDialOutRequestOptions>? options,
+    required RoomRejectedDialOutRequestRequestApplicationJson $body,
     RoomRejectedDialOutRequestApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __callId = _$jsonSerializers.serialize(callId, specifiedType: const FullType(String));
-    _parameters['callId'] = __callId;
-
     final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
     _i4.checkString(
       __token,
@@ -14753,20 +14154,13 @@ class $RoomClient {
     );
     _parameters['token'] = __token;
 
-    final __options = _$jsonSerializers.serialize(
-      options,
-      specifiedType: const FullType(ContentString, [FullType(RoomRejectedDialOutRequestOptions)]),
-    );
-    _parameters['options'] = __options;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(RoomRejectedDialOutRequestApiVersion));
     __apiVersion ??= 'v4';
     _parameters['apiVersion'] = __apiVersion;
 
     final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/rejected-dialout{?callId*,options*}')
-            .expand(_parameters);
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/room/{token}/rejected-dialout').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -14789,6 +14183,13 @@ class $RoomClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(RoomRejectedDialOutRequestRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -14798,8 +14199,6 @@ class $RoomClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [callId] The call ID provided by the SIP bridge earlier to uniquely identify the call to terminate.
-  ///   * [options] Additional details to verify the validity of the request.
   ///   * [apiVersion] Defaults to `"v4"`.
   ///   * [token]
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -14815,18 +14214,16 @@ class $RoomClient {
   ///  * [$rejectedDialOutRequest_Request] for the request send by this method.
   ///  * [$rejectedDialOutRequest_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<RoomRejectedDialOutRequestResponseApplicationJson, void>> rejectedDialOutRequest({
-    required String callId,
     required String token,
-    ContentString<RoomRejectedDialOutRequestOptions>? options,
+    required RoomRejectedDialOutRequestRequestApplicationJson $body,
     RoomRejectedDialOutRequestApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $rejectedDialOutRequest_Request(
-      callId: callId,
       token: token,
-      options: options,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -14860,8 +14257,6 @@ class $SettingsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [key] Key to update.
-  ///   * [value] New value for the key.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -14874,25 +14269,17 @@ class $SettingsClient {
   ///  * [$setUserSetting_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setUserSetting_Request({
-    required SettingsSetUserSettingKey key,
-    SettingsSetUserSettingValue? value,
+    required SettingsSetUserSettingRequestApplicationJson $body,
     SettingsSetUserSettingApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __key = _$jsonSerializers.serialize(key, specifiedType: const FullType(SettingsSetUserSettingKey));
-    _parameters['key'] = __key;
-
-    final __value = _$jsonSerializers.serialize(value, specifiedType: const FullType(SettingsSetUserSettingValue));
-    _parameters['value'] = __value;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SettingsSetUserSettingApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/user{?key*,value*}').expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/user').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -14917,6 +14304,13 @@ class $SettingsClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(SettingsSetUserSettingRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -14926,8 +14320,6 @@ class $SettingsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [key] Key to update.
-  ///   * [value] New value for the key.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -14939,16 +14331,14 @@ class $SettingsClient {
   ///  * [$setUserSetting_Request] for the request send by this method.
   ///  * [$setUserSetting_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<SettingsSetUserSettingResponseApplicationJson, void>> setUserSetting({
-    required SettingsSetUserSettingKey key,
-    SettingsSetUserSettingValue? value,
+    required SettingsSetUserSettingRequestApplicationJson $body,
     SettingsSetUserSettingApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setUserSetting_Request(
-      key: key,
-      value: value,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -15077,7 +14467,6 @@ class $SettingsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [host] Host to check.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -15090,14 +14479,11 @@ class $SettingsClient {
   ///  * [$certificateGetCertificateExpiration_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $certificateGetCertificateExpiration_Request({
-    required String host,
+    required CertificateGetCertificateExpirationRequestApplicationJson $body,
     CertificateGetCertificateExpirationApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __host = _$jsonSerializers.serialize(host, specifiedType: const FullType(String));
-    _parameters['host'] = __host;
-
     var __apiVersion = _$jsonSerializers.serialize(
       apiVersion,
       specifiedType: const FullType(CertificateGetCertificateExpirationApiVersion),
@@ -15106,7 +14492,7 @@ class $SettingsClient {
     _parameters['apiVersion'] = __apiVersion;
 
     final _path =
-        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/certificate/expiration{?host*}').expand(_parameters);
+        _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/certificate/expiration').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -15131,6 +14517,13 @@ class $SettingsClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(CertificateGetCertificateExpirationRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -15142,7 +14535,6 @@ class $SettingsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [host] Host to check.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -15155,14 +14547,14 @@ class $SettingsClient {
   ///  * [$certificateGetCertificateExpiration_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<CertificateGetCertificateExpirationResponseApplicationJson, void>>
       certificateGetCertificateExpiration({
-    required String host,
+    required CertificateGetCertificateExpirationRequestApplicationJson $body,
     CertificateGetCertificateExpirationApiVersion? apiVersion,
     bool? oCSAPIRequest,
   }) async {
     final _request = $certificateGetCertificateExpiration_Request(
-      host: host,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -15310,9 +14702,6 @@ class $SettingsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [sipGroups] New SIP groups. Defaults to `[]`.
-  ///   * [dialInInfo] New dial info. Defaults to `""`.
-  ///   * [sharedSecret] New shared secret. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -15324,34 +14713,17 @@ class $SettingsClient {
   ///  * [$setsipSettings_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setsipSettings_Request({
-    BuiltList<String>? sipGroups,
-    String? dialInInfo,
-    String? sharedSecret,
     SettingsSetsipSettingsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    SettingsSetsipSettingsRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
-    var __sipGroups =
-        _$jsonSerializers.serialize(sipGroups, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    __sipGroups ??= const [];
-    _parameters['sipGroups%5B%5D'] = __sipGroups;
-
-    var __dialInInfo = _$jsonSerializers.serialize(dialInInfo, specifiedType: const FullType(String));
-    __dialInInfo ??= '';
-    _parameters['dialInInfo'] = __dialInInfo;
-
-    var __sharedSecret = _$jsonSerializers.serialize(sharedSecret, specifiedType: const FullType(String));
-    __sharedSecret ??= '';
-    _parameters['sharedSecret'] = __sharedSecret;
-
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(SettingsSetsipSettingsApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i5.UriTemplate(
-      '/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/sip{?sipGroups%5B%5D*,dialInInfo*,sharedSecret*}',
-    ).expand(_parameters);
+    final _path = _i5.UriTemplate('/ocs/v2.php/apps/spreed/api/{apiVersion}/settings/sip').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('post', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -15376,6 +14748,20 @@ class $SettingsClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i4.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(SettingsSetsipSettingsRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              SettingsSetsipSettingsRequestApplicationJson(),
+              specifiedType: const FullType(SettingsSetsipSettingsRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -15387,9 +14773,6 @@ class $SettingsClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [sipGroups] New SIP groups. Defaults to `[]`.
-  ///   * [dialInInfo] New dial info. Defaults to `""`.
-  ///   * [sharedSecret] New shared secret. Defaults to `""`.
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -15400,18 +14783,14 @@ class $SettingsClient {
   ///  * [$setsipSettings_Request] for the request send by this method.
   ///  * [$setsipSettings_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<SettingsSetsipSettingsResponseApplicationJson, void>> setsipSettings({
-    BuiltList<String>? sipGroups,
-    String? dialInInfo,
-    String? sharedSecret,
     SettingsSetsipSettingsApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    SettingsSetsipSettingsRequestApplicationJson? $body,
   }) async {
     final _request = $setsipSettings_Request(
-      sipGroups: sipGroups,
-      dialInInfo: dialInInfo,
-      sharedSecret: sharedSecret,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -15826,69 +15205,6 @@ class $UserAvatarClient {
 
 typedef ChatProxyMessage = BaseMessage;
 
-class AvatarGetAvatarDarkTheme extends EnumClass {
-  const AvatarGetAvatarDarkTheme._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const AvatarGetAvatarDarkTheme $0 = _$avatarGetAvatarDarkTheme$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const AvatarGetAvatarDarkTheme $1 = _$avatarGetAvatarDarkTheme$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<AvatarGetAvatarDarkTheme> get values => _$avatarGetAvatarDarkThemeValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static AvatarGetAvatarDarkTheme valueOf(String name) => _$valueOfAvatarGetAvatarDarkTheme(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for AvatarGetAvatarDarkTheme.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<AvatarGetAvatarDarkTheme> get serializer => const _$AvatarGetAvatarDarkThemeSerializer();
-}
-
-class _$AvatarGetAvatarDarkThemeSerializer implements PrimitiveSerializer<AvatarGetAvatarDarkTheme> {
-  const _$AvatarGetAvatarDarkThemeSerializer();
-
-  static const Map<AvatarGetAvatarDarkTheme, Object> _toWire = <AvatarGetAvatarDarkTheme, Object>{
-    AvatarGetAvatarDarkTheme.$0: 0,
-    AvatarGetAvatarDarkTheme.$1: 1,
-  };
-
-  static const Map<Object, AvatarGetAvatarDarkTheme> _fromWire = <Object, AvatarGetAvatarDarkTheme>{
-    0: AvatarGetAvatarDarkTheme.$0,
-    1: AvatarGetAvatarDarkTheme.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [AvatarGetAvatarDarkTheme];
-
-  @override
-  String get wireName => 'AvatarGetAvatarDarkTheme';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    AvatarGetAvatarDarkTheme object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  AvatarGetAvatarDarkTheme deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class AvatarGetAvatarApiVersion extends EnumClass {
   const AvatarGetAvatarApiVersion._(super.name);
 
@@ -15943,6 +15259,77 @@ class _$AvatarGetAvatarApiVersionSerializer implements PrimitiveSerializer<Avata
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $AvatarGetAvatarRequestApplicationJsonInterface {
+  static final _$darkTheme = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// Theme used for background.
+  bool get darkTheme;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarGetAvatarRequestApplicationJsonInterfaceBuilder].
+  $AvatarGetAvatarRequestApplicationJsonInterface rebuild(
+    void Function($AvatarGetAvatarRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarGetAvatarRequestApplicationJsonInterfaceBuilder].
+  $AvatarGetAvatarRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarGetAvatarRequestApplicationJsonInterfaceBuilder b) {
+    b.darkTheme = _$darkTheme;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarGetAvatarRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class AvatarGetAvatarRequestApplicationJson
+    implements
+        $AvatarGetAvatarRequestApplicationJsonInterface,
+        Built<AvatarGetAvatarRequestApplicationJson, AvatarGetAvatarRequestApplicationJsonBuilder> {
+  /// Creates a new AvatarGetAvatarRequestApplicationJson object using the builder pattern.
+  factory AvatarGetAvatarRequestApplicationJson([void Function(AvatarGetAvatarRequestApplicationJsonBuilder)? b]) =
+      _$AvatarGetAvatarRequestApplicationJson;
+
+  // coverage:ignore-start
+  const AvatarGetAvatarRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory AvatarGetAvatarRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for AvatarGetAvatarRequestApplicationJson.
+  static Serializer<AvatarGetAvatarRequestApplicationJson> get serializer =>
+      _$avatarGetAvatarRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarGetAvatarRequestApplicationJsonBuilder b) {
+    $AvatarGetAvatarRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarGetAvatarRequestApplicationJsonBuilder b) {
+    $AvatarGetAvatarRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 class AvatarUploadAvatarApiVersion extends EnumClass {
@@ -17288,6 +16675,72 @@ class _$AvatarEmojiAvatarApiVersionSerializer implements PrimitiveSerializer<Ava
 }
 
 @BuiltValue(instantiable: false)
+sealed class $AvatarEmojiAvatarRequestApplicationJsonInterface {
+  /// Emoji.
+  String get emoji;
+
+  /// Color of the emoji.
+  String? get color;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarEmojiAvatarRequestApplicationJsonInterfaceBuilder].
+  $AvatarEmojiAvatarRequestApplicationJsonInterface rebuild(
+    void Function($AvatarEmojiAvatarRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarEmojiAvatarRequestApplicationJsonInterfaceBuilder].
+  $AvatarEmojiAvatarRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarEmojiAvatarRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarEmojiAvatarRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class AvatarEmojiAvatarRequestApplicationJson
+    implements
+        $AvatarEmojiAvatarRequestApplicationJsonInterface,
+        Built<AvatarEmojiAvatarRequestApplicationJson, AvatarEmojiAvatarRequestApplicationJsonBuilder> {
+  /// Creates a new AvatarEmojiAvatarRequestApplicationJson object using the builder pattern.
+  factory AvatarEmojiAvatarRequestApplicationJson([void Function(AvatarEmojiAvatarRequestApplicationJsonBuilder)? b]) =
+      _$AvatarEmojiAvatarRequestApplicationJson;
+
+  // coverage:ignore-start
+  const AvatarEmojiAvatarRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory AvatarEmojiAvatarRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for AvatarEmojiAvatarRequestApplicationJson.
+  static Serializer<AvatarEmojiAvatarRequestApplicationJson> get serializer =>
+      _$avatarEmojiAvatarRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarEmojiAvatarRequestApplicationJsonBuilder b) {
+    $AvatarEmojiAvatarRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarEmojiAvatarRequestApplicationJsonBuilder b) {
+    $AvatarEmojiAvatarRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $AvatarEmojiAvatarResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
@@ -17539,75 +16992,6 @@ class _$AvatarGetUserProxyAvatarWithoutRoomSizeSerializer
       _fromWire[serialized]!;
 }
 
-class AvatarGetUserProxyAvatarWithoutRoomDarkTheme extends EnumClass {
-  const AvatarGetUserProxyAvatarWithoutRoomDarkTheme._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const AvatarGetUserProxyAvatarWithoutRoomDarkTheme $0 = _$avatarGetUserProxyAvatarWithoutRoomDarkTheme$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const AvatarGetUserProxyAvatarWithoutRoomDarkTheme $1 = _$avatarGetUserProxyAvatarWithoutRoomDarkTheme$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<AvatarGetUserProxyAvatarWithoutRoomDarkTheme> get values =>
-      _$avatarGetUserProxyAvatarWithoutRoomDarkThemeValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static AvatarGetUserProxyAvatarWithoutRoomDarkTheme valueOf(String name) =>
-      _$valueOfAvatarGetUserProxyAvatarWithoutRoomDarkTheme(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for AvatarGetUserProxyAvatarWithoutRoomDarkTheme.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<AvatarGetUserProxyAvatarWithoutRoomDarkTheme> get serializer =>
-      const _$AvatarGetUserProxyAvatarWithoutRoomDarkThemeSerializer();
-}
-
-class _$AvatarGetUserProxyAvatarWithoutRoomDarkThemeSerializer
-    implements PrimitiveSerializer<AvatarGetUserProxyAvatarWithoutRoomDarkTheme> {
-  const _$AvatarGetUserProxyAvatarWithoutRoomDarkThemeSerializer();
-
-  static const Map<AvatarGetUserProxyAvatarWithoutRoomDarkTheme, Object> _toWire =
-      <AvatarGetUserProxyAvatarWithoutRoomDarkTheme, Object>{
-    AvatarGetUserProxyAvatarWithoutRoomDarkTheme.$0: 0,
-    AvatarGetUserProxyAvatarWithoutRoomDarkTheme.$1: 1,
-  };
-
-  static const Map<Object, AvatarGetUserProxyAvatarWithoutRoomDarkTheme> _fromWire =
-      <Object, AvatarGetUserProxyAvatarWithoutRoomDarkTheme>{
-    0: AvatarGetUserProxyAvatarWithoutRoomDarkTheme.$0,
-    1: AvatarGetUserProxyAvatarWithoutRoomDarkTheme.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [AvatarGetUserProxyAvatarWithoutRoomDarkTheme];
-
-  @override
-  String get wireName => 'AvatarGetUserProxyAvatarWithoutRoomDarkTheme';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    AvatarGetUserProxyAvatarWithoutRoomDarkTheme object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  AvatarGetUserProxyAvatarWithoutRoomDarkTheme deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class AvatarGetUserProxyAvatarWithoutRoomApiVersion extends EnumClass {
   const AvatarGetUserProxyAvatarWithoutRoomApiVersion._(super.name);
 
@@ -17668,6 +17052,82 @@ class _$AvatarGetUserProxyAvatarWithoutRoomApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterface {
+  static final _$darkTheme = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// Federation CloudID to get the avatar for.
+  String get cloudId;
+
+  /// Theme used for background.
+  bool get darkTheme;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterfaceBuilder].
+  $AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterface rebuild(
+    void Function($AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterfaceBuilder].
+  $AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterfaceBuilder b) {
+    b.darkTheme = _$darkTheme;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson
+    implements
+        $AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterface,
+        Built<AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson,
+            AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder> {
+  /// Creates a new AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson object using the builder pattern.
+  factory AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson([
+    void Function(AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder)? b,
+  ]) = _$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson;
+
+  // coverage:ignore-start
+  const AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson.
+  static Serializer<AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson> get serializer =>
+      _$avatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder b) {
+    $AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder b) {
+    $AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 class AvatarGetUserProxyAvatarDarkWithoutRoomSize extends EnumClass {
@@ -17802,6 +17262,71 @@ class _$AvatarGetUserProxyAvatarDarkWithoutRoomApiVersionSerializer
       _fromWire[serialized]!;
 }
 
+@BuiltValue(instantiable: false)
+sealed class $AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterface {
+  /// Federation CloudID to get the avatar for.
+  String get cloudId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterfaceBuilder].
+  $AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterface rebuild(
+    void Function($AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterfaceBuilder].
+  $AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson
+    implements
+        $AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterface,
+        Built<AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson,
+            AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder> {
+  /// Creates a new AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson object using the builder pattern.
+  factory AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson([
+    void Function(AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder)? b,
+  ]) = _$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson;
+
+  // coverage:ignore-start
+  const AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson.
+  static Serializer<AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson> get serializer =>
+      _$avatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder b) {
+    $AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder b) {
+    $AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterface._validate(b);
+  }
+}
+
 class AvatarGetUserProxyAvatarSize extends EnumClass {
   const AvatarGetUserProxyAvatarSize._(super.name);
 
@@ -17865,70 +17390,6 @@ class _$AvatarGetUserProxyAvatarSizeSerializer implements PrimitiveSerializer<Av
       _fromWire[serialized]!;
 }
 
-class AvatarGetUserProxyAvatarDarkTheme extends EnumClass {
-  const AvatarGetUserProxyAvatarDarkTheme._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const AvatarGetUserProxyAvatarDarkTheme $0 = _$avatarGetUserProxyAvatarDarkTheme$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const AvatarGetUserProxyAvatarDarkTheme $1 = _$avatarGetUserProxyAvatarDarkTheme$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<AvatarGetUserProxyAvatarDarkTheme> get values => _$avatarGetUserProxyAvatarDarkThemeValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static AvatarGetUserProxyAvatarDarkTheme valueOf(String name) => _$valueOfAvatarGetUserProxyAvatarDarkTheme(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for AvatarGetUserProxyAvatarDarkTheme.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<AvatarGetUserProxyAvatarDarkTheme> get serializer =>
-      const _$AvatarGetUserProxyAvatarDarkThemeSerializer();
-}
-
-class _$AvatarGetUserProxyAvatarDarkThemeSerializer implements PrimitiveSerializer<AvatarGetUserProxyAvatarDarkTheme> {
-  const _$AvatarGetUserProxyAvatarDarkThemeSerializer();
-
-  static const Map<AvatarGetUserProxyAvatarDarkTheme, Object> _toWire = <AvatarGetUserProxyAvatarDarkTheme, Object>{
-    AvatarGetUserProxyAvatarDarkTheme.$0: 0,
-    AvatarGetUserProxyAvatarDarkTheme.$1: 1,
-  };
-
-  static const Map<Object, AvatarGetUserProxyAvatarDarkTheme> _fromWire = <Object, AvatarGetUserProxyAvatarDarkTheme>{
-    0: AvatarGetUserProxyAvatarDarkTheme.$0,
-    1: AvatarGetUserProxyAvatarDarkTheme.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [AvatarGetUserProxyAvatarDarkTheme];
-
-  @override
-  String get wireName => 'AvatarGetUserProxyAvatarDarkTheme';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    AvatarGetUserProxyAvatarDarkTheme object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  AvatarGetUserProxyAvatarDarkTheme deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class AvatarGetUserProxyAvatarApiVersion extends EnumClass {
   const AvatarGetUserProxyAvatarApiVersion._(super.name);
 
@@ -17985,6 +17446,81 @@ class _$AvatarGetUserProxyAvatarApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $AvatarGetUserProxyAvatarRequestApplicationJsonInterface {
+  static final _$darkTheme = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// Federation CloudID to get the avatar for.
+  String get cloudId;
+
+  /// Theme used for background.
+  bool get darkTheme;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarGetUserProxyAvatarRequestApplicationJsonInterfaceBuilder].
+  $AvatarGetUserProxyAvatarRequestApplicationJsonInterface rebuild(
+    void Function($AvatarGetUserProxyAvatarRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarGetUserProxyAvatarRequestApplicationJsonInterfaceBuilder].
+  $AvatarGetUserProxyAvatarRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarGetUserProxyAvatarRequestApplicationJsonInterfaceBuilder b) {
+    b.darkTheme = _$darkTheme;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarGetUserProxyAvatarRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class AvatarGetUserProxyAvatarRequestApplicationJson
+    implements
+        $AvatarGetUserProxyAvatarRequestApplicationJsonInterface,
+        Built<AvatarGetUserProxyAvatarRequestApplicationJson, AvatarGetUserProxyAvatarRequestApplicationJsonBuilder> {
+  /// Creates a new AvatarGetUserProxyAvatarRequestApplicationJson object using the builder pattern.
+  factory AvatarGetUserProxyAvatarRequestApplicationJson([
+    void Function(AvatarGetUserProxyAvatarRequestApplicationJsonBuilder)? b,
+  ]) = _$AvatarGetUserProxyAvatarRequestApplicationJson;
+
+  // coverage:ignore-start
+  const AvatarGetUserProxyAvatarRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory AvatarGetUserProxyAvatarRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for AvatarGetUserProxyAvatarRequestApplicationJson.
+  static Serializer<AvatarGetUserProxyAvatarRequestApplicationJson> get serializer =>
+      _$avatarGetUserProxyAvatarRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarGetUserProxyAvatarRequestApplicationJsonBuilder b) {
+    $AvatarGetUserProxyAvatarRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarGetUserProxyAvatarRequestApplicationJsonBuilder b) {
+    $AvatarGetUserProxyAvatarRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 class AvatarGetUserProxyAvatarDarkSize extends EnumClass {
@@ -18110,6 +17646,71 @@ class _$AvatarGetUserProxyAvatarDarkApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterface {
+  /// Federation CloudID to get the avatar for.
+  String get cloudId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterfaceBuilder].
+  $AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterface rebuild(
+    void Function($AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterfaceBuilder].
+  $AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class AvatarGetUserProxyAvatarDarkRequestApplicationJson
+    implements
+        $AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterface,
+        Built<AvatarGetUserProxyAvatarDarkRequestApplicationJson,
+            AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder> {
+  /// Creates a new AvatarGetUserProxyAvatarDarkRequestApplicationJson object using the builder pattern.
+  factory AvatarGetUserProxyAvatarDarkRequestApplicationJson([
+    void Function(AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder)? b,
+  ]) = _$AvatarGetUserProxyAvatarDarkRequestApplicationJson;
+
+  // coverage:ignore-start
+  const AvatarGetUserProxyAvatarDarkRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory AvatarGetUserProxyAvatarDarkRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for AvatarGetUserProxyAvatarDarkRequestApplicationJson.
+  static Serializer<AvatarGetUserProxyAvatarDarkRequestApplicationJson> get serializer =>
+      _$avatarGetUserProxyAvatarDarkRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder b) {
+    $AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder b) {
+    $AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 class BotListBotsApiVersion extends EnumClass {
@@ -18713,69 +18314,6 @@ abstract class BotDisableBotResponseApplicationJson
   }
 }
 
-class BotSendMessageSilent extends EnumClass {
-  const BotSendMessageSilent._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const BotSendMessageSilent $0 = _$botSendMessageSilent$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const BotSendMessageSilent $1 = _$botSendMessageSilent$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<BotSendMessageSilent> get values => _$botSendMessageSilentValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static BotSendMessageSilent valueOf(String name) => _$valueOfBotSendMessageSilent(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for BotSendMessageSilent.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<BotSendMessageSilent> get serializer => const _$BotSendMessageSilentSerializer();
-}
-
-class _$BotSendMessageSilentSerializer implements PrimitiveSerializer<BotSendMessageSilent> {
-  const _$BotSendMessageSilentSerializer();
-
-  static const Map<BotSendMessageSilent, Object> _toWire = <BotSendMessageSilent, Object>{
-    BotSendMessageSilent.$0: 0,
-    BotSendMessageSilent.$1: 1,
-  };
-
-  static const Map<Object, BotSendMessageSilent> _fromWire = <Object, BotSendMessageSilent>{
-    0: BotSendMessageSilent.$0,
-    1: BotSendMessageSilent.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [BotSendMessageSilent];
-
-  @override
-  String get wireName => 'BotSendMessageSilent';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    BotSendMessageSilent object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  BotSendMessageSilent deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class BotSendMessageApiVersion extends EnumClass {
   const BotSendMessageApiVersion._(super.name);
 
@@ -18830,6 +18368,98 @@ class _$BotSendMessageApiVersionSerializer implements PrimitiveSerializer<BotSen
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $BotSendMessageRequestApplicationJsonInterface {
+  static final _$referenceId = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$replyTo = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$silent = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// The message to send.
+  String get message;
+
+  /// For the message to be able to later identify it again.
+  String get referenceId;
+
+  /// Parent id which this message is a reply to.
+  int get replyTo;
+
+  /// If sent silent the chat message will not create any notifications.
+  bool get silent;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotSendMessageRequestApplicationJsonInterfaceBuilder].
+  $BotSendMessageRequestApplicationJsonInterface rebuild(
+    void Function($BotSendMessageRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotSendMessageRequestApplicationJsonInterfaceBuilder].
+  $BotSendMessageRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotSendMessageRequestApplicationJsonInterfaceBuilder b) {
+    b.referenceId = _$referenceId;
+    b.replyTo = _$replyTo;
+    b.silent = _$silent;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotSendMessageRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class BotSendMessageRequestApplicationJson
+    implements
+        $BotSendMessageRequestApplicationJsonInterface,
+        Built<BotSendMessageRequestApplicationJson, BotSendMessageRequestApplicationJsonBuilder> {
+  /// Creates a new BotSendMessageRequestApplicationJson object using the builder pattern.
+  factory BotSendMessageRequestApplicationJson([void Function(BotSendMessageRequestApplicationJsonBuilder)? b]) =
+      _$BotSendMessageRequestApplicationJson;
+
+  // coverage:ignore-start
+  const BotSendMessageRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory BotSendMessageRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for BotSendMessageRequestApplicationJson.
+  static Serializer<BotSendMessageRequestApplicationJson> get serializer =>
+      _$botSendMessageRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotSendMessageRequestApplicationJsonBuilder b) {
+    $BotSendMessageRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotSendMessageRequestApplicationJsonBuilder b) {
+    $BotSendMessageRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -19015,6 +18645,68 @@ class _$BotReactApiVersionSerializer implements PrimitiveSerializer<BotReactApiV
 }
 
 @BuiltValue(instantiable: false)
+sealed class $BotReactRequestApplicationJsonInterface {
+  /// Reaction to add.
+  String get reaction;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotReactRequestApplicationJsonInterfaceBuilder].
+  $BotReactRequestApplicationJsonInterface rebuild(
+    void Function($BotReactRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotReactRequestApplicationJsonInterfaceBuilder].
+  $BotReactRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotReactRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotReactRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class BotReactRequestApplicationJson
+    implements
+        $BotReactRequestApplicationJsonInterface,
+        Built<BotReactRequestApplicationJson, BotReactRequestApplicationJsonBuilder> {
+  /// Creates a new BotReactRequestApplicationJson object using the builder pattern.
+  factory BotReactRequestApplicationJson([void Function(BotReactRequestApplicationJsonBuilder)? b]) =
+      _$BotReactRequestApplicationJson;
+
+  // coverage:ignore-start
+  const BotReactRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory BotReactRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for BotReactRequestApplicationJson.
+  static Serializer<BotReactRequestApplicationJson> get serializer => _$botReactRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotReactRequestApplicationJsonBuilder b) {
+    $BotReactRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotReactRequestApplicationJsonBuilder b) {
+    $BotReactRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $BotReactResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -19195,6 +18887,69 @@ class _$BotDeleteReactionApiVersionSerializer implements PrimitiveSerializer<Bot
 }
 
 @BuiltValue(instantiable: false)
+sealed class $BotDeleteReactionRequestApplicationJsonInterface {
+  /// Reaction to delete.
+  String get reaction;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BotDeleteReactionRequestApplicationJsonInterfaceBuilder].
+  $BotDeleteReactionRequestApplicationJsonInterface rebuild(
+    void Function($BotDeleteReactionRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BotDeleteReactionRequestApplicationJsonInterfaceBuilder].
+  $BotDeleteReactionRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BotDeleteReactionRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BotDeleteReactionRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class BotDeleteReactionRequestApplicationJson
+    implements
+        $BotDeleteReactionRequestApplicationJsonInterface,
+        Built<BotDeleteReactionRequestApplicationJson, BotDeleteReactionRequestApplicationJsonBuilder> {
+  /// Creates a new BotDeleteReactionRequestApplicationJson object using the builder pattern.
+  factory BotDeleteReactionRequestApplicationJson([void Function(BotDeleteReactionRequestApplicationJsonBuilder)? b]) =
+      _$BotDeleteReactionRequestApplicationJson;
+
+  // coverage:ignore-start
+  const BotDeleteReactionRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory BotDeleteReactionRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for BotDeleteReactionRequestApplicationJson.
+  static Serializer<BotDeleteReactionRequestApplicationJson> get serializer =>
+      _$botDeleteReactionRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BotDeleteReactionRequestApplicationJsonBuilder b) {
+    $BotDeleteReactionRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BotDeleteReactionRequestApplicationJsonBuilder b) {
+    $BotDeleteReactionRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $BotDeleteReactionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -19321,86 +19076,6 @@ abstract class BotDeleteReactionResponseApplicationJson
   }
 }
 
-class BreakoutRoomConfigureBreakoutRoomsMode extends EnumClass {
-  const BreakoutRoomConfigureBreakoutRoomsMode._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const BreakoutRoomConfigureBreakoutRoomsMode $0 = _$breakoutRoomConfigureBreakoutRoomsMode$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const BreakoutRoomConfigureBreakoutRoomsMode $1 = _$breakoutRoomConfigureBreakoutRoomsMode$1;
-
-  /// `2`
-  @BuiltValueEnumConst(wireName: '2')
-  static const BreakoutRoomConfigureBreakoutRoomsMode $2 = _$breakoutRoomConfigureBreakoutRoomsMode$2;
-
-  /// `3`
-  @BuiltValueEnumConst(wireName: '3')
-  static const BreakoutRoomConfigureBreakoutRoomsMode $3 = _$breakoutRoomConfigureBreakoutRoomsMode$3;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<BreakoutRoomConfigureBreakoutRoomsMode> get values => _$breakoutRoomConfigureBreakoutRoomsModeValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static BreakoutRoomConfigureBreakoutRoomsMode valueOf(String name) =>
-      _$valueOfBreakoutRoomConfigureBreakoutRoomsMode(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for BreakoutRoomConfigureBreakoutRoomsMode.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<BreakoutRoomConfigureBreakoutRoomsMode> get serializer =>
-      const _$BreakoutRoomConfigureBreakoutRoomsModeSerializer();
-}
-
-class _$BreakoutRoomConfigureBreakoutRoomsModeSerializer
-    implements PrimitiveSerializer<BreakoutRoomConfigureBreakoutRoomsMode> {
-  const _$BreakoutRoomConfigureBreakoutRoomsModeSerializer();
-
-  static const Map<BreakoutRoomConfigureBreakoutRoomsMode, Object> _toWire =
-      <BreakoutRoomConfigureBreakoutRoomsMode, Object>{
-    BreakoutRoomConfigureBreakoutRoomsMode.$0: 0,
-    BreakoutRoomConfigureBreakoutRoomsMode.$1: 1,
-    BreakoutRoomConfigureBreakoutRoomsMode.$2: 2,
-    BreakoutRoomConfigureBreakoutRoomsMode.$3: 3,
-  };
-
-  static const Map<Object, BreakoutRoomConfigureBreakoutRoomsMode> _fromWire =
-      <Object, BreakoutRoomConfigureBreakoutRoomsMode>{
-    0: BreakoutRoomConfigureBreakoutRoomsMode.$0,
-    1: BreakoutRoomConfigureBreakoutRoomsMode.$1,
-    2: BreakoutRoomConfigureBreakoutRoomsMode.$2,
-    3: BreakoutRoomConfigureBreakoutRoomsMode.$3,
-  };
-
-  @override
-  Iterable<Type> get types => const [BreakoutRoomConfigureBreakoutRoomsMode];
-
-  @override
-  String get wireName => 'BreakoutRoomConfigureBreakoutRoomsMode';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    BreakoutRoomConfigureBreakoutRoomsMode object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  BreakoutRoomConfigureBreakoutRoomsMode deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class BreakoutRoomConfigureBreakoutRoomsApiVersion extends EnumClass {
   const BreakoutRoomConfigureBreakoutRoomsApiVersion._(super.name);
 
@@ -19461,6 +19136,178 @@ class _$BreakoutRoomConfigureBreakoutRoomsApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// Mode of the breakout rooms.
+class BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode extends EnumClass {
+  const BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode $0 =
+      _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode $1 =
+      _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$1;
+
+  /// `2`
+  @BuiltValueEnumConst(wireName: '2')
+  static const BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode $2 =
+      _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$2;
+
+  /// `3`
+  @BuiltValueEnumConst(wireName: '3')
+  static const BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode $3 =
+      _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$3;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode> get values =>
+      _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonModeValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode valueOf(String name) =>
+      _$valueOfBreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode> get serializer =>
+      const _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_ModeSerializer();
+}
+
+class _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_ModeSerializer
+    implements PrimitiveSerializer<BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode> {
+  const _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_ModeSerializer();
+
+  static const Map<BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode, Object> _toWire =
+      <BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode, Object>{
+    BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode.$0: 0,
+    BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode.$1: 1,
+    BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode.$2: 2,
+    BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode.$3: 3,
+  };
+
+  static const Map<Object, BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode> _fromWire =
+      <Object, BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode>{
+    0: BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode.$0,
+    1: BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode.$1,
+    2: BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode.$2,
+    3: BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode.$3,
+  };
+
+  @override
+  Iterable<Type> get types => const [BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode];
+
+  @override
+  String get wireName => 'BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterface {
+  static final _$attendeeMap = _$jsonSerializers.deserialize(
+    '[]',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// Mode of the breakout rooms.
+  BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode get mode;
+
+  /// Number of breakout rooms - Constants {@see BreakoutRoom::MINIMUM_ROOM_AMOUNT} and {@see BreakoutRoom::MAXIMUM_ROOM_AMOUNT}.
+  int get amount;
+
+  /// Mapping of the attendees to breakout rooms.
+  String get attendeeMap;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterfaceBuilder].
+  $BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterfaceBuilder].
+  $BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterfaceBuilder b) {
+    b.attendeeMap = _$attendeeMap;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.amount,
+      'amount',
+      maximum: 20,
+      minimum: 1,
+    );
+  }
+}
+
+abstract class BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson
+    implements
+        $BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterface,
+        Built<BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson,
+            BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder> {
+  /// Creates a new BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson object using the builder pattern.
+  factory BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson([
+    void Function(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder)? b,
+  ]) = _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson.
+  static Serializer<BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson> get serializer =>
+      _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder b) {
+    $BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder b) {
+    $BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -19846,6 +19693,71 @@ class _$BreakoutRoomBroadcastChatMessageApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
+sealed class $BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterface {
+  /// Message to broadcast.
+  String get message;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterfaceBuilder].
+  $BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterfaceBuilder].
+  $BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class BreakoutRoomBroadcastChatMessageRequestApplicationJson
+    implements
+        $BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterface,
+        Built<BreakoutRoomBroadcastChatMessageRequestApplicationJson,
+            BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder> {
+  /// Creates a new BreakoutRoomBroadcastChatMessageRequestApplicationJson object using the builder pattern.
+  factory BreakoutRoomBroadcastChatMessageRequestApplicationJson([
+    void Function(BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder)? b,
+  ]) = _$BreakoutRoomBroadcastChatMessageRequestApplicationJson;
+
+  // coverage:ignore-start
+  const BreakoutRoomBroadcastChatMessageRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory BreakoutRoomBroadcastChatMessageRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for BreakoutRoomBroadcastChatMessageRequestApplicationJson.
+  static Serializer<BreakoutRoomBroadcastChatMessageRequestApplicationJson> get serializer =>
+      _$breakoutRoomBroadcastChatMessageRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder b) {
+    $BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder b) {
+    $BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Room> get data;
@@ -20033,6 +19945,71 @@ class _$BreakoutRoomApplyAttendeeMapApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterface {
+  /// JSON encoded mapping of the attendees to breakout rooms `array<int, int>`.
+  String get attendeeMap;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterfaceBuilder].
+  $BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterfaceBuilder].
+  $BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class BreakoutRoomApplyAttendeeMapRequestApplicationJson
+    implements
+        $BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterface,
+        Built<BreakoutRoomApplyAttendeeMapRequestApplicationJson,
+            BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder> {
+  /// Creates a new BreakoutRoomApplyAttendeeMapRequestApplicationJson object using the builder pattern.
+  factory BreakoutRoomApplyAttendeeMapRequestApplicationJson([
+    void Function(BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder)? b,
+  ]) = _$BreakoutRoomApplyAttendeeMapRequestApplicationJson;
+
+  // coverage:ignore-start
+  const BreakoutRoomApplyAttendeeMapRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory BreakoutRoomApplyAttendeeMapRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for BreakoutRoomApplyAttendeeMapRequestApplicationJson.
+  static Serializer<BreakoutRoomApplyAttendeeMapRequestApplicationJson> get serializer =>
+      _$breakoutRoomApplyAttendeeMapRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder b) {
+    $BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder b) {
+    $BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -20991,6 +20968,71 @@ class _$BreakoutRoomSwitchBreakoutRoomApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
+sealed class $BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterface {
+  /// Target breakout room.
+  String get target;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterfaceBuilder].
+  $BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterface rebuild(
+    void Function($BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterfaceBuilder].
+  $BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class BreakoutRoomSwitchBreakoutRoomRequestApplicationJson
+    implements
+        $BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterface,
+        Built<BreakoutRoomSwitchBreakoutRoomRequestApplicationJson,
+            BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder> {
+  /// Creates a new BreakoutRoomSwitchBreakoutRoomRequestApplicationJson object using the builder pattern.
+  factory BreakoutRoomSwitchBreakoutRoomRequestApplicationJson([
+    void Function(BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder)? b,
+  ]) = _$BreakoutRoomSwitchBreakoutRoomRequestApplicationJson;
+
+  // coverage:ignore-start
+  const BreakoutRoomSwitchBreakoutRoomRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory BreakoutRoomSwitchBreakoutRoomRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for BreakoutRoomSwitchBreakoutRoomRequestApplicationJson.
+  static Serializer<BreakoutRoomSwitchBreakoutRoomRequestApplicationJson> get serializer =>
+      _$breakoutRoomSwitchBreakoutRoomRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder b) {
+    $BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder b) {
+    $BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
@@ -21418,6 +21460,77 @@ class _$CallUpdateCallFlagsApiVersionSerializer implements PrimitiveSerializer<C
 }
 
 @BuiltValue(instantiable: false)
+sealed class $CallUpdateCallFlagsRequestApplicationJsonInterface {
+  /// New flags.
+  int get flags;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallUpdateCallFlagsRequestApplicationJsonInterfaceBuilder].
+  $CallUpdateCallFlagsRequestApplicationJsonInterface rebuild(
+    void Function($CallUpdateCallFlagsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallUpdateCallFlagsRequestApplicationJsonInterfaceBuilder].
+  $CallUpdateCallFlagsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallUpdateCallFlagsRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallUpdateCallFlagsRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.flags,
+      'flags',
+      maximum: 15,
+      minimum: 0,
+    );
+  }
+}
+
+abstract class CallUpdateCallFlagsRequestApplicationJson
+    implements
+        $CallUpdateCallFlagsRequestApplicationJsonInterface,
+        Built<CallUpdateCallFlagsRequestApplicationJson, CallUpdateCallFlagsRequestApplicationJsonBuilder> {
+  /// Creates a new CallUpdateCallFlagsRequestApplicationJson object using the builder pattern.
+  factory CallUpdateCallFlagsRequestApplicationJson([
+    void Function(CallUpdateCallFlagsRequestApplicationJsonBuilder)? b,
+  ]) = _$CallUpdateCallFlagsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const CallUpdateCallFlagsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory CallUpdateCallFlagsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for CallUpdateCallFlagsRequestApplicationJson.
+  static Serializer<CallUpdateCallFlagsRequestApplicationJson> get serializer =>
+      _$callUpdateCallFlagsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallUpdateCallFlagsRequestApplicationJsonBuilder b) {
+    $CallUpdateCallFlagsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallUpdateCallFlagsRequestApplicationJsonBuilder b) {
+    $CallUpdateCallFlagsRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $CallUpdateCallFlagsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -21544,132 +21657,6 @@ abstract class CallUpdateCallFlagsResponseApplicationJson
   }
 }
 
-class CallJoinCallSilent extends EnumClass {
-  const CallJoinCallSilent._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const CallJoinCallSilent $0 = _$callJoinCallSilent$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const CallJoinCallSilent $1 = _$callJoinCallSilent$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<CallJoinCallSilent> get values => _$callJoinCallSilentValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static CallJoinCallSilent valueOf(String name) => _$valueOfCallJoinCallSilent(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for CallJoinCallSilent.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<CallJoinCallSilent> get serializer => const _$CallJoinCallSilentSerializer();
-}
-
-class _$CallJoinCallSilentSerializer implements PrimitiveSerializer<CallJoinCallSilent> {
-  const _$CallJoinCallSilentSerializer();
-
-  static const Map<CallJoinCallSilent, Object> _toWire = <CallJoinCallSilent, Object>{
-    CallJoinCallSilent.$0: 0,
-    CallJoinCallSilent.$1: 1,
-  };
-
-  static const Map<Object, CallJoinCallSilent> _fromWire = <Object, CallJoinCallSilent>{
-    0: CallJoinCallSilent.$0,
-    1: CallJoinCallSilent.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [CallJoinCallSilent];
-
-  @override
-  String get wireName => 'CallJoinCallSilent';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    CallJoinCallSilent object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  CallJoinCallSilent deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-class CallJoinCallRecordingConsent extends EnumClass {
-  const CallJoinCallRecordingConsent._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const CallJoinCallRecordingConsent $0 = _$callJoinCallRecordingConsent$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const CallJoinCallRecordingConsent $1 = _$callJoinCallRecordingConsent$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<CallJoinCallRecordingConsent> get values => _$callJoinCallRecordingConsentValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static CallJoinCallRecordingConsent valueOf(String name) => _$valueOfCallJoinCallRecordingConsent(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for CallJoinCallRecordingConsent.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<CallJoinCallRecordingConsent> get serializer => const _$CallJoinCallRecordingConsentSerializer();
-}
-
-class _$CallJoinCallRecordingConsentSerializer implements PrimitiveSerializer<CallJoinCallRecordingConsent> {
-  const _$CallJoinCallRecordingConsentSerializer();
-
-  static const Map<CallJoinCallRecordingConsent, Object> _toWire = <CallJoinCallRecordingConsent, Object>{
-    CallJoinCallRecordingConsent.$0: 0,
-    CallJoinCallRecordingConsent.$1: 1,
-  };
-
-  static const Map<Object, CallJoinCallRecordingConsent> _fromWire = <Object, CallJoinCallRecordingConsent>{
-    0: CallJoinCallRecordingConsent.$0,
-    1: CallJoinCallRecordingConsent.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [CallJoinCallRecordingConsent];
-
-  @override
-  String get wireName => 'CallJoinCallRecordingConsent';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    CallJoinCallRecordingConsent object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  CallJoinCallRecordingConsent deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class CallJoinCallApiVersion extends EnumClass {
   const CallJoinCallApiVersion._(super.name);
 
@@ -21724,6 +21711,108 @@ class _$CallJoinCallApiVersionSerializer implements PrimitiveSerializer<CallJoin
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $CallJoinCallRequestApplicationJsonInterface {
+  static final _$silent = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  static final _$recordingConsent = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// In-Call flags.
+  int? get flags;
+
+  /// In-call permissions.
+  int? get forcePermissions;
+
+  /// Join the call silently.
+  bool get silent;
+
+  /// When the user ticked a checkbox and agreed with being recorded.
+  /// (Only needed when the `config => call => recording-consent` capability is set to {@see RecordingService::CONSENT_REQUIRED_YES}.
+  /// or the capability is {@see RecordingService::CONSENT_REQUIRED_OPTIONAL}.
+  /// and the conversation `recordingConsent` value is {@see RecordingService::CONSENT_REQUIRED_YES} ).
+  bool get recordingConsent;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallJoinCallRequestApplicationJsonInterfaceBuilder].
+  $CallJoinCallRequestApplicationJsonInterface rebuild(
+    void Function($CallJoinCallRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallJoinCallRequestApplicationJsonInterfaceBuilder].
+  $CallJoinCallRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallJoinCallRequestApplicationJsonInterfaceBuilder b) {
+    b.silent = _$silent;
+    b.recordingConsent = _$recordingConsent;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallJoinCallRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.flags,
+      'flags',
+      maximum: 15,
+      minimum: 0,
+    );
+    _i4.checkNumber(
+      b.forcePermissions,
+      'forcePermissions',
+      maximum: 255,
+      minimum: 0,
+    );
+  }
+}
+
+abstract class CallJoinCallRequestApplicationJson
+    implements
+        $CallJoinCallRequestApplicationJsonInterface,
+        Built<CallJoinCallRequestApplicationJson, CallJoinCallRequestApplicationJsonBuilder> {
+  /// Creates a new CallJoinCallRequestApplicationJson object using the builder pattern.
+  factory CallJoinCallRequestApplicationJson([void Function(CallJoinCallRequestApplicationJsonBuilder)? b]) =
+      _$CallJoinCallRequestApplicationJson;
+
+  // coverage:ignore-start
+  const CallJoinCallRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory CallJoinCallRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for CallJoinCallRequestApplicationJson.
+  static Serializer<CallJoinCallRequestApplicationJson> get serializer =>
+      _$callJoinCallRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallJoinCallRequestApplicationJsonBuilder b) {
+    $CallJoinCallRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallJoinCallRequestApplicationJsonBuilder b) {
+    $CallJoinCallRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -21851,69 +21940,6 @@ abstract class CallJoinCallResponseApplicationJson
   }
 }
 
-class CallLeaveCallAll extends EnumClass {
-  const CallLeaveCallAll._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const CallLeaveCallAll $0 = _$callLeaveCallAll$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const CallLeaveCallAll $1 = _$callLeaveCallAll$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<CallLeaveCallAll> get values => _$callLeaveCallAllValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static CallLeaveCallAll valueOf(String name) => _$valueOfCallLeaveCallAll(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for CallLeaveCallAll.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<CallLeaveCallAll> get serializer => const _$CallLeaveCallAllSerializer();
-}
-
-class _$CallLeaveCallAllSerializer implements PrimitiveSerializer<CallLeaveCallAll> {
-  const _$CallLeaveCallAllSerializer();
-
-  static const Map<CallLeaveCallAll, Object> _toWire = <CallLeaveCallAll, Object>{
-    CallLeaveCallAll.$0: 0,
-    CallLeaveCallAll.$1: 1,
-  };
-
-  static const Map<Object, CallLeaveCallAll> _fromWire = <Object, CallLeaveCallAll>{
-    0: CallLeaveCallAll.$0,
-    1: CallLeaveCallAll.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [CallLeaveCallAll];
-
-  @override
-  String get wireName => 'CallLeaveCallAll';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    CallLeaveCallAll object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  CallLeaveCallAll deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class CallLeaveCallApiVersion extends EnumClass {
   const CallLeaveCallApiVersion._(super.name);
 
@@ -21968,6 +21994,77 @@ class _$CallLeaveCallApiVersionSerializer implements PrimitiveSerializer<CallLea
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $CallLeaveCallRequestApplicationJsonInterface {
+  static final _$all = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// whether to also terminate the call for all participants.
+  bool get all;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CallLeaveCallRequestApplicationJsonInterfaceBuilder].
+  $CallLeaveCallRequestApplicationJsonInterface rebuild(
+    void Function($CallLeaveCallRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CallLeaveCallRequestApplicationJsonInterfaceBuilder].
+  $CallLeaveCallRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CallLeaveCallRequestApplicationJsonInterfaceBuilder b) {
+    b.all = _$all;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CallLeaveCallRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class CallLeaveCallRequestApplicationJson
+    implements
+        $CallLeaveCallRequestApplicationJsonInterface,
+        Built<CallLeaveCallRequestApplicationJson, CallLeaveCallRequestApplicationJsonBuilder> {
+  /// Creates a new CallLeaveCallRequestApplicationJson object using the builder pattern.
+  factory CallLeaveCallRequestApplicationJson([void Function(CallLeaveCallRequestApplicationJsonBuilder)? b]) =
+      _$CallLeaveCallRequestApplicationJson;
+
+  // coverage:ignore-start
+  const CallLeaveCallRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory CallLeaveCallRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for CallLeaveCallRequestApplicationJson.
+  static Serializer<CallLeaveCallRequestApplicationJson> get serializer =>
+      _$callLeaveCallRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CallLeaveCallRequestApplicationJsonBuilder b) {
+    $CallLeaveCallRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CallLeaveCallRequestApplicationJsonBuilder b) {
+    $CallLeaveCallRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -22524,333 +22621,6 @@ abstract class CallSipDialOutResponseApplicationJson
   }
 }
 
-class ChatReceiveMessagesLookIntoFuture extends EnumClass {
-  const ChatReceiveMessagesLookIntoFuture._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ChatReceiveMessagesLookIntoFuture $0 = _$chatReceiveMessagesLookIntoFuture$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ChatReceiveMessagesLookIntoFuture $1 = _$chatReceiveMessagesLookIntoFuture$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<ChatReceiveMessagesLookIntoFuture> get values => _$chatReceiveMessagesLookIntoFutureValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static ChatReceiveMessagesLookIntoFuture valueOf(String name) => _$valueOfChatReceiveMessagesLookIntoFuture(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for ChatReceiveMessagesLookIntoFuture.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ChatReceiveMessagesLookIntoFuture> get serializer =>
-      const _$ChatReceiveMessagesLookIntoFutureSerializer();
-}
-
-class _$ChatReceiveMessagesLookIntoFutureSerializer implements PrimitiveSerializer<ChatReceiveMessagesLookIntoFuture> {
-  const _$ChatReceiveMessagesLookIntoFutureSerializer();
-
-  static const Map<ChatReceiveMessagesLookIntoFuture, Object> _toWire = <ChatReceiveMessagesLookIntoFuture, Object>{
-    ChatReceiveMessagesLookIntoFuture.$0: 0,
-    ChatReceiveMessagesLookIntoFuture.$1: 1,
-  };
-
-  static const Map<Object, ChatReceiveMessagesLookIntoFuture> _fromWire = <Object, ChatReceiveMessagesLookIntoFuture>{
-    0: ChatReceiveMessagesLookIntoFuture.$0,
-    1: ChatReceiveMessagesLookIntoFuture.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [ChatReceiveMessagesLookIntoFuture];
-
-  @override
-  String get wireName => 'ChatReceiveMessagesLookIntoFuture';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    ChatReceiveMessagesLookIntoFuture object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  ChatReceiveMessagesLookIntoFuture deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-class ChatReceiveMessagesSetReadMarker extends EnumClass {
-  const ChatReceiveMessagesSetReadMarker._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ChatReceiveMessagesSetReadMarker $0 = _$chatReceiveMessagesSetReadMarker$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ChatReceiveMessagesSetReadMarker $1 = _$chatReceiveMessagesSetReadMarker$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<ChatReceiveMessagesSetReadMarker> get values => _$chatReceiveMessagesSetReadMarkerValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static ChatReceiveMessagesSetReadMarker valueOf(String name) => _$valueOfChatReceiveMessagesSetReadMarker(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for ChatReceiveMessagesSetReadMarker.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ChatReceiveMessagesSetReadMarker> get serializer =>
-      const _$ChatReceiveMessagesSetReadMarkerSerializer();
-}
-
-class _$ChatReceiveMessagesSetReadMarkerSerializer implements PrimitiveSerializer<ChatReceiveMessagesSetReadMarker> {
-  const _$ChatReceiveMessagesSetReadMarkerSerializer();
-
-  static const Map<ChatReceiveMessagesSetReadMarker, Object> _toWire = <ChatReceiveMessagesSetReadMarker, Object>{
-    ChatReceiveMessagesSetReadMarker.$0: 0,
-    ChatReceiveMessagesSetReadMarker.$1: 1,
-  };
-
-  static const Map<Object, ChatReceiveMessagesSetReadMarker> _fromWire = <Object, ChatReceiveMessagesSetReadMarker>{
-    0: ChatReceiveMessagesSetReadMarker.$0,
-    1: ChatReceiveMessagesSetReadMarker.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [ChatReceiveMessagesSetReadMarker];
-
-  @override
-  String get wireName => 'ChatReceiveMessagesSetReadMarker';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    ChatReceiveMessagesSetReadMarker object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  ChatReceiveMessagesSetReadMarker deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-class ChatReceiveMessagesIncludeLastKnown extends EnumClass {
-  const ChatReceiveMessagesIncludeLastKnown._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ChatReceiveMessagesIncludeLastKnown $0 = _$chatReceiveMessagesIncludeLastKnown$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ChatReceiveMessagesIncludeLastKnown $1 = _$chatReceiveMessagesIncludeLastKnown$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<ChatReceiveMessagesIncludeLastKnown> get values => _$chatReceiveMessagesIncludeLastKnownValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static ChatReceiveMessagesIncludeLastKnown valueOf(String name) => _$valueOfChatReceiveMessagesIncludeLastKnown(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for ChatReceiveMessagesIncludeLastKnown.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ChatReceiveMessagesIncludeLastKnown> get serializer =>
-      const _$ChatReceiveMessagesIncludeLastKnownSerializer();
-}
-
-class _$ChatReceiveMessagesIncludeLastKnownSerializer
-    implements PrimitiveSerializer<ChatReceiveMessagesIncludeLastKnown> {
-  const _$ChatReceiveMessagesIncludeLastKnownSerializer();
-
-  static const Map<ChatReceiveMessagesIncludeLastKnown, Object> _toWire = <ChatReceiveMessagesIncludeLastKnown, Object>{
-    ChatReceiveMessagesIncludeLastKnown.$0: 0,
-    ChatReceiveMessagesIncludeLastKnown.$1: 1,
-  };
-
-  static const Map<Object, ChatReceiveMessagesIncludeLastKnown> _fromWire =
-      <Object, ChatReceiveMessagesIncludeLastKnown>{
-    0: ChatReceiveMessagesIncludeLastKnown.$0,
-    1: ChatReceiveMessagesIncludeLastKnown.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [ChatReceiveMessagesIncludeLastKnown];
-
-  @override
-  String get wireName => 'ChatReceiveMessagesIncludeLastKnown';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    ChatReceiveMessagesIncludeLastKnown object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  ChatReceiveMessagesIncludeLastKnown deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-class ChatReceiveMessagesNoStatusUpdate extends EnumClass {
-  const ChatReceiveMessagesNoStatusUpdate._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ChatReceiveMessagesNoStatusUpdate $0 = _$chatReceiveMessagesNoStatusUpdate$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ChatReceiveMessagesNoStatusUpdate $1 = _$chatReceiveMessagesNoStatusUpdate$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<ChatReceiveMessagesNoStatusUpdate> get values => _$chatReceiveMessagesNoStatusUpdateValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static ChatReceiveMessagesNoStatusUpdate valueOf(String name) => _$valueOfChatReceiveMessagesNoStatusUpdate(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for ChatReceiveMessagesNoStatusUpdate.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ChatReceiveMessagesNoStatusUpdate> get serializer =>
-      const _$ChatReceiveMessagesNoStatusUpdateSerializer();
-}
-
-class _$ChatReceiveMessagesNoStatusUpdateSerializer implements PrimitiveSerializer<ChatReceiveMessagesNoStatusUpdate> {
-  const _$ChatReceiveMessagesNoStatusUpdateSerializer();
-
-  static const Map<ChatReceiveMessagesNoStatusUpdate, Object> _toWire = <ChatReceiveMessagesNoStatusUpdate, Object>{
-    ChatReceiveMessagesNoStatusUpdate.$0: 0,
-    ChatReceiveMessagesNoStatusUpdate.$1: 1,
-  };
-
-  static const Map<Object, ChatReceiveMessagesNoStatusUpdate> _fromWire = <Object, ChatReceiveMessagesNoStatusUpdate>{
-    0: ChatReceiveMessagesNoStatusUpdate.$0,
-    1: ChatReceiveMessagesNoStatusUpdate.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [ChatReceiveMessagesNoStatusUpdate];
-
-  @override
-  String get wireName => 'ChatReceiveMessagesNoStatusUpdate';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    ChatReceiveMessagesNoStatusUpdate object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  ChatReceiveMessagesNoStatusUpdate deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-class ChatReceiveMessagesMarkNotificationsAsRead extends EnumClass {
-  const ChatReceiveMessagesMarkNotificationsAsRead._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ChatReceiveMessagesMarkNotificationsAsRead $0 = _$chatReceiveMessagesMarkNotificationsAsRead$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ChatReceiveMessagesMarkNotificationsAsRead $1 = _$chatReceiveMessagesMarkNotificationsAsRead$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<ChatReceiveMessagesMarkNotificationsAsRead> get values =>
-      _$chatReceiveMessagesMarkNotificationsAsReadValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static ChatReceiveMessagesMarkNotificationsAsRead valueOf(String name) =>
-      _$valueOfChatReceiveMessagesMarkNotificationsAsRead(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for ChatReceiveMessagesMarkNotificationsAsRead.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ChatReceiveMessagesMarkNotificationsAsRead> get serializer =>
-      const _$ChatReceiveMessagesMarkNotificationsAsReadSerializer();
-}
-
-class _$ChatReceiveMessagesMarkNotificationsAsReadSerializer
-    implements PrimitiveSerializer<ChatReceiveMessagesMarkNotificationsAsRead> {
-  const _$ChatReceiveMessagesMarkNotificationsAsReadSerializer();
-
-  static const Map<ChatReceiveMessagesMarkNotificationsAsRead, Object> _toWire =
-      <ChatReceiveMessagesMarkNotificationsAsRead, Object>{
-    ChatReceiveMessagesMarkNotificationsAsRead.$0: 0,
-    ChatReceiveMessagesMarkNotificationsAsRead.$1: 1,
-  };
-
-  static const Map<Object, ChatReceiveMessagesMarkNotificationsAsRead> _fromWire =
-      <Object, ChatReceiveMessagesMarkNotificationsAsRead>{
-    0: ChatReceiveMessagesMarkNotificationsAsRead.$0,
-    1: ChatReceiveMessagesMarkNotificationsAsRead.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [ChatReceiveMessagesMarkNotificationsAsRead];
-
-  @override
-  String get wireName => 'ChatReceiveMessagesMarkNotificationsAsRead';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    ChatReceiveMessagesMarkNotificationsAsRead object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  ChatReceiveMessagesMarkNotificationsAsRead deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class ChatReceiveMessagesApiVersion extends EnumClass {
   const ChatReceiveMessagesApiVersion._(super.name);
 
@@ -22905,6 +22675,525 @@ class _$ChatReceiveMessagesApiVersionSerializer implements PrimitiveSerializer<C
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// Polling for new messages (1) or getting the history of the chat (0).
+class ChatReceiveMessagesRequestApplicationJson_LookIntoFuture extends EnumClass {
+  const ChatReceiveMessagesRequestApplicationJson_LookIntoFuture._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ChatReceiveMessagesRequestApplicationJson_LookIntoFuture $0 =
+      _$chatReceiveMessagesRequestApplicationJsonLookIntoFuture$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ChatReceiveMessagesRequestApplicationJson_LookIntoFuture $1 =
+      _$chatReceiveMessagesRequestApplicationJsonLookIntoFuture$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ChatReceiveMessagesRequestApplicationJson_LookIntoFuture> get values =>
+      _$chatReceiveMessagesRequestApplicationJsonLookIntoFutureValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ChatReceiveMessagesRequestApplicationJson_LookIntoFuture valueOf(String name) =>
+      _$valueOfChatReceiveMessagesRequestApplicationJson_LookIntoFuture(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ChatReceiveMessagesRequestApplicationJson_LookIntoFuture> get serializer =>
+      const _$ChatReceiveMessagesRequestApplicationJson_LookIntoFutureSerializer();
+}
+
+class _$ChatReceiveMessagesRequestApplicationJson_LookIntoFutureSerializer
+    implements PrimitiveSerializer<ChatReceiveMessagesRequestApplicationJson_LookIntoFuture> {
+  const _$ChatReceiveMessagesRequestApplicationJson_LookIntoFutureSerializer();
+
+  static const Map<ChatReceiveMessagesRequestApplicationJson_LookIntoFuture, Object> _toWire =
+      <ChatReceiveMessagesRequestApplicationJson_LookIntoFuture, Object>{
+    ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.$0: 0,
+    ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.$1: 1,
+  };
+
+  static const Map<Object, ChatReceiveMessagesRequestApplicationJson_LookIntoFuture> _fromWire =
+      <Object, ChatReceiveMessagesRequestApplicationJson_LookIntoFuture>{
+    0: ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.$0,
+    1: ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ChatReceiveMessagesRequestApplicationJson_LookIntoFuture];
+
+  @override
+  String get wireName => 'ChatReceiveMessagesRequestApplicationJson_LookIntoFuture';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ChatReceiveMessagesRequestApplicationJson_LookIntoFuture object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ChatReceiveMessagesRequestApplicationJson_LookIntoFuture deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+/// Automatically set the last read marker when 1,.
+/// if your client does this itself via chat/{token}/read set to 0.
+class ChatReceiveMessagesRequestApplicationJson_SetReadMarker extends EnumClass {
+  const ChatReceiveMessagesRequestApplicationJson_SetReadMarker._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ChatReceiveMessagesRequestApplicationJson_SetReadMarker $0 =
+      _$chatReceiveMessagesRequestApplicationJsonSetReadMarker$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ChatReceiveMessagesRequestApplicationJson_SetReadMarker $1 =
+      _$chatReceiveMessagesRequestApplicationJsonSetReadMarker$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ChatReceiveMessagesRequestApplicationJson_SetReadMarker> get values =>
+      _$chatReceiveMessagesRequestApplicationJsonSetReadMarkerValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ChatReceiveMessagesRequestApplicationJson_SetReadMarker valueOf(String name) =>
+      _$valueOfChatReceiveMessagesRequestApplicationJson_SetReadMarker(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ChatReceiveMessagesRequestApplicationJson_SetReadMarker.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ChatReceiveMessagesRequestApplicationJson_SetReadMarker> get serializer =>
+      const _$ChatReceiveMessagesRequestApplicationJson_SetReadMarkerSerializer();
+}
+
+class _$ChatReceiveMessagesRequestApplicationJson_SetReadMarkerSerializer
+    implements PrimitiveSerializer<ChatReceiveMessagesRequestApplicationJson_SetReadMarker> {
+  const _$ChatReceiveMessagesRequestApplicationJson_SetReadMarkerSerializer();
+
+  static const Map<ChatReceiveMessagesRequestApplicationJson_SetReadMarker, Object> _toWire =
+      <ChatReceiveMessagesRequestApplicationJson_SetReadMarker, Object>{
+    ChatReceiveMessagesRequestApplicationJson_SetReadMarker.$0: 0,
+    ChatReceiveMessagesRequestApplicationJson_SetReadMarker.$1: 1,
+  };
+
+  static const Map<Object, ChatReceiveMessagesRequestApplicationJson_SetReadMarker> _fromWire =
+      <Object, ChatReceiveMessagesRequestApplicationJson_SetReadMarker>{
+    0: ChatReceiveMessagesRequestApplicationJson_SetReadMarker.$0,
+    1: ChatReceiveMessagesRequestApplicationJson_SetReadMarker.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ChatReceiveMessagesRequestApplicationJson_SetReadMarker];
+
+  @override
+  String get wireName => 'ChatReceiveMessagesRequestApplicationJson_SetReadMarker';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ChatReceiveMessagesRequestApplicationJson_SetReadMarker object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ChatReceiveMessagesRequestApplicationJson_SetReadMarker deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+/// Include the $lastKnownMessageId in the messages when 1 (default 0).
+class ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown extends EnumClass {
+  const ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown $0 =
+      _$chatReceiveMessagesRequestApplicationJsonIncludeLastKnown$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown $1 =
+      _$chatReceiveMessagesRequestApplicationJsonIncludeLastKnown$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown> get values =>
+      _$chatReceiveMessagesRequestApplicationJsonIncludeLastKnownValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown valueOf(String name) =>
+      _$valueOfChatReceiveMessagesRequestApplicationJson_IncludeLastKnown(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown> get serializer =>
+      const _$ChatReceiveMessagesRequestApplicationJson_IncludeLastKnownSerializer();
+}
+
+class _$ChatReceiveMessagesRequestApplicationJson_IncludeLastKnownSerializer
+    implements PrimitiveSerializer<ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown> {
+  const _$ChatReceiveMessagesRequestApplicationJson_IncludeLastKnownSerializer();
+
+  static const Map<ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown, Object> _toWire =
+      <ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown, Object>{
+    ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown.$0: 0,
+    ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown.$1: 1,
+  };
+
+  static const Map<Object, ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown> _fromWire =
+      <Object, ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown>{
+    0: ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown.$0,
+    1: ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown];
+
+  @override
+  String get wireName => 'ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+/// When the user status should not be automatically set to online set to 1 (default 0).
+class ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate extends EnumClass {
+  const ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate $0 =
+      _$chatReceiveMessagesRequestApplicationJsonNoStatusUpdate$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate $1 =
+      _$chatReceiveMessagesRequestApplicationJsonNoStatusUpdate$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate> get values =>
+      _$chatReceiveMessagesRequestApplicationJsonNoStatusUpdateValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate valueOf(String name) =>
+      _$valueOfChatReceiveMessagesRequestApplicationJson_NoStatusUpdate(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate> get serializer =>
+      const _$ChatReceiveMessagesRequestApplicationJson_NoStatusUpdateSerializer();
+}
+
+class _$ChatReceiveMessagesRequestApplicationJson_NoStatusUpdateSerializer
+    implements PrimitiveSerializer<ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate> {
+  const _$ChatReceiveMessagesRequestApplicationJson_NoStatusUpdateSerializer();
+
+  static const Map<ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate, Object> _toWire =
+      <ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate, Object>{
+    ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate.$0: 0,
+    ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate.$1: 1,
+  };
+
+  static const Map<Object, ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate> _fromWire =
+      <Object, ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate>{
+    0: ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate.$0,
+    1: ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate];
+
+  @override
+  String get wireName => 'ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+/// Set to 0 when notifications should not be marked as read (default 1).
+class ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead extends EnumClass {
+  const ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead $0 =
+      _$chatReceiveMessagesRequestApplicationJsonMarkNotificationsAsRead$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead $1 =
+      _$chatReceiveMessagesRequestApplicationJsonMarkNotificationsAsRead$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead> get values =>
+      _$chatReceiveMessagesRequestApplicationJsonMarkNotificationsAsReadValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead valueOf(String name) =>
+      _$valueOfChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead> get serializer =>
+      const _$ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsReadSerializer();
+}
+
+class _$ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsReadSerializer
+    implements PrimitiveSerializer<ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead> {
+  const _$ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsReadSerializer();
+
+  static const Map<ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead, Object> _toWire =
+      <ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead, Object>{
+    ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead.$0: 0,
+    ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead.$1: 1,
+  };
+
+  static const Map<Object, ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead> _fromWire =
+      <Object, ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead>{
+    0: ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead.$0,
+    1: ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead];
+
+  @override
+  String get wireName => 'ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ChatReceiveMessagesRequestApplicationJsonInterface {
+  static final _$limit = _$jsonSerializers.deserialize(
+    100,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$lastKnownMessageId = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$lastCommonReadId = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$timeout = _$jsonSerializers.deserialize(
+    30,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$setReadMarker = _$jsonSerializers.deserialize(
+    1,
+    specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_SetReadMarker),
+  )! as ChatReceiveMessagesRequestApplicationJson_SetReadMarker;
+
+  static final _$includeLastKnown = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown),
+  )! as ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown;
+
+  static final _$noStatusUpdate = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate),
+  )! as ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate;
+
+  static final _$markNotificationsAsRead = _$jsonSerializers.deserialize(
+    1,
+    specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead),
+  )! as ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead;
+
+  /// Polling for new messages (1) or getting the history of the chat (0).
+  ChatReceiveMessagesRequestApplicationJson_LookIntoFuture get lookIntoFuture;
+
+  /// Number of chat messages to receive (100 by default, 200 at most).
+  int get limit;
+
+  /// The last known message (serves as offset).
+  int get lastKnownMessageId;
+
+  /// The last known common read message.
+  /// (so the response is 200 instead of 304 when.
+  /// it changes even when there are no messages).
+  int get lastCommonReadId;
+
+  /// Number of seconds to wait for new messages (30 by default, 30 at most).
+  int get timeout;
+
+  /// Automatically set the last read marker when 1,.
+  /// if your client does this itself via chat/{token}/read set to 0.
+  ChatReceiveMessagesRequestApplicationJson_SetReadMarker get setReadMarker;
+
+  /// Include the $lastKnownMessageId in the messages when 1 (default 0).
+  ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown get includeLastKnown;
+
+  /// When the user status should not be automatically set to online set to 1 (default 0).
+  ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate get noStatusUpdate;
+
+  /// Set to 0 when notifications should not be marked as read (default 1).
+  ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead get markNotificationsAsRead;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatReceiveMessagesRequestApplicationJsonInterfaceBuilder].
+  $ChatReceiveMessagesRequestApplicationJsonInterface rebuild(
+    void Function($ChatReceiveMessagesRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatReceiveMessagesRequestApplicationJsonInterfaceBuilder].
+  $ChatReceiveMessagesRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatReceiveMessagesRequestApplicationJsonInterfaceBuilder b) {
+    b.limit = _$limit;
+    b.lastKnownMessageId = _$lastKnownMessageId;
+    b.lastCommonReadId = _$lastCommonReadId;
+    b.timeout = _$timeout;
+    b.setReadMarker = _$setReadMarker;
+    b.includeLastKnown = _$includeLastKnown;
+    b.noStatusUpdate = _$noStatusUpdate;
+    b.markNotificationsAsRead = _$markNotificationsAsRead;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatReceiveMessagesRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.lastKnownMessageId,
+      'lastKnownMessageId',
+      minimum: 0,
+    );
+    _i4.checkNumber(
+      b.lastCommonReadId,
+      'lastCommonReadId',
+      minimum: 0,
+    );
+    _i4.checkNumber(
+      b.timeout,
+      'timeout',
+      maximum: 30,
+      minimum: 0,
+    );
+  }
+}
+
+abstract class ChatReceiveMessagesRequestApplicationJson
+    implements
+        $ChatReceiveMessagesRequestApplicationJsonInterface,
+        Built<ChatReceiveMessagesRequestApplicationJson, ChatReceiveMessagesRequestApplicationJsonBuilder> {
+  /// Creates a new ChatReceiveMessagesRequestApplicationJson object using the builder pattern.
+  factory ChatReceiveMessagesRequestApplicationJson([
+    void Function(ChatReceiveMessagesRequestApplicationJsonBuilder)? b,
+  ]) = _$ChatReceiveMessagesRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ChatReceiveMessagesRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatReceiveMessagesRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatReceiveMessagesRequestApplicationJson.
+  static Serializer<ChatReceiveMessagesRequestApplicationJson> get serializer =>
+      _$chatReceiveMessagesRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatReceiveMessagesRequestApplicationJsonBuilder b) {
+    $ChatReceiveMessagesRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatReceiveMessagesRequestApplicationJsonBuilder b) {
+    $ChatReceiveMessagesRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -23161,69 +23450,6 @@ abstract class ChatChatReceiveMessagesHeaders
   }
 }
 
-class ChatSendMessageSilent extends EnumClass {
-  const ChatSendMessageSilent._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ChatSendMessageSilent $0 = _$chatSendMessageSilent$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ChatSendMessageSilent $1 = _$chatSendMessageSilent$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<ChatSendMessageSilent> get values => _$chatSendMessageSilentValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static ChatSendMessageSilent valueOf(String name) => _$valueOfChatSendMessageSilent(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for ChatSendMessageSilent.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ChatSendMessageSilent> get serializer => const _$ChatSendMessageSilentSerializer();
-}
-
-class _$ChatSendMessageSilentSerializer implements PrimitiveSerializer<ChatSendMessageSilent> {
-  const _$ChatSendMessageSilentSerializer();
-
-  static const Map<ChatSendMessageSilent, Object> _toWire = <ChatSendMessageSilent, Object>{
-    ChatSendMessageSilent.$0: 0,
-    ChatSendMessageSilent.$1: 1,
-  };
-
-  static const Map<Object, ChatSendMessageSilent> _fromWire = <Object, ChatSendMessageSilent>{
-    0: ChatSendMessageSilent.$0,
-    1: ChatSendMessageSilent.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [ChatSendMessageSilent];
-
-  @override
-  String get wireName => 'ChatSendMessageSilent';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    ChatSendMessageSilent object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  ChatSendMessageSilent deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class ChatSendMessageApiVersion extends EnumClass {
   const ChatSendMessageApiVersion._(super.name);
 
@@ -23278,6 +23504,113 @@ class _$ChatSendMessageApiVersionSerializer implements PrimitiveSerializer<ChatS
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ChatSendMessageRequestApplicationJsonInterface {
+  static final _$actorDisplayName = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$referenceId = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$replyTo = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$silent = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// the message to send.
+  String get message;
+
+  /// for guests.
+  String get actorDisplayName;
+
+  /// for the message to be able to later identify it again.
+  String get referenceId;
+
+  /// Parent id which this message is a reply to.
+  int get replyTo;
+
+  /// If sent silent the chat message will not create any notifications.
+  bool get silent;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatSendMessageRequestApplicationJsonInterfaceBuilder].
+  $ChatSendMessageRequestApplicationJsonInterface rebuild(
+    void Function($ChatSendMessageRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatSendMessageRequestApplicationJsonInterfaceBuilder].
+  $ChatSendMessageRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatSendMessageRequestApplicationJsonInterfaceBuilder b) {
+    b.actorDisplayName = _$actorDisplayName;
+    b.referenceId = _$referenceId;
+    b.replyTo = _$replyTo;
+    b.silent = _$silent;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatSendMessageRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.replyTo,
+      'replyTo',
+      minimum: 0,
+    );
+  }
+}
+
+abstract class ChatSendMessageRequestApplicationJson
+    implements
+        $ChatSendMessageRequestApplicationJsonInterface,
+        Built<ChatSendMessageRequestApplicationJson, ChatSendMessageRequestApplicationJsonBuilder> {
+  /// Creates a new ChatSendMessageRequestApplicationJson object using the builder pattern.
+  factory ChatSendMessageRequestApplicationJson([void Function(ChatSendMessageRequestApplicationJsonBuilder)? b]) =
+      _$ChatSendMessageRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ChatSendMessageRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatSendMessageRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatSendMessageRequestApplicationJson.
+  static Serializer<ChatSendMessageRequestApplicationJson> get serializer =>
+      _$chatSendMessageRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatSendMessageRequestApplicationJsonBuilder b) {
+    $ChatSendMessageRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatSendMessageRequestApplicationJsonBuilder b) {
+    $ChatSendMessageRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -23765,6 +24098,69 @@ class _$ChatEditMessageApiVersionSerializer implements PrimitiveSerializer<ChatE
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ChatEditMessageRequestApplicationJsonInterface {
+  /// the message to send.
+  String get message;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatEditMessageRequestApplicationJsonInterfaceBuilder].
+  $ChatEditMessageRequestApplicationJsonInterface rebuild(
+    void Function($ChatEditMessageRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatEditMessageRequestApplicationJsonInterfaceBuilder].
+  $ChatEditMessageRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatEditMessageRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatEditMessageRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ChatEditMessageRequestApplicationJson
+    implements
+        $ChatEditMessageRequestApplicationJsonInterface,
+        Built<ChatEditMessageRequestApplicationJson, ChatEditMessageRequestApplicationJsonBuilder> {
+  /// Creates a new ChatEditMessageRequestApplicationJson object using the builder pattern.
+  factory ChatEditMessageRequestApplicationJson([void Function(ChatEditMessageRequestApplicationJsonBuilder)? b]) =
+      _$ChatEditMessageRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ChatEditMessageRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatEditMessageRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatEditMessageRequestApplicationJson.
+  static Serializer<ChatEditMessageRequestApplicationJson> get serializer =>
+      _$chatEditMessageRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatEditMessageRequestApplicationJsonBuilder b) {
+    $ChatEditMessageRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatEditMessageRequestApplicationJsonBuilder b) {
+    $ChatEditMessageRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ChatEditMessageResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatMessageWithParent get data;
@@ -24248,6 +24644,85 @@ class _$ChatGetMessageContextApiVersionSerializer implements PrimitiveSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ChatGetMessageContextRequestApplicationJsonInterface {
+  static final _$limit = _$jsonSerializers.deserialize(
+    50,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// Number of chat messages to receive in both directions (50 by default, 100 at most, might return 201 messages).
+  int get limit;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatGetMessageContextRequestApplicationJsonInterfaceBuilder].
+  $ChatGetMessageContextRequestApplicationJsonInterface rebuild(
+    void Function($ChatGetMessageContextRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatGetMessageContextRequestApplicationJsonInterfaceBuilder].
+  $ChatGetMessageContextRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatGetMessageContextRequestApplicationJsonInterfaceBuilder b) {
+    b.limit = _$limit;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatGetMessageContextRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.limit,
+      'limit',
+      maximum: 100,
+      minimum: 1,
+    );
+  }
+}
+
+abstract class ChatGetMessageContextRequestApplicationJson
+    implements
+        $ChatGetMessageContextRequestApplicationJsonInterface,
+        Built<ChatGetMessageContextRequestApplicationJson, ChatGetMessageContextRequestApplicationJsonBuilder> {
+  /// Creates a new ChatGetMessageContextRequestApplicationJson object using the builder pattern.
+  factory ChatGetMessageContextRequestApplicationJson([
+    void Function(ChatGetMessageContextRequestApplicationJsonBuilder)? b,
+  ]) = _$ChatGetMessageContextRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ChatGetMessageContextRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatGetMessageContextRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatGetMessageContextRequestApplicationJson.
+  static Serializer<ChatGetMessageContextRequestApplicationJson> get serializer =>
+      _$chatGetMessageContextRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatGetMessageContextRequestApplicationJsonBuilder b) {
+    $ChatGetMessageContextRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatGetMessageContextRequestApplicationJsonBuilder b) {
+    $ChatGetMessageContextRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -24738,6 +25213,75 @@ class _$ChatSetReminderApiVersionSerializer implements PrimitiveSerializer<ChatS
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ChatSetReminderRequestApplicationJsonInterface {
+  /// Timestamp of the reminder.
+  int get timestamp;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatSetReminderRequestApplicationJsonInterfaceBuilder].
+  $ChatSetReminderRequestApplicationJsonInterface rebuild(
+    void Function($ChatSetReminderRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatSetReminderRequestApplicationJsonInterfaceBuilder].
+  $ChatSetReminderRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatSetReminderRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatSetReminderRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.timestamp,
+      'timestamp',
+      minimum: 0,
+    );
+  }
+}
+
+abstract class ChatSetReminderRequestApplicationJson
+    implements
+        $ChatSetReminderRequestApplicationJsonInterface,
+        Built<ChatSetReminderRequestApplicationJson, ChatSetReminderRequestApplicationJsonBuilder> {
+  /// Creates a new ChatSetReminderRequestApplicationJson object using the builder pattern.
+  factory ChatSetReminderRequestApplicationJson([void Function(ChatSetReminderRequestApplicationJsonBuilder)? b]) =
+      _$ChatSetReminderRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ChatSetReminderRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatSetReminderRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatSetReminderRequestApplicationJson.
+  static Serializer<ChatSetReminderRequestApplicationJson> get serializer =>
+      _$chatSetReminderRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatSetReminderRequestApplicationJsonBuilder b) {
+    $ChatSetReminderRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatSetReminderRequestApplicationJsonBuilder b) {
+    $ChatSetReminderRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ChatSetReminderResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   ChatReminder get data;
@@ -25167,6 +25711,75 @@ class _$ChatSetReadMarkerApiVersionSerializer implements PrimitiveSerializer<Cha
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ChatSetReadMarkerRequestApplicationJsonInterface {
+  /// ID if the last read message (Optional only with `chat-read-last` capability).
+  int? get lastReadMessage;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatSetReadMarkerRequestApplicationJsonInterfaceBuilder].
+  $ChatSetReadMarkerRequestApplicationJsonInterface rebuild(
+    void Function($ChatSetReadMarkerRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatSetReadMarkerRequestApplicationJsonInterfaceBuilder].
+  $ChatSetReadMarkerRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatSetReadMarkerRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatSetReadMarkerRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.lastReadMessage,
+      'lastReadMessage',
+      minimum: 0,
+    );
+  }
+}
+
+abstract class ChatSetReadMarkerRequestApplicationJson
+    implements
+        $ChatSetReadMarkerRequestApplicationJsonInterface,
+        Built<ChatSetReadMarkerRequestApplicationJson, ChatSetReadMarkerRequestApplicationJsonBuilder> {
+  /// Creates a new ChatSetReadMarkerRequestApplicationJson object using the builder pattern.
+  factory ChatSetReadMarkerRequestApplicationJson([void Function(ChatSetReadMarkerRequestApplicationJsonBuilder)? b]) =
+      _$ChatSetReadMarkerRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ChatSetReadMarkerRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatSetReadMarkerRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatSetReadMarkerRequestApplicationJson.
+  static Serializer<ChatSetReadMarkerRequestApplicationJson> get serializer =>
+      _$chatSetReadMarkerRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatSetReadMarkerRequestApplicationJsonBuilder b) {
+    $ChatSetReadMarkerRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatSetReadMarkerRequestApplicationJsonBuilder b) {
+    $ChatSetReadMarkerRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ChatSetReadMarkerResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
@@ -25592,69 +26205,6 @@ abstract class ChatChatMarkUnreadHeaders
   }
 }
 
-class ChatMentionsIncludeStatus extends EnumClass {
-  const ChatMentionsIncludeStatus._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ChatMentionsIncludeStatus $0 = _$chatMentionsIncludeStatus$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ChatMentionsIncludeStatus $1 = _$chatMentionsIncludeStatus$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<ChatMentionsIncludeStatus> get values => _$chatMentionsIncludeStatusValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static ChatMentionsIncludeStatus valueOf(String name) => _$valueOfChatMentionsIncludeStatus(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for ChatMentionsIncludeStatus.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ChatMentionsIncludeStatus> get serializer => const _$ChatMentionsIncludeStatusSerializer();
-}
-
-class _$ChatMentionsIncludeStatusSerializer implements PrimitiveSerializer<ChatMentionsIncludeStatus> {
-  const _$ChatMentionsIncludeStatusSerializer();
-
-  static const Map<ChatMentionsIncludeStatus, Object> _toWire = <ChatMentionsIncludeStatus, Object>{
-    ChatMentionsIncludeStatus.$0: 0,
-    ChatMentionsIncludeStatus.$1: 1,
-  };
-
-  static const Map<Object, ChatMentionsIncludeStatus> _fromWire = <Object, ChatMentionsIncludeStatus>{
-    0: ChatMentionsIncludeStatus.$0,
-    1: ChatMentionsIncludeStatus.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [ChatMentionsIncludeStatus];
-
-  @override
-  String get wireName => 'ChatMentionsIncludeStatus';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    ChatMentionsIncludeStatus object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  ChatMentionsIncludeStatus deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class ChatMentionsApiVersion extends EnumClass {
   const ChatMentionsApiVersion._(super.name);
 
@@ -25709,6 +26259,89 @@ class _$ChatMentionsApiVersionSerializer implements PrimitiveSerializer<ChatMent
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ChatMentionsRequestApplicationJsonInterface {
+  static final _$limit = _$jsonSerializers.deserialize(
+    20,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$includeStatus = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// Text to search for.
+  String get search;
+
+  /// Maximum number of results.
+  int get limit;
+
+  /// Include the user statuses.
+  bool get includeStatus;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatMentionsRequestApplicationJsonInterfaceBuilder].
+  $ChatMentionsRequestApplicationJsonInterface rebuild(
+    void Function($ChatMentionsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatMentionsRequestApplicationJsonInterfaceBuilder].
+  $ChatMentionsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatMentionsRequestApplicationJsonInterfaceBuilder b) {
+    b.limit = _$limit;
+    b.includeStatus = _$includeStatus;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatMentionsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ChatMentionsRequestApplicationJson
+    implements
+        $ChatMentionsRequestApplicationJsonInterface,
+        Built<ChatMentionsRequestApplicationJson, ChatMentionsRequestApplicationJsonBuilder> {
+  /// Creates a new ChatMentionsRequestApplicationJson object using the builder pattern.
+  factory ChatMentionsRequestApplicationJson([void Function(ChatMentionsRequestApplicationJsonBuilder)? b]) =
+      _$ChatMentionsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ChatMentionsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatMentionsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatMentionsRequestApplicationJson.
+  static Serializer<ChatMentionsRequestApplicationJson> get serializer =>
+      _$chatMentionsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatMentionsRequestApplicationJsonBuilder b) {
+    $ChatMentionsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatMentionsRequestApplicationJsonBuilder b) {
+    $ChatMentionsRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -25961,6 +26594,103 @@ class _$ChatGetObjectsSharedInRoomApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ChatGetObjectsSharedInRoomRequestApplicationJsonInterface {
+  static final _$lastKnownMessageId = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  static final _$limit = _$jsonSerializers.deserialize(
+    100,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// Type of the objects.
+  String get objectType;
+
+  /// ID of the last known message.
+  int get lastKnownMessageId;
+
+  /// Maximum number of objects.
+  int get limit;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatGetObjectsSharedInRoomRequestApplicationJsonInterfaceBuilder].
+  $ChatGetObjectsSharedInRoomRequestApplicationJsonInterface rebuild(
+    void Function($ChatGetObjectsSharedInRoomRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatGetObjectsSharedInRoomRequestApplicationJsonInterfaceBuilder].
+  $ChatGetObjectsSharedInRoomRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatGetObjectsSharedInRoomRequestApplicationJsonInterfaceBuilder b) {
+    b.lastKnownMessageId = _$lastKnownMessageId;
+    b.limit = _$limit;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatGetObjectsSharedInRoomRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.lastKnownMessageId,
+      'lastKnownMessageId',
+      minimum: 0,
+    );
+    _i4.checkNumber(
+      b.limit,
+      'limit',
+      maximum: 200,
+      minimum: 1,
+    );
+  }
+}
+
+abstract class ChatGetObjectsSharedInRoomRequestApplicationJson
+    implements
+        $ChatGetObjectsSharedInRoomRequestApplicationJsonInterface,
+        Built<ChatGetObjectsSharedInRoomRequestApplicationJson,
+            ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder> {
+  /// Creates a new ChatGetObjectsSharedInRoomRequestApplicationJson object using the builder pattern.
+  factory ChatGetObjectsSharedInRoomRequestApplicationJson([
+    void Function(ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder)? b,
+  ]) = _$ChatGetObjectsSharedInRoomRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ChatGetObjectsSharedInRoomRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatGetObjectsSharedInRoomRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatGetObjectsSharedInRoomRequestApplicationJson.
+  static Serializer<ChatGetObjectsSharedInRoomRequestApplicationJson> get serializer =>
+      _$chatGetObjectsSharedInRoomRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder b) {
+    $ChatGetObjectsSharedInRoomRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder b) {
+    $ChatGetObjectsSharedInRoomRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<ChatMessage> get data;
@@ -26207,6 +26937,102 @@ class _$ChatShareObjectToChatApiVersionSerializer implements PrimitiveSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ChatShareObjectToChatRequestApplicationJsonInterface {
+  static final _$metaData = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$actorDisplayName = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$referenceId = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// Type of the object.
+  String get objectType;
+
+  /// ID of the object.
+  String get objectId;
+
+  /// Additional metadata.
+  String get metaData;
+
+  /// Guest name.
+  String get actorDisplayName;
+
+  /// Reference ID.
+  String get referenceId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatShareObjectToChatRequestApplicationJsonInterfaceBuilder].
+  $ChatShareObjectToChatRequestApplicationJsonInterface rebuild(
+    void Function($ChatShareObjectToChatRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatShareObjectToChatRequestApplicationJsonInterfaceBuilder].
+  $ChatShareObjectToChatRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatShareObjectToChatRequestApplicationJsonInterfaceBuilder b) {
+    b.metaData = _$metaData;
+    b.actorDisplayName = _$actorDisplayName;
+    b.referenceId = _$referenceId;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatShareObjectToChatRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ChatShareObjectToChatRequestApplicationJson
+    implements
+        $ChatShareObjectToChatRequestApplicationJsonInterface,
+        Built<ChatShareObjectToChatRequestApplicationJson, ChatShareObjectToChatRequestApplicationJsonBuilder> {
+  /// Creates a new ChatShareObjectToChatRequestApplicationJson object using the builder pattern.
+  factory ChatShareObjectToChatRequestApplicationJson([
+    void Function(ChatShareObjectToChatRequestApplicationJsonBuilder)? b,
+  ]) = _$ChatShareObjectToChatRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ChatShareObjectToChatRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatShareObjectToChatRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatShareObjectToChatRequestApplicationJson.
+  static Serializer<ChatShareObjectToChatRequestApplicationJson> get serializer =>
+      _$chatShareObjectToChatRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatShareObjectToChatRequestApplicationJsonBuilder b) {
+    $ChatShareObjectToChatRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatShareObjectToChatRequestApplicationJsonBuilder b) {
+    $ChatShareObjectToChatRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -26462,6 +27288,86 @@ class _$ChatGetObjectsSharedInRoomOverviewApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterface {
+  static final _$limit = _$jsonSerializers.deserialize(
+    7,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// Maximum number of objects.
+  int get limit;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterfaceBuilder].
+  $ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterface rebuild(
+    void Function($ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterfaceBuilder].
+  $ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterfaceBuilder b) {
+    b.limit = _$limit;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.limit,
+      'limit',
+      maximum: 20,
+      minimum: 1,
+    );
+  }
+}
+
+abstract class ChatGetObjectsSharedInRoomOverviewRequestApplicationJson
+    implements
+        $ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterface,
+        Built<ChatGetObjectsSharedInRoomOverviewRequestApplicationJson,
+            ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder> {
+  /// Creates a new ChatGetObjectsSharedInRoomOverviewRequestApplicationJson object using the builder pattern.
+  factory ChatGetObjectsSharedInRoomOverviewRequestApplicationJson([
+    void Function(ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder)? b,
+  ]) = _$ChatGetObjectsSharedInRoomOverviewRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ChatGetObjectsSharedInRoomOverviewRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ChatGetObjectsSharedInRoomOverviewRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ChatGetObjectsSharedInRoomOverviewRequestApplicationJson.
+  static Serializer<ChatGetObjectsSharedInRoomOverviewRequestApplicationJson> get serializer =>
+      _$chatGetObjectsSharedInRoomOverviewRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder b) {
+    $ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder b) {
+    $ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<ChatMessage>> get data;
@@ -26645,6 +27551,78 @@ class _$SignalingGetSettingsApiVersionSerializer implements PrimitiveSerializer<
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $SignalingGetSettingsRequestApplicationJsonInterface {
+  static final _$token = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// Token of the room.
+  String get token;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingGetSettingsRequestApplicationJsonInterfaceBuilder].
+  $SignalingGetSettingsRequestApplicationJsonInterface rebuild(
+    void Function($SignalingGetSettingsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingGetSettingsRequestApplicationJsonInterfaceBuilder].
+  $SignalingGetSettingsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingGetSettingsRequestApplicationJsonInterfaceBuilder b) {
+    b.token = _$token;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingGetSettingsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class SignalingGetSettingsRequestApplicationJson
+    implements
+        $SignalingGetSettingsRequestApplicationJsonInterface,
+        Built<SignalingGetSettingsRequestApplicationJson, SignalingGetSettingsRequestApplicationJsonBuilder> {
+  /// Creates a new SignalingGetSettingsRequestApplicationJson object using the builder pattern.
+  factory SignalingGetSettingsRequestApplicationJson([
+    void Function(SignalingGetSettingsRequestApplicationJsonBuilder)? b,
+  ]) = _$SignalingGetSettingsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const SignalingGetSettingsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory SignalingGetSettingsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for SignalingGetSettingsRequestApplicationJson.
+  static Serializer<SignalingGetSettingsRequestApplicationJson> get serializer =>
+      _$signalingGetSettingsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingGetSettingsRequestApplicationJsonBuilder b) {
+    $SignalingGetSettingsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingGetSettingsRequestApplicationJsonBuilder b) {
+    $SignalingGetSettingsRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -28340,6 +29318,70 @@ class _$PublicShareAuthCreateRoomApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
+sealed class $PublicShareAuthCreateRoomRequestApplicationJsonInterface {
+  /// Token of the file share.
+  String get shareToken;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PublicShareAuthCreateRoomRequestApplicationJsonInterfaceBuilder].
+  $PublicShareAuthCreateRoomRequestApplicationJsonInterface rebuild(
+    void Function($PublicShareAuthCreateRoomRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PublicShareAuthCreateRoomRequestApplicationJsonInterfaceBuilder].
+  $PublicShareAuthCreateRoomRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PublicShareAuthCreateRoomRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PublicShareAuthCreateRoomRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class PublicShareAuthCreateRoomRequestApplicationJson
+    implements
+        $PublicShareAuthCreateRoomRequestApplicationJsonInterface,
+        Built<PublicShareAuthCreateRoomRequestApplicationJson, PublicShareAuthCreateRoomRequestApplicationJsonBuilder> {
+  /// Creates a new PublicShareAuthCreateRoomRequestApplicationJson object using the builder pattern.
+  factory PublicShareAuthCreateRoomRequestApplicationJson([
+    void Function(PublicShareAuthCreateRoomRequestApplicationJsonBuilder)? b,
+  ]) = _$PublicShareAuthCreateRoomRequestApplicationJson;
+
+  // coverage:ignore-start
+  const PublicShareAuthCreateRoomRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory PublicShareAuthCreateRoomRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for PublicShareAuthCreateRoomRequestApplicationJson.
+  static Serializer<PublicShareAuthCreateRoomRequestApplicationJson> get serializer =>
+      _$publicShareAuthCreateRoomRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PublicShareAuthCreateRoomRequestApplicationJsonBuilder b) {
+    $PublicShareAuthCreateRoomRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PublicShareAuthCreateRoomRequestApplicationJsonBuilder b) {
+    $PublicShareAuthCreateRoomRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterface {
   String get token;
   String get name;
@@ -28591,6 +29633,70 @@ class _$GuestSetDisplayNameApiVersionSerializer implements PrimitiveSerializer<G
 }
 
 @BuiltValue(instantiable: false)
+sealed class $GuestSetDisplayNameRequestApplicationJsonInterface {
+  /// New display name.
+  String get displayName;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$GuestSetDisplayNameRequestApplicationJsonInterfaceBuilder].
+  $GuestSetDisplayNameRequestApplicationJsonInterface rebuild(
+    void Function($GuestSetDisplayNameRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$GuestSetDisplayNameRequestApplicationJsonInterfaceBuilder].
+  $GuestSetDisplayNameRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($GuestSetDisplayNameRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($GuestSetDisplayNameRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class GuestSetDisplayNameRequestApplicationJson
+    implements
+        $GuestSetDisplayNameRequestApplicationJsonInterface,
+        Built<GuestSetDisplayNameRequestApplicationJson, GuestSetDisplayNameRequestApplicationJsonBuilder> {
+  /// Creates a new GuestSetDisplayNameRequestApplicationJson object using the builder pattern.
+  factory GuestSetDisplayNameRequestApplicationJson([
+    void Function(GuestSetDisplayNameRequestApplicationJsonBuilder)? b,
+  ]) = _$GuestSetDisplayNameRequestApplicationJson;
+
+  // coverage:ignore-start
+  const GuestSetDisplayNameRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory GuestSetDisplayNameRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for GuestSetDisplayNameRequestApplicationJson.
+  static Serializer<GuestSetDisplayNameRequestApplicationJson> get serializer =>
+      _$guestSetDisplayNameRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(GuestSetDisplayNameRequestApplicationJsonBuilder b) {
+    $GuestSetDisplayNameRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(GuestSetDisplayNameRequestApplicationJsonBuilder b) {
+    $GuestSetDisplayNameRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $GuestSetDisplayNameResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -28777,6 +29883,83 @@ class _$HostedSignalingServerRequestTrialApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $HostedSignalingServerRequestTrialRequestApplicationJsonInterface {
+  /// Server URL.
+  String get url;
+
+  /// Display name of the user.
+  String get name;
+
+  /// Email of the user.
+  String get email;
+
+  /// Language of the user.
+  String get language;
+
+  /// Country of the user.
+  String get country;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$HostedSignalingServerRequestTrialRequestApplicationJsonInterfaceBuilder].
+  $HostedSignalingServerRequestTrialRequestApplicationJsonInterface rebuild(
+    void Function($HostedSignalingServerRequestTrialRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$HostedSignalingServerRequestTrialRequestApplicationJsonInterfaceBuilder].
+  $HostedSignalingServerRequestTrialRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($HostedSignalingServerRequestTrialRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($HostedSignalingServerRequestTrialRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class HostedSignalingServerRequestTrialRequestApplicationJson
+    implements
+        $HostedSignalingServerRequestTrialRequestApplicationJsonInterface,
+        Built<HostedSignalingServerRequestTrialRequestApplicationJson,
+            HostedSignalingServerRequestTrialRequestApplicationJsonBuilder> {
+  /// Creates a new HostedSignalingServerRequestTrialRequestApplicationJson object using the builder pattern.
+  factory HostedSignalingServerRequestTrialRequestApplicationJson([
+    void Function(HostedSignalingServerRequestTrialRequestApplicationJsonBuilder)? b,
+  ]) = _$HostedSignalingServerRequestTrialRequestApplicationJson;
+
+  // coverage:ignore-start
+  const HostedSignalingServerRequestTrialRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory HostedSignalingServerRequestTrialRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for HostedSignalingServerRequestTrialRequestApplicationJson.
+  static Serializer<HostedSignalingServerRequestTrialRequestApplicationJson> get serializer =>
+      _$hostedSignalingServerRequestTrialRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(HostedSignalingServerRequestTrialRequestApplicationJsonBuilder b) {
+    $HostedSignalingServerRequestTrialRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(HostedSignalingServerRequestTrialRequestApplicationJsonBuilder b) {
+    $HostedSignalingServerRequestTrialRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -29345,6 +30528,70 @@ class _$SignalingSendMessagesApiVersionSerializer implements PrimitiveSerializer
 }
 
 @BuiltValue(instantiable: false)
+sealed class $SignalingSendMessagesRequestApplicationJsonInterface {
+  /// JSON encoded messages.
+  String get messages;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SignalingSendMessagesRequestApplicationJsonInterfaceBuilder].
+  $SignalingSendMessagesRequestApplicationJsonInterface rebuild(
+    void Function($SignalingSendMessagesRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SignalingSendMessagesRequestApplicationJsonInterfaceBuilder].
+  $SignalingSendMessagesRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SignalingSendMessagesRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SignalingSendMessagesRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class SignalingSendMessagesRequestApplicationJson
+    implements
+        $SignalingSendMessagesRequestApplicationJsonInterface,
+        Built<SignalingSendMessagesRequestApplicationJson, SignalingSendMessagesRequestApplicationJsonBuilder> {
+  /// Creates a new SignalingSendMessagesRequestApplicationJson object using the builder pattern.
+  factory SignalingSendMessagesRequestApplicationJson([
+    void Function(SignalingSendMessagesRequestApplicationJsonBuilder)? b,
+  ]) = _$SignalingSendMessagesRequestApplicationJson;
+
+  // coverage:ignore-start
+  const SignalingSendMessagesRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory SignalingSendMessagesRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for SignalingSendMessagesRequestApplicationJson.
+  static Serializer<SignalingSendMessagesRequestApplicationJson> get serializer =>
+      _$signalingSendMessagesRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SignalingSendMessagesRequestApplicationJsonBuilder b) {
+    $SignalingSendMessagesRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SignalingSendMessagesRequestApplicationJsonBuilder b) {
+    $SignalingSendMessagesRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $SignalingSendMessagesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -29840,72 +31087,6 @@ abstract class MatterbridgeGetBridgeOfRoomResponseApplicationJson
   }
 }
 
-class MatterbridgeEditBridgeOfRoomEnabled extends EnumClass {
-  const MatterbridgeEditBridgeOfRoomEnabled._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const MatterbridgeEditBridgeOfRoomEnabled $0 = _$matterbridgeEditBridgeOfRoomEnabled$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const MatterbridgeEditBridgeOfRoomEnabled $1 = _$matterbridgeEditBridgeOfRoomEnabled$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<MatterbridgeEditBridgeOfRoomEnabled> get values => _$matterbridgeEditBridgeOfRoomEnabledValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static MatterbridgeEditBridgeOfRoomEnabled valueOf(String name) => _$valueOfMatterbridgeEditBridgeOfRoomEnabled(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for MatterbridgeEditBridgeOfRoomEnabled.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<MatterbridgeEditBridgeOfRoomEnabled> get serializer =>
-      const _$MatterbridgeEditBridgeOfRoomEnabledSerializer();
-}
-
-class _$MatterbridgeEditBridgeOfRoomEnabledSerializer
-    implements PrimitiveSerializer<MatterbridgeEditBridgeOfRoomEnabled> {
-  const _$MatterbridgeEditBridgeOfRoomEnabledSerializer();
-
-  static const Map<MatterbridgeEditBridgeOfRoomEnabled, Object> _toWire = <MatterbridgeEditBridgeOfRoomEnabled, Object>{
-    MatterbridgeEditBridgeOfRoomEnabled.$0: 0,
-    MatterbridgeEditBridgeOfRoomEnabled.$1: 1,
-  };
-
-  static const Map<Object, MatterbridgeEditBridgeOfRoomEnabled> _fromWire =
-      <Object, MatterbridgeEditBridgeOfRoomEnabled>{
-    0: MatterbridgeEditBridgeOfRoomEnabled.$0,
-    1: MatterbridgeEditBridgeOfRoomEnabled.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [MatterbridgeEditBridgeOfRoomEnabled];
-
-  @override
-  String get wireName => 'MatterbridgeEditBridgeOfRoomEnabled';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    MatterbridgeEditBridgeOfRoomEnabled object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  MatterbridgeEditBridgeOfRoomEnabled deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class MatterbridgeEditBridgeOfRoomApiVersion extends EnumClass {
   const MatterbridgeEditBridgeOfRoomApiVersion._(super.name);
 
@@ -29965,6 +31146,84 @@ class _$MatterbridgeEditBridgeOfRoomApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterface {
+  static final _$parts = _$jsonSerializers.deserialize(
+    const [],
+    specifiedType: const FullType(BuiltList, [
+      FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
+    ]),
+  )! as BuiltList<BuiltMap<String, JsonObject>>;
+
+  /// If the bridge should be enabled.
+  bool get enabled;
+
+  /// New parts.
+  BuiltList<BuiltMap<String, JsonObject>> get parts;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterfaceBuilder].
+  $MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterface rebuild(
+    void Function($MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterfaceBuilder].
+  $MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterfaceBuilder b) {
+    b.parts.replace(_$parts);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class MatterbridgeEditBridgeOfRoomRequestApplicationJson
+    implements
+        $MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterface,
+        Built<MatterbridgeEditBridgeOfRoomRequestApplicationJson,
+            MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder> {
+  /// Creates a new MatterbridgeEditBridgeOfRoomRequestApplicationJson object using the builder pattern.
+  factory MatterbridgeEditBridgeOfRoomRequestApplicationJson([
+    void Function(MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder)? b,
+  ]) = _$MatterbridgeEditBridgeOfRoomRequestApplicationJson;
+
+  // coverage:ignore-start
+  const MatterbridgeEditBridgeOfRoomRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory MatterbridgeEditBridgeOfRoomRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for MatterbridgeEditBridgeOfRoomRequestApplicationJson.
+  static Serializer<MatterbridgeEditBridgeOfRoomRequestApplicationJson> get serializer =>
+      _$matterbridgeEditBridgeOfRoomRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder b) {
+    $MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder b) {
+    $MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -30931,69 +32190,6 @@ abstract class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson
   }
 }
 
-class PollCreatePollResultMode extends EnumClass {
-  const PollCreatePollResultMode._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const PollCreatePollResultMode $0 = _$pollCreatePollResultMode$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const PollCreatePollResultMode $1 = _$pollCreatePollResultMode$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<PollCreatePollResultMode> get values => _$pollCreatePollResultModeValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static PollCreatePollResultMode valueOf(String name) => _$valueOfPollCreatePollResultMode(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for PollCreatePollResultMode.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<PollCreatePollResultMode> get serializer => const _$PollCreatePollResultModeSerializer();
-}
-
-class _$PollCreatePollResultModeSerializer implements PrimitiveSerializer<PollCreatePollResultMode> {
-  const _$PollCreatePollResultModeSerializer();
-
-  static const Map<PollCreatePollResultMode, Object> _toWire = <PollCreatePollResultMode, Object>{
-    PollCreatePollResultMode.$0: 0,
-    PollCreatePollResultMode.$1: 1,
-  };
-
-  static const Map<Object, PollCreatePollResultMode> _fromWire = <Object, PollCreatePollResultMode>{
-    0: PollCreatePollResultMode.$0,
-    1: PollCreatePollResultMode.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [PollCreatePollResultMode];
-
-  @override
-  String get wireName => 'PollCreatePollResultMode';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    PollCreatePollResultMode object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  PollCreatePollResultMode deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class PollCreatePollApiVersion extends EnumClass {
   const PollCreatePollApiVersion._(super.name);
 
@@ -31048,6 +32244,148 @@ class _$PollCreatePollApiVersionSerializer implements PrimitiveSerializer<PollCr
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// Mode how the results will be shown.
+class PollCreatePollRequestApplicationJson_ResultMode extends EnumClass {
+  const PollCreatePollRequestApplicationJson_ResultMode._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const PollCreatePollRequestApplicationJson_ResultMode $0 = _$pollCreatePollRequestApplicationJsonResultMode$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const PollCreatePollRequestApplicationJson_ResultMode $1 = _$pollCreatePollRequestApplicationJsonResultMode$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<PollCreatePollRequestApplicationJson_ResultMode> get values =>
+      _$pollCreatePollRequestApplicationJsonResultModeValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static PollCreatePollRequestApplicationJson_ResultMode valueOf(String name) =>
+      _$valueOfPollCreatePollRequestApplicationJson_ResultMode(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for PollCreatePollRequestApplicationJson_ResultMode.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<PollCreatePollRequestApplicationJson_ResultMode> get serializer =>
+      const _$PollCreatePollRequestApplicationJson_ResultModeSerializer();
+}
+
+class _$PollCreatePollRequestApplicationJson_ResultModeSerializer
+    implements PrimitiveSerializer<PollCreatePollRequestApplicationJson_ResultMode> {
+  const _$PollCreatePollRequestApplicationJson_ResultModeSerializer();
+
+  static const Map<PollCreatePollRequestApplicationJson_ResultMode, Object> _toWire =
+      <PollCreatePollRequestApplicationJson_ResultMode, Object>{
+    PollCreatePollRequestApplicationJson_ResultMode.$0: 0,
+    PollCreatePollRequestApplicationJson_ResultMode.$1: 1,
+  };
+
+  static const Map<Object, PollCreatePollRequestApplicationJson_ResultMode> _fromWire =
+      <Object, PollCreatePollRequestApplicationJson_ResultMode>{
+    0: PollCreatePollRequestApplicationJson_ResultMode.$0,
+    1: PollCreatePollRequestApplicationJson_ResultMode.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [PollCreatePollRequestApplicationJson_ResultMode];
+
+  @override
+  String get wireName => 'PollCreatePollRequestApplicationJson_ResultMode';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    PollCreatePollRequestApplicationJson_ResultMode object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  PollCreatePollRequestApplicationJson_ResultMode deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $PollCreatePollRequestApplicationJsonInterface {
+  /// Question of the poll.
+  String get question;
+
+  /// Options of the poll.
+  BuiltList<String> get options;
+
+  /// Mode how the results will be shown.
+  PollCreatePollRequestApplicationJson_ResultMode get resultMode;
+
+  /// Number of maximum votes per voter.
+  int get maxVotes;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PollCreatePollRequestApplicationJsonInterfaceBuilder].
+  $PollCreatePollRequestApplicationJsonInterface rebuild(
+    void Function($PollCreatePollRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PollCreatePollRequestApplicationJsonInterfaceBuilder].
+  $PollCreatePollRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PollCreatePollRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PollCreatePollRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class PollCreatePollRequestApplicationJson
+    implements
+        $PollCreatePollRequestApplicationJsonInterface,
+        Built<PollCreatePollRequestApplicationJson, PollCreatePollRequestApplicationJsonBuilder> {
+  /// Creates a new PollCreatePollRequestApplicationJson object using the builder pattern.
+  factory PollCreatePollRequestApplicationJson([void Function(PollCreatePollRequestApplicationJsonBuilder)? b]) =
+      _$PollCreatePollRequestApplicationJson;
+
+  // coverage:ignore-start
+  const PollCreatePollRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory PollCreatePollRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for PollCreatePollRequestApplicationJson.
+  static Serializer<PollCreatePollRequestApplicationJson> get serializer =>
+      _$pollCreatePollRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PollCreatePollRequestApplicationJsonBuilder b) {
+    $PollCreatePollRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PollCreatePollRequestApplicationJsonBuilder b) {
+    $PollCreatePollRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -31537,6 +32875,77 @@ class _$PollVotePollApiVersionSerializer implements PrimitiveSerializer<PollVote
 }
 
 @BuiltValue(instantiable: false)
+sealed class $PollVotePollRequestApplicationJsonInterface {
+  static final _$optionIds = _$jsonSerializers.deserialize(
+    const [],
+    specifiedType: const FullType(BuiltList, [FullType(int)]),
+  )! as BuiltList<int>;
+
+  /// IDs of the selected options.
+  BuiltList<int> get optionIds;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$PollVotePollRequestApplicationJsonInterfaceBuilder].
+  $PollVotePollRequestApplicationJsonInterface rebuild(
+    void Function($PollVotePollRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$PollVotePollRequestApplicationJsonInterfaceBuilder].
+  $PollVotePollRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($PollVotePollRequestApplicationJsonInterfaceBuilder b) {
+    b.optionIds.replace(_$optionIds);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($PollVotePollRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class PollVotePollRequestApplicationJson
+    implements
+        $PollVotePollRequestApplicationJsonInterface,
+        Built<PollVotePollRequestApplicationJson, PollVotePollRequestApplicationJsonBuilder> {
+  /// Creates a new PollVotePollRequestApplicationJson object using the builder pattern.
+  factory PollVotePollRequestApplicationJson([void Function(PollVotePollRequestApplicationJsonBuilder)? b]) =
+      _$PollVotePollRequestApplicationJson;
+
+  // coverage:ignore-start
+  const PollVotePollRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory PollVotePollRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for PollVotePollRequestApplicationJson.
+  static Serializer<PollVotePollRequestApplicationJson> get serializer =>
+      _$pollVotePollRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(PollVotePollRequestApplicationJsonBuilder b) {
+    $PollVotePollRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(PollVotePollRequestApplicationJsonBuilder b) {
+    $PollVotePollRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $PollVotePollResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Poll get data;
@@ -31901,6 +33310,70 @@ class _$ReactionGetReactionsApiVersionSerializer implements PrimitiveSerializer<
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ReactionGetReactionsRequestApplicationJsonInterface {
+  /// Emoji to filter.
+  String? get reaction;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReactionGetReactionsRequestApplicationJsonInterfaceBuilder].
+  $ReactionGetReactionsRequestApplicationJsonInterface rebuild(
+    void Function($ReactionGetReactionsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReactionGetReactionsRequestApplicationJsonInterfaceBuilder].
+  $ReactionGetReactionsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReactionGetReactionsRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReactionGetReactionsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ReactionGetReactionsRequestApplicationJson
+    implements
+        $ReactionGetReactionsRequestApplicationJsonInterface,
+        Built<ReactionGetReactionsRequestApplicationJson, ReactionGetReactionsRequestApplicationJsonBuilder> {
+  /// Creates a new ReactionGetReactionsRequestApplicationJson object using the builder pattern.
+  factory ReactionGetReactionsRequestApplicationJson([
+    void Function(ReactionGetReactionsRequestApplicationJsonBuilder)? b,
+  ]) = _$ReactionGetReactionsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ReactionGetReactionsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ReactionGetReactionsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ReactionGetReactionsRequestApplicationJson.
+  static Serializer<ReactionGetReactionsRequestApplicationJson> get serializer =>
+      _$reactionGetReactionsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReactionGetReactionsRequestApplicationJsonBuilder b) {
+    $ReactionGetReactionsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReactionGetReactionsRequestApplicationJsonBuilder b) {
+    $ReactionGetReactionsRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ReactionInterface {
   String get actorDisplayName;
   String get actorId;
@@ -32141,6 +33614,69 @@ class _$ReactionReactApiVersionSerializer implements PrimitiveSerializer<Reactio
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ReactionReactRequestApplicationJsonInterface {
+  /// Emoji to add.
+  String get reaction;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReactionReactRequestApplicationJsonInterfaceBuilder].
+  $ReactionReactRequestApplicationJsonInterface rebuild(
+    void Function($ReactionReactRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReactionReactRequestApplicationJsonInterfaceBuilder].
+  $ReactionReactRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReactionReactRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReactionReactRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ReactionReactRequestApplicationJson
+    implements
+        $ReactionReactRequestApplicationJsonInterface,
+        Built<ReactionReactRequestApplicationJson, ReactionReactRequestApplicationJsonBuilder> {
+  /// Creates a new ReactionReactRequestApplicationJson object using the builder pattern.
+  factory ReactionReactRequestApplicationJson([void Function(ReactionReactRequestApplicationJsonBuilder)? b]) =
+      _$ReactionReactRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ReactionReactRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ReactionReactRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ReactionReactRequestApplicationJson.
+  static Serializer<ReactionReactRequestApplicationJson> get serializer =>
+      _$reactionReactRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReactionReactRequestApplicationJsonBuilder b) {
+    $ReactionReactRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReactionReactRequestApplicationJsonBuilder b) {
+    $ReactionReactRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ReactionReactResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<Reaction>> get data;
@@ -32323,6 +33859,69 @@ class _$ReactionDeleteApiVersionSerializer implements PrimitiveSerializer<Reacti
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ReactionDeleteRequestApplicationJsonInterface {
+  /// Emoji to remove.
+  String get reaction;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ReactionDeleteRequestApplicationJsonInterfaceBuilder].
+  $ReactionDeleteRequestApplicationJsonInterface rebuild(
+    void Function($ReactionDeleteRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ReactionDeleteRequestApplicationJsonInterfaceBuilder].
+  $ReactionDeleteRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ReactionDeleteRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ReactionDeleteRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ReactionDeleteRequestApplicationJson
+    implements
+        $ReactionDeleteRequestApplicationJsonInterface,
+        Built<ReactionDeleteRequestApplicationJson, ReactionDeleteRequestApplicationJsonBuilder> {
+  /// Creates a new ReactionDeleteRequestApplicationJson object using the builder pattern.
+  factory ReactionDeleteRequestApplicationJson([void Function(ReactionDeleteRequestApplicationJsonBuilder)? b]) =
+      _$ReactionDeleteRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ReactionDeleteRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ReactionDeleteRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ReactionDeleteRequestApplicationJson.
+  static Serializer<ReactionDeleteRequestApplicationJson> get serializer =>
+      _$reactionDeleteRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ReactionDeleteRequestApplicationJsonBuilder b) {
+    $ReactionDeleteRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ReactionDeleteRequestApplicationJsonBuilder b) {
+    $ReactionDeleteRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ReactionDeleteResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltMap<String, BuiltList<Reaction>> get data;
@@ -32502,6 +34101,69 @@ class _$RecordingStartApiVersionSerializer implements PrimitiveSerializer<Record
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RecordingStartRequestApplicationJsonInterface {
+  /// Type of the recording.
+  int get status;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingStartRequestApplicationJsonInterfaceBuilder].
+  $RecordingStartRequestApplicationJsonInterface rebuild(
+    void Function($RecordingStartRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingStartRequestApplicationJsonInterfaceBuilder].
+  $RecordingStartRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingStartRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingStartRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RecordingStartRequestApplicationJson
+    implements
+        $RecordingStartRequestApplicationJsonInterface,
+        Built<RecordingStartRequestApplicationJson, RecordingStartRequestApplicationJsonBuilder> {
+  /// Creates a new RecordingStartRequestApplicationJson object using the builder pattern.
+  factory RecordingStartRequestApplicationJson([void Function(RecordingStartRequestApplicationJsonBuilder)? b]) =
+      _$RecordingStartRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RecordingStartRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RecordingStartRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RecordingStartRequestApplicationJson.
+  static Serializer<RecordingStartRequestApplicationJson> get serializer =>
+      _$recordingStartRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingStartRequestApplicationJsonBuilder b) {
+    $RecordingStartRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingStartRequestApplicationJsonBuilder b) {
+    $RecordingStartRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -32874,6 +34536,77 @@ class _$RecordingNotificationDismissApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
+sealed class $RecordingNotificationDismissRequestApplicationJsonInterface {
+  /// Timestamp of the notification to be dismissed.
+  int get timestamp;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingNotificationDismissRequestApplicationJsonInterfaceBuilder].
+  $RecordingNotificationDismissRequestApplicationJsonInterface rebuild(
+    void Function($RecordingNotificationDismissRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingNotificationDismissRequestApplicationJsonInterfaceBuilder].
+  $RecordingNotificationDismissRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingNotificationDismissRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingNotificationDismissRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.timestamp,
+      'timestamp',
+      minimum: 0,
+    );
+  }
+}
+
+abstract class RecordingNotificationDismissRequestApplicationJson
+    implements
+        $RecordingNotificationDismissRequestApplicationJsonInterface,
+        Built<RecordingNotificationDismissRequestApplicationJson,
+            RecordingNotificationDismissRequestApplicationJsonBuilder> {
+  /// Creates a new RecordingNotificationDismissRequestApplicationJson object using the builder pattern.
+  factory RecordingNotificationDismissRequestApplicationJson([
+    void Function(RecordingNotificationDismissRequestApplicationJsonBuilder)? b,
+  ]) = _$RecordingNotificationDismissRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RecordingNotificationDismissRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RecordingNotificationDismissRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RecordingNotificationDismissRequestApplicationJson.
+  static Serializer<RecordingNotificationDismissRequestApplicationJson> get serializer =>
+      _$recordingNotificationDismissRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingNotificationDismissRequestApplicationJsonBuilder b) {
+    $RecordingNotificationDismissRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingNotificationDismissRequestApplicationJsonBuilder b) {
+    $RecordingNotificationDismissRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $RecordingNotificationDismissResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -33057,6 +34790,84 @@ class _$RecordingShareToChatApiVersionSerializer implements PrimitiveSerializer<
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RecordingShareToChatRequestApplicationJsonInterface {
+  /// ID of the file.
+  int get fileId;
+
+  /// Timestamp of the notification to be dismissed.
+  int get timestamp;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingShareToChatRequestApplicationJsonInterfaceBuilder].
+  $RecordingShareToChatRequestApplicationJsonInterface rebuild(
+    void Function($RecordingShareToChatRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingShareToChatRequestApplicationJsonInterfaceBuilder].
+  $RecordingShareToChatRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingShareToChatRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingShareToChatRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.fileId,
+      'fileId',
+      minimum: 0,
+    );
+    _i4.checkNumber(
+      b.timestamp,
+      'timestamp',
+      minimum: 0,
+    );
+  }
+}
+
+abstract class RecordingShareToChatRequestApplicationJson
+    implements
+        $RecordingShareToChatRequestApplicationJsonInterface,
+        Built<RecordingShareToChatRequestApplicationJson, RecordingShareToChatRequestApplicationJsonBuilder> {
+  /// Creates a new RecordingShareToChatRequestApplicationJson object using the builder pattern.
+  factory RecordingShareToChatRequestApplicationJson([
+    void Function(RecordingShareToChatRequestApplicationJsonBuilder)? b,
+  ]) = _$RecordingShareToChatRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RecordingShareToChatRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RecordingShareToChatRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RecordingShareToChatRequestApplicationJson.
+  static Serializer<RecordingShareToChatRequestApplicationJson> get serializer =>
+      _$recordingShareToChatRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingShareToChatRequestApplicationJsonBuilder b) {
+    $RecordingShareToChatRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingShareToChatRequestApplicationJsonBuilder b) {
+    $RecordingShareToChatRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -33425,6 +35236,69 @@ class _$RecordingStoreApiVersionSerializer implements PrimitiveSerializer<Record
 }
 
 @BuiltValue(instantiable: false)
+sealed class $RecordingStoreRequestApplicationJsonInterface {
+  /// User that will own the recording file.
+  String get owner;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RecordingStoreRequestApplicationJsonInterfaceBuilder].
+  $RecordingStoreRequestApplicationJsonInterface rebuild(
+    void Function($RecordingStoreRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RecordingStoreRequestApplicationJsonInterfaceBuilder].
+  $RecordingStoreRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RecordingStoreRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RecordingStoreRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RecordingStoreRequestApplicationJson
+    implements
+        $RecordingStoreRequestApplicationJsonInterface,
+        Built<RecordingStoreRequestApplicationJson, RecordingStoreRequestApplicationJsonBuilder> {
+  /// Creates a new RecordingStoreRequestApplicationJson object using the builder pattern.
+  factory RecordingStoreRequestApplicationJson([void Function(RecordingStoreRequestApplicationJsonBuilder)? b]) =
+      _$RecordingStoreRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RecordingStoreRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RecordingStoreRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RecordingStoreRequestApplicationJson.
+  static Serializer<RecordingStoreRequestApplicationJson> get serializer =>
+      _$recordingStoreRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RecordingStoreRequestApplicationJsonBuilder b) {
+    $RecordingStoreRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RecordingStoreRequestApplicationJsonBuilder b) {
+    $RecordingStoreRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $RecordingStoreResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -33550,132 +35424,6 @@ abstract class RecordingStoreResponseApplicationJson
   }
 }
 
-class RoomGetRoomsNoStatusUpdate extends EnumClass {
-  const RoomGetRoomsNoStatusUpdate._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const RoomGetRoomsNoStatusUpdate $0 = _$roomGetRoomsNoStatusUpdate$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const RoomGetRoomsNoStatusUpdate $1 = _$roomGetRoomsNoStatusUpdate$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<RoomGetRoomsNoStatusUpdate> get values => _$roomGetRoomsNoStatusUpdateValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static RoomGetRoomsNoStatusUpdate valueOf(String name) => _$valueOfRoomGetRoomsNoStatusUpdate(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for RoomGetRoomsNoStatusUpdate.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<RoomGetRoomsNoStatusUpdate> get serializer => const _$RoomGetRoomsNoStatusUpdateSerializer();
-}
-
-class _$RoomGetRoomsNoStatusUpdateSerializer implements PrimitiveSerializer<RoomGetRoomsNoStatusUpdate> {
-  const _$RoomGetRoomsNoStatusUpdateSerializer();
-
-  static const Map<RoomGetRoomsNoStatusUpdate, Object> _toWire = <RoomGetRoomsNoStatusUpdate, Object>{
-    RoomGetRoomsNoStatusUpdate.$0: 0,
-    RoomGetRoomsNoStatusUpdate.$1: 1,
-  };
-
-  static const Map<Object, RoomGetRoomsNoStatusUpdate> _fromWire = <Object, RoomGetRoomsNoStatusUpdate>{
-    0: RoomGetRoomsNoStatusUpdate.$0,
-    1: RoomGetRoomsNoStatusUpdate.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [RoomGetRoomsNoStatusUpdate];
-
-  @override
-  String get wireName => 'RoomGetRoomsNoStatusUpdate';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    RoomGetRoomsNoStatusUpdate object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  RoomGetRoomsNoStatusUpdate deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-class RoomGetRoomsIncludeStatus extends EnumClass {
-  const RoomGetRoomsIncludeStatus._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const RoomGetRoomsIncludeStatus $0 = _$roomGetRoomsIncludeStatus$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const RoomGetRoomsIncludeStatus $1 = _$roomGetRoomsIncludeStatus$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<RoomGetRoomsIncludeStatus> get values => _$roomGetRoomsIncludeStatusValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static RoomGetRoomsIncludeStatus valueOf(String name) => _$valueOfRoomGetRoomsIncludeStatus(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for RoomGetRoomsIncludeStatus.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<RoomGetRoomsIncludeStatus> get serializer => const _$RoomGetRoomsIncludeStatusSerializer();
-}
-
-class _$RoomGetRoomsIncludeStatusSerializer implements PrimitiveSerializer<RoomGetRoomsIncludeStatus> {
-  const _$RoomGetRoomsIncludeStatusSerializer();
-
-  static const Map<RoomGetRoomsIncludeStatus, Object> _toWire = <RoomGetRoomsIncludeStatus, Object>{
-    RoomGetRoomsIncludeStatus.$0: 0,
-    RoomGetRoomsIncludeStatus.$1: 1,
-  };
-
-  static const Map<Object, RoomGetRoomsIncludeStatus> _fromWire = <Object, RoomGetRoomsIncludeStatus>{
-    0: RoomGetRoomsIncludeStatus.$0,
-    1: RoomGetRoomsIncludeStatus.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [RoomGetRoomsIncludeStatus];
-
-  @override
-  String get wireName => 'RoomGetRoomsIncludeStatus';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    RoomGetRoomsIncludeStatus object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  RoomGetRoomsIncludeStatus deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class RoomGetRoomsApiVersion extends EnumClass {
   const RoomGetRoomsApiVersion._(super.name);
 
@@ -33730,6 +35478,173 @@ class _$RoomGetRoomsApiVersionSerializer implements PrimitiveSerializer<RoomGetR
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// When the user status should not be automatically set to online set to 1 (default 0).
+class RoomGetRoomsRequestApplicationJson_NoStatusUpdate extends EnumClass {
+  const RoomGetRoomsRequestApplicationJson_NoStatusUpdate._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const RoomGetRoomsRequestApplicationJson_NoStatusUpdate $0 =
+      _$roomGetRoomsRequestApplicationJsonNoStatusUpdate$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const RoomGetRoomsRequestApplicationJson_NoStatusUpdate $1 =
+      _$roomGetRoomsRequestApplicationJsonNoStatusUpdate$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<RoomGetRoomsRequestApplicationJson_NoStatusUpdate> get values =>
+      _$roomGetRoomsRequestApplicationJsonNoStatusUpdateValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static RoomGetRoomsRequestApplicationJson_NoStatusUpdate valueOf(String name) =>
+      _$valueOfRoomGetRoomsRequestApplicationJson_NoStatusUpdate(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for RoomGetRoomsRequestApplicationJson_NoStatusUpdate.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<RoomGetRoomsRequestApplicationJson_NoStatusUpdate> get serializer =>
+      const _$RoomGetRoomsRequestApplicationJson_NoStatusUpdateSerializer();
+}
+
+class _$RoomGetRoomsRequestApplicationJson_NoStatusUpdateSerializer
+    implements PrimitiveSerializer<RoomGetRoomsRequestApplicationJson_NoStatusUpdate> {
+  const _$RoomGetRoomsRequestApplicationJson_NoStatusUpdateSerializer();
+
+  static const Map<RoomGetRoomsRequestApplicationJson_NoStatusUpdate, Object> _toWire =
+      <RoomGetRoomsRequestApplicationJson_NoStatusUpdate, Object>{
+    RoomGetRoomsRequestApplicationJson_NoStatusUpdate.$0: 0,
+    RoomGetRoomsRequestApplicationJson_NoStatusUpdate.$1: 1,
+  };
+
+  static const Map<Object, RoomGetRoomsRequestApplicationJson_NoStatusUpdate> _fromWire =
+      <Object, RoomGetRoomsRequestApplicationJson_NoStatusUpdate>{
+    0: RoomGetRoomsRequestApplicationJson_NoStatusUpdate.$0,
+    1: RoomGetRoomsRequestApplicationJson_NoStatusUpdate.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [RoomGetRoomsRequestApplicationJson_NoStatusUpdate];
+
+  @override
+  String get wireName => 'RoomGetRoomsRequestApplicationJson_NoStatusUpdate';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RoomGetRoomsRequestApplicationJson_NoStatusUpdate object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  RoomGetRoomsRequestApplicationJson_NoStatusUpdate deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomGetRoomsRequestApplicationJsonInterface {
+  static final _$noStatusUpdate = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(RoomGetRoomsRequestApplicationJson_NoStatusUpdate),
+  )! as RoomGetRoomsRequestApplicationJson_NoStatusUpdate;
+
+  static final _$includeStatus = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  static final _$modifiedSince = _$jsonSerializers.deserialize(
+    0,
+    specifiedType: const FullType(int),
+  )! as int;
+
+  /// When the user status should not be automatically set to online set to 1 (default 0).
+  RoomGetRoomsRequestApplicationJson_NoStatusUpdate get noStatusUpdate;
+
+  /// Include the user status.
+  bool get includeStatus;
+
+  /// Filter rooms modified after a timestamp.
+  int get modifiedSince;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetRoomsRequestApplicationJsonInterfaceBuilder].
+  $RoomGetRoomsRequestApplicationJsonInterface rebuild(
+    void Function($RoomGetRoomsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetRoomsRequestApplicationJsonInterfaceBuilder].
+  $RoomGetRoomsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetRoomsRequestApplicationJsonInterfaceBuilder b) {
+    b.noStatusUpdate = _$noStatusUpdate;
+    b.includeStatus = _$includeStatus;
+    b.modifiedSince = _$modifiedSince;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetRoomsRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.modifiedSince,
+      'modifiedSince',
+      minimum: 0,
+    );
+  }
+}
+
+abstract class RoomGetRoomsRequestApplicationJson
+    implements
+        $RoomGetRoomsRequestApplicationJsonInterface,
+        Built<RoomGetRoomsRequestApplicationJson, RoomGetRoomsRequestApplicationJsonBuilder> {
+  /// Creates a new RoomGetRoomsRequestApplicationJson object using the builder pattern.
+  factory RoomGetRoomsRequestApplicationJson([void Function(RoomGetRoomsRequestApplicationJsonBuilder)? b]) =
+      _$RoomGetRoomsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomGetRoomsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomGetRoomsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomGetRoomsRequestApplicationJson.
+  static Serializer<RoomGetRoomsRequestApplicationJson> get serializer =>
+      _$roomGetRoomsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetRoomsRequestApplicationJsonBuilder b) {
+    $RoomGetRoomsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetRoomsRequestApplicationJsonBuilder b) {
+    $RoomGetRoomsRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -33975,6 +35890,116 @@ class _$RoomCreateRoomApiVersionSerializer implements PrimitiveSerializer<RoomCr
 }
 
 @BuiltValue(instantiable: false)
+sealed class $RoomCreateRoomRequestApplicationJsonInterface {
+  static final _$invite = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$roomName = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$source = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$objectType = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$objectId = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// Type of the room.
+  int get roomType;
+
+  /// User, group, … ID to invite.
+  String get invite;
+
+  /// Name of the room.
+  String get roomName;
+
+  /// Source of the invite ID ('circles' to create a room with a circle, etc.).
+  String get source;
+
+  /// Type of the object.
+  String get objectType;
+
+  /// ID of the object.
+  String get objectId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomCreateRoomRequestApplicationJsonInterfaceBuilder].
+  $RoomCreateRoomRequestApplicationJsonInterface rebuild(
+    void Function($RoomCreateRoomRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomCreateRoomRequestApplicationJsonInterfaceBuilder].
+  $RoomCreateRoomRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomCreateRoomRequestApplicationJsonInterfaceBuilder b) {
+    b.invite = _$invite;
+    b.roomName = _$roomName;
+    b.source = _$source;
+    b.objectType = _$objectType;
+    b.objectId = _$objectId;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomCreateRoomRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomCreateRoomRequestApplicationJson
+    implements
+        $RoomCreateRoomRequestApplicationJsonInterface,
+        Built<RoomCreateRoomRequestApplicationJson, RoomCreateRoomRequestApplicationJsonBuilder> {
+  /// Creates a new RoomCreateRoomRequestApplicationJson object using the builder pattern.
+  factory RoomCreateRoomRequestApplicationJson([void Function(RoomCreateRoomRequestApplicationJsonBuilder)? b]) =
+      _$RoomCreateRoomRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomCreateRoomRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomCreateRoomRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomCreateRoomRequestApplicationJson.
+  static Serializer<RoomCreateRoomRequestApplicationJson> get serializer =>
+      _$roomCreateRoomRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomCreateRoomRequestApplicationJsonBuilder b) {
+    $RoomCreateRoomRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomCreateRoomRequestApplicationJsonBuilder b) {
+    $RoomCreateRoomRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $RoomCreateRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
@@ -34154,6 +36179,78 @@ class _$RoomGetListedRoomsApiVersionSerializer implements PrimitiveSerializer<Ro
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomGetListedRoomsRequestApplicationJsonInterface {
+  static final _$searchTerm = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// search term.
+  String get searchTerm;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetListedRoomsRequestApplicationJsonInterfaceBuilder].
+  $RoomGetListedRoomsRequestApplicationJsonInterface rebuild(
+    void Function($RoomGetListedRoomsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetListedRoomsRequestApplicationJsonInterfaceBuilder].
+  $RoomGetListedRoomsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetListedRoomsRequestApplicationJsonInterfaceBuilder b) {
+    b.searchTerm = _$searchTerm;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetListedRoomsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomGetListedRoomsRequestApplicationJson
+    implements
+        $RoomGetListedRoomsRequestApplicationJsonInterface,
+        Built<RoomGetListedRoomsRequestApplicationJson, RoomGetListedRoomsRequestApplicationJsonBuilder> {
+  /// Creates a new RoomGetListedRoomsRequestApplicationJson object using the builder pattern.
+  factory RoomGetListedRoomsRequestApplicationJson([
+    void Function(RoomGetListedRoomsRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomGetListedRoomsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomGetListedRoomsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomGetListedRoomsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomGetListedRoomsRequestApplicationJson.
+  static Serializer<RoomGetListedRoomsRequestApplicationJson> get serializer =>
+      _$roomGetListedRoomsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetListedRoomsRequestApplicationJsonBuilder b) {
+    $RoomGetListedRoomsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetListedRoomsRequestApplicationJsonBuilder b) {
+    $RoomGetListedRoomsRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -35386,6 +37483,70 @@ class _$RoomSetDescriptionApiVersionSerializer implements PrimitiveSerializer<Ro
 }
 
 @BuiltValue(instantiable: false)
+sealed class $RoomSetDescriptionRequestApplicationJsonInterface {
+  /// New description.
+  String get description;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetDescriptionRequestApplicationJsonInterfaceBuilder].
+  $RoomSetDescriptionRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetDescriptionRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetDescriptionRequestApplicationJsonInterfaceBuilder].
+  $RoomSetDescriptionRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetDescriptionRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetDescriptionRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomSetDescriptionRequestApplicationJson
+    implements
+        $RoomSetDescriptionRequestApplicationJsonInterface,
+        Built<RoomSetDescriptionRequestApplicationJson, RoomSetDescriptionRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetDescriptionRequestApplicationJson object using the builder pattern.
+  factory RoomSetDescriptionRequestApplicationJson([
+    void Function(RoomSetDescriptionRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomSetDescriptionRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetDescriptionRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetDescriptionRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetDescriptionRequestApplicationJson.
+  static Serializer<RoomSetDescriptionRequestApplicationJson> get serializer =>
+      _$roomSetDescriptionRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetDescriptionRequestApplicationJsonBuilder b) {
+    $RoomSetDescriptionRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetDescriptionRequestApplicationJsonBuilder b) {
+    $RoomSetDescriptionRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $RoomSetDescriptionResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -35512,69 +37673,6 @@ abstract class RoomSetDescriptionResponseApplicationJson
   }
 }
 
-class RoomSetReadOnlyState extends EnumClass {
-  const RoomSetReadOnlyState._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const RoomSetReadOnlyState $0 = _$roomSetReadOnlyState$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const RoomSetReadOnlyState $1 = _$roomSetReadOnlyState$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<RoomSetReadOnlyState> get values => _$roomSetReadOnlyStateValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static RoomSetReadOnlyState valueOf(String name) => _$valueOfRoomSetReadOnlyState(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for RoomSetReadOnlyState.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<RoomSetReadOnlyState> get serializer => const _$RoomSetReadOnlyStateSerializer();
-}
-
-class _$RoomSetReadOnlyStateSerializer implements PrimitiveSerializer<RoomSetReadOnlyState> {
-  const _$RoomSetReadOnlyStateSerializer();
-
-  static const Map<RoomSetReadOnlyState, Object> _toWire = <RoomSetReadOnlyState, Object>{
-    RoomSetReadOnlyState.$0: 0,
-    RoomSetReadOnlyState.$1: 1,
-  };
-
-  static const Map<Object, RoomSetReadOnlyState> _fromWire = <Object, RoomSetReadOnlyState>{
-    0: RoomSetReadOnlyState.$0,
-    1: RoomSetReadOnlyState.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [RoomSetReadOnlyState];
-
-  @override
-  String get wireName => 'RoomSetReadOnlyState';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    RoomSetReadOnlyState object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  RoomSetReadOnlyState deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class RoomSetReadOnlyApiVersion extends EnumClass {
   const RoomSetReadOnlyApiVersion._(super.name);
 
@@ -35629,6 +37727,139 @@ class _$RoomSetReadOnlyApiVersionSerializer implements PrimitiveSerializer<RoomS
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// New read-only state.
+class RoomSetReadOnlyRequestApplicationJson_State extends EnumClass {
+  const RoomSetReadOnlyRequestApplicationJson_State._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const RoomSetReadOnlyRequestApplicationJson_State $0 = _$roomSetReadOnlyRequestApplicationJsonState$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const RoomSetReadOnlyRequestApplicationJson_State $1 = _$roomSetReadOnlyRequestApplicationJsonState$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<RoomSetReadOnlyRequestApplicationJson_State> get values =>
+      _$roomSetReadOnlyRequestApplicationJsonStateValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static RoomSetReadOnlyRequestApplicationJson_State valueOf(String name) =>
+      _$valueOfRoomSetReadOnlyRequestApplicationJson_State(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for RoomSetReadOnlyRequestApplicationJson_State.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<RoomSetReadOnlyRequestApplicationJson_State> get serializer =>
+      const _$RoomSetReadOnlyRequestApplicationJson_StateSerializer();
+}
+
+class _$RoomSetReadOnlyRequestApplicationJson_StateSerializer
+    implements PrimitiveSerializer<RoomSetReadOnlyRequestApplicationJson_State> {
+  const _$RoomSetReadOnlyRequestApplicationJson_StateSerializer();
+
+  static const Map<RoomSetReadOnlyRequestApplicationJson_State, Object> _toWire =
+      <RoomSetReadOnlyRequestApplicationJson_State, Object>{
+    RoomSetReadOnlyRequestApplicationJson_State.$0: 0,
+    RoomSetReadOnlyRequestApplicationJson_State.$1: 1,
+  };
+
+  static const Map<Object, RoomSetReadOnlyRequestApplicationJson_State> _fromWire =
+      <Object, RoomSetReadOnlyRequestApplicationJson_State>{
+    0: RoomSetReadOnlyRequestApplicationJson_State.$0,
+    1: RoomSetReadOnlyRequestApplicationJson_State.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [RoomSetReadOnlyRequestApplicationJson_State];
+
+  @override
+  String get wireName => 'RoomSetReadOnlyRequestApplicationJson_State';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RoomSetReadOnlyRequestApplicationJson_State object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  RoomSetReadOnlyRequestApplicationJson_State deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomSetReadOnlyRequestApplicationJsonInterface {
+  /// New read-only state.
+  RoomSetReadOnlyRequestApplicationJson_State get state;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetReadOnlyRequestApplicationJsonInterfaceBuilder].
+  $RoomSetReadOnlyRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetReadOnlyRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetReadOnlyRequestApplicationJsonInterfaceBuilder].
+  $RoomSetReadOnlyRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetReadOnlyRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetReadOnlyRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomSetReadOnlyRequestApplicationJson
+    implements
+        $RoomSetReadOnlyRequestApplicationJsonInterface,
+        Built<RoomSetReadOnlyRequestApplicationJson, RoomSetReadOnlyRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetReadOnlyRequestApplicationJson object using the builder pattern.
+  factory RoomSetReadOnlyRequestApplicationJson([void Function(RoomSetReadOnlyRequestApplicationJsonBuilder)? b]) =
+      _$RoomSetReadOnlyRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetReadOnlyRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetReadOnlyRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetReadOnlyRequestApplicationJson.
+  static Serializer<RoomSetReadOnlyRequestApplicationJson> get serializer =>
+      _$roomSetReadOnlyRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetReadOnlyRequestApplicationJsonBuilder b) {
+    $RoomSetReadOnlyRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetReadOnlyRequestApplicationJsonBuilder b) {
+    $RoomSetReadOnlyRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -35757,75 +37988,6 @@ abstract class RoomSetReadOnlyResponseApplicationJson
   }
 }
 
-class RoomSetListableScope extends EnumClass {
-  const RoomSetListableScope._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const RoomSetListableScope $0 = _$roomSetListableScope$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const RoomSetListableScope $1 = _$roomSetListableScope$1;
-
-  /// `2`
-  @BuiltValueEnumConst(wireName: '2')
-  static const RoomSetListableScope $2 = _$roomSetListableScope$2;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<RoomSetListableScope> get values => _$roomSetListableScopeValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static RoomSetListableScope valueOf(String name) => _$valueOfRoomSetListableScope(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for RoomSetListableScope.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<RoomSetListableScope> get serializer => const _$RoomSetListableScopeSerializer();
-}
-
-class _$RoomSetListableScopeSerializer implements PrimitiveSerializer<RoomSetListableScope> {
-  const _$RoomSetListableScopeSerializer();
-
-  static const Map<RoomSetListableScope, Object> _toWire = <RoomSetListableScope, Object>{
-    RoomSetListableScope.$0: 0,
-    RoomSetListableScope.$1: 1,
-    RoomSetListableScope.$2: 2,
-  };
-
-  static const Map<Object, RoomSetListableScope> _fromWire = <Object, RoomSetListableScope>{
-    0: RoomSetListableScope.$0,
-    1: RoomSetListableScope.$1,
-    2: RoomSetListableScope.$2,
-  };
-
-  @override
-  Iterable<Type> get types => const [RoomSetListableScope];
-
-  @override
-  String get wireName => 'RoomSetListableScope';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    RoomSetListableScope object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  RoomSetListableScope deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class RoomSetListableApiVersion extends EnumClass {
   const RoomSetListableApiVersion._(super.name);
 
@@ -35880,6 +38042,145 @@ class _$RoomSetListableApiVersionSerializer implements PrimitiveSerializer<RoomS
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// Scope where the room is listable.
+class RoomSetListableRequestApplicationJson_Scope extends EnumClass {
+  const RoomSetListableRequestApplicationJson_Scope._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const RoomSetListableRequestApplicationJson_Scope $0 = _$roomSetListableRequestApplicationJsonScope$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const RoomSetListableRequestApplicationJson_Scope $1 = _$roomSetListableRequestApplicationJsonScope$1;
+
+  /// `2`
+  @BuiltValueEnumConst(wireName: '2')
+  static const RoomSetListableRequestApplicationJson_Scope $2 = _$roomSetListableRequestApplicationJsonScope$2;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<RoomSetListableRequestApplicationJson_Scope> get values =>
+      _$roomSetListableRequestApplicationJsonScopeValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static RoomSetListableRequestApplicationJson_Scope valueOf(String name) =>
+      _$valueOfRoomSetListableRequestApplicationJson_Scope(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for RoomSetListableRequestApplicationJson_Scope.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<RoomSetListableRequestApplicationJson_Scope> get serializer =>
+      const _$RoomSetListableRequestApplicationJson_ScopeSerializer();
+}
+
+class _$RoomSetListableRequestApplicationJson_ScopeSerializer
+    implements PrimitiveSerializer<RoomSetListableRequestApplicationJson_Scope> {
+  const _$RoomSetListableRequestApplicationJson_ScopeSerializer();
+
+  static const Map<RoomSetListableRequestApplicationJson_Scope, Object> _toWire =
+      <RoomSetListableRequestApplicationJson_Scope, Object>{
+    RoomSetListableRequestApplicationJson_Scope.$0: 0,
+    RoomSetListableRequestApplicationJson_Scope.$1: 1,
+    RoomSetListableRequestApplicationJson_Scope.$2: 2,
+  };
+
+  static const Map<Object, RoomSetListableRequestApplicationJson_Scope> _fromWire =
+      <Object, RoomSetListableRequestApplicationJson_Scope>{
+    0: RoomSetListableRequestApplicationJson_Scope.$0,
+    1: RoomSetListableRequestApplicationJson_Scope.$1,
+    2: RoomSetListableRequestApplicationJson_Scope.$2,
+  };
+
+  @override
+  Iterable<Type> get types => const [RoomSetListableRequestApplicationJson_Scope];
+
+  @override
+  String get wireName => 'RoomSetListableRequestApplicationJson_Scope';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RoomSetListableRequestApplicationJson_Scope object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  RoomSetListableRequestApplicationJson_Scope deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomSetListableRequestApplicationJsonInterface {
+  /// Scope where the room is listable.
+  RoomSetListableRequestApplicationJson_Scope get scope;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetListableRequestApplicationJsonInterfaceBuilder].
+  $RoomSetListableRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetListableRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetListableRequestApplicationJsonInterfaceBuilder].
+  $RoomSetListableRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetListableRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetListableRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomSetListableRequestApplicationJson
+    implements
+        $RoomSetListableRequestApplicationJsonInterface,
+        Built<RoomSetListableRequestApplicationJson, RoomSetListableRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetListableRequestApplicationJson object using the builder pattern.
+  factory RoomSetListableRequestApplicationJson([void Function(RoomSetListableRequestApplicationJsonBuilder)? b]) =
+      _$RoomSetListableRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetListableRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetListableRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetListableRequestApplicationJson.
+  static Serializer<RoomSetListableRequestApplicationJson> get serializer =>
+      _$roomSetListableRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetListableRequestApplicationJsonBuilder b) {
+    $RoomSetListableRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetListableRequestApplicationJsonBuilder b) {
+    $RoomSetListableRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -36062,6 +38363,69 @@ class _$RoomSetPasswordApiVersionSerializer implements PrimitiveSerializer<RoomS
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomSetPasswordRequestApplicationJsonInterface {
+  /// New password.
+  String get password;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetPasswordRequestApplicationJsonInterfaceBuilder].
+  $RoomSetPasswordRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetPasswordRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetPasswordRequestApplicationJsonInterfaceBuilder].
+  $RoomSetPasswordRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetPasswordRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetPasswordRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomSetPasswordRequestApplicationJson
+    implements
+        $RoomSetPasswordRequestApplicationJsonInterface,
+        Built<RoomSetPasswordRequestApplicationJson, RoomSetPasswordRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetPasswordRequestApplicationJson object using the builder pattern.
+  factory RoomSetPasswordRequestApplicationJson([void Function(RoomSetPasswordRequestApplicationJsonBuilder)? b]) =
+      _$RoomSetPasswordRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetPasswordRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetPasswordRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetPasswordRequestApplicationJson.
+  static Serializer<RoomSetPasswordRequestApplicationJson> get serializer =>
+      _$roomSetPasswordRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetPasswordRequestApplicationJsonBuilder b) {
+    $RoomSetPasswordRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetPasswordRequestApplicationJsonBuilder b) {
+    $RoomSetPasswordRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -36309,6 +38673,77 @@ class _$RoomSetPermissionsApiVersionSerializer implements PrimitiveSerializer<Ro
 }
 
 @BuiltValue(instantiable: false)
+sealed class $RoomSetPermissionsRequestApplicationJsonInterface {
+  /// New permissions.
+  int get permissions;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetPermissionsRequestApplicationJsonInterfaceBuilder].
+  $RoomSetPermissionsRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetPermissionsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetPermissionsRequestApplicationJsonInterfaceBuilder].
+  $RoomSetPermissionsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetPermissionsRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetPermissionsRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.permissions,
+      'permissions',
+      maximum: 255,
+      minimum: 0,
+    );
+  }
+}
+
+abstract class RoomSetPermissionsRequestApplicationJson
+    implements
+        $RoomSetPermissionsRequestApplicationJsonInterface,
+        Built<RoomSetPermissionsRequestApplicationJson, RoomSetPermissionsRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetPermissionsRequestApplicationJson object using the builder pattern.
+  factory RoomSetPermissionsRequestApplicationJson([
+    void Function(RoomSetPermissionsRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomSetPermissionsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetPermissionsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetPermissionsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetPermissionsRequestApplicationJson.
+  static Serializer<RoomSetPermissionsRequestApplicationJson> get serializer =>
+      _$roomSetPermissionsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetPermissionsRequestApplicationJsonBuilder b) {
+    $RoomSetPermissionsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetPermissionsRequestApplicationJsonBuilder b) {
+    $RoomSetPermissionsRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $RoomSetPermissionsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
@@ -36435,70 +38870,6 @@ abstract class RoomSetPermissionsResponseApplicationJson
   }
 }
 
-class RoomGetParticipantsIncludeStatus extends EnumClass {
-  const RoomGetParticipantsIncludeStatus._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const RoomGetParticipantsIncludeStatus $0 = _$roomGetParticipantsIncludeStatus$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const RoomGetParticipantsIncludeStatus $1 = _$roomGetParticipantsIncludeStatus$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<RoomGetParticipantsIncludeStatus> get values => _$roomGetParticipantsIncludeStatusValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static RoomGetParticipantsIncludeStatus valueOf(String name) => _$valueOfRoomGetParticipantsIncludeStatus(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for RoomGetParticipantsIncludeStatus.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<RoomGetParticipantsIncludeStatus> get serializer =>
-      const _$RoomGetParticipantsIncludeStatusSerializer();
-}
-
-class _$RoomGetParticipantsIncludeStatusSerializer implements PrimitiveSerializer<RoomGetParticipantsIncludeStatus> {
-  const _$RoomGetParticipantsIncludeStatusSerializer();
-
-  static const Map<RoomGetParticipantsIncludeStatus, Object> _toWire = <RoomGetParticipantsIncludeStatus, Object>{
-    RoomGetParticipantsIncludeStatus.$0: 0,
-    RoomGetParticipantsIncludeStatus.$1: 1,
-  };
-
-  static const Map<Object, RoomGetParticipantsIncludeStatus> _fromWire = <Object, RoomGetParticipantsIncludeStatus>{
-    0: RoomGetParticipantsIncludeStatus.$0,
-    1: RoomGetParticipantsIncludeStatus.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [RoomGetParticipantsIncludeStatus];
-
-  @override
-  String get wireName => 'RoomGetParticipantsIncludeStatus';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    RoomGetParticipantsIncludeStatus object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  RoomGetParticipantsIncludeStatus deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class RoomGetParticipantsApiVersion extends EnumClass {
   const RoomGetParticipantsApiVersion._(super.name);
 
@@ -36553,6 +38924,78 @@ class _$RoomGetParticipantsApiVersionSerializer implements PrimitiveSerializer<R
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomGetParticipantsRequestApplicationJsonInterface {
+  static final _$includeStatus = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// Include the user statuses.
+  bool get includeStatus;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetParticipantsRequestApplicationJsonInterfaceBuilder].
+  $RoomGetParticipantsRequestApplicationJsonInterface rebuild(
+    void Function($RoomGetParticipantsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetParticipantsRequestApplicationJsonInterfaceBuilder].
+  $RoomGetParticipantsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetParticipantsRequestApplicationJsonInterfaceBuilder b) {
+    b.includeStatus = _$includeStatus;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetParticipantsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomGetParticipantsRequestApplicationJson
+    implements
+        $RoomGetParticipantsRequestApplicationJsonInterface,
+        Built<RoomGetParticipantsRequestApplicationJson, RoomGetParticipantsRequestApplicationJsonBuilder> {
+  /// Creates a new RoomGetParticipantsRequestApplicationJson object using the builder pattern.
+  factory RoomGetParticipantsRequestApplicationJson([
+    void Function(RoomGetParticipantsRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomGetParticipantsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomGetParticipantsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomGetParticipantsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomGetParticipantsRequestApplicationJson.
+  static Serializer<RoomGetParticipantsRequestApplicationJson> get serializer =>
+      _$roomGetParticipantsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetParticipantsRequestApplicationJsonBuilder b) {
+    $RoomGetParticipantsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetParticipantsRequestApplicationJsonBuilder b) {
+    $RoomGetParticipantsRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -36815,89 +39258,6 @@ abstract class RoomRoomGetParticipantsHeaders
   }
 }
 
-class RoomAddParticipantToRoomSource extends EnumClass {
-  const RoomAddParticipantToRoomSource._(super.name);
-
-  /// `users`
-  static const RoomAddParticipantToRoomSource users = _$roomAddParticipantToRoomSourceUsers;
-
-  /// `groups`
-  static const RoomAddParticipantToRoomSource groups = _$roomAddParticipantToRoomSourceGroups;
-
-  /// `circles`
-  static const RoomAddParticipantToRoomSource circles = _$roomAddParticipantToRoomSourceCircles;
-
-  /// `emails`
-  static const RoomAddParticipantToRoomSource emails = _$roomAddParticipantToRoomSourceEmails;
-
-  /// `federated_users`
-  @BuiltValueEnumConst(wireName: 'federated_users')
-  static const RoomAddParticipantToRoomSource federatedUsers = _$roomAddParticipantToRoomSourceFederatedUsers;
-
-  /// `phones`
-  static const RoomAddParticipantToRoomSource phones = _$roomAddParticipantToRoomSourcePhones;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<RoomAddParticipantToRoomSource> get values => _$roomAddParticipantToRoomSourceValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static RoomAddParticipantToRoomSource valueOf(String name) => _$valueOfRoomAddParticipantToRoomSource(name);
-
-  /// Returns the serialized value of this enum value.
-  String get value => _$jsonSerializers.serializeWith(serializer, this)! as String;
-
-  /// Serializer for RoomAddParticipantToRoomSource.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<RoomAddParticipantToRoomSource> get serializer =>
-      const _$RoomAddParticipantToRoomSourceSerializer();
-}
-
-class _$RoomAddParticipantToRoomSourceSerializer implements PrimitiveSerializer<RoomAddParticipantToRoomSource> {
-  const _$RoomAddParticipantToRoomSourceSerializer();
-
-  static const Map<RoomAddParticipantToRoomSource, Object> _toWire = <RoomAddParticipantToRoomSource, Object>{
-    RoomAddParticipantToRoomSource.users: 'users',
-    RoomAddParticipantToRoomSource.groups: 'groups',
-    RoomAddParticipantToRoomSource.circles: 'circles',
-    RoomAddParticipantToRoomSource.emails: 'emails',
-    RoomAddParticipantToRoomSource.federatedUsers: 'federated_users',
-    RoomAddParticipantToRoomSource.phones: 'phones',
-  };
-
-  static const Map<Object, RoomAddParticipantToRoomSource> _fromWire = <Object, RoomAddParticipantToRoomSource>{
-    'users': RoomAddParticipantToRoomSource.users,
-    'groups': RoomAddParticipantToRoomSource.groups,
-    'circles': RoomAddParticipantToRoomSource.circles,
-    'emails': RoomAddParticipantToRoomSource.emails,
-    'federated_users': RoomAddParticipantToRoomSource.federatedUsers,
-    'phones': RoomAddParticipantToRoomSource.phones,
-  };
-
-  @override
-  Iterable<Type> get types => const [RoomAddParticipantToRoomSource];
-
-  @override
-  String get wireName => 'RoomAddParticipantToRoomSource';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    RoomAddParticipantToRoomSource object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  RoomAddParticipantToRoomSource deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class RoomAddParticipantToRoomApiVersion extends EnumClass {
   const RoomAddParticipantToRoomApiVersion._(super.name);
 
@@ -36954,6 +39314,176 @@ class _$RoomAddParticipantToRoomApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// Source of the participant.
+class RoomAddParticipantToRoomRequestApplicationJson_Source extends EnumClass {
+  const RoomAddParticipantToRoomRequestApplicationJson_Source._(super.name);
+
+  /// `users`
+  static const RoomAddParticipantToRoomRequestApplicationJson_Source users =
+      _$roomAddParticipantToRoomRequestApplicationJsonSourceUsers;
+
+  /// `groups`
+  static const RoomAddParticipantToRoomRequestApplicationJson_Source groups =
+      _$roomAddParticipantToRoomRequestApplicationJsonSourceGroups;
+
+  /// `circles`
+  static const RoomAddParticipantToRoomRequestApplicationJson_Source circles =
+      _$roomAddParticipantToRoomRequestApplicationJsonSourceCircles;
+
+  /// `emails`
+  static const RoomAddParticipantToRoomRequestApplicationJson_Source emails =
+      _$roomAddParticipantToRoomRequestApplicationJsonSourceEmails;
+
+  /// `federated_users`
+  @BuiltValueEnumConst(wireName: 'federated_users')
+  static const RoomAddParticipantToRoomRequestApplicationJson_Source federatedUsers =
+      _$roomAddParticipantToRoomRequestApplicationJsonSourceFederatedUsers;
+
+  /// `phones`
+  static const RoomAddParticipantToRoomRequestApplicationJson_Source phones =
+      _$roomAddParticipantToRoomRequestApplicationJsonSourcePhones;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<RoomAddParticipantToRoomRequestApplicationJson_Source> get values =>
+      _$roomAddParticipantToRoomRequestApplicationJsonSourceValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static RoomAddParticipantToRoomRequestApplicationJson_Source valueOf(String name) =>
+      _$valueOfRoomAddParticipantToRoomRequestApplicationJson_Source(name);
+
+  /// Returns the serialized value of this enum value.
+  String get value => _$jsonSerializers.serializeWith(serializer, this)! as String;
+
+  /// Serializer for RoomAddParticipantToRoomRequestApplicationJson_Source.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<RoomAddParticipantToRoomRequestApplicationJson_Source> get serializer =>
+      const _$RoomAddParticipantToRoomRequestApplicationJson_SourceSerializer();
+}
+
+class _$RoomAddParticipantToRoomRequestApplicationJson_SourceSerializer
+    implements PrimitiveSerializer<RoomAddParticipantToRoomRequestApplicationJson_Source> {
+  const _$RoomAddParticipantToRoomRequestApplicationJson_SourceSerializer();
+
+  static const Map<RoomAddParticipantToRoomRequestApplicationJson_Source, Object> _toWire =
+      <RoomAddParticipantToRoomRequestApplicationJson_Source, Object>{
+    RoomAddParticipantToRoomRequestApplicationJson_Source.users: 'users',
+    RoomAddParticipantToRoomRequestApplicationJson_Source.groups: 'groups',
+    RoomAddParticipantToRoomRequestApplicationJson_Source.circles: 'circles',
+    RoomAddParticipantToRoomRequestApplicationJson_Source.emails: 'emails',
+    RoomAddParticipantToRoomRequestApplicationJson_Source.federatedUsers: 'federated_users',
+    RoomAddParticipantToRoomRequestApplicationJson_Source.phones: 'phones',
+  };
+
+  static const Map<Object, RoomAddParticipantToRoomRequestApplicationJson_Source> _fromWire =
+      <Object, RoomAddParticipantToRoomRequestApplicationJson_Source>{
+    'users': RoomAddParticipantToRoomRequestApplicationJson_Source.users,
+    'groups': RoomAddParticipantToRoomRequestApplicationJson_Source.groups,
+    'circles': RoomAddParticipantToRoomRequestApplicationJson_Source.circles,
+    'emails': RoomAddParticipantToRoomRequestApplicationJson_Source.emails,
+    'federated_users': RoomAddParticipantToRoomRequestApplicationJson_Source.federatedUsers,
+    'phones': RoomAddParticipantToRoomRequestApplicationJson_Source.phones,
+  };
+
+  @override
+  Iterable<Type> get types => const [RoomAddParticipantToRoomRequestApplicationJson_Source];
+
+  @override
+  String get wireName => 'RoomAddParticipantToRoomRequestApplicationJson_Source';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RoomAddParticipantToRoomRequestApplicationJson_Source object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  RoomAddParticipantToRoomRequestApplicationJson_Source deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomAddParticipantToRoomRequestApplicationJsonInterface {
+  static final _$source = _$jsonSerializers.deserialize(
+    'users',
+    specifiedType: const FullType(RoomAddParticipantToRoomRequestApplicationJson_Source),
+  )! as RoomAddParticipantToRoomRequestApplicationJson_Source;
+
+  /// New participant.
+  String get newParticipant;
+
+  /// Source of the participant.
+  RoomAddParticipantToRoomRequestApplicationJson_Source get source;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomAddParticipantToRoomRequestApplicationJsonInterfaceBuilder].
+  $RoomAddParticipantToRoomRequestApplicationJsonInterface rebuild(
+    void Function($RoomAddParticipantToRoomRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomAddParticipantToRoomRequestApplicationJsonInterfaceBuilder].
+  $RoomAddParticipantToRoomRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomAddParticipantToRoomRequestApplicationJsonInterfaceBuilder b) {
+    b.source = _$source;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomAddParticipantToRoomRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomAddParticipantToRoomRequestApplicationJson
+    implements
+        $RoomAddParticipantToRoomRequestApplicationJsonInterface,
+        Built<RoomAddParticipantToRoomRequestApplicationJson, RoomAddParticipantToRoomRequestApplicationJsonBuilder> {
+  /// Creates a new RoomAddParticipantToRoomRequestApplicationJson object using the builder pattern.
+  factory RoomAddParticipantToRoomRequestApplicationJson([
+    void Function(RoomAddParticipantToRoomRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomAddParticipantToRoomRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomAddParticipantToRoomRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomAddParticipantToRoomRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomAddParticipantToRoomRequestApplicationJson.
+  static Serializer<RoomAddParticipantToRoomRequestApplicationJson> get serializer =>
+      _$roomAddParticipantToRoomRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomAddParticipantToRoomRequestApplicationJsonBuilder b) {
+    $RoomAddParticipantToRoomRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomAddParticipantToRoomRequestApplicationJsonBuilder b) {
+    $RoomAddParticipantToRoomRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -37155,75 +39685,6 @@ abstract class RoomAddParticipantToRoomResponseApplicationJson
   }
 }
 
-class RoomGetBreakoutRoomParticipantsIncludeStatus extends EnumClass {
-  const RoomGetBreakoutRoomParticipantsIncludeStatus._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const RoomGetBreakoutRoomParticipantsIncludeStatus $0 = _$roomGetBreakoutRoomParticipantsIncludeStatus$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const RoomGetBreakoutRoomParticipantsIncludeStatus $1 = _$roomGetBreakoutRoomParticipantsIncludeStatus$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<RoomGetBreakoutRoomParticipantsIncludeStatus> get values =>
-      _$roomGetBreakoutRoomParticipantsIncludeStatusValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static RoomGetBreakoutRoomParticipantsIncludeStatus valueOf(String name) =>
-      _$valueOfRoomGetBreakoutRoomParticipantsIncludeStatus(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for RoomGetBreakoutRoomParticipantsIncludeStatus.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<RoomGetBreakoutRoomParticipantsIncludeStatus> get serializer =>
-      const _$RoomGetBreakoutRoomParticipantsIncludeStatusSerializer();
-}
-
-class _$RoomGetBreakoutRoomParticipantsIncludeStatusSerializer
-    implements PrimitiveSerializer<RoomGetBreakoutRoomParticipantsIncludeStatus> {
-  const _$RoomGetBreakoutRoomParticipantsIncludeStatusSerializer();
-
-  static const Map<RoomGetBreakoutRoomParticipantsIncludeStatus, Object> _toWire =
-      <RoomGetBreakoutRoomParticipantsIncludeStatus, Object>{
-    RoomGetBreakoutRoomParticipantsIncludeStatus.$0: 0,
-    RoomGetBreakoutRoomParticipantsIncludeStatus.$1: 1,
-  };
-
-  static const Map<Object, RoomGetBreakoutRoomParticipantsIncludeStatus> _fromWire =
-      <Object, RoomGetBreakoutRoomParticipantsIncludeStatus>{
-    0: RoomGetBreakoutRoomParticipantsIncludeStatus.$0,
-    1: RoomGetBreakoutRoomParticipantsIncludeStatus.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [RoomGetBreakoutRoomParticipantsIncludeStatus];
-
-  @override
-  String get wireName => 'RoomGetBreakoutRoomParticipantsIncludeStatus';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    RoomGetBreakoutRoomParticipantsIncludeStatus object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  RoomGetBreakoutRoomParticipantsIncludeStatus deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class RoomGetBreakoutRoomParticipantsApiVersion extends EnumClass {
   const RoomGetBreakoutRoomParticipantsApiVersion._(super.name);
 
@@ -37284,6 +39745,79 @@ class _$RoomGetBreakoutRoomParticipantsApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterface {
+  static final _$includeStatus = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// Include the user statuses.
+  bool get includeStatus;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterfaceBuilder].
+  $RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterface rebuild(
+    void Function($RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterfaceBuilder].
+  $RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterfaceBuilder b) {
+    b.includeStatus = _$includeStatus;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomGetBreakoutRoomParticipantsRequestApplicationJson
+    implements
+        $RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterface,
+        Built<RoomGetBreakoutRoomParticipantsRequestApplicationJson,
+            RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder> {
+  /// Creates a new RoomGetBreakoutRoomParticipantsRequestApplicationJson object using the builder pattern.
+  factory RoomGetBreakoutRoomParticipantsRequestApplicationJson([
+    void Function(RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomGetBreakoutRoomParticipantsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomGetBreakoutRoomParticipantsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomGetBreakoutRoomParticipantsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomGetBreakoutRoomParticipantsRequestApplicationJson.
+  static Serializer<RoomGetBreakoutRoomParticipantsRequestApplicationJson> get serializer =>
+      _$roomGetBreakoutRoomParticipantsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder b) {
+    $RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder b) {
+    $RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -37726,6 +40260,77 @@ class _$RoomRemoveAttendeeFromRoomApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
+sealed class $RoomRemoveAttendeeFromRoomRequestApplicationJsonInterface {
+  /// ID of the attendee.
+  int get attendeeId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRemoveAttendeeFromRoomRequestApplicationJsonInterfaceBuilder].
+  $RoomRemoveAttendeeFromRoomRequestApplicationJsonInterface rebuild(
+    void Function($RoomRemoveAttendeeFromRoomRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRemoveAttendeeFromRoomRequestApplicationJsonInterfaceBuilder].
+  $RoomRemoveAttendeeFromRoomRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRemoveAttendeeFromRoomRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRemoveAttendeeFromRoomRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.attendeeId,
+      'attendeeId',
+      minimum: 0,
+    );
+  }
+}
+
+abstract class RoomRemoveAttendeeFromRoomRequestApplicationJson
+    implements
+        $RoomRemoveAttendeeFromRoomRequestApplicationJsonInterface,
+        Built<RoomRemoveAttendeeFromRoomRequestApplicationJson,
+            RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder> {
+  /// Creates a new RoomRemoveAttendeeFromRoomRequestApplicationJson object using the builder pattern.
+  factory RoomRemoveAttendeeFromRoomRequestApplicationJson([
+    void Function(RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomRemoveAttendeeFromRoomRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomRemoveAttendeeFromRoomRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomRemoveAttendeeFromRoomRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomRemoveAttendeeFromRoomRequestApplicationJson.
+  static Serializer<RoomRemoveAttendeeFromRoomRequestApplicationJson> get serializer =>
+      _$roomRemoveAttendeeFromRoomRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder b) {
+    $RoomRemoveAttendeeFromRoomRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder b) {
+    $RoomRemoveAttendeeFromRoomRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -37854,74 +40459,6 @@ abstract class RoomRemoveAttendeeFromRoomResponseApplicationJson
   }
 }
 
-class RoomSetAttendeePermissionsMethod extends EnumClass {
-  const RoomSetAttendeePermissionsMethod._(super.name);
-
-  /// `set`
-  @BuiltValueEnumConst(wireName: 'set')
-  static const RoomSetAttendeePermissionsMethod $set = _$roomSetAttendeePermissionsMethod$set;
-
-  /// `remove`
-  static const RoomSetAttendeePermissionsMethod remove = _$roomSetAttendeePermissionsMethodRemove;
-
-  /// `add`
-  static const RoomSetAttendeePermissionsMethod add = _$roomSetAttendeePermissionsMethodAdd;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<RoomSetAttendeePermissionsMethod> get values => _$roomSetAttendeePermissionsMethodValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static RoomSetAttendeePermissionsMethod valueOf(String name) => _$valueOfRoomSetAttendeePermissionsMethod(name);
-
-  /// Returns the serialized value of this enum value.
-  String get value => _$jsonSerializers.serializeWith(serializer, this)! as String;
-
-  /// Serializer for RoomSetAttendeePermissionsMethod.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<RoomSetAttendeePermissionsMethod> get serializer =>
-      const _$RoomSetAttendeePermissionsMethodSerializer();
-}
-
-class _$RoomSetAttendeePermissionsMethodSerializer implements PrimitiveSerializer<RoomSetAttendeePermissionsMethod> {
-  const _$RoomSetAttendeePermissionsMethodSerializer();
-
-  static const Map<RoomSetAttendeePermissionsMethod, Object> _toWire = <RoomSetAttendeePermissionsMethod, Object>{
-    RoomSetAttendeePermissionsMethod.$set: 'set',
-    RoomSetAttendeePermissionsMethod.remove: 'remove',
-    RoomSetAttendeePermissionsMethod.add: 'add',
-  };
-
-  static const Map<Object, RoomSetAttendeePermissionsMethod> _fromWire = <Object, RoomSetAttendeePermissionsMethod>{
-    'set': RoomSetAttendeePermissionsMethod.$set,
-    'remove': RoomSetAttendeePermissionsMethod.remove,
-    'add': RoomSetAttendeePermissionsMethod.add,
-  };
-
-  @override
-  Iterable<Type> get types => const [RoomSetAttendeePermissionsMethod];
-
-  @override
-  String get wireName => 'RoomSetAttendeePermissionsMethod';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    RoomSetAttendeePermissionsMethod object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  RoomSetAttendeePermissionsMethod deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class RoomSetAttendeePermissionsApiVersion extends EnumClass {
   const RoomSetAttendeePermissionsApiVersion._(super.name);
 
@@ -37981,6 +40518,166 @@ class _$RoomSetAttendeePermissionsApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// Method of updating permissions ('set', 'remove', 'add').
+class RoomSetAttendeePermissionsRequestApplicationJson_Method extends EnumClass {
+  const RoomSetAttendeePermissionsRequestApplicationJson_Method._(super.name);
+
+  /// `set`
+  @BuiltValueEnumConst(wireName: 'set')
+  static const RoomSetAttendeePermissionsRequestApplicationJson_Method $set =
+      _$roomSetAttendeePermissionsRequestApplicationJsonMethod$set;
+
+  /// `remove`
+  static const RoomSetAttendeePermissionsRequestApplicationJson_Method remove =
+      _$roomSetAttendeePermissionsRequestApplicationJsonMethodRemove;
+
+  /// `add`
+  static const RoomSetAttendeePermissionsRequestApplicationJson_Method add =
+      _$roomSetAttendeePermissionsRequestApplicationJsonMethodAdd;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<RoomSetAttendeePermissionsRequestApplicationJson_Method> get values =>
+      _$roomSetAttendeePermissionsRequestApplicationJsonMethodValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static RoomSetAttendeePermissionsRequestApplicationJson_Method valueOf(String name) =>
+      _$valueOfRoomSetAttendeePermissionsRequestApplicationJson_Method(name);
+
+  /// Returns the serialized value of this enum value.
+  String get value => _$jsonSerializers.serializeWith(serializer, this)! as String;
+
+  /// Serializer for RoomSetAttendeePermissionsRequestApplicationJson_Method.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<RoomSetAttendeePermissionsRequestApplicationJson_Method> get serializer =>
+      const _$RoomSetAttendeePermissionsRequestApplicationJson_MethodSerializer();
+}
+
+class _$RoomSetAttendeePermissionsRequestApplicationJson_MethodSerializer
+    implements PrimitiveSerializer<RoomSetAttendeePermissionsRequestApplicationJson_Method> {
+  const _$RoomSetAttendeePermissionsRequestApplicationJson_MethodSerializer();
+
+  static const Map<RoomSetAttendeePermissionsRequestApplicationJson_Method, Object> _toWire =
+      <RoomSetAttendeePermissionsRequestApplicationJson_Method, Object>{
+    RoomSetAttendeePermissionsRequestApplicationJson_Method.$set: 'set',
+    RoomSetAttendeePermissionsRequestApplicationJson_Method.remove: 'remove',
+    RoomSetAttendeePermissionsRequestApplicationJson_Method.add: 'add',
+  };
+
+  static const Map<Object, RoomSetAttendeePermissionsRequestApplicationJson_Method> _fromWire =
+      <Object, RoomSetAttendeePermissionsRequestApplicationJson_Method>{
+    'set': RoomSetAttendeePermissionsRequestApplicationJson_Method.$set,
+    'remove': RoomSetAttendeePermissionsRequestApplicationJson_Method.remove,
+    'add': RoomSetAttendeePermissionsRequestApplicationJson_Method.add,
+  };
+
+  @override
+  Iterable<Type> get types => const [RoomSetAttendeePermissionsRequestApplicationJson_Method];
+
+  @override
+  String get wireName => 'RoomSetAttendeePermissionsRequestApplicationJson_Method';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RoomSetAttendeePermissionsRequestApplicationJson_Method object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  RoomSetAttendeePermissionsRequestApplicationJson_Method deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomSetAttendeePermissionsRequestApplicationJsonInterface {
+  /// ID of the attendee.
+  int get attendeeId;
+
+  /// Method of updating permissions ('set', 'remove', 'add').
+  RoomSetAttendeePermissionsRequestApplicationJson_Method get method;
+
+  /// New permissions.
+  int get permissions;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetAttendeePermissionsRequestApplicationJsonInterfaceBuilder].
+  $RoomSetAttendeePermissionsRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetAttendeePermissionsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetAttendeePermissionsRequestApplicationJsonInterfaceBuilder].
+  $RoomSetAttendeePermissionsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetAttendeePermissionsRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetAttendeePermissionsRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.attendeeId,
+      'attendeeId',
+      minimum: 0,
+    );
+    _i4.checkNumber(
+      b.permissions,
+      'permissions',
+      maximum: 255,
+      minimum: 0,
+    );
+  }
+}
+
+abstract class RoomSetAttendeePermissionsRequestApplicationJson
+    implements
+        $RoomSetAttendeePermissionsRequestApplicationJsonInterface,
+        Built<RoomSetAttendeePermissionsRequestApplicationJson,
+            RoomSetAttendeePermissionsRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetAttendeePermissionsRequestApplicationJson object using the builder pattern.
+  factory RoomSetAttendeePermissionsRequestApplicationJson([
+    void Function(RoomSetAttendeePermissionsRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomSetAttendeePermissionsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetAttendeePermissionsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetAttendeePermissionsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetAttendeePermissionsRequestApplicationJson.
+  static Serializer<RoomSetAttendeePermissionsRequestApplicationJson> get serializer =>
+      _$roomSetAttendeePermissionsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetAttendeePermissionsRequestApplicationJsonBuilder b) {
+    $RoomSetAttendeePermissionsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetAttendeePermissionsRequestApplicationJsonBuilder b) {
+    $RoomSetAttendeePermissionsRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -38112,78 +40809,6 @@ abstract class RoomSetAttendeePermissionsResponseApplicationJson
   }
 }
 
-class RoomSetAllAttendeesPermissionsMethod extends EnumClass {
-  const RoomSetAllAttendeesPermissionsMethod._(super.name);
-
-  /// `set`
-  @BuiltValueEnumConst(wireName: 'set')
-  static const RoomSetAllAttendeesPermissionsMethod $set = _$roomSetAllAttendeesPermissionsMethod$set;
-
-  /// `remove`
-  static const RoomSetAllAttendeesPermissionsMethod remove = _$roomSetAllAttendeesPermissionsMethodRemove;
-
-  /// `add`
-  static const RoomSetAllAttendeesPermissionsMethod add = _$roomSetAllAttendeesPermissionsMethodAdd;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<RoomSetAllAttendeesPermissionsMethod> get values => _$roomSetAllAttendeesPermissionsMethodValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static RoomSetAllAttendeesPermissionsMethod valueOf(String name) =>
-      _$valueOfRoomSetAllAttendeesPermissionsMethod(name);
-
-  /// Returns the serialized value of this enum value.
-  String get value => _$jsonSerializers.serializeWith(serializer, this)! as String;
-
-  /// Serializer for RoomSetAllAttendeesPermissionsMethod.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<RoomSetAllAttendeesPermissionsMethod> get serializer =>
-      const _$RoomSetAllAttendeesPermissionsMethodSerializer();
-}
-
-class _$RoomSetAllAttendeesPermissionsMethodSerializer
-    implements PrimitiveSerializer<RoomSetAllAttendeesPermissionsMethod> {
-  const _$RoomSetAllAttendeesPermissionsMethodSerializer();
-
-  static const Map<RoomSetAllAttendeesPermissionsMethod, Object> _toWire =
-      <RoomSetAllAttendeesPermissionsMethod, Object>{
-    RoomSetAllAttendeesPermissionsMethod.$set: 'set',
-    RoomSetAllAttendeesPermissionsMethod.remove: 'remove',
-    RoomSetAllAttendeesPermissionsMethod.add: 'add',
-  };
-
-  static const Map<Object, RoomSetAllAttendeesPermissionsMethod> _fromWire =
-      <Object, RoomSetAllAttendeesPermissionsMethod>{
-    'set': RoomSetAllAttendeesPermissionsMethod.$set,
-    'remove': RoomSetAllAttendeesPermissionsMethod.remove,
-    'add': RoomSetAllAttendeesPermissionsMethod.add,
-  };
-
-  @override
-  Iterable<Type> get types => const [RoomSetAllAttendeesPermissionsMethod];
-
-  @override
-  String get wireName => 'RoomSetAllAttendeesPermissionsMethod';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    RoomSetAllAttendeesPermissionsMethod object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  RoomSetAllAttendeesPermissionsMethod deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class RoomSetAllAttendeesPermissionsApiVersion extends EnumClass {
   const RoomSetAllAttendeesPermissionsApiVersion._(super.name);
 
@@ -38244,6 +40869,158 @@ class _$RoomSetAllAttendeesPermissionsApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// Method of updating permissions ('set', 'remove', 'add').
+class RoomSetAllAttendeesPermissionsRequestApplicationJson_Method extends EnumClass {
+  const RoomSetAllAttendeesPermissionsRequestApplicationJson_Method._(super.name);
+
+  /// `set`
+  @BuiltValueEnumConst(wireName: 'set')
+  static const RoomSetAllAttendeesPermissionsRequestApplicationJson_Method $set =
+      _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethod$set;
+
+  /// `remove`
+  static const RoomSetAllAttendeesPermissionsRequestApplicationJson_Method remove =
+      _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethodRemove;
+
+  /// `add`
+  static const RoomSetAllAttendeesPermissionsRequestApplicationJson_Method add =
+      _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethodAdd;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<RoomSetAllAttendeesPermissionsRequestApplicationJson_Method> get values =>
+      _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethodValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static RoomSetAllAttendeesPermissionsRequestApplicationJson_Method valueOf(String name) =>
+      _$valueOfRoomSetAllAttendeesPermissionsRequestApplicationJson_Method(name);
+
+  /// Returns the serialized value of this enum value.
+  String get value => _$jsonSerializers.serializeWith(serializer, this)! as String;
+
+  /// Serializer for RoomSetAllAttendeesPermissionsRequestApplicationJson_Method.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<RoomSetAllAttendeesPermissionsRequestApplicationJson_Method> get serializer =>
+      const _$RoomSetAllAttendeesPermissionsRequestApplicationJson_MethodSerializer();
+}
+
+class _$RoomSetAllAttendeesPermissionsRequestApplicationJson_MethodSerializer
+    implements PrimitiveSerializer<RoomSetAllAttendeesPermissionsRequestApplicationJson_Method> {
+  const _$RoomSetAllAttendeesPermissionsRequestApplicationJson_MethodSerializer();
+
+  static const Map<RoomSetAllAttendeesPermissionsRequestApplicationJson_Method, Object> _toWire =
+      <RoomSetAllAttendeesPermissionsRequestApplicationJson_Method, Object>{
+    RoomSetAllAttendeesPermissionsRequestApplicationJson_Method.$set: 'set',
+    RoomSetAllAttendeesPermissionsRequestApplicationJson_Method.remove: 'remove',
+    RoomSetAllAttendeesPermissionsRequestApplicationJson_Method.add: 'add',
+  };
+
+  static const Map<Object, RoomSetAllAttendeesPermissionsRequestApplicationJson_Method> _fromWire =
+      <Object, RoomSetAllAttendeesPermissionsRequestApplicationJson_Method>{
+    'set': RoomSetAllAttendeesPermissionsRequestApplicationJson_Method.$set,
+    'remove': RoomSetAllAttendeesPermissionsRequestApplicationJson_Method.remove,
+    'add': RoomSetAllAttendeesPermissionsRequestApplicationJson_Method.add,
+  };
+
+  @override
+  Iterable<Type> get types => const [RoomSetAllAttendeesPermissionsRequestApplicationJson_Method];
+
+  @override
+  String get wireName => 'RoomSetAllAttendeesPermissionsRequestApplicationJson_Method';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RoomSetAllAttendeesPermissionsRequestApplicationJson_Method object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  RoomSetAllAttendeesPermissionsRequestApplicationJson_Method deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomSetAllAttendeesPermissionsRequestApplicationJsonInterface {
+  /// Method of updating permissions ('set', 'remove', 'add').
+  RoomSetAllAttendeesPermissionsRequestApplicationJson_Method get method;
+
+  /// New permissions.
+  int get permissions;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetAllAttendeesPermissionsRequestApplicationJsonInterfaceBuilder].
+  $RoomSetAllAttendeesPermissionsRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetAllAttendeesPermissionsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetAllAttendeesPermissionsRequestApplicationJsonInterfaceBuilder].
+  $RoomSetAllAttendeesPermissionsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetAllAttendeesPermissionsRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetAllAttendeesPermissionsRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.permissions,
+      'permissions',
+      maximum: 255,
+      minimum: 0,
+    );
+  }
+}
+
+abstract class RoomSetAllAttendeesPermissionsRequestApplicationJson
+    implements
+        $RoomSetAllAttendeesPermissionsRequestApplicationJsonInterface,
+        Built<RoomSetAllAttendeesPermissionsRequestApplicationJson,
+            RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetAllAttendeesPermissionsRequestApplicationJson object using the builder pattern.
+  factory RoomSetAllAttendeesPermissionsRequestApplicationJson([
+    void Function(RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomSetAllAttendeesPermissionsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetAllAttendeesPermissionsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetAllAttendeesPermissionsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetAllAttendeesPermissionsRequestApplicationJson.
+  static Serializer<RoomSetAllAttendeesPermissionsRequestApplicationJson> get serializer =>
+      _$roomSetAllAttendeesPermissionsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder b) {
+    $RoomSetAllAttendeesPermissionsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder b) {
+    $RoomSetAllAttendeesPermissionsRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -38375,69 +41152,6 @@ abstract class RoomSetAllAttendeesPermissionsResponseApplicationJson
   }
 }
 
-class RoomJoinRoomForce extends EnumClass {
-  const RoomJoinRoomForce._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const RoomJoinRoomForce $0 = _$roomJoinRoomForce$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const RoomJoinRoomForce $1 = _$roomJoinRoomForce$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<RoomJoinRoomForce> get values => _$roomJoinRoomForceValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static RoomJoinRoomForce valueOf(String name) => _$valueOfRoomJoinRoomForce(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for RoomJoinRoomForce.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<RoomJoinRoomForce> get serializer => const _$RoomJoinRoomForceSerializer();
-}
-
-class _$RoomJoinRoomForceSerializer implements PrimitiveSerializer<RoomJoinRoomForce> {
-  const _$RoomJoinRoomForceSerializer();
-
-  static const Map<RoomJoinRoomForce, Object> _toWire = <RoomJoinRoomForce, Object>{
-    RoomJoinRoomForce.$0: 0,
-    RoomJoinRoomForce.$1: 1,
-  };
-
-  static const Map<Object, RoomJoinRoomForce> _fromWire = <Object, RoomJoinRoomForce>{
-    0: RoomJoinRoomForce.$0,
-    1: RoomJoinRoomForce.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [RoomJoinRoomForce];
-
-  @override
-  String get wireName => 'RoomJoinRoomForce';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    RoomJoinRoomForce object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  RoomJoinRoomForce deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class RoomJoinRoomApiVersion extends EnumClass {
   const RoomJoinRoomApiVersion._(super.name);
 
@@ -38492,6 +41206,86 @@ class _$RoomJoinRoomApiVersionSerializer implements PrimitiveSerializer<RoomJoin
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomJoinRoomRequestApplicationJsonInterface {
+  static final _$password = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$force = _$jsonSerializers.deserialize(
+    true,
+    specifiedType: const FullType(bool),
+  )! as bool;
+
+  /// Password of the room.
+  String get password;
+
+  /// Create a new session if necessary.
+  bool get force;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomJoinRoomRequestApplicationJsonInterfaceBuilder].
+  $RoomJoinRoomRequestApplicationJsonInterface rebuild(
+    void Function($RoomJoinRoomRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomJoinRoomRequestApplicationJsonInterfaceBuilder].
+  $RoomJoinRoomRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomJoinRoomRequestApplicationJsonInterfaceBuilder b) {
+    b.password = _$password;
+    b.force = _$force;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomJoinRoomRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomJoinRoomRequestApplicationJson
+    implements
+        $RoomJoinRoomRequestApplicationJsonInterface,
+        Built<RoomJoinRoomRequestApplicationJson, RoomJoinRoomRequestApplicationJsonBuilder> {
+  /// Creates a new RoomJoinRoomRequestApplicationJson object using the builder pattern.
+  factory RoomJoinRoomRequestApplicationJson([void Function(RoomJoinRoomRequestApplicationJsonBuilder)? b]) =
+      _$RoomJoinRoomRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomJoinRoomRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomJoinRoomRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomJoinRoomRequestApplicationJson.
+  static Serializer<RoomJoinRoomRequestApplicationJson> get serializer =>
+      _$roomJoinRoomRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomJoinRoomRequestApplicationJsonBuilder b) {
+    $RoomJoinRoomRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomJoinRoomRequestApplicationJsonBuilder b) {
+    $RoomJoinRoomRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -38916,6 +41710,76 @@ class _$RoomResendInvitationsApiVersionSerializer implements PrimitiveSerializer
 }
 
 @BuiltValue(instantiable: false)
+sealed class $RoomResendInvitationsRequestApplicationJsonInterface {
+  /// ID of the attendee.
+  int? get attendeeId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomResendInvitationsRequestApplicationJsonInterfaceBuilder].
+  $RoomResendInvitationsRequestApplicationJsonInterface rebuild(
+    void Function($RoomResendInvitationsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomResendInvitationsRequestApplicationJsonInterfaceBuilder].
+  $RoomResendInvitationsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomResendInvitationsRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomResendInvitationsRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.attendeeId,
+      'attendeeId',
+      minimum: 0,
+    );
+  }
+}
+
+abstract class RoomResendInvitationsRequestApplicationJson
+    implements
+        $RoomResendInvitationsRequestApplicationJsonInterface,
+        Built<RoomResendInvitationsRequestApplicationJson, RoomResendInvitationsRequestApplicationJsonBuilder> {
+  /// Creates a new RoomResendInvitationsRequestApplicationJson object using the builder pattern.
+  factory RoomResendInvitationsRequestApplicationJson([
+    void Function(RoomResendInvitationsRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomResendInvitationsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomResendInvitationsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomResendInvitationsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomResendInvitationsRequestApplicationJson.
+  static Serializer<RoomResendInvitationsRequestApplicationJson> get serializer =>
+      _$roomResendInvitationsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomResendInvitationsRequestApplicationJsonBuilder b) {
+    $RoomResendInvitationsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomResendInvitationsRequestApplicationJsonBuilder b) {
+    $RoomResendInvitationsRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $RoomResendInvitationsResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -39043,69 +41907,6 @@ abstract class RoomResendInvitationsResponseApplicationJson
   }
 }
 
-class RoomSetSessionStateState extends EnumClass {
-  const RoomSetSessionStateState._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const RoomSetSessionStateState $0 = _$roomSetSessionStateState$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const RoomSetSessionStateState $1 = _$roomSetSessionStateState$1;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<RoomSetSessionStateState> get values => _$roomSetSessionStateStateValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static RoomSetSessionStateState valueOf(String name) => _$valueOfRoomSetSessionStateState(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for RoomSetSessionStateState.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<RoomSetSessionStateState> get serializer => const _$RoomSetSessionStateStateSerializer();
-}
-
-class _$RoomSetSessionStateStateSerializer implements PrimitiveSerializer<RoomSetSessionStateState> {
-  const _$RoomSetSessionStateStateSerializer();
-
-  static const Map<RoomSetSessionStateState, Object> _toWire = <RoomSetSessionStateState, Object>{
-    RoomSetSessionStateState.$0: 0,
-    RoomSetSessionStateState.$1: 1,
-  };
-
-  static const Map<Object, RoomSetSessionStateState> _fromWire = <Object, RoomSetSessionStateState>{
-    0: RoomSetSessionStateState.$0,
-    1: RoomSetSessionStateState.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [RoomSetSessionStateState];
-
-  @override
-  String get wireName => 'RoomSetSessionStateState';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    RoomSetSessionStateState object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  RoomSetSessionStateState deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class RoomSetSessionStateApiVersion extends EnumClass {
   const RoomSetSessionStateApiVersion._(super.name);
 
@@ -39160,6 +41961,140 @@ class _$RoomSetSessionStateApiVersionSerializer implements PrimitiveSerializer<R
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// of the room.
+class RoomSetSessionStateRequestApplicationJson_State extends EnumClass {
+  const RoomSetSessionStateRequestApplicationJson_State._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const RoomSetSessionStateRequestApplicationJson_State $0 = _$roomSetSessionStateRequestApplicationJsonState$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const RoomSetSessionStateRequestApplicationJson_State $1 = _$roomSetSessionStateRequestApplicationJsonState$1;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<RoomSetSessionStateRequestApplicationJson_State> get values =>
+      _$roomSetSessionStateRequestApplicationJsonStateValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static RoomSetSessionStateRequestApplicationJson_State valueOf(String name) =>
+      _$valueOfRoomSetSessionStateRequestApplicationJson_State(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for RoomSetSessionStateRequestApplicationJson_State.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<RoomSetSessionStateRequestApplicationJson_State> get serializer =>
+      const _$RoomSetSessionStateRequestApplicationJson_StateSerializer();
+}
+
+class _$RoomSetSessionStateRequestApplicationJson_StateSerializer
+    implements PrimitiveSerializer<RoomSetSessionStateRequestApplicationJson_State> {
+  const _$RoomSetSessionStateRequestApplicationJson_StateSerializer();
+
+  static const Map<RoomSetSessionStateRequestApplicationJson_State, Object> _toWire =
+      <RoomSetSessionStateRequestApplicationJson_State, Object>{
+    RoomSetSessionStateRequestApplicationJson_State.$0: 0,
+    RoomSetSessionStateRequestApplicationJson_State.$1: 1,
+  };
+
+  static const Map<Object, RoomSetSessionStateRequestApplicationJson_State> _fromWire =
+      <Object, RoomSetSessionStateRequestApplicationJson_State>{
+    0: RoomSetSessionStateRequestApplicationJson_State.$0,
+    1: RoomSetSessionStateRequestApplicationJson_State.$1,
+  };
+
+  @override
+  Iterable<Type> get types => const [RoomSetSessionStateRequestApplicationJson_State];
+
+  @override
+  String get wireName => 'RoomSetSessionStateRequestApplicationJson_State';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RoomSetSessionStateRequestApplicationJson_State object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  RoomSetSessionStateRequestApplicationJson_State deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomSetSessionStateRequestApplicationJsonInterface {
+  /// of the room.
+  RoomSetSessionStateRequestApplicationJson_State get state;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetSessionStateRequestApplicationJsonInterfaceBuilder].
+  $RoomSetSessionStateRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetSessionStateRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetSessionStateRequestApplicationJsonInterfaceBuilder].
+  $RoomSetSessionStateRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetSessionStateRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetSessionStateRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomSetSessionStateRequestApplicationJson
+    implements
+        $RoomSetSessionStateRequestApplicationJsonInterface,
+        Built<RoomSetSessionStateRequestApplicationJson, RoomSetSessionStateRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetSessionStateRequestApplicationJson object using the builder pattern.
+  factory RoomSetSessionStateRequestApplicationJson([
+    void Function(RoomSetSessionStateRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomSetSessionStateRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetSessionStateRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetSessionStateRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetSessionStateRequestApplicationJson.
+  static Serializer<RoomSetSessionStateRequestApplicationJson> get serializer =>
+      _$roomSetSessionStateRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetSessionStateRequestApplicationJsonBuilder b) {
+    $RoomSetSessionStateRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetSessionStateRequestApplicationJsonBuilder b) {
+    $RoomSetSessionStateRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -39347,6 +42282,76 @@ class _$RoomPromoteModeratorApiVersionSerializer implements PrimitiveSerializer<
 }
 
 @BuiltValue(instantiable: false)
+sealed class $RoomPromoteModeratorRequestApplicationJsonInterface {
+  /// ID of the attendee.
+  int get attendeeId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomPromoteModeratorRequestApplicationJsonInterfaceBuilder].
+  $RoomPromoteModeratorRequestApplicationJsonInterface rebuild(
+    void Function($RoomPromoteModeratorRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomPromoteModeratorRequestApplicationJsonInterfaceBuilder].
+  $RoomPromoteModeratorRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomPromoteModeratorRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomPromoteModeratorRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.attendeeId,
+      'attendeeId',
+      minimum: 0,
+    );
+  }
+}
+
+abstract class RoomPromoteModeratorRequestApplicationJson
+    implements
+        $RoomPromoteModeratorRequestApplicationJsonInterface,
+        Built<RoomPromoteModeratorRequestApplicationJson, RoomPromoteModeratorRequestApplicationJsonBuilder> {
+  /// Creates a new RoomPromoteModeratorRequestApplicationJson object using the builder pattern.
+  factory RoomPromoteModeratorRequestApplicationJson([
+    void Function(RoomPromoteModeratorRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomPromoteModeratorRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomPromoteModeratorRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomPromoteModeratorRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomPromoteModeratorRequestApplicationJson.
+  static Serializer<RoomPromoteModeratorRequestApplicationJson> get serializer =>
+      _$roomPromoteModeratorRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomPromoteModeratorRequestApplicationJsonBuilder b) {
+    $RoomPromoteModeratorRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomPromoteModeratorRequestApplicationJsonBuilder b) {
+    $RoomPromoteModeratorRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $RoomPromoteModeratorResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -39527,6 +42532,76 @@ class _$RoomDemoteModeratorApiVersionSerializer implements PrimitiveSerializer<R
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomDemoteModeratorRequestApplicationJsonInterface {
+  /// ID of the attendee.
+  int get attendeeId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomDemoteModeratorRequestApplicationJsonInterfaceBuilder].
+  $RoomDemoteModeratorRequestApplicationJsonInterface rebuild(
+    void Function($RoomDemoteModeratorRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomDemoteModeratorRequestApplicationJsonInterfaceBuilder].
+  $RoomDemoteModeratorRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomDemoteModeratorRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomDemoteModeratorRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.attendeeId,
+      'attendeeId',
+      minimum: 0,
+    );
+  }
+}
+
+abstract class RoomDemoteModeratorRequestApplicationJson
+    implements
+        $RoomDemoteModeratorRequestApplicationJsonInterface,
+        Built<RoomDemoteModeratorRequestApplicationJson, RoomDemoteModeratorRequestApplicationJsonBuilder> {
+  /// Creates a new RoomDemoteModeratorRequestApplicationJson object using the builder pattern.
+  factory RoomDemoteModeratorRequestApplicationJson([
+    void Function(RoomDemoteModeratorRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomDemoteModeratorRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomDemoteModeratorRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomDemoteModeratorRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomDemoteModeratorRequestApplicationJson.
+  static Serializer<RoomDemoteModeratorRequestApplicationJson> get serializer =>
+      _$roomDemoteModeratorRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomDemoteModeratorRequestApplicationJsonBuilder b) {
+    $RoomDemoteModeratorRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomDemoteModeratorRequestApplicationJsonBuilder b) {
+    $RoomDemoteModeratorRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -40083,6 +43158,70 @@ class _$RoomSetNotificationLevelApiVersionSerializer
 }
 
 @BuiltValue(instantiable: false)
+sealed class $RoomSetNotificationLevelRequestApplicationJsonInterface {
+  /// New level.
+  int get level;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetNotificationLevelRequestApplicationJsonInterfaceBuilder].
+  $RoomSetNotificationLevelRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetNotificationLevelRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetNotificationLevelRequestApplicationJsonInterfaceBuilder].
+  $RoomSetNotificationLevelRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetNotificationLevelRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetNotificationLevelRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomSetNotificationLevelRequestApplicationJson
+    implements
+        $RoomSetNotificationLevelRequestApplicationJsonInterface,
+        Built<RoomSetNotificationLevelRequestApplicationJson, RoomSetNotificationLevelRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetNotificationLevelRequestApplicationJson object using the builder pattern.
+  factory RoomSetNotificationLevelRequestApplicationJson([
+    void Function(RoomSetNotificationLevelRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomSetNotificationLevelRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetNotificationLevelRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetNotificationLevelRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetNotificationLevelRequestApplicationJson.
+  static Serializer<RoomSetNotificationLevelRequestApplicationJson> get serializer =>
+      _$roomSetNotificationLevelRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetNotificationLevelRequestApplicationJsonBuilder b) {
+    $RoomSetNotificationLevelRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetNotificationLevelRequestApplicationJsonBuilder b) {
+    $RoomSetNotificationLevelRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $RoomSetNotificationLevelResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   JsonObject get data;
@@ -40266,6 +43405,70 @@ class _$RoomSetNotificationCallsApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomSetNotificationCallsRequestApplicationJsonInterface {
+  /// New level.
+  int get level;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetNotificationCallsRequestApplicationJsonInterfaceBuilder].
+  $RoomSetNotificationCallsRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetNotificationCallsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetNotificationCallsRequestApplicationJsonInterfaceBuilder].
+  $RoomSetNotificationCallsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetNotificationCallsRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetNotificationCallsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomSetNotificationCallsRequestApplicationJson
+    implements
+        $RoomSetNotificationCallsRequestApplicationJsonInterface,
+        Built<RoomSetNotificationCallsRequestApplicationJson, RoomSetNotificationCallsRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetNotificationCallsRequestApplicationJson object using the builder pattern.
+  factory RoomSetNotificationCallsRequestApplicationJson([
+    void Function(RoomSetNotificationCallsRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomSetNotificationCallsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetNotificationCallsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetNotificationCallsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetNotificationCallsRequestApplicationJson.
+  static Serializer<RoomSetNotificationCallsRequestApplicationJson> get serializer =>
+      _$roomSetNotificationCallsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetNotificationCallsRequestApplicationJsonBuilder b) {
+    $RoomSetNotificationCallsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetNotificationCallsRequestApplicationJsonBuilder b) {
+    $RoomSetNotificationCallsRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -40453,6 +43656,78 @@ class _$RoomSetLobbyApiVersionSerializer implements PrimitiveSerializer<RoomSetL
 }
 
 @BuiltValue(instantiable: false)
+sealed class $RoomSetLobbyRequestApplicationJsonInterface {
+  /// New state.
+  int get state;
+
+  /// Timer when the lobby will be removed.
+  int? get timer;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetLobbyRequestApplicationJsonInterfaceBuilder].
+  $RoomSetLobbyRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetLobbyRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetLobbyRequestApplicationJsonInterfaceBuilder].
+  $RoomSetLobbyRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetLobbyRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetLobbyRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.timer,
+      'timer',
+      minimum: 0,
+    );
+  }
+}
+
+abstract class RoomSetLobbyRequestApplicationJson
+    implements
+        $RoomSetLobbyRequestApplicationJsonInterface,
+        Built<RoomSetLobbyRequestApplicationJson, RoomSetLobbyRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetLobbyRequestApplicationJson object using the builder pattern.
+  factory RoomSetLobbyRequestApplicationJson([void Function(RoomSetLobbyRequestApplicationJsonBuilder)? b]) =
+      _$RoomSetLobbyRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetLobbyRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetLobbyRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetLobbyRequestApplicationJson.
+  static Serializer<RoomSetLobbyRequestApplicationJson> get serializer =>
+      _$roomSetLobbyRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetLobbyRequestApplicationJsonBuilder b) {
+    $RoomSetLobbyRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetLobbyRequestApplicationJsonBuilder b) {
+    $RoomSetLobbyRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $RoomSetLobbyResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
@@ -40577,75 +43852,6 @@ abstract class RoomSetLobbyResponseApplicationJson
   }
 }
 
-class RoomSetsipEnabledState extends EnumClass {
-  const RoomSetsipEnabledState._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const RoomSetsipEnabledState $0 = _$roomSetsipEnabledState$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const RoomSetsipEnabledState $1 = _$roomSetsipEnabledState$1;
-
-  /// `2`
-  @BuiltValueEnumConst(wireName: '2')
-  static const RoomSetsipEnabledState $2 = _$roomSetsipEnabledState$2;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<RoomSetsipEnabledState> get values => _$roomSetsipEnabledStateValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static RoomSetsipEnabledState valueOf(String name) => _$valueOfRoomSetsipEnabledState(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for RoomSetsipEnabledState.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<RoomSetsipEnabledState> get serializer => const _$RoomSetsipEnabledStateSerializer();
-}
-
-class _$RoomSetsipEnabledStateSerializer implements PrimitiveSerializer<RoomSetsipEnabledState> {
-  const _$RoomSetsipEnabledStateSerializer();
-
-  static const Map<RoomSetsipEnabledState, Object> _toWire = <RoomSetsipEnabledState, Object>{
-    RoomSetsipEnabledState.$0: 0,
-    RoomSetsipEnabledState.$1: 1,
-    RoomSetsipEnabledState.$2: 2,
-  };
-
-  static const Map<Object, RoomSetsipEnabledState> _fromWire = <Object, RoomSetsipEnabledState>{
-    0: RoomSetsipEnabledState.$0,
-    1: RoomSetsipEnabledState.$1,
-    2: RoomSetsipEnabledState.$2,
-  };
-
-  @override
-  Iterable<Type> get types => const [RoomSetsipEnabledState];
-
-  @override
-  String get wireName => 'RoomSetsipEnabledState';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    RoomSetsipEnabledState object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  RoomSetsipEnabledState deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
 class RoomSetsipEnabledApiVersion extends EnumClass {
   const RoomSetsipEnabledApiVersion._(super.name);
 
@@ -40700,6 +43906,145 @@ class _$RoomSetsipEnabledApiVersionSerializer implements PrimitiveSerializer<Roo
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// New state.
+class RoomSetsipEnabledRequestApplicationJson_State extends EnumClass {
+  const RoomSetsipEnabledRequestApplicationJson_State._(super.name);
+
+  /// `0`
+  @BuiltValueEnumConst(wireName: '0')
+  static const RoomSetsipEnabledRequestApplicationJson_State $0 = _$roomSetsipEnabledRequestApplicationJsonState$0;
+
+  /// `1`
+  @BuiltValueEnumConst(wireName: '1')
+  static const RoomSetsipEnabledRequestApplicationJson_State $1 = _$roomSetsipEnabledRequestApplicationJsonState$1;
+
+  /// `2`
+  @BuiltValueEnumConst(wireName: '2')
+  static const RoomSetsipEnabledRequestApplicationJson_State $2 = _$roomSetsipEnabledRequestApplicationJsonState$2;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<RoomSetsipEnabledRequestApplicationJson_State> get values =>
+      _$roomSetsipEnabledRequestApplicationJsonStateValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static RoomSetsipEnabledRequestApplicationJson_State valueOf(String name) =>
+      _$valueOfRoomSetsipEnabledRequestApplicationJson_State(name);
+
+  /// Returns the serialized value of this enum value.
+  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+
+  /// Serializer for RoomSetsipEnabledRequestApplicationJson_State.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<RoomSetsipEnabledRequestApplicationJson_State> get serializer =>
+      const _$RoomSetsipEnabledRequestApplicationJson_StateSerializer();
+}
+
+class _$RoomSetsipEnabledRequestApplicationJson_StateSerializer
+    implements PrimitiveSerializer<RoomSetsipEnabledRequestApplicationJson_State> {
+  const _$RoomSetsipEnabledRequestApplicationJson_StateSerializer();
+
+  static const Map<RoomSetsipEnabledRequestApplicationJson_State, Object> _toWire =
+      <RoomSetsipEnabledRequestApplicationJson_State, Object>{
+    RoomSetsipEnabledRequestApplicationJson_State.$0: 0,
+    RoomSetsipEnabledRequestApplicationJson_State.$1: 1,
+    RoomSetsipEnabledRequestApplicationJson_State.$2: 2,
+  };
+
+  static const Map<Object, RoomSetsipEnabledRequestApplicationJson_State> _fromWire =
+      <Object, RoomSetsipEnabledRequestApplicationJson_State>{
+    0: RoomSetsipEnabledRequestApplicationJson_State.$0,
+    1: RoomSetsipEnabledRequestApplicationJson_State.$1,
+    2: RoomSetsipEnabledRequestApplicationJson_State.$2,
+  };
+
+  @override
+  Iterable<Type> get types => const [RoomSetsipEnabledRequestApplicationJson_State];
+
+  @override
+  String get wireName => 'RoomSetsipEnabledRequestApplicationJson_State';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    RoomSetsipEnabledRequestApplicationJson_State object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  RoomSetsipEnabledRequestApplicationJson_State deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomSetsipEnabledRequestApplicationJsonInterface {
+  /// New state.
+  RoomSetsipEnabledRequestApplicationJson_State get state;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetsipEnabledRequestApplicationJsonInterfaceBuilder].
+  $RoomSetsipEnabledRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetsipEnabledRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetsipEnabledRequestApplicationJsonInterfaceBuilder].
+  $RoomSetsipEnabledRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetsipEnabledRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetsipEnabledRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomSetsipEnabledRequestApplicationJson
+    implements
+        $RoomSetsipEnabledRequestApplicationJsonInterface,
+        Built<RoomSetsipEnabledRequestApplicationJson, RoomSetsipEnabledRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetsipEnabledRequestApplicationJson object using the builder pattern.
+  factory RoomSetsipEnabledRequestApplicationJson([void Function(RoomSetsipEnabledRequestApplicationJsonBuilder)? b]) =
+      _$RoomSetsipEnabledRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetsipEnabledRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetsipEnabledRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetsipEnabledRequestApplicationJson.
+  static Serializer<RoomSetsipEnabledRequestApplicationJson> get serializer =>
+      _$roomSetsipEnabledRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetsipEnabledRequestApplicationJsonBuilder b) {
+    $RoomSetsipEnabledRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetsipEnabledRequestApplicationJsonBuilder b) {
+    $RoomSetsipEnabledRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -40887,6 +44232,71 @@ class _$RoomSetRecordingConsentApiVersionSerializer implements PrimitiveSerializ
 }
 
 @BuiltValue(instantiable: false)
+sealed class $RoomSetRecordingConsentRequestApplicationJsonInterface {
+  /// New consent setting for the conversation.
+  /// (Only {@see RecordingService::CONSENT_REQUIRED_NO} and {@see RecordingService::CONSENT_REQUIRED_YES} are allowed here.).
+  int get recordingConsent;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetRecordingConsentRequestApplicationJsonInterfaceBuilder].
+  $RoomSetRecordingConsentRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetRecordingConsentRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetRecordingConsentRequestApplicationJsonInterfaceBuilder].
+  $RoomSetRecordingConsentRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetRecordingConsentRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetRecordingConsentRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomSetRecordingConsentRequestApplicationJson
+    implements
+        $RoomSetRecordingConsentRequestApplicationJsonInterface,
+        Built<RoomSetRecordingConsentRequestApplicationJson, RoomSetRecordingConsentRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetRecordingConsentRequestApplicationJson object using the builder pattern.
+  factory RoomSetRecordingConsentRequestApplicationJson([
+    void Function(RoomSetRecordingConsentRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomSetRecordingConsentRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetRecordingConsentRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetRecordingConsentRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetRecordingConsentRequestApplicationJson.
+  static Serializer<RoomSetRecordingConsentRequestApplicationJson> get serializer =>
+      _$roomSetRecordingConsentRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetRecordingConsentRequestApplicationJsonBuilder b) {
+    $RoomSetRecordingConsentRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetRecordingConsentRequestApplicationJsonBuilder b) {
+    $RoomSetRecordingConsentRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $RoomSetRecordingConsentResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
@@ -41070,6 +44480,76 @@ class _$RoomSetMessageExpirationApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomSetMessageExpirationRequestApplicationJsonInterface {
+  /// New time.
+  int get seconds;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomSetMessageExpirationRequestApplicationJsonInterfaceBuilder].
+  $RoomSetMessageExpirationRequestApplicationJsonInterface rebuild(
+    void Function($RoomSetMessageExpirationRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomSetMessageExpirationRequestApplicationJsonInterfaceBuilder].
+  $RoomSetMessageExpirationRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomSetMessageExpirationRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomSetMessageExpirationRequestApplicationJsonInterfaceBuilder b) {
+    _i4.checkNumber(
+      b.seconds,
+      'seconds',
+      minimum: 0,
+    );
+  }
+}
+
+abstract class RoomSetMessageExpirationRequestApplicationJson
+    implements
+        $RoomSetMessageExpirationRequestApplicationJsonInterface,
+        Built<RoomSetMessageExpirationRequestApplicationJson, RoomSetMessageExpirationRequestApplicationJsonBuilder> {
+  /// Creates a new RoomSetMessageExpirationRequestApplicationJson object using the builder pattern.
+  factory RoomSetMessageExpirationRequestApplicationJson([
+    void Function(RoomSetMessageExpirationRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomSetMessageExpirationRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomSetMessageExpirationRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomSetMessageExpirationRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomSetMessageExpirationRequestApplicationJson.
+  static Serializer<RoomSetMessageExpirationRequestApplicationJson> get serializer =>
+      _$roomSetMessageExpirationRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomSetMessageExpirationRequestApplicationJsonBuilder b) {
+    $RoomSetMessageExpirationRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomSetMessageExpirationRequestApplicationJsonBuilder b) {
+    $RoomSetMessageExpirationRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -42518,6 +45998,70 @@ class _$RoomVerifyDialInPinApiVersionSerializer implements PrimitiveSerializer<R
 }
 
 @BuiltValue(instantiable: false)
+sealed class $RoomVerifyDialInPinRequestApplicationJsonInterface {
+  /// PIN the participant used to dial-in.
+  String get pin;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomVerifyDialInPinRequestApplicationJsonInterfaceBuilder].
+  $RoomVerifyDialInPinRequestApplicationJsonInterface rebuild(
+    void Function($RoomVerifyDialInPinRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomVerifyDialInPinRequestApplicationJsonInterfaceBuilder].
+  $RoomVerifyDialInPinRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomVerifyDialInPinRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomVerifyDialInPinRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomVerifyDialInPinRequestApplicationJson
+    implements
+        $RoomVerifyDialInPinRequestApplicationJsonInterface,
+        Built<RoomVerifyDialInPinRequestApplicationJson, RoomVerifyDialInPinRequestApplicationJsonBuilder> {
+  /// Creates a new RoomVerifyDialInPinRequestApplicationJson object using the builder pattern.
+  factory RoomVerifyDialInPinRequestApplicationJson([
+    void Function(RoomVerifyDialInPinRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomVerifyDialInPinRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomVerifyDialInPinRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomVerifyDialInPinRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomVerifyDialInPinRequestApplicationJson.
+  static Serializer<RoomVerifyDialInPinRequestApplicationJson> get serializer =>
+      _$roomVerifyDialInPinRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomVerifyDialInPinRequestApplicationJsonBuilder b) {
+    $RoomVerifyDialInPinRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomVerifyDialInPinRequestApplicationJsonBuilder b) {
+    $RoomVerifyDialInPinRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $RoomVerifyDialInPinResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Room get data;
@@ -42644,71 +46188,6 @@ abstract class RoomVerifyDialInPinResponseApplicationJson
   }
 }
 
-/// Additional details to verify the validity of the request.
-@BuiltValue(instantiable: false)
-sealed class $RoomVerifyDialOutNumberOptionsInterface {
-  String? get actorId;
-  ActorType? get actorType;
-  int? get attendeeId;
-
-  /// Rebuilds the instance.
-  ///
-  /// The result is the same as this instance but with [updates] applied.
-  /// [updates] is a function that takes a builder [$RoomVerifyDialOutNumberOptionsInterfaceBuilder].
-  $RoomVerifyDialOutNumberOptionsInterface rebuild(
-    void Function($RoomVerifyDialOutNumberOptionsInterfaceBuilder) updates,
-  );
-
-  /// Converts the instance to a builder [$RoomVerifyDialOutNumberOptionsInterfaceBuilder].
-  $RoomVerifyDialOutNumberOptionsInterfaceBuilder toBuilder();
-  @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($RoomVerifyDialOutNumberOptionsInterfaceBuilder b) {}
-  @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($RoomVerifyDialOutNumberOptionsInterfaceBuilder b) {}
-}
-
-/// Additional details to verify the validity of the request.
-abstract class RoomVerifyDialOutNumberOptions
-    implements
-        $RoomVerifyDialOutNumberOptionsInterface,
-        Built<RoomVerifyDialOutNumberOptions, RoomVerifyDialOutNumberOptionsBuilder> {
-  /// Creates a new RoomVerifyDialOutNumberOptions object using the builder pattern.
-  factory RoomVerifyDialOutNumberOptions([void Function(RoomVerifyDialOutNumberOptionsBuilder)? b]) =
-      _$RoomVerifyDialOutNumberOptions;
-
-  // coverage:ignore-start
-  const RoomVerifyDialOutNumberOptions._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory RoomVerifyDialOutNumberOptions.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for RoomVerifyDialOutNumberOptions.
-  static Serializer<RoomVerifyDialOutNumberOptions> get serializer => _$roomVerifyDialOutNumberOptionsSerializer;
-
-  @BuiltValueHook(initializeBuilder: true)
-  static void _defaults(RoomVerifyDialOutNumberOptionsBuilder b) {
-    $RoomVerifyDialOutNumberOptionsInterface._defaults(b);
-  }
-
-  @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(RoomVerifyDialOutNumberOptionsBuilder b) {
-    $RoomVerifyDialOutNumberOptionsInterface._validate(b);
-  }
-}
-
 class RoomVerifyDialOutNumberApiVersion extends EnumClass {
   const RoomVerifyDialOutNumberApiVersion._(super.name);
 
@@ -42764,6 +46243,149 @@ class _$RoomVerifyDialOutNumberApiVersionSerializer implements PrimitiveSerializ
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// Additional details to verify the validity of the request.
+@BuiltValue(instantiable: false)
+sealed class $RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterface {
+  String? get actorId;
+  ActorType? get actorType;
+  int? get attendeeId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterfaceBuilder].
+  $RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterface rebuild(
+    void Function($RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterfaceBuilder].
+  $RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterfaceBuilder b) {}
+}
+
+/// Additional details to verify the validity of the request.
+abstract class RoomVerifyDialOutNumberRequestApplicationJson_Options
+    implements
+        $RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterface,
+        Built<RoomVerifyDialOutNumberRequestApplicationJson_Options,
+            RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder> {
+  /// Creates a new RoomVerifyDialOutNumberRequestApplicationJson_Options object using the builder pattern.
+  factory RoomVerifyDialOutNumberRequestApplicationJson_Options([
+    void Function(RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder)? b,
+  ]) = _$RoomVerifyDialOutNumberRequestApplicationJson_Options;
+
+  // coverage:ignore-start
+  const RoomVerifyDialOutNumberRequestApplicationJson_Options._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomVerifyDialOutNumberRequestApplicationJson_Options.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomVerifyDialOutNumberRequestApplicationJson_Options.
+  static Serializer<RoomVerifyDialOutNumberRequestApplicationJson_Options> get serializer =>
+      _$roomVerifyDialOutNumberRequestApplicationJsonOptionsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder b) {
+    $RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder b) {
+    $RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomVerifyDialOutNumberRequestApplicationJsonInterface {
+  static final _$options = _$jsonSerializers.deserialize(
+    const [],
+    specifiedType: const FullType(RoomVerifyDialOutNumberRequestApplicationJson_Options),
+  )! as RoomVerifyDialOutNumberRequestApplicationJson_Options;
+
+  /// E164 formatted phone number.
+  String get number;
+
+  /// Additional details to verify the validity of the request.
+  RoomVerifyDialOutNumberRequestApplicationJson_Options get options;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomVerifyDialOutNumberRequestApplicationJsonInterfaceBuilder].
+  $RoomVerifyDialOutNumberRequestApplicationJsonInterface rebuild(
+    void Function($RoomVerifyDialOutNumberRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomVerifyDialOutNumberRequestApplicationJsonInterfaceBuilder].
+  $RoomVerifyDialOutNumberRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomVerifyDialOutNumberRequestApplicationJsonInterfaceBuilder b) {
+    b.options.replace(_$options);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomVerifyDialOutNumberRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomVerifyDialOutNumberRequestApplicationJson
+    implements
+        $RoomVerifyDialOutNumberRequestApplicationJsonInterface,
+        Built<RoomVerifyDialOutNumberRequestApplicationJson, RoomVerifyDialOutNumberRequestApplicationJsonBuilder> {
+  /// Creates a new RoomVerifyDialOutNumberRequestApplicationJson object using the builder pattern.
+  factory RoomVerifyDialOutNumberRequestApplicationJson([
+    void Function(RoomVerifyDialOutNumberRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomVerifyDialOutNumberRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomVerifyDialOutNumberRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomVerifyDialOutNumberRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomVerifyDialOutNumberRequestApplicationJson.
+  static Serializer<RoomVerifyDialOutNumberRequestApplicationJson> get serializer =>
+      _$roomVerifyDialOutNumberRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomVerifyDialOutNumberRequestApplicationJsonBuilder b) {
+    $RoomVerifyDialOutNumberRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomVerifyDialOutNumberRequestApplicationJsonBuilder b) {
+    $RoomVerifyDialOutNumberRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -43079,71 +46701,6 @@ abstract class RoomCreateGuestByDialInResponseApplicationJson
   }
 }
 
-/// Additional details to verify the validity of the request.
-@BuiltValue(instantiable: false)
-sealed class $RoomRejectedDialOutRequestOptionsInterface {
-  String? get actorId;
-  ActorType? get actorType;
-  int? get attendeeId;
-
-  /// Rebuilds the instance.
-  ///
-  /// The result is the same as this instance but with [updates] applied.
-  /// [updates] is a function that takes a builder [$RoomRejectedDialOutRequestOptionsInterfaceBuilder].
-  $RoomRejectedDialOutRequestOptionsInterface rebuild(
-    void Function($RoomRejectedDialOutRequestOptionsInterfaceBuilder) updates,
-  );
-
-  /// Converts the instance to a builder [$RoomRejectedDialOutRequestOptionsInterfaceBuilder].
-  $RoomRejectedDialOutRequestOptionsInterfaceBuilder toBuilder();
-  @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($RoomRejectedDialOutRequestOptionsInterfaceBuilder b) {}
-  @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($RoomRejectedDialOutRequestOptionsInterfaceBuilder b) {}
-}
-
-/// Additional details to verify the validity of the request.
-abstract class RoomRejectedDialOutRequestOptions
-    implements
-        $RoomRejectedDialOutRequestOptionsInterface,
-        Built<RoomRejectedDialOutRequestOptions, RoomRejectedDialOutRequestOptionsBuilder> {
-  /// Creates a new RoomRejectedDialOutRequestOptions object using the builder pattern.
-  factory RoomRejectedDialOutRequestOptions([void Function(RoomRejectedDialOutRequestOptionsBuilder)? b]) =
-      _$RoomRejectedDialOutRequestOptions;
-
-  // coverage:ignore-start
-  const RoomRejectedDialOutRequestOptions._();
-  // coverage:ignore-end
-
-  /// Creates a new object from the given [json] data.
-  ///
-  /// Use [toJson] to serialize it back into json.
-  // coverage:ignore-start
-  factory RoomRejectedDialOutRequestOptions.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
-  // coverage:ignore-end
-
-  /// Parses this object into a json like map.
-  ///
-  /// Use the fromJson factory to revive it again.
-  // coverage:ignore-start
-  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-  // coverage:ignore-end
-
-  /// Serializer for RoomRejectedDialOutRequestOptions.
-  static Serializer<RoomRejectedDialOutRequestOptions> get serializer => _$roomRejectedDialOutRequestOptionsSerializer;
-
-  @BuiltValueHook(initializeBuilder: true)
-  static void _defaults(RoomRejectedDialOutRequestOptionsBuilder b) {
-    $RoomRejectedDialOutRequestOptionsInterface._defaults(b);
-  }
-
-  @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(RoomRejectedDialOutRequestOptionsBuilder b) {
-    $RoomRejectedDialOutRequestOptionsInterface._validate(b);
-  }
-}
-
 class RoomRejectedDialOutRequestApiVersion extends EnumClass {
   const RoomRejectedDialOutRequestApiVersion._(super.name);
 
@@ -43203,6 +46760,150 @@ class _$RoomRejectedDialOutRequestApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// Additional details to verify the validity of the request.
+@BuiltValue(instantiable: false)
+sealed class $RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterface {
+  String? get actorId;
+  ActorType? get actorType;
+  int? get attendeeId;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterfaceBuilder].
+  $RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterface rebuild(
+    void Function($RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterfaceBuilder].
+  $RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterfaceBuilder b) {}
+}
+
+/// Additional details to verify the validity of the request.
+abstract class RoomRejectedDialOutRequestRequestApplicationJson_Options
+    implements
+        $RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterface,
+        Built<RoomRejectedDialOutRequestRequestApplicationJson_Options,
+            RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder> {
+  /// Creates a new RoomRejectedDialOutRequestRequestApplicationJson_Options object using the builder pattern.
+  factory RoomRejectedDialOutRequestRequestApplicationJson_Options([
+    void Function(RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder)? b,
+  ]) = _$RoomRejectedDialOutRequestRequestApplicationJson_Options;
+
+  // coverage:ignore-start
+  const RoomRejectedDialOutRequestRequestApplicationJson_Options._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomRejectedDialOutRequestRequestApplicationJson_Options.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomRejectedDialOutRequestRequestApplicationJson_Options.
+  static Serializer<RoomRejectedDialOutRequestRequestApplicationJson_Options> get serializer =>
+      _$roomRejectedDialOutRequestRequestApplicationJsonOptionsSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder b) {
+    $RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder b) {
+    $RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $RoomRejectedDialOutRequestRequestApplicationJsonInterface {
+  static final _$options = _$jsonSerializers.deserialize(
+    const [],
+    specifiedType: const FullType(RoomRejectedDialOutRequestRequestApplicationJson_Options),
+  )! as RoomRejectedDialOutRequestRequestApplicationJson_Options;
+
+  /// The call ID provided by the SIP bridge earlier to uniquely identify the call to terminate.
+  String get callId;
+
+  /// Additional details to verify the validity of the request.
+  RoomRejectedDialOutRequestRequestApplicationJson_Options get options;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$RoomRejectedDialOutRequestRequestApplicationJsonInterfaceBuilder].
+  $RoomRejectedDialOutRequestRequestApplicationJsonInterface rebuild(
+    void Function($RoomRejectedDialOutRequestRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$RoomRejectedDialOutRequestRequestApplicationJsonInterfaceBuilder].
+  $RoomRejectedDialOutRequestRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($RoomRejectedDialOutRequestRequestApplicationJsonInterfaceBuilder b) {
+    b.options.replace(_$options);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($RoomRejectedDialOutRequestRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class RoomRejectedDialOutRequestRequestApplicationJson
+    implements
+        $RoomRejectedDialOutRequestRequestApplicationJsonInterface,
+        Built<RoomRejectedDialOutRequestRequestApplicationJson,
+            RoomRejectedDialOutRequestRequestApplicationJsonBuilder> {
+  /// Creates a new RoomRejectedDialOutRequestRequestApplicationJson object using the builder pattern.
+  factory RoomRejectedDialOutRequestRequestApplicationJson([
+    void Function(RoomRejectedDialOutRequestRequestApplicationJsonBuilder)? b,
+  ]) = _$RoomRejectedDialOutRequestRequestApplicationJson;
+
+  // coverage:ignore-start
+  const RoomRejectedDialOutRequestRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory RoomRejectedDialOutRequestRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for RoomRejectedDialOutRequestRequestApplicationJson.
+  static Serializer<RoomRejectedDialOutRequestRequestApplicationJson> get serializer =>
+      _$roomRejectedDialOutRequestRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(RoomRejectedDialOutRequestRequestApplicationJsonBuilder b) {
+    $RoomRejectedDialOutRequestRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(RoomRejectedDialOutRequestRequestApplicationJsonBuilder b) {
+    $RoomRejectedDialOutRequestRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -43334,83 +47035,6 @@ abstract class RoomRejectedDialOutRequestResponseApplicationJson
   }
 }
 
-class SettingsSetUserSettingKey extends EnumClass {
-  const SettingsSetUserSettingKey._(super.name);
-
-  /// `attachment_folder`
-  @BuiltValueEnumConst(wireName: 'attachment_folder')
-  static const SettingsSetUserSettingKey attachmentFolder = _$settingsSetUserSettingKeyAttachmentFolder;
-
-  /// `read_status_privacy`
-  @BuiltValueEnumConst(wireName: 'read_status_privacy')
-  static const SettingsSetUserSettingKey readStatusPrivacy = _$settingsSetUserSettingKeyReadStatusPrivacy;
-
-  /// `typing_privacy`
-  @BuiltValueEnumConst(wireName: 'typing_privacy')
-  static const SettingsSetUserSettingKey typingPrivacy = _$settingsSetUserSettingKeyTypingPrivacy;
-
-  /// `play_sounds`
-  @BuiltValueEnumConst(wireName: 'play_sounds')
-  static const SettingsSetUserSettingKey playSounds = _$settingsSetUserSettingKeyPlaySounds;
-
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<SettingsSetUserSettingKey> get values => _$settingsSetUserSettingKeyValues;
-  // coverage:ignore-end
-
-  /// Returns the enum value associated to the [name].
-  static SettingsSetUserSettingKey valueOf(String name) => _$valueOfSettingsSetUserSettingKey(name);
-
-  /// Returns the serialized value of this enum value.
-  String get value => _$jsonSerializers.serializeWith(serializer, this)! as String;
-
-  /// Serializer for SettingsSetUserSettingKey.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<SettingsSetUserSettingKey> get serializer => const _$SettingsSetUserSettingKeySerializer();
-}
-
-class _$SettingsSetUserSettingKeySerializer implements PrimitiveSerializer<SettingsSetUserSettingKey> {
-  const _$SettingsSetUserSettingKeySerializer();
-
-  static const Map<SettingsSetUserSettingKey, Object> _toWire = <SettingsSetUserSettingKey, Object>{
-    SettingsSetUserSettingKey.attachmentFolder: 'attachment_folder',
-    SettingsSetUserSettingKey.readStatusPrivacy: 'read_status_privacy',
-    SettingsSetUserSettingKey.typingPrivacy: 'typing_privacy',
-    SettingsSetUserSettingKey.playSounds: 'play_sounds',
-  };
-
-  static const Map<Object, SettingsSetUserSettingKey> _fromWire = <Object, SettingsSetUserSettingKey>{
-    'attachment_folder': SettingsSetUserSettingKey.attachmentFolder,
-    'read_status_privacy': SettingsSetUserSettingKey.readStatusPrivacy,
-    'typing_privacy': SettingsSetUserSettingKey.typingPrivacy,
-    'play_sounds': SettingsSetUserSettingKey.playSounds,
-  };
-
-  @override
-  Iterable<Type> get types => const [SettingsSetUserSettingKey];
-
-  @override
-  String get wireName => 'SettingsSetUserSettingKey';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    SettingsSetUserSettingKey object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  SettingsSetUserSettingKey deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-typedef SettingsSetUserSettingValue = ({int? $int, String? string});
-
 class SettingsSetUserSettingApiVersion extends EnumClass {
   const SettingsSetUserSettingApiVersion._(super.name);
 
@@ -43466,6 +47090,164 @@ class _$SettingsSetUserSettingApiVersionSerializer implements PrimitiveSerialize
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+/// Key to update.
+class SettingsSetUserSettingRequestApplicationJson_Key extends EnumClass {
+  const SettingsSetUserSettingRequestApplicationJson_Key._(super.name);
+
+  /// `attachment_folder`
+  @BuiltValueEnumConst(wireName: 'attachment_folder')
+  static const SettingsSetUserSettingRequestApplicationJson_Key attachmentFolder =
+      _$settingsSetUserSettingRequestApplicationJsonKeyAttachmentFolder;
+
+  /// `read_status_privacy`
+  @BuiltValueEnumConst(wireName: 'read_status_privacy')
+  static const SettingsSetUserSettingRequestApplicationJson_Key readStatusPrivacy =
+      _$settingsSetUserSettingRequestApplicationJsonKeyReadStatusPrivacy;
+
+  /// `typing_privacy`
+  @BuiltValueEnumConst(wireName: 'typing_privacy')
+  static const SettingsSetUserSettingRequestApplicationJson_Key typingPrivacy =
+      _$settingsSetUserSettingRequestApplicationJsonKeyTypingPrivacy;
+
+  /// `play_sounds`
+  @BuiltValueEnumConst(wireName: 'play_sounds')
+  static const SettingsSetUserSettingRequestApplicationJson_Key playSounds =
+      _$settingsSetUserSettingRequestApplicationJsonKeyPlaySounds;
+
+  /// Returns a set with all values this enum contains.
+  // coverage:ignore-start
+  static BuiltSet<SettingsSetUserSettingRequestApplicationJson_Key> get values =>
+      _$settingsSetUserSettingRequestApplicationJsonKeyValues;
+  // coverage:ignore-end
+
+  /// Returns the enum value associated to the [name].
+  static SettingsSetUserSettingRequestApplicationJson_Key valueOf(String name) =>
+      _$valueOfSettingsSetUserSettingRequestApplicationJson_Key(name);
+
+  /// Returns the serialized value of this enum value.
+  String get value => _$jsonSerializers.serializeWith(serializer, this)! as String;
+
+  /// Serializer for SettingsSetUserSettingRequestApplicationJson_Key.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<SettingsSetUserSettingRequestApplicationJson_Key> get serializer =>
+      const _$SettingsSetUserSettingRequestApplicationJson_KeySerializer();
+}
+
+class _$SettingsSetUserSettingRequestApplicationJson_KeySerializer
+    implements PrimitiveSerializer<SettingsSetUserSettingRequestApplicationJson_Key> {
+  const _$SettingsSetUserSettingRequestApplicationJson_KeySerializer();
+
+  static const Map<SettingsSetUserSettingRequestApplicationJson_Key, Object> _toWire =
+      <SettingsSetUserSettingRequestApplicationJson_Key, Object>{
+    SettingsSetUserSettingRequestApplicationJson_Key.attachmentFolder: 'attachment_folder',
+    SettingsSetUserSettingRequestApplicationJson_Key.readStatusPrivacy: 'read_status_privacy',
+    SettingsSetUserSettingRequestApplicationJson_Key.typingPrivacy: 'typing_privacy',
+    SettingsSetUserSettingRequestApplicationJson_Key.playSounds: 'play_sounds',
+  };
+
+  static const Map<Object, SettingsSetUserSettingRequestApplicationJson_Key> _fromWire =
+      <Object, SettingsSetUserSettingRequestApplicationJson_Key>{
+    'attachment_folder': SettingsSetUserSettingRequestApplicationJson_Key.attachmentFolder,
+    'read_status_privacy': SettingsSetUserSettingRequestApplicationJson_Key.readStatusPrivacy,
+    'typing_privacy': SettingsSetUserSettingRequestApplicationJson_Key.typingPrivacy,
+    'play_sounds': SettingsSetUserSettingRequestApplicationJson_Key.playSounds,
+  };
+
+  @override
+  Iterable<Type> get types => const [SettingsSetUserSettingRequestApplicationJson_Key];
+
+  @override
+  String get wireName => 'SettingsSetUserSettingRequestApplicationJson_Key';
+
+  @override
+  Object serialize(
+    Serializers serializers,
+    SettingsSetUserSettingRequestApplicationJson_Key object, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _toWire[object]!;
+
+  @override
+  SettingsSetUserSettingRequestApplicationJson_Key deserialize(
+    Serializers serializers,
+    Object serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) =>
+      _fromWire[serialized]!;
+}
+
+/// New value for the key.
+typedef SettingsSetUserSettingRequestApplicationJson_Value = ({int? $int, String? string});
+
+@BuiltValue(instantiable: false)
+sealed class $SettingsSetUserSettingRequestApplicationJsonInterface {
+  /// Key to update.
+  SettingsSetUserSettingRequestApplicationJson_Key get key;
+
+  /// New value for the key.
+  SettingsSetUserSettingRequestApplicationJson_Value? get value;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsSetUserSettingRequestApplicationJsonInterfaceBuilder].
+  $SettingsSetUserSettingRequestApplicationJsonInterface rebuild(
+    void Function($SettingsSetUserSettingRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SettingsSetUserSettingRequestApplicationJsonInterfaceBuilder].
+  $SettingsSetUserSettingRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsSetUserSettingRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsSetUserSettingRequestApplicationJsonInterfaceBuilder b) {
+    b.value?.validateOneOf();
+  }
+}
+
+abstract class SettingsSetUserSettingRequestApplicationJson
+    implements
+        $SettingsSetUserSettingRequestApplicationJsonInterface,
+        Built<SettingsSetUserSettingRequestApplicationJson, SettingsSetUserSettingRequestApplicationJsonBuilder> {
+  /// Creates a new SettingsSetUserSettingRequestApplicationJson object using the builder pattern.
+  factory SettingsSetUserSettingRequestApplicationJson([
+    void Function(SettingsSetUserSettingRequestApplicationJsonBuilder)? b,
+  ]) = _$SettingsSetUserSettingRequestApplicationJson;
+
+  // coverage:ignore-start
+  const SettingsSetUserSettingRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory SettingsSetUserSettingRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for SettingsSetUserSettingRequestApplicationJson.
+  static Serializer<SettingsSetUserSettingRequestApplicationJson> get serializer =>
+      _$settingsSetUserSettingRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsSetUserSettingRequestApplicationJsonBuilder b) {
+    $SettingsSetUserSettingRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsSetUserSettingRequestApplicationJsonBuilder b) {
+    $SettingsSetUserSettingRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -43908,6 +47690,71 @@ class _$CertificateGetCertificateExpirationApiVersionSerializer
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $CertificateGetCertificateExpirationRequestApplicationJsonInterface {
+  /// Host to check.
+  String get host;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$CertificateGetCertificateExpirationRequestApplicationJsonInterfaceBuilder].
+  $CertificateGetCertificateExpirationRequestApplicationJsonInterface rebuild(
+    void Function($CertificateGetCertificateExpirationRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$CertificateGetCertificateExpirationRequestApplicationJsonInterfaceBuilder].
+  $CertificateGetCertificateExpirationRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($CertificateGetCertificateExpirationRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($CertificateGetCertificateExpirationRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class CertificateGetCertificateExpirationRequestApplicationJson
+    implements
+        $CertificateGetCertificateExpirationRequestApplicationJsonInterface,
+        Built<CertificateGetCertificateExpirationRequestApplicationJson,
+            CertificateGetCertificateExpirationRequestApplicationJsonBuilder> {
+  /// Creates a new CertificateGetCertificateExpirationRequestApplicationJson object using the builder pattern.
+  factory CertificateGetCertificateExpirationRequestApplicationJson([
+    void Function(CertificateGetCertificateExpirationRequestApplicationJsonBuilder)? b,
+  ]) = _$CertificateGetCertificateExpirationRequestApplicationJson;
+
+  // coverage:ignore-start
+  const CertificateGetCertificateExpirationRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory CertificateGetCertificateExpirationRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for CertificateGetCertificateExpirationRequestApplicationJson.
+  static Serializer<CertificateGetCertificateExpirationRequestApplicationJson> get serializer =>
+      _$certificateGetCertificateExpirationRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(CertificateGetCertificateExpirationRequestApplicationJsonBuilder b) {
+    $CertificateGetCertificateExpirationRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(CertificateGetCertificateExpirationRequestApplicationJsonBuilder b) {
+    $CertificateGetCertificateExpirationRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -44413,6 +48260,96 @@ class _$SettingsSetsipSettingsApiVersionSerializer implements PrimitiveSerialize
     FullType specifiedType = FullType.unspecified,
   }) =>
       _fromWire[serialized]!;
+}
+
+@BuiltValue(instantiable: false)
+sealed class $SettingsSetsipSettingsRequestApplicationJsonInterface {
+  static final _$sipGroups = _$jsonSerializers.deserialize(
+    const [],
+    specifiedType: const FullType(BuiltList, [FullType(String)]),
+  )! as BuiltList<String>;
+
+  static final _$dialInInfo = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  static final _$sharedSecret = _$jsonSerializers.deserialize(
+    '',
+    specifiedType: const FullType(String),
+  )! as String;
+
+  /// New SIP groups.
+  BuiltList<String> get sipGroups;
+
+  /// New dial info.
+  String get dialInInfo;
+
+  /// New shared secret.
+  String get sharedSecret;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$SettingsSetsipSettingsRequestApplicationJsonInterfaceBuilder].
+  $SettingsSetsipSettingsRequestApplicationJsonInterface rebuild(
+    void Function($SettingsSetsipSettingsRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$SettingsSetsipSettingsRequestApplicationJsonInterfaceBuilder].
+  $SettingsSetsipSettingsRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($SettingsSetsipSettingsRequestApplicationJsonInterfaceBuilder b) {
+    b.sipGroups.replace(_$sipGroups);
+    b.dialInInfo = _$dialInInfo;
+    b.sharedSecret = _$sharedSecret;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($SettingsSetsipSettingsRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class SettingsSetsipSettingsRequestApplicationJson
+    implements
+        $SettingsSetsipSettingsRequestApplicationJsonInterface,
+        Built<SettingsSetsipSettingsRequestApplicationJson, SettingsSetsipSettingsRequestApplicationJsonBuilder> {
+  /// Creates a new SettingsSetsipSettingsRequestApplicationJson object using the builder pattern.
+  factory SettingsSetsipSettingsRequestApplicationJson([
+    void Function(SettingsSetsipSettingsRequestApplicationJsonBuilder)? b,
+  ]) = _$SettingsSetsipSettingsRequestApplicationJson;
+
+  // coverage:ignore-start
+  const SettingsSetsipSettingsRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory SettingsSetsipSettingsRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for SettingsSetsipSettingsRequestApplicationJson.
+  static Serializer<SettingsSetsipSettingsRequestApplicationJson> get serializer =>
+      _$settingsSetsipSettingsRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(SettingsSetsipSettingsRequestApplicationJsonBuilder b) {
+    $SettingsSetsipSettingsRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(SettingsSetsipSettingsRequestApplicationJsonBuilder b) {
+    $SettingsSetsipSettingsRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -45664,17 +49601,18 @@ extension $RoomGetCapabilitiesResponseApplicationJson_Ocs_DataExtension
       $973dc40faeda3fa3aa7e7b9895ee7a34Extension._fromJson(json);
 }
 
-/// Serialization extension for `SettingsSetUserSettingValue`.
-extension $SettingsSetUserSettingValueExtension on SettingsSetUserSettingValue {
-  /// Serializer for SettingsSetUserSettingValue.
+/// Serialization extension for `SettingsSetUserSettingRequestApplicationJson_Value`.
+extension $SettingsSetUserSettingRequestApplicationJson_ValueExtension
+    on SettingsSetUserSettingRequestApplicationJson_Value {
+  /// Serializer for SettingsSetUserSettingRequestApplicationJson_Value.
   @BuiltValueSerializer(custom: true)
-  static Serializer<SettingsSetUserSettingValue> get serializer =>
+  static Serializer<SettingsSetUserSettingRequestApplicationJson_Value> get serializer =>
       $b2c4857c0136baea42828d89c87c757dExtension._serializer;
 
   /// Creates a new object from the given [json] data.
   ///
   /// Use `toJson` to serialize it back into json.
-  static SettingsSetUserSettingValue fromJson(Object? json) =>
+  static SettingsSetUserSettingRequestApplicationJson_Value fromJson(Object? json) =>
       $b2c4857c0136baea42828d89c87c757dExtension._fromJson(json);
 }
 
@@ -46299,8 +50237,12 @@ class _$bc4aac45771b11649d372f39a92b1cf3Serializer implements PrimitiveSerialize
 @_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
-      ..add(AvatarGetAvatarDarkTheme.serializer)
       ..add(AvatarGetAvatarApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(AvatarGetAvatarRequestApplicationJson),
+        AvatarGetAvatarRequestApplicationJsonBuilder.new,
+      )
+      ..add(AvatarGetAvatarRequestApplicationJson.serializer)
       ..add(AvatarUploadAvatarApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(AvatarUploadAvatarResponseApplicationJson),
@@ -46352,6 +50294,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(AvatarDeleteAvatarResponseApplicationJson_Ocs.serializer)
       ..add(AvatarEmojiAvatarApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(AvatarEmojiAvatarRequestApplicationJson),
+        AvatarEmojiAvatarRequestApplicationJsonBuilder.new,
+      )
+      ..add(AvatarEmojiAvatarRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(AvatarEmojiAvatarResponseApplicationJson),
         AvatarEmojiAvatarResponseApplicationJsonBuilder.new,
       )
@@ -46363,15 +50310,33 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(AvatarEmojiAvatarResponseApplicationJson_Ocs.serializer)
       ..add(AvatarGetAvatarDarkApiVersion.serializer)
       ..add(AvatarGetUserProxyAvatarWithoutRoomSize.serializer)
-      ..add(AvatarGetUserProxyAvatarWithoutRoomDarkTheme.serializer)
       ..add(AvatarGetUserProxyAvatarWithoutRoomApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson),
+        AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder.new,
+      )
+      ..add(AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson.serializer)
       ..add(AvatarGetUserProxyAvatarDarkWithoutRoomSize.serializer)
       ..add(AvatarGetUserProxyAvatarDarkWithoutRoomApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson),
+        AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder.new,
+      )
+      ..add(AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson.serializer)
       ..add(AvatarGetUserProxyAvatarSize.serializer)
-      ..add(AvatarGetUserProxyAvatarDarkTheme.serializer)
       ..add(AvatarGetUserProxyAvatarApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(AvatarGetUserProxyAvatarRequestApplicationJson),
+        AvatarGetUserProxyAvatarRequestApplicationJsonBuilder.new,
+      )
+      ..add(AvatarGetUserProxyAvatarRequestApplicationJson.serializer)
       ..add(AvatarGetUserProxyAvatarDarkSize.serializer)
       ..add(AvatarGetUserProxyAvatarDarkApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(AvatarGetUserProxyAvatarDarkRequestApplicationJson),
+        AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder.new,
+      )
+      ..add(AvatarGetUserProxyAvatarDarkRequestApplicationJson.serializer)
       ..add(BotListBotsApiVersion.serializer)
       ..addBuilderFactory(
         const FullType(BotListBotsResponseApplicationJson),
@@ -46408,8 +50373,12 @@ final Serializers _$serializers = (Serializers().toBuilder()
         BotDisableBotResponseApplicationJson_OcsBuilder.new,
       )
       ..add(BotDisableBotResponseApplicationJson_Ocs.serializer)
-      ..add(BotSendMessageSilent.serializer)
       ..add(BotSendMessageApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(BotSendMessageRequestApplicationJson),
+        BotSendMessageRequestApplicationJsonBuilder.new,
+      )
+      ..add(BotSendMessageRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(BotSendMessageResponseApplicationJson),
         BotSendMessageResponseApplicationJsonBuilder.new,
@@ -46421,6 +50390,8 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(BotSendMessageResponseApplicationJson_Ocs.serializer)
       ..add(BotReactApiVersion.serializer)
+      ..addBuilderFactory(const FullType(BotReactRequestApplicationJson), BotReactRequestApplicationJsonBuilder.new)
+      ..add(BotReactRequestApplicationJson.serializer)
       ..addBuilderFactory(const FullType(BotReactResponseApplicationJson), BotReactResponseApplicationJsonBuilder.new)
       ..add(BotReactResponseApplicationJson.serializer)
       ..addBuilderFactory(
@@ -46429,6 +50400,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(BotReactResponseApplicationJson_Ocs.serializer)
       ..add(BotDeleteReactionApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(BotDeleteReactionRequestApplicationJson),
+        BotDeleteReactionRequestApplicationJsonBuilder.new,
+      )
+      ..add(BotDeleteReactionRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(BotDeleteReactionResponseApplicationJson),
         BotDeleteReactionResponseApplicationJsonBuilder.new,
@@ -46439,8 +50415,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
         BotDeleteReactionResponseApplicationJson_OcsBuilder.new,
       )
       ..add(BotDeleteReactionResponseApplicationJson_Ocs.serializer)
-      ..add(BreakoutRoomConfigureBreakoutRoomsMode.serializer)
       ..add(BreakoutRoomConfigureBreakoutRoomsApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson),
+        BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder.new,
+      )
+      ..add(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson.serializer)
+      ..add(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode.serializer)
       ..addBuilderFactory(
         const FullType(BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson),
         BreakoutRoomConfigureBreakoutRoomsResponseApplicationJsonBuilder.new,
@@ -46465,6 +50446,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs.serializer)
       ..add(BreakoutRoomBroadcastChatMessageApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(BreakoutRoomBroadcastChatMessageRequestApplicationJson),
+        BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder.new,
+      )
+      ..add(BreakoutRoomBroadcastChatMessageRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(BreakoutRoomBroadcastChatMessageResponseApplicationJson),
         BreakoutRoomBroadcastChatMessageResponseApplicationJsonBuilder.new,
       )
@@ -46475,6 +50461,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs.serializer)
       ..add(BreakoutRoomApplyAttendeeMapApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(BreakoutRoomApplyAttendeeMapRequestApplicationJson),
+        BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder.new,
+      )
+      ..add(BreakoutRoomApplyAttendeeMapRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(BreakoutRoomApplyAttendeeMapResponseApplicationJson),
         BreakoutRoomApplyAttendeeMapResponseApplicationJsonBuilder.new,
@@ -46531,6 +50522,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs.serializer)
       ..add(BreakoutRoomSwitchBreakoutRoomApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(BreakoutRoomSwitchBreakoutRoomRequestApplicationJson),
+        BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder.new,
+      )
+      ..add(BreakoutRoomSwitchBreakoutRoomRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(BreakoutRoomSwitchBreakoutRoomResponseApplicationJson),
         BreakoutRoomSwitchBreakoutRoomResponseApplicationJsonBuilder.new,
       )
@@ -46556,6 +50552,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(BuiltList, [FullType(CallPeer)]), ListBuilder<CallPeer>.new)
       ..add(CallUpdateCallFlagsApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(CallUpdateCallFlagsRequestApplicationJson),
+        CallUpdateCallFlagsRequestApplicationJsonBuilder.new,
+      )
+      ..add(CallUpdateCallFlagsRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(CallUpdateCallFlagsResponseApplicationJson),
         CallUpdateCallFlagsResponseApplicationJsonBuilder.new,
       )
@@ -46565,9 +50566,12 @@ final Serializers _$serializers = (Serializers().toBuilder()
         CallUpdateCallFlagsResponseApplicationJson_OcsBuilder.new,
       )
       ..add(CallUpdateCallFlagsResponseApplicationJson_Ocs.serializer)
-      ..add(CallJoinCallSilent.serializer)
-      ..add(CallJoinCallRecordingConsent.serializer)
       ..add(CallJoinCallApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(CallJoinCallRequestApplicationJson),
+        CallJoinCallRequestApplicationJsonBuilder.new,
+      )
+      ..add(CallJoinCallRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(CallJoinCallResponseApplicationJson),
         CallJoinCallResponseApplicationJsonBuilder.new,
@@ -46578,8 +50582,12 @@ final Serializers _$serializers = (Serializers().toBuilder()
         CallJoinCallResponseApplicationJson_OcsBuilder.new,
       )
       ..add(CallJoinCallResponseApplicationJson_Ocs.serializer)
-      ..add(CallLeaveCallAll.serializer)
       ..add(CallLeaveCallApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(CallLeaveCallRequestApplicationJson),
+        CallLeaveCallRequestApplicationJsonBuilder.new,
+      )
+      ..add(CallLeaveCallRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(CallLeaveCallResponseApplicationJson),
         CallLeaveCallResponseApplicationJsonBuilder.new,
@@ -46617,12 +50625,17 @@ final Serializers _$serializers = (Serializers().toBuilder()
         CallSipDialOutResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(CallSipDialOutResponseApplicationJson_Ocs_Data.serializer)
-      ..add(ChatReceiveMessagesLookIntoFuture.serializer)
-      ..add(ChatReceiveMessagesSetReadMarker.serializer)
-      ..add(ChatReceiveMessagesIncludeLastKnown.serializer)
-      ..add(ChatReceiveMessagesNoStatusUpdate.serializer)
-      ..add(ChatReceiveMessagesMarkNotificationsAsRead.serializer)
       ..add(ChatReceiveMessagesApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(ChatReceiveMessagesRequestApplicationJson),
+        ChatReceiveMessagesRequestApplicationJsonBuilder.new,
+      )
+      ..add(ChatReceiveMessagesRequestApplicationJson.serializer)
+      ..add(ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.serializer)
+      ..add(ChatReceiveMessagesRequestApplicationJson_SetReadMarker.serializer)
+      ..add(ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown.serializer)
+      ..add(ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate.serializer)
+      ..add(ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead.serializer)
       ..addBuilderFactory(
         const FullType(ChatReceiveMessagesResponseApplicationJson),
         ChatReceiveMessagesResponseApplicationJsonBuilder.new,
@@ -46641,8 +50654,12 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..addBuilderFactory(const FullType(ChatChatReceiveMessagesHeaders), ChatChatReceiveMessagesHeadersBuilder.new)
       ..add(ChatChatReceiveMessagesHeaders.serializer)
-      ..add(ChatSendMessageSilent.serializer)
       ..add(ChatSendMessageApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(ChatSendMessageRequestApplicationJson),
+        ChatSendMessageRequestApplicationJsonBuilder.new,
+      )
+      ..add(ChatSendMessageRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ChatSendMessageResponseApplicationJson),
         ChatSendMessageResponseApplicationJsonBuilder.new,
@@ -46670,6 +50687,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ChatChatClearHistoryHeaders.serializer)
       ..add(ChatEditMessageApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(ChatEditMessageRequestApplicationJson),
+        ChatEditMessageRequestApplicationJsonBuilder.new,
+      )
+      ..add(ChatEditMessageRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(ChatEditMessageResponseApplicationJson),
         ChatEditMessageResponseApplicationJsonBuilder.new,
       )
@@ -46696,6 +50718,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ChatChatDeleteMessageHeaders.serializer)
       ..add(ChatGetMessageContextApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(ChatGetMessageContextRequestApplicationJson),
+        ChatGetMessageContextRequestApplicationJsonBuilder.new,
+      )
+      ..add(ChatGetMessageContextRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(ChatGetMessageContextResponseApplicationJson),
         ChatGetMessageContextResponseApplicationJsonBuilder.new,
       )
@@ -46721,6 +50748,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(ChatReminder), ChatReminderBuilder.new)
       ..add(ChatReminder.serializer)
       ..add(ChatSetReminderApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(ChatSetReminderRequestApplicationJson),
+        ChatSetReminderRequestApplicationJsonBuilder.new,
+      )
+      ..add(ChatSetReminderRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ChatSetReminderResponseApplicationJson),
         ChatSetReminderResponseApplicationJsonBuilder.new,
@@ -46749,6 +50781,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ChatDeleteReminderResponseApplicationJson_Ocs_Data.serializer)
       ..add(ChatSetReadMarkerApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(ChatSetReadMarkerRequestApplicationJson),
+        ChatSetReadMarkerRequestApplicationJsonBuilder.new,
+      )
+      ..add(ChatSetReadMarkerRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(ChatSetReadMarkerResponseApplicationJson),
         ChatSetReadMarkerResponseApplicationJsonBuilder.new,
       )
@@ -46773,8 +50810,12 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ChatMarkUnreadResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(const FullType(ChatChatMarkUnreadHeaders), ChatChatMarkUnreadHeadersBuilder.new)
       ..add(ChatChatMarkUnreadHeaders.serializer)
-      ..add(ChatMentionsIncludeStatus.serializer)
       ..add(ChatMentionsApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(ChatMentionsRequestApplicationJson),
+        ChatMentionsRequestApplicationJsonBuilder.new,
+      )
+      ..add(ChatMentionsRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ChatMentionsResponseApplicationJson),
         ChatMentionsResponseApplicationJsonBuilder.new,
@@ -46793,6 +50834,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(ChatGetObjectsSharedInRoomApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(ChatGetObjectsSharedInRoomRequestApplicationJson),
+        ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder.new,
+      )
+      ..add(ChatGetObjectsSharedInRoomRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(ChatGetObjectsSharedInRoomResponseApplicationJson),
         ChatGetObjectsSharedInRoomResponseApplicationJsonBuilder.new,
       )
@@ -46810,6 +50856,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ChatChatGetObjectsSharedInRoomHeaders.serializer)
       ..add(ChatShareObjectToChatApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(ChatShareObjectToChatRequestApplicationJson),
+        ChatShareObjectToChatRequestApplicationJsonBuilder.new,
+      )
+      ..add(ChatShareObjectToChatRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(ChatShareObjectToChatResponseApplicationJson),
         ChatShareObjectToChatResponseApplicationJsonBuilder.new,
       )
@@ -46822,6 +50873,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(const FullType(ChatChatShareObjectToChatHeaders), ChatChatShareObjectToChatHeadersBuilder.new)
       ..add(ChatChatShareObjectToChatHeaders.serializer)
       ..add(ChatGetObjectsSharedInRoomOverviewApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(ChatGetObjectsSharedInRoomOverviewRequestApplicationJson),
+        ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder.new,
+      )
+      ..add(ChatGetObjectsSharedInRoomOverviewRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ChatGetObjectsSharedInRoomOverviewResponseApplicationJson),
         ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonBuilder.new,
@@ -46840,6 +50896,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         MapBuilder<String, BuiltList<ChatMessage>>.new,
       )
       ..add(SignalingGetSettingsApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(SignalingGetSettingsRequestApplicationJson),
+        SignalingGetSettingsRequestApplicationJsonBuilder.new,
+      )
+      ..add(SignalingGetSettingsRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(SignalingGetSettingsResponseApplicationJson),
         SignalingGetSettingsResponseApplicationJsonBuilder.new,
@@ -46949,6 +51010,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs_Data.serializer)
       ..add(PublicShareAuthCreateRoomApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(PublicShareAuthCreateRoomRequestApplicationJson),
+        PublicShareAuthCreateRoomRequestApplicationJsonBuilder.new,
+      )
+      ..add(PublicShareAuthCreateRoomRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(PublicShareAuthCreateRoomResponseApplicationJson),
         PublicShareAuthCreateRoomResponseApplicationJsonBuilder.new,
       )
@@ -46965,6 +51031,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data.serializer)
       ..add(GuestSetDisplayNameApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(GuestSetDisplayNameRequestApplicationJson),
+        GuestSetDisplayNameRequestApplicationJsonBuilder.new,
+      )
+      ..add(GuestSetDisplayNameRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(GuestSetDisplayNameResponseApplicationJson),
         GuestSetDisplayNameResponseApplicationJsonBuilder.new,
       )
@@ -46975,6 +51046,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(GuestSetDisplayNameResponseApplicationJson_Ocs.serializer)
       ..add(HostedSignalingServerRequestTrialApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(HostedSignalingServerRequestTrialRequestApplicationJson),
+        HostedSignalingServerRequestTrialRequestApplicationJsonBuilder.new,
+      )
+      ..add(HostedSignalingServerRequestTrialRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(HostedSignalingServerRequestTrialResponseApplicationJson),
         HostedSignalingServerRequestTrialResponseApplicationJsonBuilder.new,
@@ -47016,6 +51092,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(SignalingSendMessagesApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(SignalingSendMessagesRequestApplicationJson),
+        SignalingSendMessagesRequestApplicationJsonBuilder.new,
+      )
+      ..add(SignalingSendMessagesRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(SignalingSendMessagesResponseApplicationJson),
         SignalingSendMessagesResponseApplicationJsonBuilder.new,
       )
@@ -47048,17 +51129,12 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..addBuilderFactory(const FullType(MatterbridgeProcessState), MatterbridgeProcessStateBuilder.new)
       ..add(MatterbridgeProcessState.serializer)
-      ..add(MatterbridgeEditBridgeOfRoomEnabled.serializer)
-      ..addBuilderFactory(
-        const FullType(ContentString, [
-          FullType(BuiltList, [
-            FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
-          ]),
-        ]),
-        ContentStringBuilder<BuiltList<BuiltMap<String, JsonObject>>>.new,
-      )
-      ..add(ContentString.serializer)
       ..add(MatterbridgeEditBridgeOfRoomApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(MatterbridgeEditBridgeOfRoomRequestApplicationJson),
+        MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder.new,
+      )
+      ..add(MatterbridgeEditBridgeOfRoomRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(MatterbridgeEditBridgeOfRoomResponseApplicationJson),
         MatterbridgeEditBridgeOfRoomResponseApplicationJsonBuilder.new,
@@ -47118,8 +51194,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
         MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs_Data.serializer)
-      ..add(PollCreatePollResultMode.serializer)
       ..add(PollCreatePollApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(PollCreatePollRequestApplicationJson),
+        PollCreatePollRequestApplicationJsonBuilder.new,
+      )
+      ..add(PollCreatePollRequestApplicationJson.serializer)
+      ..add(PollCreatePollRequestApplicationJson_ResultMode.serializer)
       ..addBuilderFactory(
         const FullType(PollCreatePollResponseApplicationJson),
         PollCreatePollResponseApplicationJsonBuilder.new,
@@ -47149,6 +51230,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(PollShowPollResponseApplicationJson_Ocs.serializer)
       ..add(PollVotePollApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(PollVotePollRequestApplicationJson),
+        PollVotePollRequestApplicationJsonBuilder.new,
+      )
+      ..add(PollVotePollRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(PollVotePollResponseApplicationJson),
         PollVotePollResponseApplicationJsonBuilder.new,
       )
@@ -47171,6 +51257,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(PollClosePollResponseApplicationJson_Ocs.serializer)
       ..add(ReactionGetReactionsApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(ReactionGetReactionsRequestApplicationJson),
+        ReactionGetReactionsRequestApplicationJsonBuilder.new,
+      )
+      ..add(ReactionGetReactionsRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(ReactionGetReactionsResponseApplicationJson),
         ReactionGetReactionsResponseApplicationJsonBuilder.new,
       )
@@ -47192,6 +51283,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(ReactionReactApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(ReactionReactRequestApplicationJson),
+        ReactionReactRequestApplicationJsonBuilder.new,
+      )
+      ..add(ReactionReactRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(ReactionReactResponseApplicationJson),
         ReactionReactResponseApplicationJsonBuilder.new,
       )
@@ -47203,6 +51299,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(ReactionReactResponseApplicationJson_Ocs.serializer)
       ..add(ReactionDeleteApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(ReactionDeleteRequestApplicationJson),
+        ReactionDeleteRequestApplicationJsonBuilder.new,
+      )
+      ..add(ReactionDeleteRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(ReactionDeleteResponseApplicationJson),
         ReactionDeleteResponseApplicationJsonBuilder.new,
       )
@@ -47213,6 +51314,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(ReactionDeleteResponseApplicationJson_Ocs.serializer)
       ..add(RecordingStartApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RecordingStartRequestApplicationJson),
+        RecordingStartRequestApplicationJsonBuilder.new,
+      )
+      ..add(RecordingStartRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(RecordingStartResponseApplicationJson),
         RecordingStartResponseApplicationJsonBuilder.new,
@@ -47236,6 +51342,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RecordingStopResponseApplicationJson_Ocs.serializer)
       ..add(RecordingNotificationDismissApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(RecordingNotificationDismissRequestApplicationJson),
+        RecordingNotificationDismissRequestApplicationJsonBuilder.new,
+      )
+      ..add(RecordingNotificationDismissRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(RecordingNotificationDismissResponseApplicationJson),
         RecordingNotificationDismissResponseApplicationJsonBuilder.new,
       )
@@ -47246,6 +51357,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(RecordingNotificationDismissResponseApplicationJson_Ocs.serializer)
       ..add(RecordingShareToChatApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RecordingShareToChatRequestApplicationJson),
+        RecordingShareToChatRequestApplicationJsonBuilder.new,
+      )
+      ..add(RecordingShareToChatRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(RecordingShareToChatResponseApplicationJson),
         RecordingShareToChatResponseApplicationJsonBuilder.new,
@@ -47269,6 +51385,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RecordingBackendResponseApplicationJson_Ocs.serializer)
       ..add(RecordingStoreApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(RecordingStoreRequestApplicationJson),
+        RecordingStoreRequestApplicationJsonBuilder.new,
+      )
+      ..add(RecordingStoreRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(RecordingStoreResponseApplicationJson),
         RecordingStoreResponseApplicationJsonBuilder.new,
       )
@@ -47278,9 +51399,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RecordingStoreResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RecordingStoreResponseApplicationJson_Ocs.serializer)
-      ..add(RoomGetRoomsNoStatusUpdate.serializer)
-      ..add(RoomGetRoomsIncludeStatus.serializer)
       ..add(RoomGetRoomsApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomGetRoomsRequestApplicationJson),
+        RoomGetRoomsRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomGetRoomsRequestApplicationJson.serializer)
+      ..add(RoomGetRoomsRequestApplicationJson_NoStatusUpdate.serializer)
       ..addBuilderFactory(
         const FullType(RoomGetRoomsResponseApplicationJson),
         RoomGetRoomsResponseApplicationJsonBuilder.new,
@@ -47295,6 +51420,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomRoomGetRoomsHeaders.serializer)
       ..add(RoomCreateRoomApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(RoomCreateRoomRequestApplicationJson),
+        RoomCreateRoomRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomCreateRoomRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(RoomCreateRoomResponseApplicationJson),
         RoomCreateRoomResponseApplicationJsonBuilder.new,
       )
@@ -47305,6 +51435,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(RoomCreateRoomResponseApplicationJson_Ocs.serializer)
       ..add(RoomGetListedRoomsApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomGetListedRoomsRequestApplicationJson),
+        RoomGetListedRoomsRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomGetListedRoomsRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(RoomGetListedRoomsResponseApplicationJson),
         RoomGetListedRoomsResponseApplicationJsonBuilder.new,
@@ -47379,6 +51514,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomMakePrivateResponseApplicationJson_Ocs.serializer)
       ..add(RoomSetDescriptionApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(RoomSetDescriptionRequestApplicationJson),
+        RoomSetDescriptionRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetDescriptionRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(RoomSetDescriptionResponseApplicationJson),
         RoomSetDescriptionResponseApplicationJsonBuilder.new,
       )
@@ -47388,8 +51528,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomSetDescriptionResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomSetDescriptionResponseApplicationJson_Ocs.serializer)
-      ..add(RoomSetReadOnlyState.serializer)
       ..add(RoomSetReadOnlyApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomSetReadOnlyRequestApplicationJson),
+        RoomSetReadOnlyRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetReadOnlyRequestApplicationJson.serializer)
+      ..add(RoomSetReadOnlyRequestApplicationJson_State.serializer)
       ..addBuilderFactory(
         const FullType(RoomSetReadOnlyResponseApplicationJson),
         RoomSetReadOnlyResponseApplicationJsonBuilder.new,
@@ -47400,8 +51545,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomSetReadOnlyResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomSetReadOnlyResponseApplicationJson_Ocs.serializer)
-      ..add(RoomSetListableScope.serializer)
       ..add(RoomSetListableApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomSetListableRequestApplicationJson),
+        RoomSetListableRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetListableRequestApplicationJson.serializer)
+      ..add(RoomSetListableRequestApplicationJson_Scope.serializer)
       ..addBuilderFactory(
         const FullType(RoomSetListableResponseApplicationJson),
         RoomSetListableResponseApplicationJsonBuilder.new,
@@ -47413,6 +51563,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(RoomSetListableResponseApplicationJson_Ocs.serializer)
       ..add(RoomSetPasswordApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomSetPasswordRequestApplicationJson),
+        RoomSetPasswordRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetPasswordRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(RoomSetPasswordResponseApplicationJson),
         RoomSetPasswordResponseApplicationJsonBuilder.new,
@@ -47426,6 +51581,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomSetPermissionsMode.serializer)
       ..add(RoomSetPermissionsApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(RoomSetPermissionsRequestApplicationJson),
+        RoomSetPermissionsRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetPermissionsRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(RoomSetPermissionsResponseApplicationJson),
         RoomSetPermissionsResponseApplicationJsonBuilder.new,
       )
@@ -47435,8 +51595,12 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomSetPermissionsResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomSetPermissionsResponseApplicationJson_Ocs.serializer)
-      ..add(RoomGetParticipantsIncludeStatus.serializer)
       ..add(RoomGetParticipantsApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomGetParticipantsRequestApplicationJson),
+        RoomGetParticipantsRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomGetParticipantsRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(RoomGetParticipantsResponseApplicationJson),
         RoomGetParticipantsResponseApplicationJsonBuilder.new,
@@ -47454,8 +51618,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomRoomGetParticipantsHeaders.serializer)
       ..addBuilderFactory(const FullType(Header, [FullType.nullable(bool)]), HeaderBuilder<bool?>.new)
       ..add(Header.serializer)
-      ..add(RoomAddParticipantToRoomSource.serializer)
       ..add(RoomAddParticipantToRoomApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomAddParticipantToRoomRequestApplicationJson),
+        RoomAddParticipantToRoomRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomAddParticipantToRoomRequestApplicationJson.serializer)
+      ..add(RoomAddParticipantToRoomRequestApplicationJson_Source.serializer)
       ..addBuilderFactory(
         const FullType(RoomAddParticipantToRoomResponseApplicationJson),
         RoomAddParticipantToRoomResponseApplicationJsonBuilder.new,
@@ -47472,8 +51641,12 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0.serializer)
       ..add($bd993fb3f40af33e8594d0d698208560Extension._serializer)
-      ..add(RoomGetBreakoutRoomParticipantsIncludeStatus.serializer)
       ..add(RoomGetBreakoutRoomParticipantsApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomGetBreakoutRoomParticipantsRequestApplicationJson),
+        RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomGetBreakoutRoomParticipantsRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(RoomGetBreakoutRoomParticipantsResponseApplicationJson),
         RoomGetBreakoutRoomParticipantsResponseApplicationJsonBuilder.new,
@@ -47502,6 +51675,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomRemoveSelfFromRoomResponseApplicationJson_Ocs.serializer)
       ..add(RoomRemoveAttendeeFromRoomApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(RoomRemoveAttendeeFromRoomRequestApplicationJson),
+        RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomRemoveAttendeeFromRoomRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(RoomRemoveAttendeeFromRoomResponseApplicationJson),
         RoomRemoveAttendeeFromRoomResponseApplicationJsonBuilder.new,
       )
@@ -47511,8 +51689,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs.serializer)
-      ..add(RoomSetAttendeePermissionsMethod.serializer)
       ..add(RoomSetAttendeePermissionsApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomSetAttendeePermissionsRequestApplicationJson),
+        RoomSetAttendeePermissionsRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetAttendeePermissionsRequestApplicationJson.serializer)
+      ..add(RoomSetAttendeePermissionsRequestApplicationJson_Method.serializer)
       ..addBuilderFactory(
         const FullType(RoomSetAttendeePermissionsResponseApplicationJson),
         RoomSetAttendeePermissionsResponseApplicationJsonBuilder.new,
@@ -47523,8 +51706,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomSetAttendeePermissionsResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomSetAttendeePermissionsResponseApplicationJson_Ocs.serializer)
-      ..add(RoomSetAllAttendeesPermissionsMethod.serializer)
       ..add(RoomSetAllAttendeesPermissionsApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomSetAllAttendeesPermissionsRequestApplicationJson),
+        RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetAllAttendeesPermissionsRequestApplicationJson.serializer)
+      ..add(RoomSetAllAttendeesPermissionsRequestApplicationJson_Method.serializer)
       ..addBuilderFactory(
         const FullType(RoomSetAllAttendeesPermissionsResponseApplicationJson),
         RoomSetAllAttendeesPermissionsResponseApplicationJsonBuilder.new,
@@ -47535,8 +51723,12 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs.serializer)
-      ..add(RoomJoinRoomForce.serializer)
       ..add(RoomJoinRoomApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomJoinRoomRequestApplicationJson),
+        RoomJoinRoomRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomJoinRoomRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(RoomJoinRoomResponseApplicationJson),
         RoomJoinRoomResponseApplicationJsonBuilder.new,
@@ -47562,6 +51754,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomLeaveRoomResponseApplicationJson_Ocs.serializer)
       ..add(RoomResendInvitationsApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(RoomResendInvitationsRequestApplicationJson),
+        RoomResendInvitationsRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomResendInvitationsRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(RoomResendInvitationsResponseApplicationJson),
         RoomResendInvitationsResponseApplicationJsonBuilder.new,
       )
@@ -47571,8 +51768,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomResendInvitationsResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomResendInvitationsResponseApplicationJson_Ocs.serializer)
-      ..add(RoomSetSessionStateState.serializer)
       ..add(RoomSetSessionStateApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomSetSessionStateRequestApplicationJson),
+        RoomSetSessionStateRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetSessionStateRequestApplicationJson.serializer)
+      ..add(RoomSetSessionStateRequestApplicationJson_State.serializer)
       ..addBuilderFactory(
         const FullType(RoomSetSessionStateResponseApplicationJson),
         RoomSetSessionStateResponseApplicationJsonBuilder.new,
@@ -47585,6 +51787,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomSetSessionStateResponseApplicationJson_Ocs.serializer)
       ..add(RoomPromoteModeratorApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(RoomPromoteModeratorRequestApplicationJson),
+        RoomPromoteModeratorRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomPromoteModeratorRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(RoomPromoteModeratorResponseApplicationJson),
         RoomPromoteModeratorResponseApplicationJsonBuilder.new,
       )
@@ -47595,6 +51802,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(RoomPromoteModeratorResponseApplicationJson_Ocs.serializer)
       ..add(RoomDemoteModeratorApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomDemoteModeratorRequestApplicationJson),
+        RoomDemoteModeratorRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomDemoteModeratorRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(RoomDemoteModeratorResponseApplicationJson),
         RoomDemoteModeratorResponseApplicationJsonBuilder.new,
@@ -47629,6 +51841,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomRemoveFromFavoritesResponseApplicationJson_Ocs.serializer)
       ..add(RoomSetNotificationLevelApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(RoomSetNotificationLevelRequestApplicationJson),
+        RoomSetNotificationLevelRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetNotificationLevelRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(RoomSetNotificationLevelResponseApplicationJson),
         RoomSetNotificationLevelResponseApplicationJsonBuilder.new,
       )
@@ -47639,6 +51856,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(RoomSetNotificationLevelResponseApplicationJson_Ocs.serializer)
       ..add(RoomSetNotificationCallsApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomSetNotificationCallsRequestApplicationJson),
+        RoomSetNotificationCallsRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetNotificationCallsRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(RoomSetNotificationCallsResponseApplicationJson),
         RoomSetNotificationCallsResponseApplicationJsonBuilder.new,
@@ -47651,6 +51873,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomSetNotificationCallsResponseApplicationJson_Ocs.serializer)
       ..add(RoomSetLobbyApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(RoomSetLobbyRequestApplicationJson),
+        RoomSetLobbyRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetLobbyRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(RoomSetLobbyResponseApplicationJson),
         RoomSetLobbyResponseApplicationJsonBuilder.new,
       )
@@ -47660,8 +51887,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomSetLobbyResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomSetLobbyResponseApplicationJson_Ocs.serializer)
-      ..add(RoomSetsipEnabledState.serializer)
       ..add(RoomSetsipEnabledApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomSetsipEnabledRequestApplicationJson),
+        RoomSetsipEnabledRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetsipEnabledRequestApplicationJson.serializer)
+      ..add(RoomSetsipEnabledRequestApplicationJson_State.serializer)
       ..addBuilderFactory(
         const FullType(RoomSetsipEnabledResponseApplicationJson),
         RoomSetsipEnabledResponseApplicationJsonBuilder.new,
@@ -47674,6 +51906,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomSetsipEnabledResponseApplicationJson_Ocs.serializer)
       ..add(RoomSetRecordingConsentApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(RoomSetRecordingConsentRequestApplicationJson),
+        RoomSetRecordingConsentRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetRecordingConsentRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(RoomSetRecordingConsentResponseApplicationJson),
         RoomSetRecordingConsentResponseApplicationJsonBuilder.new,
       )
@@ -47684,6 +51921,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(RoomSetRecordingConsentResponseApplicationJson_Ocs.serializer)
       ..add(RoomSetMessageExpirationApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomSetMessageExpirationRequestApplicationJson),
+        RoomSetMessageExpirationRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomSetMessageExpirationRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(RoomSetMessageExpirationResponseApplicationJson),
         RoomSetMessageExpirationResponseApplicationJsonBuilder.new,
@@ -47755,6 +51997,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(RoomVerifyDialInPinDeprecatedResponseApplicationJson_Ocs.serializer)
       ..add(RoomVerifyDialInPinApiVersion.serializer)
       ..addBuilderFactory(
+        const FullType(RoomVerifyDialInPinRequestApplicationJson),
+        RoomVerifyDialInPinRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomVerifyDialInPinRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(RoomVerifyDialInPinResponseApplicationJson),
         RoomVerifyDialInPinResponseApplicationJsonBuilder.new,
       )
@@ -47764,13 +52011,17 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomVerifyDialInPinResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomVerifyDialInPinResponseApplicationJson_Ocs.serializer)
-      ..addBuilderFactory(const FullType(RoomVerifyDialOutNumberOptions), RoomVerifyDialOutNumberOptionsBuilder.new)
-      ..add(RoomVerifyDialOutNumberOptions.serializer)
-      ..addBuilderFactory(
-        const FullType(ContentString, [FullType(RoomVerifyDialOutNumberOptions)]),
-        ContentStringBuilder<RoomVerifyDialOutNumberOptions>.new,
-      )
       ..add(RoomVerifyDialOutNumberApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomVerifyDialOutNumberRequestApplicationJson),
+        RoomVerifyDialOutNumberRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomVerifyDialOutNumberRequestApplicationJson.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomVerifyDialOutNumberRequestApplicationJson_Options),
+        RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder.new,
+      )
+      ..add(RoomVerifyDialOutNumberRequestApplicationJson_Options.serializer)
       ..addBuilderFactory(
         const FullType(RoomVerifyDialOutNumberResponseApplicationJson),
         RoomVerifyDialOutNumberResponseApplicationJsonBuilder.new,
@@ -47792,16 +52043,17 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomCreateGuestByDialInResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomCreateGuestByDialInResponseApplicationJson_Ocs.serializer)
-      ..addBuilderFactory(
-        const FullType(RoomRejectedDialOutRequestOptions),
-        RoomRejectedDialOutRequestOptionsBuilder.new,
-      )
-      ..add(RoomRejectedDialOutRequestOptions.serializer)
-      ..addBuilderFactory(
-        const FullType(ContentString, [FullType(RoomRejectedDialOutRequestOptions)]),
-        ContentStringBuilder<RoomRejectedDialOutRequestOptions>.new,
-      )
       ..add(RoomRejectedDialOutRequestApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomRejectedDialOutRequestRequestApplicationJson),
+        RoomRejectedDialOutRequestRequestApplicationJsonBuilder.new,
+      )
+      ..add(RoomRejectedDialOutRequestRequestApplicationJson.serializer)
+      ..addBuilderFactory(
+        const FullType(RoomRejectedDialOutRequestRequestApplicationJson_Options),
+        RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder.new,
+      )
+      ..add(RoomRejectedDialOutRequestRequestApplicationJson_Options.serializer)
       ..addBuilderFactory(
         const FullType(RoomRejectedDialOutRequestResponseApplicationJson),
         RoomRejectedDialOutRequestResponseApplicationJsonBuilder.new,
@@ -47812,8 +52064,13 @@ final Serializers _$serializers = (Serializers().toBuilder()
         RoomRejectedDialOutRequestResponseApplicationJson_OcsBuilder.new,
       )
       ..add(RoomRejectedDialOutRequestResponseApplicationJson_Ocs.serializer)
-      ..add(SettingsSetUserSettingKey.serializer)
       ..add(SettingsSetUserSettingApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(SettingsSetUserSettingRequestApplicationJson),
+        SettingsSetUserSettingRequestApplicationJsonBuilder.new,
+      )
+      ..add(SettingsSetUserSettingRequestApplicationJson.serializer)
+      ..add(SettingsSetUserSettingRequestApplicationJson_Key.serializer)
       ..addBuilderFactory(
         const FullType(SettingsSetUserSettingResponseApplicationJson),
         SettingsSetUserSettingResponseApplicationJsonBuilder.new,
@@ -47839,6 +52096,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(BotWithDetails.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(BotWithDetails)]), ListBuilder<BotWithDetails>.new)
       ..add(CertificateGetCertificateExpirationApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(CertificateGetCertificateExpirationRequestApplicationJson),
+        CertificateGetCertificateExpirationRequestApplicationJsonBuilder.new,
+      )
+      ..add(CertificateGetCertificateExpirationRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(CertificateGetCertificateExpirationResponseApplicationJson),
         CertificateGetCertificateExpirationResponseApplicationJsonBuilder.new,
@@ -47871,6 +52133,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(RecordingGetWelcomeMessageResponseApplicationJson_Ocs_Data.serializer)
       ..add(SettingsSetsipSettingsApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(SettingsSetsipSettingsRequestApplicationJson),
+        SettingsSetsipSettingsRequestApplicationJsonBuilder.new,
+      )
+      ..add(SettingsSetsipSettingsRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(SettingsSetsipSettingsResponseApplicationJson),
         SettingsSetsipSettingsResponseApplicationJsonBuilder.new,

--- a/packages/nextcloud/lib/src/api/spreed.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.g.dart
@@ -6,26 +6,6 @@ part of 'spreed.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-const AvatarGetAvatarDarkTheme _$avatarGetAvatarDarkTheme$0 = AvatarGetAvatarDarkTheme._('\$0');
-const AvatarGetAvatarDarkTheme _$avatarGetAvatarDarkTheme$1 = AvatarGetAvatarDarkTheme._('\$1');
-
-AvatarGetAvatarDarkTheme _$valueOfAvatarGetAvatarDarkTheme(String name) {
-  switch (name) {
-    case '\$0':
-      return _$avatarGetAvatarDarkTheme$0;
-    case '\$1':
-      return _$avatarGetAvatarDarkTheme$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<AvatarGetAvatarDarkTheme> _$avatarGetAvatarDarkThemeValues =
-    BuiltSet<AvatarGetAvatarDarkTheme>(const <AvatarGetAvatarDarkTheme>[
-  _$avatarGetAvatarDarkTheme$0,
-  _$avatarGetAvatarDarkTheme$1,
-]);
-
 const AvatarGetAvatarApiVersion _$avatarGetAvatarApiVersionV1 = AvatarGetAvatarApiVersion._('v1');
 
 AvatarGetAvatarApiVersion _$valueOfAvatarGetAvatarApiVersion(String name) {
@@ -328,28 +308,6 @@ final BuiltSet<AvatarGetUserProxyAvatarWithoutRoomSize> _$avatarGetUserProxyAvat
   _$avatarGetUserProxyAvatarWithoutRoomSize$512,
 ]);
 
-const AvatarGetUserProxyAvatarWithoutRoomDarkTheme _$avatarGetUserProxyAvatarWithoutRoomDarkTheme$0 =
-    AvatarGetUserProxyAvatarWithoutRoomDarkTheme._('\$0');
-const AvatarGetUserProxyAvatarWithoutRoomDarkTheme _$avatarGetUserProxyAvatarWithoutRoomDarkTheme$1 =
-    AvatarGetUserProxyAvatarWithoutRoomDarkTheme._('\$1');
-
-AvatarGetUserProxyAvatarWithoutRoomDarkTheme _$valueOfAvatarGetUserProxyAvatarWithoutRoomDarkTheme(String name) {
-  switch (name) {
-    case '\$0':
-      return _$avatarGetUserProxyAvatarWithoutRoomDarkTheme$0;
-    case '\$1':
-      return _$avatarGetUserProxyAvatarWithoutRoomDarkTheme$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<AvatarGetUserProxyAvatarWithoutRoomDarkTheme> _$avatarGetUserProxyAvatarWithoutRoomDarkThemeValues =
-    BuiltSet<AvatarGetUserProxyAvatarWithoutRoomDarkTheme>(const <AvatarGetUserProxyAvatarWithoutRoomDarkTheme>[
-  _$avatarGetUserProxyAvatarWithoutRoomDarkTheme$0,
-  _$avatarGetUserProxyAvatarWithoutRoomDarkTheme$1,
-]);
-
 const AvatarGetUserProxyAvatarWithoutRoomApiVersion _$avatarGetUserProxyAvatarWithoutRoomApiVersionV1 =
     AvatarGetUserProxyAvatarWithoutRoomApiVersion._('v1');
 
@@ -426,28 +384,6 @@ final BuiltSet<AvatarGetUserProxyAvatarSize> _$avatarGetUserProxyAvatarSizeValue
     BuiltSet<AvatarGetUserProxyAvatarSize>(const <AvatarGetUserProxyAvatarSize>[
   _$avatarGetUserProxyAvatarSize$64,
   _$avatarGetUserProxyAvatarSize$512,
-]);
-
-const AvatarGetUserProxyAvatarDarkTheme _$avatarGetUserProxyAvatarDarkTheme$0 =
-    AvatarGetUserProxyAvatarDarkTheme._('\$0');
-const AvatarGetUserProxyAvatarDarkTheme _$avatarGetUserProxyAvatarDarkTheme$1 =
-    AvatarGetUserProxyAvatarDarkTheme._('\$1');
-
-AvatarGetUserProxyAvatarDarkTheme _$valueOfAvatarGetUserProxyAvatarDarkTheme(String name) {
-  switch (name) {
-    case '\$0':
-      return _$avatarGetUserProxyAvatarDarkTheme$0;
-    case '\$1':
-      return _$avatarGetUserProxyAvatarDarkTheme$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<AvatarGetUserProxyAvatarDarkTheme> _$avatarGetUserProxyAvatarDarkThemeValues =
-    BuiltSet<AvatarGetUserProxyAvatarDarkTheme>(const <AvatarGetUserProxyAvatarDarkTheme>[
-  _$avatarGetUserProxyAvatarDarkTheme$0,
-  _$avatarGetUserProxyAvatarDarkTheme$1,
 ]);
 
 const AvatarGetUserProxyAvatarApiVersion _$avatarGetUserProxyAvatarApiVersionV1 =
@@ -554,26 +490,6 @@ final BuiltSet<BotDisableBotApiVersion> _$botDisableBotApiVersionValues =
   _$botDisableBotApiVersionV1,
 ]);
 
-const BotSendMessageSilent _$botSendMessageSilent$0 = BotSendMessageSilent._('\$0');
-const BotSendMessageSilent _$botSendMessageSilent$1 = BotSendMessageSilent._('\$1');
-
-BotSendMessageSilent _$valueOfBotSendMessageSilent(String name) {
-  switch (name) {
-    case '\$0':
-      return _$botSendMessageSilent$0;
-    case '\$1':
-      return _$botSendMessageSilent$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<BotSendMessageSilent> _$botSendMessageSilentValues =
-    BuiltSet<BotSendMessageSilent>(const <BotSendMessageSilent>[
-  _$botSendMessageSilent$0,
-  _$botSendMessageSilent$1,
-]);
-
 const BotSendMessageApiVersion _$botSendMessageApiVersionV1 = BotSendMessageApiVersion._('v1');
 
 BotSendMessageApiVersion _$valueOfBotSendMessageApiVersion(String name) {
@@ -621,38 +537,6 @@ final BuiltSet<BotDeleteReactionApiVersion> _$botDeleteReactionApiVersionValues 
   _$botDeleteReactionApiVersionV1,
 ]);
 
-const BreakoutRoomConfigureBreakoutRoomsMode _$breakoutRoomConfigureBreakoutRoomsMode$0 =
-    BreakoutRoomConfigureBreakoutRoomsMode._('\$0');
-const BreakoutRoomConfigureBreakoutRoomsMode _$breakoutRoomConfigureBreakoutRoomsMode$1 =
-    BreakoutRoomConfigureBreakoutRoomsMode._('\$1');
-const BreakoutRoomConfigureBreakoutRoomsMode _$breakoutRoomConfigureBreakoutRoomsMode$2 =
-    BreakoutRoomConfigureBreakoutRoomsMode._('\$2');
-const BreakoutRoomConfigureBreakoutRoomsMode _$breakoutRoomConfigureBreakoutRoomsMode$3 =
-    BreakoutRoomConfigureBreakoutRoomsMode._('\$3');
-
-BreakoutRoomConfigureBreakoutRoomsMode _$valueOfBreakoutRoomConfigureBreakoutRoomsMode(String name) {
-  switch (name) {
-    case '\$0':
-      return _$breakoutRoomConfigureBreakoutRoomsMode$0;
-    case '\$1':
-      return _$breakoutRoomConfigureBreakoutRoomsMode$1;
-    case '\$2':
-      return _$breakoutRoomConfigureBreakoutRoomsMode$2;
-    case '\$3':
-      return _$breakoutRoomConfigureBreakoutRoomsMode$3;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<BreakoutRoomConfigureBreakoutRoomsMode> _$breakoutRoomConfigureBreakoutRoomsModeValues =
-    BuiltSet<BreakoutRoomConfigureBreakoutRoomsMode>(const <BreakoutRoomConfigureBreakoutRoomsMode>[
-  _$breakoutRoomConfigureBreakoutRoomsMode$0,
-  _$breakoutRoomConfigureBreakoutRoomsMode$1,
-  _$breakoutRoomConfigureBreakoutRoomsMode$2,
-  _$breakoutRoomConfigureBreakoutRoomsMode$3,
-]);
-
 const BreakoutRoomConfigureBreakoutRoomsApiVersion _$breakoutRoomConfigureBreakoutRoomsApiVersionV1 =
     BreakoutRoomConfigureBreakoutRoomsApiVersion._('v1');
 
@@ -668,6 +552,44 @@ BreakoutRoomConfigureBreakoutRoomsApiVersion _$valueOfBreakoutRoomConfigureBreak
 final BuiltSet<BreakoutRoomConfigureBreakoutRoomsApiVersion> _$breakoutRoomConfigureBreakoutRoomsApiVersionValues =
     BuiltSet<BreakoutRoomConfigureBreakoutRoomsApiVersion>(const <BreakoutRoomConfigureBreakoutRoomsApiVersion>[
   _$breakoutRoomConfigureBreakoutRoomsApiVersionV1,
+]);
+
+const BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode
+    _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$0 =
+    BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode._('\$0');
+const BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode
+    _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$1 =
+    BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode._('\$1');
+const BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode
+    _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$2 =
+    BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode._('\$2');
+const BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode
+    _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$3 =
+    BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode._('\$3');
+
+BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode
+    _$valueOfBreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode(String name) {
+  switch (name) {
+    case '\$0':
+      return _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$0;
+    case '\$1':
+      return _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$1;
+    case '\$2':
+      return _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$2;
+    case '\$3':
+      return _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$3;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode>
+    _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonModeValues = BuiltSet<
+        BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode>(const <BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode>[
+  _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$0,
+  _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$1,
+  _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$2,
+  _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonMode$3,
 ]);
 
 const BreakoutRoomRemoveBreakoutRoomsApiVersion _$breakoutRoomRemoveBreakoutRoomsApiVersionV1 =
@@ -839,45 +761,6 @@ final BuiltSet<CallUpdateCallFlagsApiVersion> _$callUpdateCallFlagsApiVersionVal
   _$callUpdateCallFlagsApiVersionV4,
 ]);
 
-const CallJoinCallSilent _$callJoinCallSilent$0 = CallJoinCallSilent._('\$0');
-const CallJoinCallSilent _$callJoinCallSilent$1 = CallJoinCallSilent._('\$1');
-
-CallJoinCallSilent _$valueOfCallJoinCallSilent(String name) {
-  switch (name) {
-    case '\$0':
-      return _$callJoinCallSilent$0;
-    case '\$1':
-      return _$callJoinCallSilent$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<CallJoinCallSilent> _$callJoinCallSilentValues = BuiltSet<CallJoinCallSilent>(const <CallJoinCallSilent>[
-  _$callJoinCallSilent$0,
-  _$callJoinCallSilent$1,
-]);
-
-const CallJoinCallRecordingConsent _$callJoinCallRecordingConsent$0 = CallJoinCallRecordingConsent._('\$0');
-const CallJoinCallRecordingConsent _$callJoinCallRecordingConsent$1 = CallJoinCallRecordingConsent._('\$1');
-
-CallJoinCallRecordingConsent _$valueOfCallJoinCallRecordingConsent(String name) {
-  switch (name) {
-    case '\$0':
-      return _$callJoinCallRecordingConsent$0;
-    case '\$1':
-      return _$callJoinCallRecordingConsent$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<CallJoinCallRecordingConsent> _$callJoinCallRecordingConsentValues =
-    BuiltSet<CallJoinCallRecordingConsent>(const <CallJoinCallRecordingConsent>[
-  _$callJoinCallRecordingConsent$0,
-  _$callJoinCallRecordingConsent$1,
-]);
-
 const CallJoinCallApiVersion _$callJoinCallApiVersionV4 = CallJoinCallApiVersion._('v4');
 
 CallJoinCallApiVersion _$valueOfCallJoinCallApiVersion(String name) {
@@ -892,25 +775,6 @@ CallJoinCallApiVersion _$valueOfCallJoinCallApiVersion(String name) {
 final BuiltSet<CallJoinCallApiVersion> _$callJoinCallApiVersionValues =
     BuiltSet<CallJoinCallApiVersion>(const <CallJoinCallApiVersion>[
   _$callJoinCallApiVersionV4,
-]);
-
-const CallLeaveCallAll _$callLeaveCallAll$0 = CallLeaveCallAll._('\$0');
-const CallLeaveCallAll _$callLeaveCallAll$1 = CallLeaveCallAll._('\$1');
-
-CallLeaveCallAll _$valueOfCallLeaveCallAll(String name) {
-  switch (name) {
-    case '\$0':
-      return _$callLeaveCallAll$0;
-    case '\$1':
-      return _$callLeaveCallAll$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<CallLeaveCallAll> _$callLeaveCallAllValues = BuiltSet<CallLeaveCallAll>(const <CallLeaveCallAll>[
-  _$callLeaveCallAll$0,
-  _$callLeaveCallAll$1,
 ]);
 
 const CallLeaveCallApiVersion _$callLeaveCallApiVersionV4 = CallLeaveCallApiVersion._('v4');
@@ -961,114 +825,6 @@ final BuiltSet<CallSipDialOutApiVersion> _$callSipDialOutApiVersionValues =
   _$callSipDialOutApiVersionV4,
 ]);
 
-const ChatReceiveMessagesLookIntoFuture _$chatReceiveMessagesLookIntoFuture$0 =
-    ChatReceiveMessagesLookIntoFuture._('\$0');
-const ChatReceiveMessagesLookIntoFuture _$chatReceiveMessagesLookIntoFuture$1 =
-    ChatReceiveMessagesLookIntoFuture._('\$1');
-
-ChatReceiveMessagesLookIntoFuture _$valueOfChatReceiveMessagesLookIntoFuture(String name) {
-  switch (name) {
-    case '\$0':
-      return _$chatReceiveMessagesLookIntoFuture$0;
-    case '\$1':
-      return _$chatReceiveMessagesLookIntoFuture$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ChatReceiveMessagesLookIntoFuture> _$chatReceiveMessagesLookIntoFutureValues =
-    BuiltSet<ChatReceiveMessagesLookIntoFuture>(const <ChatReceiveMessagesLookIntoFuture>[
-  _$chatReceiveMessagesLookIntoFuture$0,
-  _$chatReceiveMessagesLookIntoFuture$1,
-]);
-
-const ChatReceiveMessagesSetReadMarker _$chatReceiveMessagesSetReadMarker$0 = ChatReceiveMessagesSetReadMarker._('\$0');
-const ChatReceiveMessagesSetReadMarker _$chatReceiveMessagesSetReadMarker$1 = ChatReceiveMessagesSetReadMarker._('\$1');
-
-ChatReceiveMessagesSetReadMarker _$valueOfChatReceiveMessagesSetReadMarker(String name) {
-  switch (name) {
-    case '\$0':
-      return _$chatReceiveMessagesSetReadMarker$0;
-    case '\$1':
-      return _$chatReceiveMessagesSetReadMarker$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ChatReceiveMessagesSetReadMarker> _$chatReceiveMessagesSetReadMarkerValues =
-    BuiltSet<ChatReceiveMessagesSetReadMarker>(const <ChatReceiveMessagesSetReadMarker>[
-  _$chatReceiveMessagesSetReadMarker$0,
-  _$chatReceiveMessagesSetReadMarker$1,
-]);
-
-const ChatReceiveMessagesIncludeLastKnown _$chatReceiveMessagesIncludeLastKnown$0 =
-    ChatReceiveMessagesIncludeLastKnown._('\$0');
-const ChatReceiveMessagesIncludeLastKnown _$chatReceiveMessagesIncludeLastKnown$1 =
-    ChatReceiveMessagesIncludeLastKnown._('\$1');
-
-ChatReceiveMessagesIncludeLastKnown _$valueOfChatReceiveMessagesIncludeLastKnown(String name) {
-  switch (name) {
-    case '\$0':
-      return _$chatReceiveMessagesIncludeLastKnown$0;
-    case '\$1':
-      return _$chatReceiveMessagesIncludeLastKnown$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ChatReceiveMessagesIncludeLastKnown> _$chatReceiveMessagesIncludeLastKnownValues =
-    BuiltSet<ChatReceiveMessagesIncludeLastKnown>(const <ChatReceiveMessagesIncludeLastKnown>[
-  _$chatReceiveMessagesIncludeLastKnown$0,
-  _$chatReceiveMessagesIncludeLastKnown$1,
-]);
-
-const ChatReceiveMessagesNoStatusUpdate _$chatReceiveMessagesNoStatusUpdate$0 =
-    ChatReceiveMessagesNoStatusUpdate._('\$0');
-const ChatReceiveMessagesNoStatusUpdate _$chatReceiveMessagesNoStatusUpdate$1 =
-    ChatReceiveMessagesNoStatusUpdate._('\$1');
-
-ChatReceiveMessagesNoStatusUpdate _$valueOfChatReceiveMessagesNoStatusUpdate(String name) {
-  switch (name) {
-    case '\$0':
-      return _$chatReceiveMessagesNoStatusUpdate$0;
-    case '\$1':
-      return _$chatReceiveMessagesNoStatusUpdate$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ChatReceiveMessagesNoStatusUpdate> _$chatReceiveMessagesNoStatusUpdateValues =
-    BuiltSet<ChatReceiveMessagesNoStatusUpdate>(const <ChatReceiveMessagesNoStatusUpdate>[
-  _$chatReceiveMessagesNoStatusUpdate$0,
-  _$chatReceiveMessagesNoStatusUpdate$1,
-]);
-
-const ChatReceiveMessagesMarkNotificationsAsRead _$chatReceiveMessagesMarkNotificationsAsRead$0 =
-    ChatReceiveMessagesMarkNotificationsAsRead._('\$0');
-const ChatReceiveMessagesMarkNotificationsAsRead _$chatReceiveMessagesMarkNotificationsAsRead$1 =
-    ChatReceiveMessagesMarkNotificationsAsRead._('\$1');
-
-ChatReceiveMessagesMarkNotificationsAsRead _$valueOfChatReceiveMessagesMarkNotificationsAsRead(String name) {
-  switch (name) {
-    case '\$0':
-      return _$chatReceiveMessagesMarkNotificationsAsRead$0;
-    case '\$1':
-      return _$chatReceiveMessagesMarkNotificationsAsRead$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ChatReceiveMessagesMarkNotificationsAsRead> _$chatReceiveMessagesMarkNotificationsAsReadValues =
-    BuiltSet<ChatReceiveMessagesMarkNotificationsAsRead>(const <ChatReceiveMessagesMarkNotificationsAsRead>[
-  _$chatReceiveMessagesMarkNotificationsAsRead$0,
-  _$chatReceiveMessagesMarkNotificationsAsRead$1,
-]);
-
 const ChatReceiveMessagesApiVersion _$chatReceiveMessagesApiVersionV1 = ChatReceiveMessagesApiVersion._('v1');
 
 ChatReceiveMessagesApiVersion _$valueOfChatReceiveMessagesApiVersion(String name) {
@@ -1085,24 +841,134 @@ final BuiltSet<ChatReceiveMessagesApiVersion> _$chatReceiveMessagesApiVersionVal
   _$chatReceiveMessagesApiVersionV1,
 ]);
 
-const ChatSendMessageSilent _$chatSendMessageSilent$0 = ChatSendMessageSilent._('\$0');
-const ChatSendMessageSilent _$chatSendMessageSilent$1 = ChatSendMessageSilent._('\$1');
+const ChatReceiveMessagesRequestApplicationJson_LookIntoFuture
+    _$chatReceiveMessagesRequestApplicationJsonLookIntoFuture$0 =
+    ChatReceiveMessagesRequestApplicationJson_LookIntoFuture._('\$0');
+const ChatReceiveMessagesRequestApplicationJson_LookIntoFuture
+    _$chatReceiveMessagesRequestApplicationJsonLookIntoFuture$1 =
+    ChatReceiveMessagesRequestApplicationJson_LookIntoFuture._('\$1');
 
-ChatSendMessageSilent _$valueOfChatSendMessageSilent(String name) {
+ChatReceiveMessagesRequestApplicationJson_LookIntoFuture
+    _$valueOfChatReceiveMessagesRequestApplicationJson_LookIntoFuture(String name) {
   switch (name) {
     case '\$0':
-      return _$chatSendMessageSilent$0;
+      return _$chatReceiveMessagesRequestApplicationJsonLookIntoFuture$0;
     case '\$1':
-      return _$chatSendMessageSilent$1;
+      return _$chatReceiveMessagesRequestApplicationJsonLookIntoFuture$1;
     default:
       throw ArgumentError(name);
   }
 }
 
-final BuiltSet<ChatSendMessageSilent> _$chatSendMessageSilentValues =
-    BuiltSet<ChatSendMessageSilent>(const <ChatSendMessageSilent>[
-  _$chatSendMessageSilent$0,
-  _$chatSendMessageSilent$1,
+final BuiltSet<ChatReceiveMessagesRequestApplicationJson_LookIntoFuture>
+    _$chatReceiveMessagesRequestApplicationJsonLookIntoFutureValues = BuiltSet<
+        ChatReceiveMessagesRequestApplicationJson_LookIntoFuture>(const <ChatReceiveMessagesRequestApplicationJson_LookIntoFuture>[
+  _$chatReceiveMessagesRequestApplicationJsonLookIntoFuture$0,
+  _$chatReceiveMessagesRequestApplicationJsonLookIntoFuture$1,
+]);
+
+const ChatReceiveMessagesRequestApplicationJson_SetReadMarker
+    _$chatReceiveMessagesRequestApplicationJsonSetReadMarker$0 =
+    ChatReceiveMessagesRequestApplicationJson_SetReadMarker._('\$0');
+const ChatReceiveMessagesRequestApplicationJson_SetReadMarker
+    _$chatReceiveMessagesRequestApplicationJsonSetReadMarker$1 =
+    ChatReceiveMessagesRequestApplicationJson_SetReadMarker._('\$1');
+
+ChatReceiveMessagesRequestApplicationJson_SetReadMarker
+    _$valueOfChatReceiveMessagesRequestApplicationJson_SetReadMarker(String name) {
+  switch (name) {
+    case '\$0':
+      return _$chatReceiveMessagesRequestApplicationJsonSetReadMarker$0;
+    case '\$1':
+      return _$chatReceiveMessagesRequestApplicationJsonSetReadMarker$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ChatReceiveMessagesRequestApplicationJson_SetReadMarker>
+    _$chatReceiveMessagesRequestApplicationJsonSetReadMarkerValues = BuiltSet<
+        ChatReceiveMessagesRequestApplicationJson_SetReadMarker>(const <ChatReceiveMessagesRequestApplicationJson_SetReadMarker>[
+  _$chatReceiveMessagesRequestApplicationJsonSetReadMarker$0,
+  _$chatReceiveMessagesRequestApplicationJsonSetReadMarker$1,
+]);
+
+const ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown
+    _$chatReceiveMessagesRequestApplicationJsonIncludeLastKnown$0 =
+    ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown._('\$0');
+const ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown
+    _$chatReceiveMessagesRequestApplicationJsonIncludeLastKnown$1 =
+    ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown._('\$1');
+
+ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown
+    _$valueOfChatReceiveMessagesRequestApplicationJson_IncludeLastKnown(String name) {
+  switch (name) {
+    case '\$0':
+      return _$chatReceiveMessagesRequestApplicationJsonIncludeLastKnown$0;
+    case '\$1':
+      return _$chatReceiveMessagesRequestApplicationJsonIncludeLastKnown$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown>
+    _$chatReceiveMessagesRequestApplicationJsonIncludeLastKnownValues = BuiltSet<
+        ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown>(const <ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown>[
+  _$chatReceiveMessagesRequestApplicationJsonIncludeLastKnown$0,
+  _$chatReceiveMessagesRequestApplicationJsonIncludeLastKnown$1,
+]);
+
+const ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate
+    _$chatReceiveMessagesRequestApplicationJsonNoStatusUpdate$0 =
+    ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate._('\$0');
+const ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate
+    _$chatReceiveMessagesRequestApplicationJsonNoStatusUpdate$1 =
+    ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate._('\$1');
+
+ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate
+    _$valueOfChatReceiveMessagesRequestApplicationJson_NoStatusUpdate(String name) {
+  switch (name) {
+    case '\$0':
+      return _$chatReceiveMessagesRequestApplicationJsonNoStatusUpdate$0;
+    case '\$1':
+      return _$chatReceiveMessagesRequestApplicationJsonNoStatusUpdate$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate>
+    _$chatReceiveMessagesRequestApplicationJsonNoStatusUpdateValues = BuiltSet<
+        ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate>(const <ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate>[
+  _$chatReceiveMessagesRequestApplicationJsonNoStatusUpdate$0,
+  _$chatReceiveMessagesRequestApplicationJsonNoStatusUpdate$1,
+]);
+
+const ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead
+    _$chatReceiveMessagesRequestApplicationJsonMarkNotificationsAsRead$0 =
+    ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead._('\$0');
+const ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead
+    _$chatReceiveMessagesRequestApplicationJsonMarkNotificationsAsRead$1 =
+    ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead._('\$1');
+
+ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead
+    _$valueOfChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead(String name) {
+  switch (name) {
+    case '\$0':
+      return _$chatReceiveMessagesRequestApplicationJsonMarkNotificationsAsRead$0;
+    case '\$1':
+      return _$chatReceiveMessagesRequestApplicationJsonMarkNotificationsAsRead$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead>
+    _$chatReceiveMessagesRequestApplicationJsonMarkNotificationsAsReadValues = BuiltSet<
+        ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead>(const <ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead>[
+  _$chatReceiveMessagesRequestApplicationJsonMarkNotificationsAsRead$0,
+  _$chatReceiveMessagesRequestApplicationJsonMarkNotificationsAsRead$1,
 ]);
 
 const ChatSendMessageApiVersion _$chatSendMessageApiVersionV1 = ChatSendMessageApiVersion._('v1');
@@ -1263,26 +1129,6 @@ ChatMarkUnreadApiVersion _$valueOfChatMarkUnreadApiVersion(String name) {
 final BuiltSet<ChatMarkUnreadApiVersion> _$chatMarkUnreadApiVersionValues =
     BuiltSet<ChatMarkUnreadApiVersion>(const <ChatMarkUnreadApiVersion>[
   _$chatMarkUnreadApiVersionV1,
-]);
-
-const ChatMentionsIncludeStatus _$chatMentionsIncludeStatus$0 = ChatMentionsIncludeStatus._('\$0');
-const ChatMentionsIncludeStatus _$chatMentionsIncludeStatus$1 = ChatMentionsIncludeStatus._('\$1');
-
-ChatMentionsIncludeStatus _$valueOfChatMentionsIncludeStatus(String name) {
-  switch (name) {
-    case '\$0':
-      return _$chatMentionsIncludeStatus$0;
-    case '\$1':
-      return _$chatMentionsIncludeStatus$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ChatMentionsIncludeStatus> _$chatMentionsIncludeStatusValues =
-    BuiltSet<ChatMentionsIncludeStatus>(const <ChatMentionsIncludeStatus>[
-  _$chatMentionsIncludeStatus$0,
-  _$chatMentionsIncludeStatus$1,
 ]);
 
 const ChatMentionsApiVersion _$chatMentionsApiVersionV1 = ChatMentionsApiVersion._('v1');
@@ -1565,28 +1411,6 @@ final BuiltSet<MatterbridgeGetBridgeOfRoomApiVersion> _$matterbridgeGetBridgeOfR
   _$matterbridgeGetBridgeOfRoomApiVersionV1,
 ]);
 
-const MatterbridgeEditBridgeOfRoomEnabled _$matterbridgeEditBridgeOfRoomEnabled$0 =
-    MatterbridgeEditBridgeOfRoomEnabled._('\$0');
-const MatterbridgeEditBridgeOfRoomEnabled _$matterbridgeEditBridgeOfRoomEnabled$1 =
-    MatterbridgeEditBridgeOfRoomEnabled._('\$1');
-
-MatterbridgeEditBridgeOfRoomEnabled _$valueOfMatterbridgeEditBridgeOfRoomEnabled(String name) {
-  switch (name) {
-    case '\$0':
-      return _$matterbridgeEditBridgeOfRoomEnabled$0;
-    case '\$1':
-      return _$matterbridgeEditBridgeOfRoomEnabled$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<MatterbridgeEditBridgeOfRoomEnabled> _$matterbridgeEditBridgeOfRoomEnabledValues =
-    BuiltSet<MatterbridgeEditBridgeOfRoomEnabled>(const <MatterbridgeEditBridgeOfRoomEnabled>[
-  _$matterbridgeEditBridgeOfRoomEnabled$0,
-  _$matterbridgeEditBridgeOfRoomEnabled$1,
-]);
-
 const MatterbridgeEditBridgeOfRoomApiVersion _$matterbridgeEditBridgeOfRoomApiVersionV1 =
     MatterbridgeEditBridgeOfRoomApiVersion._('v1');
 
@@ -1674,26 +1498,6 @@ final BuiltSet<MatterbridgeSettingsGetMatterbridgeVersionApiVersion>
   _$matterbridgeSettingsGetMatterbridgeVersionApiVersionV1,
 ]);
 
-const PollCreatePollResultMode _$pollCreatePollResultMode$0 = PollCreatePollResultMode._('\$0');
-const PollCreatePollResultMode _$pollCreatePollResultMode$1 = PollCreatePollResultMode._('\$1');
-
-PollCreatePollResultMode _$valueOfPollCreatePollResultMode(String name) {
-  switch (name) {
-    case '\$0':
-      return _$pollCreatePollResultMode$0;
-    case '\$1':
-      return _$pollCreatePollResultMode$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<PollCreatePollResultMode> _$pollCreatePollResultModeValues =
-    BuiltSet<PollCreatePollResultMode>(const <PollCreatePollResultMode>[
-  _$pollCreatePollResultMode$0,
-  _$pollCreatePollResultMode$1,
-]);
-
 const PollCreatePollApiVersion _$pollCreatePollApiVersionV1 = PollCreatePollApiVersion._('v1');
 
 PollCreatePollApiVersion _$valueOfPollCreatePollApiVersion(String name) {
@@ -1708,6 +1512,28 @@ PollCreatePollApiVersion _$valueOfPollCreatePollApiVersion(String name) {
 final BuiltSet<PollCreatePollApiVersion> _$pollCreatePollApiVersionValues =
     BuiltSet<PollCreatePollApiVersion>(const <PollCreatePollApiVersion>[
   _$pollCreatePollApiVersionV1,
+]);
+
+const PollCreatePollRequestApplicationJson_ResultMode _$pollCreatePollRequestApplicationJsonResultMode$0 =
+    PollCreatePollRequestApplicationJson_ResultMode._('\$0');
+const PollCreatePollRequestApplicationJson_ResultMode _$pollCreatePollRequestApplicationJsonResultMode$1 =
+    PollCreatePollRequestApplicationJson_ResultMode._('\$1');
+
+PollCreatePollRequestApplicationJson_ResultMode _$valueOfPollCreatePollRequestApplicationJson_ResultMode(String name) {
+  switch (name) {
+    case '\$0':
+      return _$pollCreatePollRequestApplicationJsonResultMode$0;
+    case '\$1':
+      return _$pollCreatePollRequestApplicationJsonResultMode$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<PollCreatePollRequestApplicationJson_ResultMode> _$pollCreatePollRequestApplicationJsonResultModeValues =
+    BuiltSet<PollCreatePollRequestApplicationJson_ResultMode>(const <PollCreatePollRequestApplicationJson_ResultMode>[
+  _$pollCreatePollRequestApplicationJsonResultMode$0,
+  _$pollCreatePollRequestApplicationJsonResultMode$1,
 ]);
 
 const PollShowPollApiVersion _$pollShowPollApiVersionV1 = PollShowPollApiVersion._('v1');
@@ -1903,46 +1729,6 @@ final BuiltSet<RecordingStoreApiVersion> _$recordingStoreApiVersionValues =
   _$recordingStoreApiVersionV1,
 ]);
 
-const RoomGetRoomsNoStatusUpdate _$roomGetRoomsNoStatusUpdate$0 = RoomGetRoomsNoStatusUpdate._('\$0');
-const RoomGetRoomsNoStatusUpdate _$roomGetRoomsNoStatusUpdate$1 = RoomGetRoomsNoStatusUpdate._('\$1');
-
-RoomGetRoomsNoStatusUpdate _$valueOfRoomGetRoomsNoStatusUpdate(String name) {
-  switch (name) {
-    case '\$0':
-      return _$roomGetRoomsNoStatusUpdate$0;
-    case '\$1':
-      return _$roomGetRoomsNoStatusUpdate$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<RoomGetRoomsNoStatusUpdate> _$roomGetRoomsNoStatusUpdateValues =
-    BuiltSet<RoomGetRoomsNoStatusUpdate>(const <RoomGetRoomsNoStatusUpdate>[
-  _$roomGetRoomsNoStatusUpdate$0,
-  _$roomGetRoomsNoStatusUpdate$1,
-]);
-
-const RoomGetRoomsIncludeStatus _$roomGetRoomsIncludeStatus$0 = RoomGetRoomsIncludeStatus._('\$0');
-const RoomGetRoomsIncludeStatus _$roomGetRoomsIncludeStatus$1 = RoomGetRoomsIncludeStatus._('\$1');
-
-RoomGetRoomsIncludeStatus _$valueOfRoomGetRoomsIncludeStatus(String name) {
-  switch (name) {
-    case '\$0':
-      return _$roomGetRoomsIncludeStatus$0;
-    case '\$1':
-      return _$roomGetRoomsIncludeStatus$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<RoomGetRoomsIncludeStatus> _$roomGetRoomsIncludeStatusValues =
-    BuiltSet<RoomGetRoomsIncludeStatus>(const <RoomGetRoomsIncludeStatus>[
-  _$roomGetRoomsIncludeStatus$0,
-  _$roomGetRoomsIncludeStatus$1,
-]);
-
 const RoomGetRoomsApiVersion _$roomGetRoomsApiVersionV4 = RoomGetRoomsApiVersion._('v4');
 
 RoomGetRoomsApiVersion _$valueOfRoomGetRoomsApiVersion(String name) {
@@ -1957,6 +1743,30 @@ RoomGetRoomsApiVersion _$valueOfRoomGetRoomsApiVersion(String name) {
 final BuiltSet<RoomGetRoomsApiVersion> _$roomGetRoomsApiVersionValues =
     BuiltSet<RoomGetRoomsApiVersion>(const <RoomGetRoomsApiVersion>[
   _$roomGetRoomsApiVersionV4,
+]);
+
+const RoomGetRoomsRequestApplicationJson_NoStatusUpdate _$roomGetRoomsRequestApplicationJsonNoStatusUpdate$0 =
+    RoomGetRoomsRequestApplicationJson_NoStatusUpdate._('\$0');
+const RoomGetRoomsRequestApplicationJson_NoStatusUpdate _$roomGetRoomsRequestApplicationJsonNoStatusUpdate$1 =
+    RoomGetRoomsRequestApplicationJson_NoStatusUpdate._('\$1');
+
+RoomGetRoomsRequestApplicationJson_NoStatusUpdate _$valueOfRoomGetRoomsRequestApplicationJson_NoStatusUpdate(
+    String name) {
+  switch (name) {
+    case '\$0':
+      return _$roomGetRoomsRequestApplicationJsonNoStatusUpdate$0;
+    case '\$1':
+      return _$roomGetRoomsRequestApplicationJsonNoStatusUpdate$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<RoomGetRoomsRequestApplicationJson_NoStatusUpdate>
+    _$roomGetRoomsRequestApplicationJsonNoStatusUpdateValues = BuiltSet<
+        RoomGetRoomsRequestApplicationJson_NoStatusUpdate>(const <RoomGetRoomsRequestApplicationJson_NoStatusUpdate>[
+  _$roomGetRoomsRequestApplicationJsonNoStatusUpdate$0,
+  _$roomGetRoomsRequestApplicationJsonNoStatusUpdate$1,
 ]);
 
 const RoomCreateRoomApiVersion _$roomCreateRoomApiVersionV4 = RoomCreateRoomApiVersion._('v4');
@@ -2088,26 +1898,6 @@ final BuiltSet<RoomSetDescriptionApiVersion> _$roomSetDescriptionApiVersionValue
   _$roomSetDescriptionApiVersionV4,
 ]);
 
-const RoomSetReadOnlyState _$roomSetReadOnlyState$0 = RoomSetReadOnlyState._('\$0');
-const RoomSetReadOnlyState _$roomSetReadOnlyState$1 = RoomSetReadOnlyState._('\$1');
-
-RoomSetReadOnlyState _$valueOfRoomSetReadOnlyState(String name) {
-  switch (name) {
-    case '\$0':
-      return _$roomSetReadOnlyState$0;
-    case '\$1':
-      return _$roomSetReadOnlyState$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<RoomSetReadOnlyState> _$roomSetReadOnlyStateValues =
-    BuiltSet<RoomSetReadOnlyState>(const <RoomSetReadOnlyState>[
-  _$roomSetReadOnlyState$0,
-  _$roomSetReadOnlyState$1,
-]);
-
 const RoomSetReadOnlyApiVersion _$roomSetReadOnlyApiVersionV4 = RoomSetReadOnlyApiVersion._('v4');
 
 RoomSetReadOnlyApiVersion _$valueOfRoomSetReadOnlyApiVersion(String name) {
@@ -2124,28 +1914,26 @@ final BuiltSet<RoomSetReadOnlyApiVersion> _$roomSetReadOnlyApiVersionValues =
   _$roomSetReadOnlyApiVersionV4,
 ]);
 
-const RoomSetListableScope _$roomSetListableScope$0 = RoomSetListableScope._('\$0');
-const RoomSetListableScope _$roomSetListableScope$1 = RoomSetListableScope._('\$1');
-const RoomSetListableScope _$roomSetListableScope$2 = RoomSetListableScope._('\$2');
+const RoomSetReadOnlyRequestApplicationJson_State _$roomSetReadOnlyRequestApplicationJsonState$0 =
+    RoomSetReadOnlyRequestApplicationJson_State._('\$0');
+const RoomSetReadOnlyRequestApplicationJson_State _$roomSetReadOnlyRequestApplicationJsonState$1 =
+    RoomSetReadOnlyRequestApplicationJson_State._('\$1');
 
-RoomSetListableScope _$valueOfRoomSetListableScope(String name) {
+RoomSetReadOnlyRequestApplicationJson_State _$valueOfRoomSetReadOnlyRequestApplicationJson_State(String name) {
   switch (name) {
     case '\$0':
-      return _$roomSetListableScope$0;
+      return _$roomSetReadOnlyRequestApplicationJsonState$0;
     case '\$1':
-      return _$roomSetListableScope$1;
-    case '\$2':
-      return _$roomSetListableScope$2;
+      return _$roomSetReadOnlyRequestApplicationJsonState$1;
     default:
       throw ArgumentError(name);
   }
 }
 
-final BuiltSet<RoomSetListableScope> _$roomSetListableScopeValues =
-    BuiltSet<RoomSetListableScope>(const <RoomSetListableScope>[
-  _$roomSetListableScope$0,
-  _$roomSetListableScope$1,
-  _$roomSetListableScope$2,
+final BuiltSet<RoomSetReadOnlyRequestApplicationJson_State> _$roomSetReadOnlyRequestApplicationJsonStateValues =
+    BuiltSet<RoomSetReadOnlyRequestApplicationJson_State>(const <RoomSetReadOnlyRequestApplicationJson_State>[
+  _$roomSetReadOnlyRequestApplicationJsonState$0,
+  _$roomSetReadOnlyRequestApplicationJsonState$1,
 ]);
 
 const RoomSetListableApiVersion _$roomSetListableApiVersionV4 = RoomSetListableApiVersion._('v4');
@@ -2162,6 +1950,33 @@ RoomSetListableApiVersion _$valueOfRoomSetListableApiVersion(String name) {
 final BuiltSet<RoomSetListableApiVersion> _$roomSetListableApiVersionValues =
     BuiltSet<RoomSetListableApiVersion>(const <RoomSetListableApiVersion>[
   _$roomSetListableApiVersionV4,
+]);
+
+const RoomSetListableRequestApplicationJson_Scope _$roomSetListableRequestApplicationJsonScope$0 =
+    RoomSetListableRequestApplicationJson_Scope._('\$0');
+const RoomSetListableRequestApplicationJson_Scope _$roomSetListableRequestApplicationJsonScope$1 =
+    RoomSetListableRequestApplicationJson_Scope._('\$1');
+const RoomSetListableRequestApplicationJson_Scope _$roomSetListableRequestApplicationJsonScope$2 =
+    RoomSetListableRequestApplicationJson_Scope._('\$2');
+
+RoomSetListableRequestApplicationJson_Scope _$valueOfRoomSetListableRequestApplicationJson_Scope(String name) {
+  switch (name) {
+    case '\$0':
+      return _$roomSetListableRequestApplicationJsonScope$0;
+    case '\$1':
+      return _$roomSetListableRequestApplicationJsonScope$1;
+    case '\$2':
+      return _$roomSetListableRequestApplicationJsonScope$2;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<RoomSetListableRequestApplicationJson_Scope> _$roomSetListableRequestApplicationJsonScopeValues =
+    BuiltSet<RoomSetListableRequestApplicationJson_Scope>(const <RoomSetListableRequestApplicationJson_Scope>[
+  _$roomSetListableRequestApplicationJsonScope$0,
+  _$roomSetListableRequestApplicationJsonScope$1,
+  _$roomSetListableRequestApplicationJsonScope$2,
 ]);
 
 const RoomSetPasswordApiVersion _$roomSetPasswordApiVersionV4 = RoomSetPasswordApiVersion._('v4');
@@ -2216,26 +2031,6 @@ final BuiltSet<RoomSetPermissionsApiVersion> _$roomSetPermissionsApiVersionValue
   _$roomSetPermissionsApiVersionV4,
 ]);
 
-const RoomGetParticipantsIncludeStatus _$roomGetParticipantsIncludeStatus$0 = RoomGetParticipantsIncludeStatus._('\$0');
-const RoomGetParticipantsIncludeStatus _$roomGetParticipantsIncludeStatus$1 = RoomGetParticipantsIncludeStatus._('\$1');
-
-RoomGetParticipantsIncludeStatus _$valueOfRoomGetParticipantsIncludeStatus(String name) {
-  switch (name) {
-    case '\$0':
-      return _$roomGetParticipantsIncludeStatus$0;
-    case '\$1':
-      return _$roomGetParticipantsIncludeStatus$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<RoomGetParticipantsIncludeStatus> _$roomGetParticipantsIncludeStatusValues =
-    BuiltSet<RoomGetParticipantsIncludeStatus>(const <RoomGetParticipantsIncludeStatus>[
-  _$roomGetParticipantsIncludeStatus$0,
-  _$roomGetParticipantsIncludeStatus$1,
-]);
-
 const RoomGetParticipantsApiVersion _$roomGetParticipantsApiVersionV4 = RoomGetParticipantsApiVersion._('v4');
 
 RoomGetParticipantsApiVersion _$valueOfRoomGetParticipantsApiVersion(String name) {
@@ -2250,47 +2045,6 @@ RoomGetParticipantsApiVersion _$valueOfRoomGetParticipantsApiVersion(String name
 final BuiltSet<RoomGetParticipantsApiVersion> _$roomGetParticipantsApiVersionValues =
     BuiltSet<RoomGetParticipantsApiVersion>(const <RoomGetParticipantsApiVersion>[
   _$roomGetParticipantsApiVersionV4,
-]);
-
-const RoomAddParticipantToRoomSource _$roomAddParticipantToRoomSourceUsers = RoomAddParticipantToRoomSource._('users');
-const RoomAddParticipantToRoomSource _$roomAddParticipantToRoomSourceGroups =
-    RoomAddParticipantToRoomSource._('groups');
-const RoomAddParticipantToRoomSource _$roomAddParticipantToRoomSourceCircles =
-    RoomAddParticipantToRoomSource._('circles');
-const RoomAddParticipantToRoomSource _$roomAddParticipantToRoomSourceEmails =
-    RoomAddParticipantToRoomSource._('emails');
-const RoomAddParticipantToRoomSource _$roomAddParticipantToRoomSourceFederatedUsers =
-    RoomAddParticipantToRoomSource._('federatedUsers');
-const RoomAddParticipantToRoomSource _$roomAddParticipantToRoomSourcePhones =
-    RoomAddParticipantToRoomSource._('phones');
-
-RoomAddParticipantToRoomSource _$valueOfRoomAddParticipantToRoomSource(String name) {
-  switch (name) {
-    case 'users':
-      return _$roomAddParticipantToRoomSourceUsers;
-    case 'groups':
-      return _$roomAddParticipantToRoomSourceGroups;
-    case 'circles':
-      return _$roomAddParticipantToRoomSourceCircles;
-    case 'emails':
-      return _$roomAddParticipantToRoomSourceEmails;
-    case 'federatedUsers':
-      return _$roomAddParticipantToRoomSourceFederatedUsers;
-    case 'phones':
-      return _$roomAddParticipantToRoomSourcePhones;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<RoomAddParticipantToRoomSource> _$roomAddParticipantToRoomSourceValues =
-    BuiltSet<RoomAddParticipantToRoomSource>(const <RoomAddParticipantToRoomSource>[
-  _$roomAddParticipantToRoomSourceUsers,
-  _$roomAddParticipantToRoomSourceGroups,
-  _$roomAddParticipantToRoomSourceCircles,
-  _$roomAddParticipantToRoomSourceEmails,
-  _$roomAddParticipantToRoomSourceFederatedUsers,
-  _$roomAddParticipantToRoomSourcePhones,
 ]);
 
 const RoomAddParticipantToRoomApiVersion _$roomAddParticipantToRoomApiVersionV4 =
@@ -2310,26 +2064,54 @@ final BuiltSet<RoomAddParticipantToRoomApiVersion> _$roomAddParticipantToRoomApi
   _$roomAddParticipantToRoomApiVersionV4,
 ]);
 
-const RoomGetBreakoutRoomParticipantsIncludeStatus _$roomGetBreakoutRoomParticipantsIncludeStatus$0 =
-    RoomGetBreakoutRoomParticipantsIncludeStatus._('\$0');
-const RoomGetBreakoutRoomParticipantsIncludeStatus _$roomGetBreakoutRoomParticipantsIncludeStatus$1 =
-    RoomGetBreakoutRoomParticipantsIncludeStatus._('\$1');
+const RoomAddParticipantToRoomRequestApplicationJson_Source
+    _$roomAddParticipantToRoomRequestApplicationJsonSourceUsers =
+    RoomAddParticipantToRoomRequestApplicationJson_Source._('users');
+const RoomAddParticipantToRoomRequestApplicationJson_Source
+    _$roomAddParticipantToRoomRequestApplicationJsonSourceGroups =
+    RoomAddParticipantToRoomRequestApplicationJson_Source._('groups');
+const RoomAddParticipantToRoomRequestApplicationJson_Source
+    _$roomAddParticipantToRoomRequestApplicationJsonSourceCircles =
+    RoomAddParticipantToRoomRequestApplicationJson_Source._('circles');
+const RoomAddParticipantToRoomRequestApplicationJson_Source
+    _$roomAddParticipantToRoomRequestApplicationJsonSourceEmails =
+    RoomAddParticipantToRoomRequestApplicationJson_Source._('emails');
+const RoomAddParticipantToRoomRequestApplicationJson_Source
+    _$roomAddParticipantToRoomRequestApplicationJsonSourceFederatedUsers =
+    RoomAddParticipantToRoomRequestApplicationJson_Source._('federatedUsers');
+const RoomAddParticipantToRoomRequestApplicationJson_Source
+    _$roomAddParticipantToRoomRequestApplicationJsonSourcePhones =
+    RoomAddParticipantToRoomRequestApplicationJson_Source._('phones');
 
-RoomGetBreakoutRoomParticipantsIncludeStatus _$valueOfRoomGetBreakoutRoomParticipantsIncludeStatus(String name) {
+RoomAddParticipantToRoomRequestApplicationJson_Source _$valueOfRoomAddParticipantToRoomRequestApplicationJson_Source(
+    String name) {
   switch (name) {
-    case '\$0':
-      return _$roomGetBreakoutRoomParticipantsIncludeStatus$0;
-    case '\$1':
-      return _$roomGetBreakoutRoomParticipantsIncludeStatus$1;
+    case 'users':
+      return _$roomAddParticipantToRoomRequestApplicationJsonSourceUsers;
+    case 'groups':
+      return _$roomAddParticipantToRoomRequestApplicationJsonSourceGroups;
+    case 'circles':
+      return _$roomAddParticipantToRoomRequestApplicationJsonSourceCircles;
+    case 'emails':
+      return _$roomAddParticipantToRoomRequestApplicationJsonSourceEmails;
+    case 'federatedUsers':
+      return _$roomAddParticipantToRoomRequestApplicationJsonSourceFederatedUsers;
+    case 'phones':
+      return _$roomAddParticipantToRoomRequestApplicationJsonSourcePhones;
     default:
       throw ArgumentError(name);
   }
 }
 
-final BuiltSet<RoomGetBreakoutRoomParticipantsIncludeStatus> _$roomGetBreakoutRoomParticipantsIncludeStatusValues =
-    BuiltSet<RoomGetBreakoutRoomParticipantsIncludeStatus>(const <RoomGetBreakoutRoomParticipantsIncludeStatus>[
-  _$roomGetBreakoutRoomParticipantsIncludeStatus$0,
-  _$roomGetBreakoutRoomParticipantsIncludeStatus$1,
+final BuiltSet<RoomAddParticipantToRoomRequestApplicationJson_Source>
+    _$roomAddParticipantToRoomRequestApplicationJsonSourceValues = BuiltSet<
+        RoomAddParticipantToRoomRequestApplicationJson_Source>(const <RoomAddParticipantToRoomRequestApplicationJson_Source>[
+  _$roomAddParticipantToRoomRequestApplicationJsonSourceUsers,
+  _$roomAddParticipantToRoomRequestApplicationJsonSourceGroups,
+  _$roomAddParticipantToRoomRequestApplicationJsonSourceCircles,
+  _$roomAddParticipantToRoomRequestApplicationJsonSourceEmails,
+  _$roomAddParticipantToRoomRequestApplicationJsonSourceFederatedUsers,
+  _$roomAddParticipantToRoomRequestApplicationJsonSourcePhones,
 ]);
 
 const RoomGetBreakoutRoomParticipantsApiVersion _$roomGetBreakoutRoomParticipantsApiVersionV4 =
@@ -2382,33 +2164,6 @@ final BuiltSet<RoomRemoveAttendeeFromRoomApiVersion> _$roomRemoveAttendeeFromRoo
   _$roomRemoveAttendeeFromRoomApiVersionV4,
 ]);
 
-const RoomSetAttendeePermissionsMethod _$roomSetAttendeePermissionsMethod$set =
-    RoomSetAttendeePermissionsMethod._('\$set');
-const RoomSetAttendeePermissionsMethod _$roomSetAttendeePermissionsMethodRemove =
-    RoomSetAttendeePermissionsMethod._('remove');
-const RoomSetAttendeePermissionsMethod _$roomSetAttendeePermissionsMethodAdd =
-    RoomSetAttendeePermissionsMethod._('add');
-
-RoomSetAttendeePermissionsMethod _$valueOfRoomSetAttendeePermissionsMethod(String name) {
-  switch (name) {
-    case '\$set':
-      return _$roomSetAttendeePermissionsMethod$set;
-    case 'remove':
-      return _$roomSetAttendeePermissionsMethodRemove;
-    case 'add':
-      return _$roomSetAttendeePermissionsMethodAdd;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<RoomSetAttendeePermissionsMethod> _$roomSetAttendeePermissionsMethodValues =
-    BuiltSet<RoomSetAttendeePermissionsMethod>(const <RoomSetAttendeePermissionsMethod>[
-  _$roomSetAttendeePermissionsMethod$set,
-  _$roomSetAttendeePermissionsMethodRemove,
-  _$roomSetAttendeePermissionsMethodAdd,
-]);
-
 const RoomSetAttendeePermissionsApiVersion _$roomSetAttendeePermissionsApiVersionV4 =
     RoomSetAttendeePermissionsApiVersion._('v4');
 
@@ -2426,31 +2181,36 @@ final BuiltSet<RoomSetAttendeePermissionsApiVersion> _$roomSetAttendeePermission
   _$roomSetAttendeePermissionsApiVersionV4,
 ]);
 
-const RoomSetAllAttendeesPermissionsMethod _$roomSetAllAttendeesPermissionsMethod$set =
-    RoomSetAllAttendeesPermissionsMethod._('\$set');
-const RoomSetAllAttendeesPermissionsMethod _$roomSetAllAttendeesPermissionsMethodRemove =
-    RoomSetAllAttendeesPermissionsMethod._('remove');
-const RoomSetAllAttendeesPermissionsMethod _$roomSetAllAttendeesPermissionsMethodAdd =
-    RoomSetAllAttendeesPermissionsMethod._('add');
+const RoomSetAttendeePermissionsRequestApplicationJson_Method
+    _$roomSetAttendeePermissionsRequestApplicationJsonMethod$set =
+    RoomSetAttendeePermissionsRequestApplicationJson_Method._('\$set');
+const RoomSetAttendeePermissionsRequestApplicationJson_Method
+    _$roomSetAttendeePermissionsRequestApplicationJsonMethodRemove =
+    RoomSetAttendeePermissionsRequestApplicationJson_Method._('remove');
+const RoomSetAttendeePermissionsRequestApplicationJson_Method
+    _$roomSetAttendeePermissionsRequestApplicationJsonMethodAdd =
+    RoomSetAttendeePermissionsRequestApplicationJson_Method._('add');
 
-RoomSetAllAttendeesPermissionsMethod _$valueOfRoomSetAllAttendeesPermissionsMethod(String name) {
+RoomSetAttendeePermissionsRequestApplicationJson_Method
+    _$valueOfRoomSetAttendeePermissionsRequestApplicationJson_Method(String name) {
   switch (name) {
     case '\$set':
-      return _$roomSetAllAttendeesPermissionsMethod$set;
+      return _$roomSetAttendeePermissionsRequestApplicationJsonMethod$set;
     case 'remove':
-      return _$roomSetAllAttendeesPermissionsMethodRemove;
+      return _$roomSetAttendeePermissionsRequestApplicationJsonMethodRemove;
     case 'add':
-      return _$roomSetAllAttendeesPermissionsMethodAdd;
+      return _$roomSetAttendeePermissionsRequestApplicationJsonMethodAdd;
     default:
       throw ArgumentError(name);
   }
 }
 
-final BuiltSet<RoomSetAllAttendeesPermissionsMethod> _$roomSetAllAttendeesPermissionsMethodValues =
-    BuiltSet<RoomSetAllAttendeesPermissionsMethod>(const <RoomSetAllAttendeesPermissionsMethod>[
-  _$roomSetAllAttendeesPermissionsMethod$set,
-  _$roomSetAllAttendeesPermissionsMethodRemove,
-  _$roomSetAllAttendeesPermissionsMethodAdd,
+final BuiltSet<RoomSetAttendeePermissionsRequestApplicationJson_Method>
+    _$roomSetAttendeePermissionsRequestApplicationJsonMethodValues = BuiltSet<
+        RoomSetAttendeePermissionsRequestApplicationJson_Method>(const <RoomSetAttendeePermissionsRequestApplicationJson_Method>[
+  _$roomSetAttendeePermissionsRequestApplicationJsonMethod$set,
+  _$roomSetAttendeePermissionsRequestApplicationJsonMethodRemove,
+  _$roomSetAttendeePermissionsRequestApplicationJsonMethodAdd,
 ]);
 
 const RoomSetAllAttendeesPermissionsApiVersion _$roomSetAllAttendeesPermissionsApiVersionV4 =
@@ -2470,23 +2230,36 @@ final BuiltSet<RoomSetAllAttendeesPermissionsApiVersion> _$roomSetAllAttendeesPe
   _$roomSetAllAttendeesPermissionsApiVersionV4,
 ]);
 
-const RoomJoinRoomForce _$roomJoinRoomForce$0 = RoomJoinRoomForce._('\$0');
-const RoomJoinRoomForce _$roomJoinRoomForce$1 = RoomJoinRoomForce._('\$1');
+const RoomSetAllAttendeesPermissionsRequestApplicationJson_Method
+    _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethod$set =
+    RoomSetAllAttendeesPermissionsRequestApplicationJson_Method._('\$set');
+const RoomSetAllAttendeesPermissionsRequestApplicationJson_Method
+    _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethodRemove =
+    RoomSetAllAttendeesPermissionsRequestApplicationJson_Method._('remove');
+const RoomSetAllAttendeesPermissionsRequestApplicationJson_Method
+    _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethodAdd =
+    RoomSetAllAttendeesPermissionsRequestApplicationJson_Method._('add');
 
-RoomJoinRoomForce _$valueOfRoomJoinRoomForce(String name) {
+RoomSetAllAttendeesPermissionsRequestApplicationJson_Method
+    _$valueOfRoomSetAllAttendeesPermissionsRequestApplicationJson_Method(String name) {
   switch (name) {
-    case '\$0':
-      return _$roomJoinRoomForce$0;
-    case '\$1':
-      return _$roomJoinRoomForce$1;
+    case '\$set':
+      return _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethod$set;
+    case 'remove':
+      return _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethodRemove;
+    case 'add':
+      return _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethodAdd;
     default:
       throw ArgumentError(name);
   }
 }
 
-final BuiltSet<RoomJoinRoomForce> _$roomJoinRoomForceValues = BuiltSet<RoomJoinRoomForce>(const <RoomJoinRoomForce>[
-  _$roomJoinRoomForce$0,
-  _$roomJoinRoomForce$1,
+final BuiltSet<RoomSetAllAttendeesPermissionsRequestApplicationJson_Method>
+    _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethodValues = BuiltSet<
+        RoomSetAllAttendeesPermissionsRequestApplicationJson_Method>(const <RoomSetAllAttendeesPermissionsRequestApplicationJson_Method>[
+  _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethod$set,
+  _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethodRemove,
+  _$roomSetAllAttendeesPermissionsRequestApplicationJsonMethodAdd,
 ]);
 
 const RoomJoinRoomApiVersion _$roomJoinRoomApiVersionV4 = RoomJoinRoomApiVersion._('v4');
@@ -2537,26 +2310,6 @@ final BuiltSet<RoomResendInvitationsApiVersion> _$roomResendInvitationsApiVersio
   _$roomResendInvitationsApiVersionV4,
 ]);
 
-const RoomSetSessionStateState _$roomSetSessionStateState$0 = RoomSetSessionStateState._('\$0');
-const RoomSetSessionStateState _$roomSetSessionStateState$1 = RoomSetSessionStateState._('\$1');
-
-RoomSetSessionStateState _$valueOfRoomSetSessionStateState(String name) {
-  switch (name) {
-    case '\$0':
-      return _$roomSetSessionStateState$0;
-    case '\$1':
-      return _$roomSetSessionStateState$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<RoomSetSessionStateState> _$roomSetSessionStateStateValues =
-    BuiltSet<RoomSetSessionStateState>(const <RoomSetSessionStateState>[
-  _$roomSetSessionStateState$0,
-  _$roomSetSessionStateState$1,
-]);
-
 const RoomSetSessionStateApiVersion _$roomSetSessionStateApiVersionV4 = RoomSetSessionStateApiVersion._('v4');
 
 RoomSetSessionStateApiVersion _$valueOfRoomSetSessionStateApiVersion(String name) {
@@ -2571,6 +2324,28 @@ RoomSetSessionStateApiVersion _$valueOfRoomSetSessionStateApiVersion(String name
 final BuiltSet<RoomSetSessionStateApiVersion> _$roomSetSessionStateApiVersionValues =
     BuiltSet<RoomSetSessionStateApiVersion>(const <RoomSetSessionStateApiVersion>[
   _$roomSetSessionStateApiVersionV4,
+]);
+
+const RoomSetSessionStateRequestApplicationJson_State _$roomSetSessionStateRequestApplicationJsonState$0 =
+    RoomSetSessionStateRequestApplicationJson_State._('\$0');
+const RoomSetSessionStateRequestApplicationJson_State _$roomSetSessionStateRequestApplicationJsonState$1 =
+    RoomSetSessionStateRequestApplicationJson_State._('\$1');
+
+RoomSetSessionStateRequestApplicationJson_State _$valueOfRoomSetSessionStateRequestApplicationJson_State(String name) {
+  switch (name) {
+    case '\$0':
+      return _$roomSetSessionStateRequestApplicationJsonState$0;
+    case '\$1':
+      return _$roomSetSessionStateRequestApplicationJsonState$1;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<RoomSetSessionStateRequestApplicationJson_State> _$roomSetSessionStateRequestApplicationJsonStateValues =
+    BuiltSet<RoomSetSessionStateRequestApplicationJson_State>(const <RoomSetSessionStateRequestApplicationJson_State>[
+  _$roomSetSessionStateRequestApplicationJsonState$0,
+  _$roomSetSessionStateRequestApplicationJsonState$1,
 ]);
 
 const RoomPromoteModeratorApiVersion _$roomPromoteModeratorApiVersionV4 = RoomPromoteModeratorApiVersion._('v4');
@@ -2688,30 +2463,6 @@ final BuiltSet<RoomSetLobbyApiVersion> _$roomSetLobbyApiVersionValues =
   _$roomSetLobbyApiVersionV4,
 ]);
 
-const RoomSetsipEnabledState _$roomSetsipEnabledState$0 = RoomSetsipEnabledState._('\$0');
-const RoomSetsipEnabledState _$roomSetsipEnabledState$1 = RoomSetsipEnabledState._('\$1');
-const RoomSetsipEnabledState _$roomSetsipEnabledState$2 = RoomSetsipEnabledState._('\$2');
-
-RoomSetsipEnabledState _$valueOfRoomSetsipEnabledState(String name) {
-  switch (name) {
-    case '\$0':
-      return _$roomSetsipEnabledState$0;
-    case '\$1':
-      return _$roomSetsipEnabledState$1;
-    case '\$2':
-      return _$roomSetsipEnabledState$2;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<RoomSetsipEnabledState> _$roomSetsipEnabledStateValues =
-    BuiltSet<RoomSetsipEnabledState>(const <RoomSetsipEnabledState>[
-  _$roomSetsipEnabledState$0,
-  _$roomSetsipEnabledState$1,
-  _$roomSetsipEnabledState$2,
-]);
-
 const RoomSetsipEnabledApiVersion _$roomSetsipEnabledApiVersionV4 = RoomSetsipEnabledApiVersion._('v4');
 
 RoomSetsipEnabledApiVersion _$valueOfRoomSetsipEnabledApiVersion(String name) {
@@ -2726,6 +2477,33 @@ RoomSetsipEnabledApiVersion _$valueOfRoomSetsipEnabledApiVersion(String name) {
 final BuiltSet<RoomSetsipEnabledApiVersion> _$roomSetsipEnabledApiVersionValues =
     BuiltSet<RoomSetsipEnabledApiVersion>(const <RoomSetsipEnabledApiVersion>[
   _$roomSetsipEnabledApiVersionV4,
+]);
+
+const RoomSetsipEnabledRequestApplicationJson_State _$roomSetsipEnabledRequestApplicationJsonState$0 =
+    RoomSetsipEnabledRequestApplicationJson_State._('\$0');
+const RoomSetsipEnabledRequestApplicationJson_State _$roomSetsipEnabledRequestApplicationJsonState$1 =
+    RoomSetsipEnabledRequestApplicationJson_State._('\$1');
+const RoomSetsipEnabledRequestApplicationJson_State _$roomSetsipEnabledRequestApplicationJsonState$2 =
+    RoomSetsipEnabledRequestApplicationJson_State._('\$2');
+
+RoomSetsipEnabledRequestApplicationJson_State _$valueOfRoomSetsipEnabledRequestApplicationJson_State(String name) {
+  switch (name) {
+    case '\$0':
+      return _$roomSetsipEnabledRequestApplicationJsonState$0;
+    case '\$1':
+      return _$roomSetsipEnabledRequestApplicationJsonState$1;
+    case '\$2':
+      return _$roomSetsipEnabledRequestApplicationJsonState$2;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<RoomSetsipEnabledRequestApplicationJson_State> _$roomSetsipEnabledRequestApplicationJsonStateValues =
+    BuiltSet<RoomSetsipEnabledRequestApplicationJson_State>(const <RoomSetsipEnabledRequestApplicationJson_State>[
+  _$roomSetsipEnabledRequestApplicationJsonState$0,
+  _$roomSetsipEnabledRequestApplicationJsonState$1,
+  _$roomSetsipEnabledRequestApplicationJsonState$2,
 ]);
 
 const RoomSetRecordingConsentApiVersion _$roomSetRecordingConsentApiVersionV4 =
@@ -2878,36 +2656,6 @@ final BuiltSet<RoomRejectedDialOutRequestApiVersion> _$roomRejectedDialOutReques
   _$roomRejectedDialOutRequestApiVersionV4,
 ]);
 
-const SettingsSetUserSettingKey _$settingsSetUserSettingKeyAttachmentFolder =
-    SettingsSetUserSettingKey._('attachmentFolder');
-const SettingsSetUserSettingKey _$settingsSetUserSettingKeyReadStatusPrivacy =
-    SettingsSetUserSettingKey._('readStatusPrivacy');
-const SettingsSetUserSettingKey _$settingsSetUserSettingKeyTypingPrivacy = SettingsSetUserSettingKey._('typingPrivacy');
-const SettingsSetUserSettingKey _$settingsSetUserSettingKeyPlaySounds = SettingsSetUserSettingKey._('playSounds');
-
-SettingsSetUserSettingKey _$valueOfSettingsSetUserSettingKey(String name) {
-  switch (name) {
-    case 'attachmentFolder':
-      return _$settingsSetUserSettingKeyAttachmentFolder;
-    case 'readStatusPrivacy':
-      return _$settingsSetUserSettingKeyReadStatusPrivacy;
-    case 'typingPrivacy':
-      return _$settingsSetUserSettingKeyTypingPrivacy;
-    case 'playSounds':
-      return _$settingsSetUserSettingKeyPlaySounds;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<SettingsSetUserSettingKey> _$settingsSetUserSettingKeyValues =
-    BuiltSet<SettingsSetUserSettingKey>(const <SettingsSetUserSettingKey>[
-  _$settingsSetUserSettingKeyAttachmentFolder,
-  _$settingsSetUserSettingKeyReadStatusPrivacy,
-  _$settingsSetUserSettingKeyTypingPrivacy,
-  _$settingsSetUserSettingKeyPlaySounds,
-]);
-
 const SettingsSetUserSettingApiVersion _$settingsSetUserSettingApiVersionV1 = SettingsSetUserSettingApiVersion._('v1');
 
 SettingsSetUserSettingApiVersion _$valueOfSettingsSetUserSettingApiVersion(String name) {
@@ -2922,6 +2670,42 @@ SettingsSetUserSettingApiVersion _$valueOfSettingsSetUserSettingApiVersion(Strin
 final BuiltSet<SettingsSetUserSettingApiVersion> _$settingsSetUserSettingApiVersionValues =
     BuiltSet<SettingsSetUserSettingApiVersion>(const <SettingsSetUserSettingApiVersion>[
   _$settingsSetUserSettingApiVersionV1,
+]);
+
+const SettingsSetUserSettingRequestApplicationJson_Key
+    _$settingsSetUserSettingRequestApplicationJsonKeyAttachmentFolder =
+    SettingsSetUserSettingRequestApplicationJson_Key._('attachmentFolder');
+const SettingsSetUserSettingRequestApplicationJson_Key
+    _$settingsSetUserSettingRequestApplicationJsonKeyReadStatusPrivacy =
+    SettingsSetUserSettingRequestApplicationJson_Key._('readStatusPrivacy');
+const SettingsSetUserSettingRequestApplicationJson_Key _$settingsSetUserSettingRequestApplicationJsonKeyTypingPrivacy =
+    SettingsSetUserSettingRequestApplicationJson_Key._('typingPrivacy');
+const SettingsSetUserSettingRequestApplicationJson_Key _$settingsSetUserSettingRequestApplicationJsonKeyPlaySounds =
+    SettingsSetUserSettingRequestApplicationJson_Key._('playSounds');
+
+SettingsSetUserSettingRequestApplicationJson_Key _$valueOfSettingsSetUserSettingRequestApplicationJson_Key(
+    String name) {
+  switch (name) {
+    case 'attachmentFolder':
+      return _$settingsSetUserSettingRequestApplicationJsonKeyAttachmentFolder;
+    case 'readStatusPrivacy':
+      return _$settingsSetUserSettingRequestApplicationJsonKeyReadStatusPrivacy;
+    case 'typingPrivacy':
+      return _$settingsSetUserSettingRequestApplicationJsonKeyTypingPrivacy;
+    case 'playSounds':
+      return _$settingsSetUserSettingRequestApplicationJsonKeyPlaySounds;
+    default:
+      throw ArgumentError(name);
+  }
+}
+
+final BuiltSet<SettingsSetUserSettingRequestApplicationJson_Key>
+    _$settingsSetUserSettingRequestApplicationJsonKeyValues =
+    BuiltSet<SettingsSetUserSettingRequestApplicationJson_Key>(const <SettingsSetUserSettingRequestApplicationJson_Key>[
+  _$settingsSetUserSettingRequestApplicationJsonKeyAttachmentFolder,
+  _$settingsSetUserSettingRequestApplicationJsonKeyReadStatusPrivacy,
+  _$settingsSetUserSettingRequestApplicationJsonKeyTypingPrivacy,
+  _$settingsSetUserSettingRequestApplicationJsonKeyPlaySounds,
 ]);
 
 const BotAdminListBotsApiVersion _$botAdminListBotsApiVersionV1 = BotAdminListBotsApiVersion._('v1');
@@ -3023,6 +2807,8 @@ final BuiltSet<SignalingBackendApiVersion> _$signalingBackendApiVersionValues =
   _$signalingBackendApiVersionV3,
 ]);
 
+Serializer<AvatarGetAvatarRequestApplicationJson> _$avatarGetAvatarRequestApplicationJsonSerializer =
+    _$AvatarGetAvatarRequestApplicationJsonSerializer();
 Serializer<OCSMeta> _$oCSMetaSerializer = _$OCSMetaSerializer();
 Serializer<RichObjectParameter> _$richObjectParameterSerializer = _$RichObjectParameterSerializer();
 Serializer<BaseMessage> _$baseMessageSerializer = _$BaseMessageSerializer();
@@ -3036,10 +2822,23 @@ Serializer<AvatarDeleteAvatarResponseApplicationJson_Ocs> _$avatarDeleteAvatarRe
     _$AvatarDeleteAvatarResponseApplicationJson_OcsSerializer();
 Serializer<AvatarDeleteAvatarResponseApplicationJson> _$avatarDeleteAvatarResponseApplicationJsonSerializer =
     _$AvatarDeleteAvatarResponseApplicationJsonSerializer();
+Serializer<AvatarEmojiAvatarRequestApplicationJson> _$avatarEmojiAvatarRequestApplicationJsonSerializer =
+    _$AvatarEmojiAvatarRequestApplicationJsonSerializer();
 Serializer<AvatarEmojiAvatarResponseApplicationJson_Ocs> _$avatarEmojiAvatarResponseApplicationJsonOcsSerializer =
     _$AvatarEmojiAvatarResponseApplicationJson_OcsSerializer();
 Serializer<AvatarEmojiAvatarResponseApplicationJson> _$avatarEmojiAvatarResponseApplicationJsonSerializer =
     _$AvatarEmojiAvatarResponseApplicationJsonSerializer();
+Serializer<AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson>
+    _$avatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonSerializer =
+    _$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonSerializer();
+Serializer<AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson>
+    _$avatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonSerializer =
+    _$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonSerializer();
+Serializer<AvatarGetUserProxyAvatarRequestApplicationJson> _$avatarGetUserProxyAvatarRequestApplicationJsonSerializer =
+    _$AvatarGetUserProxyAvatarRequestApplicationJsonSerializer();
+Serializer<AvatarGetUserProxyAvatarDarkRequestApplicationJson>
+    _$avatarGetUserProxyAvatarDarkRequestApplicationJsonSerializer =
+    _$AvatarGetUserProxyAvatarDarkRequestApplicationJsonSerializer();
 Serializer<Bot> _$botSerializer = _$BotSerializer();
 Serializer<BotListBotsResponseApplicationJson_Ocs> _$botListBotsResponseApplicationJsonOcsSerializer =
     _$BotListBotsResponseApplicationJson_OcsSerializer();
@@ -3053,18 +2852,27 @@ Serializer<BotDisableBotResponseApplicationJson_Ocs> _$botDisableBotResponseAppl
     _$BotDisableBotResponseApplicationJson_OcsSerializer();
 Serializer<BotDisableBotResponseApplicationJson> _$botDisableBotResponseApplicationJsonSerializer =
     _$BotDisableBotResponseApplicationJsonSerializer();
+Serializer<BotSendMessageRequestApplicationJson> _$botSendMessageRequestApplicationJsonSerializer =
+    _$BotSendMessageRequestApplicationJsonSerializer();
 Serializer<BotSendMessageResponseApplicationJson_Ocs> _$botSendMessageResponseApplicationJsonOcsSerializer =
     _$BotSendMessageResponseApplicationJson_OcsSerializer();
 Serializer<BotSendMessageResponseApplicationJson> _$botSendMessageResponseApplicationJsonSerializer =
     _$BotSendMessageResponseApplicationJsonSerializer();
+Serializer<BotReactRequestApplicationJson> _$botReactRequestApplicationJsonSerializer =
+    _$BotReactRequestApplicationJsonSerializer();
 Serializer<BotReactResponseApplicationJson_Ocs> _$botReactResponseApplicationJsonOcsSerializer =
     _$BotReactResponseApplicationJson_OcsSerializer();
 Serializer<BotReactResponseApplicationJson> _$botReactResponseApplicationJsonSerializer =
     _$BotReactResponseApplicationJsonSerializer();
+Serializer<BotDeleteReactionRequestApplicationJson> _$botDeleteReactionRequestApplicationJsonSerializer =
+    _$BotDeleteReactionRequestApplicationJsonSerializer();
 Serializer<BotDeleteReactionResponseApplicationJson_Ocs> _$botDeleteReactionResponseApplicationJsonOcsSerializer =
     _$BotDeleteReactionResponseApplicationJson_OcsSerializer();
 Serializer<BotDeleteReactionResponseApplicationJson> _$botDeleteReactionResponseApplicationJsonSerializer =
     _$BotDeleteReactionResponseApplicationJsonSerializer();
+Serializer<BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson>
+    _$breakoutRoomConfigureBreakoutRoomsRequestApplicationJsonSerializer =
+    _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonSerializer();
 Serializer<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_Ocs>
     _$breakoutRoomConfigureBreakoutRoomsResponseApplicationJsonOcsSerializer =
     _$BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson_OcsSerializer();
@@ -3077,12 +2885,18 @@ Serializer<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson_Ocs>
 Serializer<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson>
     _$breakoutRoomRemoveBreakoutRoomsResponseApplicationJsonSerializer =
     _$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonSerializer();
+Serializer<BreakoutRoomBroadcastChatMessageRequestApplicationJson>
+    _$breakoutRoomBroadcastChatMessageRequestApplicationJsonSerializer =
+    _$BreakoutRoomBroadcastChatMessageRequestApplicationJsonSerializer();
 Serializer<BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs>
     _$breakoutRoomBroadcastChatMessageResponseApplicationJsonOcsSerializer =
     _$BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsSerializer();
 Serializer<BreakoutRoomBroadcastChatMessageResponseApplicationJson>
     _$breakoutRoomBroadcastChatMessageResponseApplicationJsonSerializer =
     _$BreakoutRoomBroadcastChatMessageResponseApplicationJsonSerializer();
+Serializer<BreakoutRoomApplyAttendeeMapRequestApplicationJson>
+    _$breakoutRoomApplyAttendeeMapRequestApplicationJsonSerializer =
+    _$BreakoutRoomApplyAttendeeMapRequestApplicationJsonSerializer();
 Serializer<BreakoutRoomApplyAttendeeMapResponseApplicationJson_Ocs>
     _$breakoutRoomApplyAttendeeMapResponseApplicationJsonOcsSerializer =
     _$BreakoutRoomApplyAttendeeMapResponseApplicationJson_OcsSerializer();
@@ -3113,6 +2927,9 @@ Serializer<BreakoutRoomStopBreakoutRoomsResponseApplicationJson_Ocs>
 Serializer<BreakoutRoomStopBreakoutRoomsResponseApplicationJson>
     _$breakoutRoomStopBreakoutRoomsResponseApplicationJsonSerializer =
     _$BreakoutRoomStopBreakoutRoomsResponseApplicationJsonSerializer();
+Serializer<BreakoutRoomSwitchBreakoutRoomRequestApplicationJson>
+    _$breakoutRoomSwitchBreakoutRoomRequestApplicationJsonSerializer =
+    _$BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonSerializer();
 Serializer<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs>
     _$breakoutRoomSwitchBreakoutRoomResponseApplicationJsonOcsSerializer =
     _$BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsSerializer();
@@ -3124,14 +2941,20 @@ Serializer<CallGetPeersForCallResponseApplicationJson_Ocs> _$callGetPeersForCall
     _$CallGetPeersForCallResponseApplicationJson_OcsSerializer();
 Serializer<CallGetPeersForCallResponseApplicationJson> _$callGetPeersForCallResponseApplicationJsonSerializer =
     _$CallGetPeersForCallResponseApplicationJsonSerializer();
+Serializer<CallUpdateCallFlagsRequestApplicationJson> _$callUpdateCallFlagsRequestApplicationJsonSerializer =
+    _$CallUpdateCallFlagsRequestApplicationJsonSerializer();
 Serializer<CallUpdateCallFlagsResponseApplicationJson_Ocs> _$callUpdateCallFlagsResponseApplicationJsonOcsSerializer =
     _$CallUpdateCallFlagsResponseApplicationJson_OcsSerializer();
 Serializer<CallUpdateCallFlagsResponseApplicationJson> _$callUpdateCallFlagsResponseApplicationJsonSerializer =
     _$CallUpdateCallFlagsResponseApplicationJsonSerializer();
+Serializer<CallJoinCallRequestApplicationJson> _$callJoinCallRequestApplicationJsonSerializer =
+    _$CallJoinCallRequestApplicationJsonSerializer();
 Serializer<CallJoinCallResponseApplicationJson_Ocs> _$callJoinCallResponseApplicationJsonOcsSerializer =
     _$CallJoinCallResponseApplicationJson_OcsSerializer();
 Serializer<CallJoinCallResponseApplicationJson> _$callJoinCallResponseApplicationJsonSerializer =
     _$CallJoinCallResponseApplicationJsonSerializer();
+Serializer<CallLeaveCallRequestApplicationJson> _$callLeaveCallRequestApplicationJsonSerializer =
+    _$CallLeaveCallRequestApplicationJsonSerializer();
 Serializer<CallLeaveCallResponseApplicationJson_Ocs> _$callLeaveCallResponseApplicationJsonOcsSerializer =
     _$CallLeaveCallResponseApplicationJson_OcsSerializer();
 Serializer<CallLeaveCallResponseApplicationJson> _$callLeaveCallResponseApplicationJsonSerializer =
@@ -3146,6 +2969,8 @@ Serializer<CallSipDialOutResponseApplicationJson_Ocs> _$callSipDialOutResponseAp
     _$CallSipDialOutResponseApplicationJson_OcsSerializer();
 Serializer<CallSipDialOutResponseApplicationJson> _$callSipDialOutResponseApplicationJsonSerializer =
     _$CallSipDialOutResponseApplicationJsonSerializer();
+Serializer<ChatReceiveMessagesRequestApplicationJson> _$chatReceiveMessagesRequestApplicationJsonSerializer =
+    _$ChatReceiveMessagesRequestApplicationJsonSerializer();
 Serializer<ChatMessageWithParent> _$chatMessageWithParentSerializer = _$ChatMessageWithParentSerializer();
 Serializer<ChatReceiveMessagesResponseApplicationJson_Ocs> _$chatReceiveMessagesResponseApplicationJsonOcsSerializer =
     _$ChatReceiveMessagesResponseApplicationJson_OcsSerializer();
@@ -3153,6 +2978,8 @@ Serializer<ChatReceiveMessagesResponseApplicationJson> _$chatReceiveMessagesResp
     _$ChatReceiveMessagesResponseApplicationJsonSerializer();
 Serializer<ChatChatReceiveMessagesHeaders> _$chatChatReceiveMessagesHeadersSerializer =
     _$ChatChatReceiveMessagesHeadersSerializer();
+Serializer<ChatSendMessageRequestApplicationJson> _$chatSendMessageRequestApplicationJsonSerializer =
+    _$ChatSendMessageRequestApplicationJsonSerializer();
 Serializer<ChatSendMessageResponseApplicationJson_Ocs> _$chatSendMessageResponseApplicationJsonOcsSerializer =
     _$ChatSendMessageResponseApplicationJson_OcsSerializer();
 Serializer<ChatSendMessageResponseApplicationJson> _$chatSendMessageResponseApplicationJsonSerializer =
@@ -3165,6 +2992,8 @@ Serializer<ChatClearHistoryResponseApplicationJson> _$chatClearHistoryResponseAp
     _$ChatClearHistoryResponseApplicationJsonSerializer();
 Serializer<ChatChatClearHistoryHeaders> _$chatChatClearHistoryHeadersSerializer =
     _$ChatChatClearHistoryHeadersSerializer();
+Serializer<ChatEditMessageRequestApplicationJson> _$chatEditMessageRequestApplicationJsonSerializer =
+    _$ChatEditMessageRequestApplicationJsonSerializer();
 Serializer<ChatEditMessageResponseApplicationJson_Ocs> _$chatEditMessageResponseApplicationJsonOcsSerializer =
     _$ChatEditMessageResponseApplicationJson_OcsSerializer();
 Serializer<ChatEditMessageResponseApplicationJson> _$chatEditMessageResponseApplicationJsonSerializer =
@@ -3177,6 +3006,8 @@ Serializer<ChatDeleteMessageResponseApplicationJson> _$chatDeleteMessageResponse
     _$ChatDeleteMessageResponseApplicationJsonSerializer();
 Serializer<ChatChatDeleteMessageHeaders> _$chatChatDeleteMessageHeadersSerializer =
     _$ChatChatDeleteMessageHeadersSerializer();
+Serializer<ChatGetMessageContextRequestApplicationJson> _$chatGetMessageContextRequestApplicationJsonSerializer =
+    _$ChatGetMessageContextRequestApplicationJsonSerializer();
 Serializer<ChatGetMessageContextResponseApplicationJson_Ocs>
     _$chatGetMessageContextResponseApplicationJsonOcsSerializer =
     _$ChatGetMessageContextResponseApplicationJson_OcsSerializer();
@@ -3189,6 +3020,8 @@ Serializer<ChatGetReminderResponseApplicationJson_Ocs> _$chatGetReminderResponse
     _$ChatGetReminderResponseApplicationJson_OcsSerializer();
 Serializer<ChatGetReminderResponseApplicationJson> _$chatGetReminderResponseApplicationJsonSerializer =
     _$ChatGetReminderResponseApplicationJsonSerializer();
+Serializer<ChatSetReminderRequestApplicationJson> _$chatSetReminderRequestApplicationJsonSerializer =
+    _$ChatSetReminderRequestApplicationJsonSerializer();
 Serializer<ChatSetReminderResponseApplicationJson_Ocs> _$chatSetReminderResponseApplicationJsonOcsSerializer =
     _$ChatSetReminderResponseApplicationJson_OcsSerializer();
 Serializer<ChatSetReminderResponseApplicationJson> _$chatSetReminderResponseApplicationJsonSerializer =
@@ -3200,6 +3033,8 @@ Serializer<ChatDeleteReminderResponseApplicationJson_Ocs> _$chatDeleteReminderRe
     _$ChatDeleteReminderResponseApplicationJson_OcsSerializer();
 Serializer<ChatDeleteReminderResponseApplicationJson> _$chatDeleteReminderResponseApplicationJsonSerializer =
     _$ChatDeleteReminderResponseApplicationJsonSerializer();
+Serializer<ChatSetReadMarkerRequestApplicationJson> _$chatSetReadMarkerRequestApplicationJsonSerializer =
+    _$ChatSetReadMarkerRequestApplicationJsonSerializer();
 Serializer<ChatSetReadMarkerResponseApplicationJson_Ocs> _$chatSetReadMarkerResponseApplicationJsonOcsSerializer =
     _$ChatSetReadMarkerResponseApplicationJson_OcsSerializer();
 Serializer<ChatSetReadMarkerResponseApplicationJson> _$chatSetReadMarkerResponseApplicationJsonSerializer =
@@ -3211,11 +3046,16 @@ Serializer<ChatMarkUnreadResponseApplicationJson_Ocs> _$chatMarkUnreadResponseAp
 Serializer<ChatMarkUnreadResponseApplicationJson> _$chatMarkUnreadResponseApplicationJsonSerializer =
     _$ChatMarkUnreadResponseApplicationJsonSerializer();
 Serializer<ChatChatMarkUnreadHeaders> _$chatChatMarkUnreadHeadersSerializer = _$ChatChatMarkUnreadHeadersSerializer();
+Serializer<ChatMentionsRequestApplicationJson> _$chatMentionsRequestApplicationJsonSerializer =
+    _$ChatMentionsRequestApplicationJsonSerializer();
 Serializer<ChatMentionSuggestion> _$chatMentionSuggestionSerializer = _$ChatMentionSuggestionSerializer();
 Serializer<ChatMentionsResponseApplicationJson_Ocs> _$chatMentionsResponseApplicationJsonOcsSerializer =
     _$ChatMentionsResponseApplicationJson_OcsSerializer();
 Serializer<ChatMentionsResponseApplicationJson> _$chatMentionsResponseApplicationJsonSerializer =
     _$ChatMentionsResponseApplicationJsonSerializer();
+Serializer<ChatGetObjectsSharedInRoomRequestApplicationJson>
+    _$chatGetObjectsSharedInRoomRequestApplicationJsonSerializer =
+    _$ChatGetObjectsSharedInRoomRequestApplicationJsonSerializer();
 Serializer<ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs>
     _$chatGetObjectsSharedInRoomResponseApplicationJsonOcsSerializer =
     _$ChatGetObjectsSharedInRoomResponseApplicationJson_OcsSerializer();
@@ -3224,6 +3064,8 @@ Serializer<ChatGetObjectsSharedInRoomResponseApplicationJson>
     _$ChatGetObjectsSharedInRoomResponseApplicationJsonSerializer();
 Serializer<ChatChatGetObjectsSharedInRoomHeaders> _$chatChatGetObjectsSharedInRoomHeadersSerializer =
     _$ChatChatGetObjectsSharedInRoomHeadersSerializer();
+Serializer<ChatShareObjectToChatRequestApplicationJson> _$chatShareObjectToChatRequestApplicationJsonSerializer =
+    _$ChatShareObjectToChatRequestApplicationJsonSerializer();
 Serializer<ChatShareObjectToChatResponseApplicationJson_Ocs>
     _$chatShareObjectToChatResponseApplicationJsonOcsSerializer =
     _$ChatShareObjectToChatResponseApplicationJson_OcsSerializer();
@@ -3231,12 +3073,17 @@ Serializer<ChatShareObjectToChatResponseApplicationJson> _$chatShareObjectToChat
     _$ChatShareObjectToChatResponseApplicationJsonSerializer();
 Serializer<ChatChatShareObjectToChatHeaders> _$chatChatShareObjectToChatHeadersSerializer =
     _$ChatChatShareObjectToChatHeadersSerializer();
+Serializer<ChatGetObjectsSharedInRoomOverviewRequestApplicationJson>
+    _$chatGetObjectsSharedInRoomOverviewRequestApplicationJsonSerializer =
+    _$ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonSerializer();
 Serializer<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs>
     _$chatGetObjectsSharedInRoomOverviewResponseApplicationJsonOcsSerializer =
     _$ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsSerializer();
 Serializer<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson>
     _$chatGetObjectsSharedInRoomOverviewResponseApplicationJsonSerializer =
     _$ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonSerializer();
+Serializer<SignalingGetSettingsRequestApplicationJson> _$signalingGetSettingsRequestApplicationJsonSerializer =
+    _$SignalingGetSettingsRequestApplicationJsonSerializer();
 Serializer<SignalingSettings_HelloAuthParams_10> _$signalingSettingsHelloAuthParams10Serializer =
     _$SignalingSettings_HelloAuthParams_10Serializer();
 Serializer<SignalingSettings_HelloAuthParams_20> _$signalingSettingsHelloAuthParams20Serializer =
@@ -3285,6 +3132,9 @@ Serializer<FilesIntegrationGetRoomByShareTokenResponseApplicationJson_Ocs>
 Serializer<FilesIntegrationGetRoomByShareTokenResponseApplicationJson>
     _$filesIntegrationGetRoomByShareTokenResponseApplicationJsonSerializer =
     _$FilesIntegrationGetRoomByShareTokenResponseApplicationJsonSerializer();
+Serializer<PublicShareAuthCreateRoomRequestApplicationJson>
+    _$publicShareAuthCreateRoomRequestApplicationJsonSerializer =
+    _$PublicShareAuthCreateRoomRequestApplicationJsonSerializer();
 Serializer<PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data>
     _$publicShareAuthCreateRoomResponseApplicationJsonOcsDataSerializer =
     _$PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataSerializer();
@@ -3294,10 +3144,15 @@ Serializer<PublicShareAuthCreateRoomResponseApplicationJson_Ocs>
 Serializer<PublicShareAuthCreateRoomResponseApplicationJson>
     _$publicShareAuthCreateRoomResponseApplicationJsonSerializer =
     _$PublicShareAuthCreateRoomResponseApplicationJsonSerializer();
+Serializer<GuestSetDisplayNameRequestApplicationJson> _$guestSetDisplayNameRequestApplicationJsonSerializer =
+    _$GuestSetDisplayNameRequestApplicationJsonSerializer();
 Serializer<GuestSetDisplayNameResponseApplicationJson_Ocs> _$guestSetDisplayNameResponseApplicationJsonOcsSerializer =
     _$GuestSetDisplayNameResponseApplicationJson_OcsSerializer();
 Serializer<GuestSetDisplayNameResponseApplicationJson> _$guestSetDisplayNameResponseApplicationJsonSerializer =
     _$GuestSetDisplayNameResponseApplicationJsonSerializer();
+Serializer<HostedSignalingServerRequestTrialRequestApplicationJson>
+    _$hostedSignalingServerRequestTrialRequestApplicationJsonSerializer =
+    _$HostedSignalingServerRequestTrialRequestApplicationJsonSerializer();
 Serializer<HostedSignalingServerRequestTrialResponseApplicationJson_Ocs>
     _$hostedSignalingServerRequestTrialResponseApplicationJsonOcsSerializer =
     _$HostedSignalingServerRequestTrialResponseApplicationJson_OcsSerializer();
@@ -3313,6 +3168,8 @@ Serializer<SignalingPullMessagesResponseApplicationJson_Ocs>
     _$SignalingPullMessagesResponseApplicationJson_OcsSerializer();
 Serializer<SignalingPullMessagesResponseApplicationJson> _$signalingPullMessagesResponseApplicationJsonSerializer =
     _$SignalingPullMessagesResponseApplicationJsonSerializer();
+Serializer<SignalingSendMessagesRequestApplicationJson> _$signalingSendMessagesRequestApplicationJsonSerializer =
+    _$SignalingSendMessagesRequestApplicationJsonSerializer();
 Serializer<SignalingSendMessagesResponseApplicationJson_Ocs>
     _$signalingSendMessagesResponseApplicationJsonOcsSerializer =
     _$SignalingSendMessagesResponseApplicationJson_OcsSerializer();
@@ -3328,6 +3185,9 @@ Serializer<MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs>
 Serializer<MatterbridgeGetBridgeOfRoomResponseApplicationJson>
     _$matterbridgeGetBridgeOfRoomResponseApplicationJsonSerializer =
     _$MatterbridgeGetBridgeOfRoomResponseApplicationJsonSerializer();
+Serializer<MatterbridgeEditBridgeOfRoomRequestApplicationJson>
+    _$matterbridgeEditBridgeOfRoomRequestApplicationJsonSerializer =
+    _$MatterbridgeEditBridgeOfRoomRequestApplicationJsonSerializer();
 Serializer<MatterbridgeEditBridgeOfRoomResponseApplicationJson_Ocs>
     _$matterbridgeEditBridgeOfRoomResponseApplicationJsonOcsSerializer =
     _$MatterbridgeEditBridgeOfRoomResponseApplicationJson_OcsSerializer();
@@ -3361,6 +3221,8 @@ Serializer<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson_Ocs
 Serializer<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson>
     _$matterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonSerializer =
     _$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonSerializer();
+Serializer<PollCreatePollRequestApplicationJson> _$pollCreatePollRequestApplicationJsonSerializer =
+    _$PollCreatePollRequestApplicationJsonSerializer();
 Serializer<PollVote> _$pollVoteSerializer = _$PollVoteSerializer();
 Serializer<Poll> _$pollSerializer = _$PollSerializer();
 Serializer<PollCreatePollResponseApplicationJson_Ocs> _$pollCreatePollResponseApplicationJsonOcsSerializer =
@@ -3371,6 +3233,8 @@ Serializer<PollShowPollResponseApplicationJson_Ocs> _$pollShowPollResponseApplic
     _$PollShowPollResponseApplicationJson_OcsSerializer();
 Serializer<PollShowPollResponseApplicationJson> _$pollShowPollResponseApplicationJsonSerializer =
     _$PollShowPollResponseApplicationJsonSerializer();
+Serializer<PollVotePollRequestApplicationJson> _$pollVotePollRequestApplicationJsonSerializer =
+    _$PollVotePollRequestApplicationJsonSerializer();
 Serializer<PollVotePollResponseApplicationJson_Ocs> _$pollVotePollResponseApplicationJsonOcsSerializer =
     _$PollVotePollResponseApplicationJson_OcsSerializer();
 Serializer<PollVotePollResponseApplicationJson> _$pollVotePollResponseApplicationJsonSerializer =
@@ -3379,19 +3243,27 @@ Serializer<PollClosePollResponseApplicationJson_Ocs> _$pollClosePollResponseAppl
     _$PollClosePollResponseApplicationJson_OcsSerializer();
 Serializer<PollClosePollResponseApplicationJson> _$pollClosePollResponseApplicationJsonSerializer =
     _$PollClosePollResponseApplicationJsonSerializer();
+Serializer<ReactionGetReactionsRequestApplicationJson> _$reactionGetReactionsRequestApplicationJsonSerializer =
+    _$ReactionGetReactionsRequestApplicationJsonSerializer();
 Serializer<Reaction> _$reactionSerializer = _$ReactionSerializer();
 Serializer<ReactionGetReactionsResponseApplicationJson_Ocs> _$reactionGetReactionsResponseApplicationJsonOcsSerializer =
     _$ReactionGetReactionsResponseApplicationJson_OcsSerializer();
 Serializer<ReactionGetReactionsResponseApplicationJson> _$reactionGetReactionsResponseApplicationJsonSerializer =
     _$ReactionGetReactionsResponseApplicationJsonSerializer();
+Serializer<ReactionReactRequestApplicationJson> _$reactionReactRequestApplicationJsonSerializer =
+    _$ReactionReactRequestApplicationJsonSerializer();
 Serializer<ReactionReactResponseApplicationJson_Ocs> _$reactionReactResponseApplicationJsonOcsSerializer =
     _$ReactionReactResponseApplicationJson_OcsSerializer();
 Serializer<ReactionReactResponseApplicationJson> _$reactionReactResponseApplicationJsonSerializer =
     _$ReactionReactResponseApplicationJsonSerializer();
+Serializer<ReactionDeleteRequestApplicationJson> _$reactionDeleteRequestApplicationJsonSerializer =
+    _$ReactionDeleteRequestApplicationJsonSerializer();
 Serializer<ReactionDeleteResponseApplicationJson_Ocs> _$reactionDeleteResponseApplicationJsonOcsSerializer =
     _$ReactionDeleteResponseApplicationJson_OcsSerializer();
 Serializer<ReactionDeleteResponseApplicationJson> _$reactionDeleteResponseApplicationJsonSerializer =
     _$ReactionDeleteResponseApplicationJsonSerializer();
+Serializer<RecordingStartRequestApplicationJson> _$recordingStartRequestApplicationJsonSerializer =
+    _$RecordingStartRequestApplicationJsonSerializer();
 Serializer<RecordingStartResponseApplicationJson_Ocs> _$recordingStartResponseApplicationJsonOcsSerializer =
     _$RecordingStartResponseApplicationJson_OcsSerializer();
 Serializer<RecordingStartResponseApplicationJson> _$recordingStartResponseApplicationJsonSerializer =
@@ -3400,12 +3272,17 @@ Serializer<RecordingStopResponseApplicationJson_Ocs> _$recordingStopResponseAppl
     _$RecordingStopResponseApplicationJson_OcsSerializer();
 Serializer<RecordingStopResponseApplicationJson> _$recordingStopResponseApplicationJsonSerializer =
     _$RecordingStopResponseApplicationJsonSerializer();
+Serializer<RecordingNotificationDismissRequestApplicationJson>
+    _$recordingNotificationDismissRequestApplicationJsonSerializer =
+    _$RecordingNotificationDismissRequestApplicationJsonSerializer();
 Serializer<RecordingNotificationDismissResponseApplicationJson_Ocs>
     _$recordingNotificationDismissResponseApplicationJsonOcsSerializer =
     _$RecordingNotificationDismissResponseApplicationJson_OcsSerializer();
 Serializer<RecordingNotificationDismissResponseApplicationJson>
     _$recordingNotificationDismissResponseApplicationJsonSerializer =
     _$RecordingNotificationDismissResponseApplicationJsonSerializer();
+Serializer<RecordingShareToChatRequestApplicationJson> _$recordingShareToChatRequestApplicationJsonSerializer =
+    _$RecordingShareToChatRequestApplicationJsonSerializer();
 Serializer<RecordingShareToChatResponseApplicationJson_Ocs> _$recordingShareToChatResponseApplicationJsonOcsSerializer =
     _$RecordingShareToChatResponseApplicationJson_OcsSerializer();
 Serializer<RecordingShareToChatResponseApplicationJson> _$recordingShareToChatResponseApplicationJsonSerializer =
@@ -3414,19 +3291,27 @@ Serializer<RecordingBackendResponseApplicationJson_Ocs> _$recordingBackendRespon
     _$RecordingBackendResponseApplicationJson_OcsSerializer();
 Serializer<RecordingBackendResponseApplicationJson> _$recordingBackendResponseApplicationJsonSerializer =
     _$RecordingBackendResponseApplicationJsonSerializer();
+Serializer<RecordingStoreRequestApplicationJson> _$recordingStoreRequestApplicationJsonSerializer =
+    _$RecordingStoreRequestApplicationJsonSerializer();
 Serializer<RecordingStoreResponseApplicationJson_Ocs> _$recordingStoreResponseApplicationJsonOcsSerializer =
     _$RecordingStoreResponseApplicationJson_OcsSerializer();
 Serializer<RecordingStoreResponseApplicationJson> _$recordingStoreResponseApplicationJsonSerializer =
     _$RecordingStoreResponseApplicationJsonSerializer();
+Serializer<RoomGetRoomsRequestApplicationJson> _$roomGetRoomsRequestApplicationJsonSerializer =
+    _$RoomGetRoomsRequestApplicationJsonSerializer();
 Serializer<RoomGetRoomsResponseApplicationJson_Ocs> _$roomGetRoomsResponseApplicationJsonOcsSerializer =
     _$RoomGetRoomsResponseApplicationJson_OcsSerializer();
 Serializer<RoomGetRoomsResponseApplicationJson> _$roomGetRoomsResponseApplicationJsonSerializer =
     _$RoomGetRoomsResponseApplicationJsonSerializer();
 Serializer<RoomRoomGetRoomsHeaders> _$roomRoomGetRoomsHeadersSerializer = _$RoomRoomGetRoomsHeadersSerializer();
+Serializer<RoomCreateRoomRequestApplicationJson> _$roomCreateRoomRequestApplicationJsonSerializer =
+    _$RoomCreateRoomRequestApplicationJsonSerializer();
 Serializer<RoomCreateRoomResponseApplicationJson_Ocs> _$roomCreateRoomResponseApplicationJsonOcsSerializer =
     _$RoomCreateRoomResponseApplicationJson_OcsSerializer();
 Serializer<RoomCreateRoomResponseApplicationJson> _$roomCreateRoomResponseApplicationJsonSerializer =
     _$RoomCreateRoomResponseApplicationJsonSerializer();
+Serializer<RoomGetListedRoomsRequestApplicationJson> _$roomGetListedRoomsRequestApplicationJsonSerializer =
+    _$RoomGetListedRoomsRequestApplicationJsonSerializer();
 Serializer<RoomGetListedRoomsResponseApplicationJson_Ocs> _$roomGetListedRoomsResponseApplicationJsonOcsSerializer =
     _$RoomGetListedRoomsResponseApplicationJson_OcsSerializer();
 Serializer<RoomGetListedRoomsResponseApplicationJson> _$roomGetListedRoomsResponseApplicationJsonSerializer =
@@ -3457,26 +3342,38 @@ Serializer<RoomMakePrivateResponseApplicationJson_Ocs> _$roomMakePrivateResponse
     _$RoomMakePrivateResponseApplicationJson_OcsSerializer();
 Serializer<RoomMakePrivateResponseApplicationJson> _$roomMakePrivateResponseApplicationJsonSerializer =
     _$RoomMakePrivateResponseApplicationJsonSerializer();
+Serializer<RoomSetDescriptionRequestApplicationJson> _$roomSetDescriptionRequestApplicationJsonSerializer =
+    _$RoomSetDescriptionRequestApplicationJsonSerializer();
 Serializer<RoomSetDescriptionResponseApplicationJson_Ocs> _$roomSetDescriptionResponseApplicationJsonOcsSerializer =
     _$RoomSetDescriptionResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetDescriptionResponseApplicationJson> _$roomSetDescriptionResponseApplicationJsonSerializer =
     _$RoomSetDescriptionResponseApplicationJsonSerializer();
+Serializer<RoomSetReadOnlyRequestApplicationJson> _$roomSetReadOnlyRequestApplicationJsonSerializer =
+    _$RoomSetReadOnlyRequestApplicationJsonSerializer();
 Serializer<RoomSetReadOnlyResponseApplicationJson_Ocs> _$roomSetReadOnlyResponseApplicationJsonOcsSerializer =
     _$RoomSetReadOnlyResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetReadOnlyResponseApplicationJson> _$roomSetReadOnlyResponseApplicationJsonSerializer =
     _$RoomSetReadOnlyResponseApplicationJsonSerializer();
+Serializer<RoomSetListableRequestApplicationJson> _$roomSetListableRequestApplicationJsonSerializer =
+    _$RoomSetListableRequestApplicationJsonSerializer();
 Serializer<RoomSetListableResponseApplicationJson_Ocs> _$roomSetListableResponseApplicationJsonOcsSerializer =
     _$RoomSetListableResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetListableResponseApplicationJson> _$roomSetListableResponseApplicationJsonSerializer =
     _$RoomSetListableResponseApplicationJsonSerializer();
+Serializer<RoomSetPasswordRequestApplicationJson> _$roomSetPasswordRequestApplicationJsonSerializer =
+    _$RoomSetPasswordRequestApplicationJsonSerializer();
 Serializer<RoomSetPasswordResponseApplicationJson_Ocs> _$roomSetPasswordResponseApplicationJsonOcsSerializer =
     _$RoomSetPasswordResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetPasswordResponseApplicationJson> _$roomSetPasswordResponseApplicationJsonSerializer =
     _$RoomSetPasswordResponseApplicationJsonSerializer();
+Serializer<RoomSetPermissionsRequestApplicationJson> _$roomSetPermissionsRequestApplicationJsonSerializer =
+    _$RoomSetPermissionsRequestApplicationJsonSerializer();
 Serializer<RoomSetPermissionsResponseApplicationJson_Ocs> _$roomSetPermissionsResponseApplicationJsonOcsSerializer =
     _$RoomSetPermissionsResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetPermissionsResponseApplicationJson> _$roomSetPermissionsResponseApplicationJsonSerializer =
     _$RoomSetPermissionsResponseApplicationJsonSerializer();
+Serializer<RoomGetParticipantsRequestApplicationJson> _$roomGetParticipantsRequestApplicationJsonSerializer =
+    _$RoomGetParticipantsRequestApplicationJsonSerializer();
 Serializer<Participant> _$participantSerializer = _$ParticipantSerializer();
 Serializer<RoomGetParticipantsResponseApplicationJson_Ocs> _$roomGetParticipantsResponseApplicationJsonOcsSerializer =
     _$RoomGetParticipantsResponseApplicationJson_OcsSerializer();
@@ -3484,6 +3381,8 @@ Serializer<RoomGetParticipantsResponseApplicationJson> _$roomGetParticipantsResp
     _$RoomGetParticipantsResponseApplicationJsonSerializer();
 Serializer<RoomRoomGetParticipantsHeaders> _$roomRoomGetParticipantsHeadersSerializer =
     _$RoomRoomGetParticipantsHeadersSerializer();
+Serializer<RoomAddParticipantToRoomRequestApplicationJson> _$roomAddParticipantToRoomRequestApplicationJsonSerializer =
+    _$RoomAddParticipantToRoomRequestApplicationJsonSerializer();
 Serializer<RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0>
     _$roomAddParticipantToRoomResponseApplicationJsonOcsData0Serializer =
     _$RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Serializer();
@@ -3493,6 +3392,9 @@ Serializer<RoomAddParticipantToRoomResponseApplicationJson_Ocs>
 Serializer<RoomAddParticipantToRoomResponseApplicationJson>
     _$roomAddParticipantToRoomResponseApplicationJsonSerializer =
     _$RoomAddParticipantToRoomResponseApplicationJsonSerializer();
+Serializer<RoomGetBreakoutRoomParticipantsRequestApplicationJson>
+    _$roomGetBreakoutRoomParticipantsRequestApplicationJsonSerializer =
+    _$RoomGetBreakoutRoomParticipantsRequestApplicationJsonSerializer();
 Serializer<RoomGetBreakoutRoomParticipantsResponseApplicationJson_Ocs>
     _$roomGetBreakoutRoomParticipantsResponseApplicationJsonOcsSerializer =
     _$RoomGetBreakoutRoomParticipantsResponseApplicationJson_OcsSerializer();
@@ -3506,24 +3408,35 @@ Serializer<RoomRemoveSelfFromRoomResponseApplicationJson_Ocs>
     _$RoomRemoveSelfFromRoomResponseApplicationJson_OcsSerializer();
 Serializer<RoomRemoveSelfFromRoomResponseApplicationJson> _$roomRemoveSelfFromRoomResponseApplicationJsonSerializer =
     _$RoomRemoveSelfFromRoomResponseApplicationJsonSerializer();
+Serializer<RoomRemoveAttendeeFromRoomRequestApplicationJson>
+    _$roomRemoveAttendeeFromRoomRequestApplicationJsonSerializer =
+    _$RoomRemoveAttendeeFromRoomRequestApplicationJsonSerializer();
 Serializer<RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs>
     _$roomRemoveAttendeeFromRoomResponseApplicationJsonOcsSerializer =
     _$RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsSerializer();
 Serializer<RoomRemoveAttendeeFromRoomResponseApplicationJson>
     _$roomRemoveAttendeeFromRoomResponseApplicationJsonSerializer =
     _$RoomRemoveAttendeeFromRoomResponseApplicationJsonSerializer();
+Serializer<RoomSetAttendeePermissionsRequestApplicationJson>
+    _$roomSetAttendeePermissionsRequestApplicationJsonSerializer =
+    _$RoomSetAttendeePermissionsRequestApplicationJsonSerializer();
 Serializer<RoomSetAttendeePermissionsResponseApplicationJson_Ocs>
     _$roomSetAttendeePermissionsResponseApplicationJsonOcsSerializer =
     _$RoomSetAttendeePermissionsResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetAttendeePermissionsResponseApplicationJson>
     _$roomSetAttendeePermissionsResponseApplicationJsonSerializer =
     _$RoomSetAttendeePermissionsResponseApplicationJsonSerializer();
+Serializer<RoomSetAllAttendeesPermissionsRequestApplicationJson>
+    _$roomSetAllAttendeesPermissionsRequestApplicationJsonSerializer =
+    _$RoomSetAllAttendeesPermissionsRequestApplicationJsonSerializer();
 Serializer<RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs>
     _$roomSetAllAttendeesPermissionsResponseApplicationJsonOcsSerializer =
     _$RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetAllAttendeesPermissionsResponseApplicationJson>
     _$roomSetAllAttendeesPermissionsResponseApplicationJsonSerializer =
     _$RoomSetAllAttendeesPermissionsResponseApplicationJsonSerializer();
+Serializer<RoomJoinRoomRequestApplicationJson> _$roomJoinRoomRequestApplicationJsonSerializer =
+    _$RoomJoinRoomRequestApplicationJsonSerializer();
 Serializer<RoomJoinRoomResponseApplicationJson_Ocs> _$roomJoinRoomResponseApplicationJsonOcsSerializer =
     _$RoomJoinRoomResponseApplicationJson_OcsSerializer();
 Serializer<RoomJoinRoomResponseApplicationJson> _$roomJoinRoomResponseApplicationJsonSerializer =
@@ -3533,19 +3446,27 @@ Serializer<RoomLeaveRoomResponseApplicationJson_Ocs> _$roomLeaveRoomResponseAppl
     _$RoomLeaveRoomResponseApplicationJson_OcsSerializer();
 Serializer<RoomLeaveRoomResponseApplicationJson> _$roomLeaveRoomResponseApplicationJsonSerializer =
     _$RoomLeaveRoomResponseApplicationJsonSerializer();
+Serializer<RoomResendInvitationsRequestApplicationJson> _$roomResendInvitationsRequestApplicationJsonSerializer =
+    _$RoomResendInvitationsRequestApplicationJsonSerializer();
 Serializer<RoomResendInvitationsResponseApplicationJson_Ocs>
     _$roomResendInvitationsResponseApplicationJsonOcsSerializer =
     _$RoomResendInvitationsResponseApplicationJson_OcsSerializer();
 Serializer<RoomResendInvitationsResponseApplicationJson> _$roomResendInvitationsResponseApplicationJsonSerializer =
     _$RoomResendInvitationsResponseApplicationJsonSerializer();
+Serializer<RoomSetSessionStateRequestApplicationJson> _$roomSetSessionStateRequestApplicationJsonSerializer =
+    _$RoomSetSessionStateRequestApplicationJsonSerializer();
 Serializer<RoomSetSessionStateResponseApplicationJson_Ocs> _$roomSetSessionStateResponseApplicationJsonOcsSerializer =
     _$RoomSetSessionStateResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetSessionStateResponseApplicationJson> _$roomSetSessionStateResponseApplicationJsonSerializer =
     _$RoomSetSessionStateResponseApplicationJsonSerializer();
+Serializer<RoomPromoteModeratorRequestApplicationJson> _$roomPromoteModeratorRequestApplicationJsonSerializer =
+    _$RoomPromoteModeratorRequestApplicationJsonSerializer();
 Serializer<RoomPromoteModeratorResponseApplicationJson_Ocs> _$roomPromoteModeratorResponseApplicationJsonOcsSerializer =
     _$RoomPromoteModeratorResponseApplicationJson_OcsSerializer();
 Serializer<RoomPromoteModeratorResponseApplicationJson> _$roomPromoteModeratorResponseApplicationJsonSerializer =
     _$RoomPromoteModeratorResponseApplicationJsonSerializer();
+Serializer<RoomDemoteModeratorRequestApplicationJson> _$roomDemoteModeratorRequestApplicationJsonSerializer =
+    _$RoomDemoteModeratorRequestApplicationJsonSerializer();
 Serializer<RoomDemoteModeratorResponseApplicationJson_Ocs> _$roomDemoteModeratorResponseApplicationJsonOcsSerializer =
     _$RoomDemoteModeratorResponseApplicationJson_OcsSerializer();
 Serializer<RoomDemoteModeratorResponseApplicationJson> _$roomDemoteModeratorResponseApplicationJsonSerializer =
@@ -3559,31 +3480,43 @@ Serializer<RoomRemoveFromFavoritesResponseApplicationJson_Ocs>
     _$RoomRemoveFromFavoritesResponseApplicationJson_OcsSerializer();
 Serializer<RoomRemoveFromFavoritesResponseApplicationJson> _$roomRemoveFromFavoritesResponseApplicationJsonSerializer =
     _$RoomRemoveFromFavoritesResponseApplicationJsonSerializer();
+Serializer<RoomSetNotificationLevelRequestApplicationJson> _$roomSetNotificationLevelRequestApplicationJsonSerializer =
+    _$RoomSetNotificationLevelRequestApplicationJsonSerializer();
 Serializer<RoomSetNotificationLevelResponseApplicationJson_Ocs>
     _$roomSetNotificationLevelResponseApplicationJsonOcsSerializer =
     _$RoomSetNotificationLevelResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetNotificationLevelResponseApplicationJson>
     _$roomSetNotificationLevelResponseApplicationJsonSerializer =
     _$RoomSetNotificationLevelResponseApplicationJsonSerializer();
+Serializer<RoomSetNotificationCallsRequestApplicationJson> _$roomSetNotificationCallsRequestApplicationJsonSerializer =
+    _$RoomSetNotificationCallsRequestApplicationJsonSerializer();
 Serializer<RoomSetNotificationCallsResponseApplicationJson_Ocs>
     _$roomSetNotificationCallsResponseApplicationJsonOcsSerializer =
     _$RoomSetNotificationCallsResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetNotificationCallsResponseApplicationJson>
     _$roomSetNotificationCallsResponseApplicationJsonSerializer =
     _$RoomSetNotificationCallsResponseApplicationJsonSerializer();
+Serializer<RoomSetLobbyRequestApplicationJson> _$roomSetLobbyRequestApplicationJsonSerializer =
+    _$RoomSetLobbyRequestApplicationJsonSerializer();
 Serializer<RoomSetLobbyResponseApplicationJson_Ocs> _$roomSetLobbyResponseApplicationJsonOcsSerializer =
     _$RoomSetLobbyResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetLobbyResponseApplicationJson> _$roomSetLobbyResponseApplicationJsonSerializer =
     _$RoomSetLobbyResponseApplicationJsonSerializer();
+Serializer<RoomSetsipEnabledRequestApplicationJson> _$roomSetsipEnabledRequestApplicationJsonSerializer =
+    _$RoomSetsipEnabledRequestApplicationJsonSerializer();
 Serializer<RoomSetsipEnabledResponseApplicationJson_Ocs> _$roomSetsipEnabledResponseApplicationJsonOcsSerializer =
     _$RoomSetsipEnabledResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetsipEnabledResponseApplicationJson> _$roomSetsipEnabledResponseApplicationJsonSerializer =
     _$RoomSetsipEnabledResponseApplicationJsonSerializer();
+Serializer<RoomSetRecordingConsentRequestApplicationJson> _$roomSetRecordingConsentRequestApplicationJsonSerializer =
+    _$RoomSetRecordingConsentRequestApplicationJsonSerializer();
 Serializer<RoomSetRecordingConsentResponseApplicationJson_Ocs>
     _$roomSetRecordingConsentResponseApplicationJsonOcsSerializer =
     _$RoomSetRecordingConsentResponseApplicationJson_OcsSerializer();
 Serializer<RoomSetRecordingConsentResponseApplicationJson> _$roomSetRecordingConsentResponseApplicationJsonSerializer =
     _$RoomSetRecordingConsentResponseApplicationJsonSerializer();
+Serializer<RoomSetMessageExpirationRequestApplicationJson> _$roomSetMessageExpirationRequestApplicationJsonSerializer =
+    _$RoomSetMessageExpirationRequestApplicationJsonSerializer();
 Serializer<RoomSetMessageExpirationResponseApplicationJson_Ocs>
     _$roomSetMessageExpirationResponseApplicationJsonOcsSerializer =
     _$RoomSetMessageExpirationResponseApplicationJson_OcsSerializer();
@@ -3623,12 +3556,17 @@ Serializer<RoomVerifyDialInPinDeprecatedResponseApplicationJson_Ocs>
 Serializer<RoomVerifyDialInPinDeprecatedResponseApplicationJson>
     _$roomVerifyDialInPinDeprecatedResponseApplicationJsonSerializer =
     _$RoomVerifyDialInPinDeprecatedResponseApplicationJsonSerializer();
+Serializer<RoomVerifyDialInPinRequestApplicationJson> _$roomVerifyDialInPinRequestApplicationJsonSerializer =
+    _$RoomVerifyDialInPinRequestApplicationJsonSerializer();
 Serializer<RoomVerifyDialInPinResponseApplicationJson_Ocs> _$roomVerifyDialInPinResponseApplicationJsonOcsSerializer =
     _$RoomVerifyDialInPinResponseApplicationJson_OcsSerializer();
 Serializer<RoomVerifyDialInPinResponseApplicationJson> _$roomVerifyDialInPinResponseApplicationJsonSerializer =
     _$RoomVerifyDialInPinResponseApplicationJsonSerializer();
-Serializer<RoomVerifyDialOutNumberOptions> _$roomVerifyDialOutNumberOptionsSerializer =
-    _$RoomVerifyDialOutNumberOptionsSerializer();
+Serializer<RoomVerifyDialOutNumberRequestApplicationJson_Options>
+    _$roomVerifyDialOutNumberRequestApplicationJsonOptionsSerializer =
+    _$RoomVerifyDialOutNumberRequestApplicationJson_OptionsSerializer();
+Serializer<RoomVerifyDialOutNumberRequestApplicationJson> _$roomVerifyDialOutNumberRequestApplicationJsonSerializer =
+    _$RoomVerifyDialOutNumberRequestApplicationJsonSerializer();
 Serializer<RoomVerifyDialOutNumberResponseApplicationJson_Ocs>
     _$roomVerifyDialOutNumberResponseApplicationJsonOcsSerializer =
     _$RoomVerifyDialOutNumberResponseApplicationJson_OcsSerializer();
@@ -3639,14 +3577,20 @@ Serializer<RoomCreateGuestByDialInResponseApplicationJson_Ocs>
     _$RoomCreateGuestByDialInResponseApplicationJson_OcsSerializer();
 Serializer<RoomCreateGuestByDialInResponseApplicationJson> _$roomCreateGuestByDialInResponseApplicationJsonSerializer =
     _$RoomCreateGuestByDialInResponseApplicationJsonSerializer();
-Serializer<RoomRejectedDialOutRequestOptions> _$roomRejectedDialOutRequestOptionsSerializer =
-    _$RoomRejectedDialOutRequestOptionsSerializer();
+Serializer<RoomRejectedDialOutRequestRequestApplicationJson_Options>
+    _$roomRejectedDialOutRequestRequestApplicationJsonOptionsSerializer =
+    _$RoomRejectedDialOutRequestRequestApplicationJson_OptionsSerializer();
+Serializer<RoomRejectedDialOutRequestRequestApplicationJson>
+    _$roomRejectedDialOutRequestRequestApplicationJsonSerializer =
+    _$RoomRejectedDialOutRequestRequestApplicationJsonSerializer();
 Serializer<RoomRejectedDialOutRequestResponseApplicationJson_Ocs>
     _$roomRejectedDialOutRequestResponseApplicationJsonOcsSerializer =
     _$RoomRejectedDialOutRequestResponseApplicationJson_OcsSerializer();
 Serializer<RoomRejectedDialOutRequestResponseApplicationJson>
     _$roomRejectedDialOutRequestResponseApplicationJsonSerializer =
     _$RoomRejectedDialOutRequestResponseApplicationJsonSerializer();
+Serializer<SettingsSetUserSettingRequestApplicationJson> _$settingsSetUserSettingRequestApplicationJsonSerializer =
+    _$SettingsSetUserSettingRequestApplicationJsonSerializer();
 Serializer<SettingsSetUserSettingResponseApplicationJson_Ocs>
     _$settingsSetUserSettingResponseApplicationJsonOcsSerializer =
     _$SettingsSetUserSettingResponseApplicationJson_OcsSerializer();
@@ -3657,6 +3601,9 @@ Serializer<BotAdminListBotsResponseApplicationJson_Ocs> _$botAdminListBotsRespon
     _$BotAdminListBotsResponseApplicationJson_OcsSerializer();
 Serializer<BotAdminListBotsResponseApplicationJson> _$botAdminListBotsResponseApplicationJsonSerializer =
     _$BotAdminListBotsResponseApplicationJsonSerializer();
+Serializer<CertificateGetCertificateExpirationRequestApplicationJson>
+    _$certificateGetCertificateExpirationRequestApplicationJsonSerializer =
+    _$CertificateGetCertificateExpirationRequestApplicationJsonSerializer();
 Serializer<CertificateGetCertificateExpirationResponseApplicationJson_Ocs_Data>
     _$certificateGetCertificateExpirationResponseApplicationJsonOcsDataSerializer =
     _$CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataSerializer();
@@ -3675,6 +3622,8 @@ Serializer<RecordingGetWelcomeMessageResponseApplicationJson_Ocs>
 Serializer<RecordingGetWelcomeMessageResponseApplicationJson>
     _$recordingGetWelcomeMessageResponseApplicationJsonSerializer =
     _$RecordingGetWelcomeMessageResponseApplicationJsonSerializer();
+Serializer<SettingsSetsipSettingsRequestApplicationJson> _$settingsSetsipSettingsRequestApplicationJsonSerializer =
+    _$SettingsSetsipSettingsRequestApplicationJsonSerializer();
 Serializer<SettingsSetsipSettingsResponseApplicationJson_Ocs>
     _$settingsSetsipSettingsResponseApplicationJsonOcsSerializer =
     _$SettingsSetsipSettingsResponseApplicationJson_OcsSerializer();
@@ -3713,6 +3662,45 @@ Serializer<TempAvatarDeleteAvatarResponseApplicationJson> _$tempAvatarDeleteAvat
     _$TempAvatarDeleteAvatarResponseApplicationJsonSerializer();
 Serializer<BotWithDetailsAndSecret> _$botWithDetailsAndSecretSerializer = _$BotWithDetailsAndSecretSerializer();
 Serializer<PublicCapabilities0> _$publicCapabilities0Serializer = _$PublicCapabilities0Serializer();
+
+class _$AvatarGetAvatarRequestApplicationJsonSerializer
+    implements StructuredSerializer<AvatarGetAvatarRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [AvatarGetAvatarRequestApplicationJson, _$AvatarGetAvatarRequestApplicationJson];
+  @override
+  final String wireName = 'AvatarGetAvatarRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, AvatarGetAvatarRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'darkTheme',
+      serializers.serialize(object.darkTheme, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  AvatarGetAvatarRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = AvatarGetAvatarRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'darkTheme':
+          result.darkTheme = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
 
 class _$OCSMetaSerializer implements StructuredSerializer<OCSMeta> {
   @override
@@ -4808,6 +4796,57 @@ class _$AvatarDeleteAvatarResponseApplicationJsonSerializer
   }
 }
 
+class _$AvatarEmojiAvatarRequestApplicationJsonSerializer
+    implements StructuredSerializer<AvatarEmojiAvatarRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    AvatarEmojiAvatarRequestApplicationJson,
+    _$AvatarEmojiAvatarRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'AvatarEmojiAvatarRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, AvatarEmojiAvatarRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'emoji',
+      serializers.serialize(object.emoji, specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.color;
+    if (value != null) {
+      result
+        ..add('color')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  AvatarEmojiAvatarRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = AvatarEmojiAvatarRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'emoji':
+          result.emoji = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'color':
+          result.color = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$AvatarEmojiAvatarResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<AvatarEmojiAvatarResponseApplicationJson_Ocs> {
   @override
@@ -4891,6 +4930,187 @@ class _$AvatarEmojiAvatarResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(AvatarEmojiAvatarResponseApplicationJson_Ocs))!
               as AvatarEmojiAvatarResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonSerializer
+    implements StructuredSerializer<AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson,
+    _$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'cloudId',
+      serializers.serialize(object.cloudId, specifiedType: const FullType(String)),
+      'darkTheme',
+      serializers.serialize(object.darkTheme, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'cloudId':
+          result.cloudId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'darkTheme':
+          result.darkTheme = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonSerializer
+    implements StructuredSerializer<AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson,
+    _$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'cloudId',
+      serializers.serialize(object.cloudId, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'cloudId':
+          result.cloudId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$AvatarGetUserProxyAvatarRequestApplicationJsonSerializer
+    implements StructuredSerializer<AvatarGetUserProxyAvatarRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    AvatarGetUserProxyAvatarRequestApplicationJson,
+    _$AvatarGetUserProxyAvatarRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'AvatarGetUserProxyAvatarRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, AvatarGetUserProxyAvatarRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'cloudId',
+      serializers.serialize(object.cloudId, specifiedType: const FullType(String)),
+      'darkTheme',
+      serializers.serialize(object.darkTheme, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  AvatarGetUserProxyAvatarRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = AvatarGetUserProxyAvatarRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'cloudId':
+          result.cloudId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'darkTheme':
+          result.darkTheme = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$AvatarGetUserProxyAvatarDarkRequestApplicationJsonSerializer
+    implements StructuredSerializer<AvatarGetUserProxyAvatarDarkRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    AvatarGetUserProxyAvatarDarkRequestApplicationJson,
+    _$AvatarGetUserProxyAvatarDarkRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'AvatarGetUserProxyAvatarDarkRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, AvatarGetUserProxyAvatarDarkRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'cloudId',
+      serializers.serialize(object.cloudId, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  AvatarGetUserProxyAvatarDarkRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'cloudId':
+          result.cloudId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -5225,6 +5445,60 @@ class _$BotDisableBotResponseApplicationJsonSerializer
   }
 }
 
+class _$BotSendMessageRequestApplicationJsonSerializer
+    implements StructuredSerializer<BotSendMessageRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [BotSendMessageRequestApplicationJson, _$BotSendMessageRequestApplicationJson];
+  @override
+  final String wireName = 'BotSendMessageRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, BotSendMessageRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'message',
+      serializers.serialize(object.message, specifiedType: const FullType(String)),
+      'referenceId',
+      serializers.serialize(object.referenceId, specifiedType: const FullType(String)),
+      'replyTo',
+      serializers.serialize(object.replyTo, specifiedType: const FullType(int)),
+      'silent',
+      serializers.serialize(object.silent, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  BotSendMessageRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = BotSendMessageRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'message':
+          result.message = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'referenceId':
+          result.referenceId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'replyTo':
+          result.replyTo = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'silent':
+          result.silent = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$BotSendMessageResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<BotSendMessageResponseApplicationJson_Ocs> {
   @override
@@ -5305,6 +5579,44 @@ class _$BotSendMessageResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(BotSendMessageResponseApplicationJson_Ocs))!
                   as BotSendMessageResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$BotReactRequestApplicationJsonSerializer implements StructuredSerializer<BotReactRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [BotReactRequestApplicationJson, _$BotReactRequestApplicationJson];
+  @override
+  final String wireName = 'BotReactRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, BotReactRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'reaction',
+      serializers.serialize(object.reaction, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  BotReactRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = BotReactRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'reaction':
+          result.reaction = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -5397,6 +5709,48 @@ class _$BotReactResponseApplicationJsonSerializer implements StructuredSerialize
   }
 }
 
+class _$BotDeleteReactionRequestApplicationJsonSerializer
+    implements StructuredSerializer<BotDeleteReactionRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    BotDeleteReactionRequestApplicationJson,
+    _$BotDeleteReactionRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'BotDeleteReactionRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, BotDeleteReactionRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'reaction',
+      serializers.serialize(object.reaction, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  BotDeleteReactionRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = BotDeleteReactionRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'reaction':
+          result.reaction = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$BotDeleteReactionResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<BotDeleteReactionResponseApplicationJson_Ocs> {
   @override
@@ -5480,6 +5834,62 @@ class _$BotDeleteReactionResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(BotDeleteReactionResponseApplicationJson_Ocs))!
               as BotDeleteReactionResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonSerializer
+    implements StructuredSerializer<BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson,
+    _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'mode',
+      serializers.serialize(object.mode,
+          specifiedType: const FullType(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode)),
+      'amount',
+      serializers.serialize(object.amount, specifiedType: const FullType(int)),
+      'attendeeMap',
+      serializers.serialize(object.attendeeMap, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'mode':
+          result.mode = serializers.deserialize(value,
+                  specifiedType: const FullType(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode))!
+              as BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode;
+          break;
+        case 'amount':
+          result.amount = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'attendeeMap':
+          result.attendeeMap = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -5679,6 +6089,49 @@ class _$BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonSerializer
   }
 }
 
+class _$BreakoutRoomBroadcastChatMessageRequestApplicationJsonSerializer
+    implements StructuredSerializer<BreakoutRoomBroadcastChatMessageRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    BreakoutRoomBroadcastChatMessageRequestApplicationJson,
+    _$BreakoutRoomBroadcastChatMessageRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'BreakoutRoomBroadcastChatMessageRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, BreakoutRoomBroadcastChatMessageRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'message',
+      serializers.serialize(object.message, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  BreakoutRoomBroadcastChatMessageRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'message':
+          result.message = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs> {
   @override
@@ -5767,6 +6220,48 @@ class _$BreakoutRoomBroadcastChatMessageResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs))!
               as BreakoutRoomBroadcastChatMessageResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$BreakoutRoomApplyAttendeeMapRequestApplicationJsonSerializer
+    implements StructuredSerializer<BreakoutRoomApplyAttendeeMapRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    BreakoutRoomApplyAttendeeMapRequestApplicationJson,
+    _$BreakoutRoomApplyAttendeeMapRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'BreakoutRoomApplyAttendeeMapRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, BreakoutRoomApplyAttendeeMapRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'attendeeMap',
+      serializers.serialize(object.attendeeMap, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  BreakoutRoomApplyAttendeeMapRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'attendeeMap':
+          result.attendeeMap = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -6249,6 +6744,49 @@ class _$BreakoutRoomStopBreakoutRoomsResponseApplicationJsonSerializer
   }
 }
 
+class _$BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonSerializer
+    implements StructuredSerializer<BreakoutRoomSwitchBreakoutRoomRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    BreakoutRoomSwitchBreakoutRoomRequestApplicationJson,
+    _$BreakoutRoomSwitchBreakoutRoomRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'BreakoutRoomSwitchBreakoutRoomRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, BreakoutRoomSwitchBreakoutRoomRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'target',
+      serializers.serialize(object.target, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  BreakoutRoomSwitchBreakoutRoomRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'target':
+          result.target = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_Ocs> {
   @override
@@ -6498,6 +7036,48 @@ class _$CallGetPeersForCallResponseApplicationJsonSerializer
   }
 }
 
+class _$CallUpdateCallFlagsRequestApplicationJsonSerializer
+    implements StructuredSerializer<CallUpdateCallFlagsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    CallUpdateCallFlagsRequestApplicationJson,
+    _$CallUpdateCallFlagsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'CallUpdateCallFlagsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, CallUpdateCallFlagsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'flags',
+      serializers.serialize(object.flags, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  CallUpdateCallFlagsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CallUpdateCallFlagsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'flags':
+          result.flags = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$CallUpdateCallFlagsResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<CallUpdateCallFlagsResponseApplicationJson_Ocs> {
   @override
@@ -6589,6 +7169,68 @@ class _$CallUpdateCallFlagsResponseApplicationJsonSerializer
   }
 }
 
+class _$CallJoinCallRequestApplicationJsonSerializer
+    implements StructuredSerializer<CallJoinCallRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [CallJoinCallRequestApplicationJson, _$CallJoinCallRequestApplicationJson];
+  @override
+  final String wireName = 'CallJoinCallRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, CallJoinCallRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'silent',
+      serializers.serialize(object.silent, specifiedType: const FullType(bool)),
+      'recordingConsent',
+      serializers.serialize(object.recordingConsent, specifiedType: const FullType(bool)),
+    ];
+    Object? value;
+    value = object.flags;
+    if (value != null) {
+      result
+        ..add('flags')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.forcePermissions;
+    if (value != null) {
+      result
+        ..add('forcePermissions')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  CallJoinCallRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CallJoinCallRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'flags':
+          result.flags = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'forcePermissions':
+          result.forcePermissions = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'silent':
+          result.silent = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'recordingConsent':
+          result.recordingConsent = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$CallJoinCallResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<CallJoinCallResponseApplicationJson_Ocs> {
   @override
@@ -6669,6 +7311,45 @@ class _$CallJoinCallResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(CallJoinCallResponseApplicationJson_Ocs))!
                   as CallJoinCallResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CallLeaveCallRequestApplicationJsonSerializer
+    implements StructuredSerializer<CallLeaveCallRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [CallLeaveCallRequestApplicationJson, _$CallLeaveCallRequestApplicationJson];
+  @override
+  final String wireName = 'CallLeaveCallRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, CallLeaveCallRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'all',
+      serializers.serialize(object.all, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  CallLeaveCallRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CallLeaveCallRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'all':
+          result.all = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -6992,6 +7673,103 @@ class _$CallSipDialOutResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(CallSipDialOutResponseApplicationJson_Ocs))!
                   as CallSipDialOutResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ChatReceiveMessagesRequestApplicationJsonSerializer
+    implements StructuredSerializer<ChatReceiveMessagesRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ChatReceiveMessagesRequestApplicationJson,
+    _$ChatReceiveMessagesRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ChatReceiveMessagesRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatReceiveMessagesRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'lookIntoFuture',
+      serializers.serialize(object.lookIntoFuture,
+          specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_LookIntoFuture)),
+      'limit',
+      serializers.serialize(object.limit, specifiedType: const FullType(int)),
+      'lastKnownMessageId',
+      serializers.serialize(object.lastKnownMessageId, specifiedType: const FullType(int)),
+      'lastCommonReadId',
+      serializers.serialize(object.lastCommonReadId, specifiedType: const FullType(int)),
+      'timeout',
+      serializers.serialize(object.timeout, specifiedType: const FullType(int)),
+      'setReadMarker',
+      serializers.serialize(object.setReadMarker,
+          specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_SetReadMarker)),
+      'includeLastKnown',
+      serializers.serialize(object.includeLastKnown,
+          specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown)),
+      'noStatusUpdate',
+      serializers.serialize(object.noStatusUpdate,
+          specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate)),
+      'markNotificationsAsRead',
+      serializers.serialize(object.markNotificationsAsRead,
+          specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ChatReceiveMessagesRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatReceiveMessagesRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'lookIntoFuture':
+          result.lookIntoFuture = serializers.deserialize(value,
+                  specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_LookIntoFuture))!
+              as ChatReceiveMessagesRequestApplicationJson_LookIntoFuture;
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'lastKnownMessageId':
+          result.lastKnownMessageId = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'lastCommonReadId':
+          result.lastCommonReadId = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'timeout':
+          result.timeout = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'setReadMarker':
+          result.setReadMarker = serializers.deserialize(value,
+                  specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_SetReadMarker))!
+              as ChatReceiveMessagesRequestApplicationJson_SetReadMarker;
+          break;
+        case 'includeLastKnown':
+          result.includeLastKnown = serializers.deserialize(value,
+                  specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown))!
+              as ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown;
+          break;
+        case 'noStatusUpdate':
+          result.noStatusUpdate = serializers.deserialize(value,
+                  specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate))!
+              as ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate;
+          break;
+        case 'markNotificationsAsRead':
+          result.markNotificationsAsRead = serializers.deserialize(value,
+                  specifiedType: const FullType(ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead))!
+              as ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead;
           break;
       }
     }
@@ -7332,6 +8110,65 @@ class _$ChatChatReceiveMessagesHeadersSerializer implements StructuredSerializer
   }
 }
 
+class _$ChatSendMessageRequestApplicationJsonSerializer
+    implements StructuredSerializer<ChatSendMessageRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ChatSendMessageRequestApplicationJson, _$ChatSendMessageRequestApplicationJson];
+  @override
+  final String wireName = 'ChatSendMessageRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatSendMessageRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'message',
+      serializers.serialize(object.message, specifiedType: const FullType(String)),
+      'actorDisplayName',
+      serializers.serialize(object.actorDisplayName, specifiedType: const FullType(String)),
+      'referenceId',
+      serializers.serialize(object.referenceId, specifiedType: const FullType(String)),
+      'replyTo',
+      serializers.serialize(object.replyTo, specifiedType: const FullType(int)),
+      'silent',
+      serializers.serialize(object.silent, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ChatSendMessageRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatSendMessageRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'message':
+          result.message = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'actorDisplayName':
+          result.actorDisplayName = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'referenceId':
+          result.referenceId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'replyTo':
+          result.replyTo = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'silent':
+          result.silent = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ChatSendMessageResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ChatSendMessageResponseApplicationJson_Ocs> {
   @override
@@ -7599,6 +8436,45 @@ class _$ChatChatClearHistoryHeadersSerializer implements StructuredSerializer<Ch
   }
 }
 
+class _$ChatEditMessageRequestApplicationJsonSerializer
+    implements StructuredSerializer<ChatEditMessageRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ChatEditMessageRequestApplicationJson, _$ChatEditMessageRequestApplicationJson];
+  @override
+  final String wireName = 'ChatEditMessageRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatEditMessageRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'message',
+      serializers.serialize(object.message, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ChatEditMessageRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatEditMessageRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'message':
+          result.message = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ChatEditMessageResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ChatEditMessageResponseApplicationJson_Ocs> {
   @override
@@ -7854,6 +8730,48 @@ class _$ChatChatDeleteMessageHeadersSerializer implements StructuredSerializer<C
       switch (key) {
         case 'x-chat-last-common-read':
           result.xChatLastCommonRead = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ChatGetMessageContextRequestApplicationJsonSerializer
+    implements StructuredSerializer<ChatGetMessageContextRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ChatGetMessageContextRequestApplicationJson,
+    _$ChatGetMessageContextRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ChatGetMessageContextRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatGetMessageContextRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'limit',
+      serializers.serialize(object.limit, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ChatGetMessageContextRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatGetMessageContextRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -8147,6 +9065,45 @@ class _$ChatGetReminderResponseApplicationJsonSerializer
   }
 }
 
+class _$ChatSetReminderRequestApplicationJsonSerializer
+    implements StructuredSerializer<ChatSetReminderRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ChatSetReminderRequestApplicationJson, _$ChatSetReminderRequestApplicationJson];
+  @override
+  final String wireName = 'ChatSetReminderRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatSetReminderRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'timestamp',
+      serializers.serialize(object.timestamp, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ChatSetReminderRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatSetReminderRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'timestamp':
+          result.timestamp = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ChatSetReminderResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ChatSetReminderResponseApplicationJson_Ocs> {
   @override
@@ -8367,6 +9324,51 @@ class _$ChatDeleteReminderResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(ChatDeleteReminderResponseApplicationJson_Ocs))!
               as ChatDeleteReminderResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ChatSetReadMarkerRequestApplicationJsonSerializer
+    implements StructuredSerializer<ChatSetReadMarkerRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ChatSetReadMarkerRequestApplicationJson,
+    _$ChatSetReadMarkerRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ChatSetReadMarkerRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatSetReadMarkerRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.lastReadMessage;
+    if (value != null) {
+      result
+        ..add('lastReadMessage')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  ChatSetReadMarkerRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatSetReadMarkerRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'lastReadMessage':
+          result.lastReadMessage = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
           break;
       }
     }
@@ -8636,6 +9638,55 @@ class _$ChatChatMarkUnreadHeadersSerializer implements StructuredSerializer<Chat
   }
 }
 
+class _$ChatMentionsRequestApplicationJsonSerializer
+    implements StructuredSerializer<ChatMentionsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ChatMentionsRequestApplicationJson, _$ChatMentionsRequestApplicationJson];
+  @override
+  final String wireName = 'ChatMentionsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatMentionsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'search',
+      serializers.serialize(object.search, specifiedType: const FullType(String)),
+      'limit',
+      serializers.serialize(object.limit, specifiedType: const FullType(int)),
+      'includeStatus',
+      serializers.serialize(object.includeStatus, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ChatMentionsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatMentionsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'search':
+          result.search = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'includeStatus':
+          result.includeStatus = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ChatMentionSuggestionSerializer implements StructuredSerializer<ChatMentionSuggestion> {
   @override
   final Iterable<Type> types = const [ChatMentionSuggestion, _$ChatMentionSuggestion];
@@ -8818,6 +9869,58 @@ class _$ChatMentionsResponseApplicationJsonSerializer
   }
 }
 
+class _$ChatGetObjectsSharedInRoomRequestApplicationJsonSerializer
+    implements StructuredSerializer<ChatGetObjectsSharedInRoomRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ChatGetObjectsSharedInRoomRequestApplicationJson,
+    _$ChatGetObjectsSharedInRoomRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ChatGetObjectsSharedInRoomRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatGetObjectsSharedInRoomRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'objectType',
+      serializers.serialize(object.objectType, specifiedType: const FullType(String)),
+      'lastKnownMessageId',
+      serializers.serialize(object.lastKnownMessageId, specifiedType: const FullType(int)),
+      'limit',
+      serializers.serialize(object.limit, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ChatGetObjectsSharedInRoomRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'objectType':
+          result.objectType = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastKnownMessageId':
+          result.lastKnownMessageId = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ChatGetObjectsSharedInRoomResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ChatGetObjectsSharedInRoomResponseApplicationJson_Ocs> {
   @override
@@ -8946,6 +10049,68 @@ class _$ChatChatGetObjectsSharedInRoomHeadersSerializer
       switch (key) {
         case 'x-chat-last-given':
           result.xChatLastGiven = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ChatShareObjectToChatRequestApplicationJsonSerializer
+    implements StructuredSerializer<ChatShareObjectToChatRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ChatShareObjectToChatRequestApplicationJson,
+    _$ChatShareObjectToChatRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ChatShareObjectToChatRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatShareObjectToChatRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'objectType',
+      serializers.serialize(object.objectType, specifiedType: const FullType(String)),
+      'objectId',
+      serializers.serialize(object.objectId, specifiedType: const FullType(String)),
+      'metaData',
+      serializers.serialize(object.metaData, specifiedType: const FullType(String)),
+      'actorDisplayName',
+      serializers.serialize(object.actorDisplayName, specifiedType: const FullType(String)),
+      'referenceId',
+      serializers.serialize(object.referenceId, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ChatShareObjectToChatRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatShareObjectToChatRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'objectType':
+          result.objectType = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'objectId':
+          result.objectId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'metaData':
+          result.metaData = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'actorDisplayName':
+          result.actorDisplayName = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'referenceId':
+          result.referenceId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -9092,6 +10257,49 @@ class _$ChatChatShareObjectToChatHeadersSerializer implements StructuredSerializ
   }
 }
 
+class _$ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonSerializer
+    implements StructuredSerializer<ChatGetObjectsSharedInRoomOverviewRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ChatGetObjectsSharedInRoomOverviewRequestApplicationJson,
+    _$ChatGetObjectsSharedInRoomOverviewRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ChatGetObjectsSharedInRoomOverviewRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ChatGetObjectsSharedInRoomOverviewRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'limit',
+      serializers.serialize(object.limit, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ChatGetObjectsSharedInRoomOverviewRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs> {
   @override
@@ -9187,6 +10395,48 @@ class _$ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs))!
               as ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SignalingGetSettingsRequestApplicationJsonSerializer
+    implements StructuredSerializer<SignalingGetSettingsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    SignalingGetSettingsRequestApplicationJson,
+    _$SignalingGetSettingsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'SignalingGetSettingsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, SignalingGetSettingsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'token',
+      serializers.serialize(object.token, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  SignalingGetSettingsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = SignalingGetSettingsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'token':
+          result.token = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -10257,6 +11507,48 @@ class _$FilesIntegrationGetRoomByShareTokenResponseApplicationJsonSerializer
   }
 }
 
+class _$PublicShareAuthCreateRoomRequestApplicationJsonSerializer
+    implements StructuredSerializer<PublicShareAuthCreateRoomRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    PublicShareAuthCreateRoomRequestApplicationJson,
+    _$PublicShareAuthCreateRoomRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'PublicShareAuthCreateRoomRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PublicShareAuthCreateRoomRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'shareToken',
+      serializers.serialize(object.shareToken, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  PublicShareAuthCreateRoomRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PublicShareAuthCreateRoomRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'shareToken':
+          result.shareToken = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataSerializer
     implements StructuredSerializer<PublicShareAuthCreateRoomResponseApplicationJson_Ocs_Data> {
   @override
@@ -10406,6 +11698,48 @@ class _$PublicShareAuthCreateRoomResponseApplicationJsonSerializer
   }
 }
 
+class _$GuestSetDisplayNameRequestApplicationJsonSerializer
+    implements StructuredSerializer<GuestSetDisplayNameRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    GuestSetDisplayNameRequestApplicationJson,
+    _$GuestSetDisplayNameRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'GuestSetDisplayNameRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GuestSetDisplayNameRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'displayName',
+      serializers.serialize(object.displayName, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GuestSetDisplayNameRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GuestSetDisplayNameRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'displayName':
+          result.displayName = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$GuestSetDisplayNameResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<GuestSetDisplayNameResponseApplicationJson_Ocs> {
   @override
@@ -10489,6 +11823,69 @@ class _$GuestSetDisplayNameResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(GuestSetDisplayNameResponseApplicationJson_Ocs))!
               as GuestSetDisplayNameResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$HostedSignalingServerRequestTrialRequestApplicationJsonSerializer
+    implements StructuredSerializer<HostedSignalingServerRequestTrialRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    HostedSignalingServerRequestTrialRequestApplicationJson,
+    _$HostedSignalingServerRequestTrialRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'HostedSignalingServerRequestTrialRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, HostedSignalingServerRequestTrialRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'url',
+      serializers.serialize(object.url, specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'email',
+      serializers.serialize(object.email, specifiedType: const FullType(String)),
+      'language',
+      serializers.serialize(object.language, specifiedType: const FullType(String)),
+      'country',
+      serializers.serialize(object.country, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  HostedSignalingServerRequestTrialRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = HostedSignalingServerRequestTrialRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'url':
+          result.url = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'email':
+          result.email = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'language':
+          result.language = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'country':
+          result.country = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -10796,6 +12193,48 @@ class _$SignalingPullMessagesResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(SignalingPullMessagesResponseApplicationJson_Ocs))!
               as SignalingPullMessagesResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SignalingSendMessagesRequestApplicationJsonSerializer
+    implements StructuredSerializer<SignalingSendMessagesRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    SignalingSendMessagesRequestApplicationJson,
+    _$SignalingSendMessagesRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'SignalingSendMessagesRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, SignalingSendMessagesRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'messages',
+      serializers.serialize(object.messages, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  SignalingSendMessagesRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = SignalingSendMessagesRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'messages':
+          result.messages = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -11143,6 +12582,59 @@ class _$MatterbridgeGetBridgeOfRoomResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs))!
               as MatterbridgeGetBridgeOfRoomResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$MatterbridgeEditBridgeOfRoomRequestApplicationJsonSerializer
+    implements StructuredSerializer<MatterbridgeEditBridgeOfRoomRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    MatterbridgeEditBridgeOfRoomRequestApplicationJson,
+    _$MatterbridgeEditBridgeOfRoomRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'MatterbridgeEditBridgeOfRoomRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, MatterbridgeEditBridgeOfRoomRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'enabled',
+      serializers.serialize(object.enabled, specifiedType: const FullType(bool)),
+      'parts',
+      serializers.serialize(object.parts,
+          specifiedType: const FullType(BuiltList, [
+            FullType(BuiltMap, [FullType(String), FullType(JsonObject)])
+          ])),
+    ];
+
+    return result;
+  }
+
+  @override
+  MatterbridgeEditBridgeOfRoomRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'enabled':
+          result.enabled = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'parts':
+          result.parts.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, [
+                FullType(BuiltMap, [FullType(String), FullType(JsonObject)])
+              ]))! as BuiltList<Object?>);
           break;
       }
     }
@@ -11674,6 +13166,64 @@ class _$MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonSeriali
   }
 }
 
+class _$PollCreatePollRequestApplicationJsonSerializer
+    implements StructuredSerializer<PollCreatePollRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [PollCreatePollRequestApplicationJson, _$PollCreatePollRequestApplicationJson];
+  @override
+  final String wireName = 'PollCreatePollRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PollCreatePollRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'question',
+      serializers.serialize(object.question, specifiedType: const FullType(String)),
+      'options',
+      serializers.serialize(object.options, specifiedType: const FullType(BuiltList, [FullType(String)])),
+      'resultMode',
+      serializers.serialize(object.resultMode,
+          specifiedType: const FullType(PollCreatePollRequestApplicationJson_ResultMode)),
+      'maxVotes',
+      serializers.serialize(object.maxVotes, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  PollCreatePollRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PollCreatePollRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'question':
+          result.question = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'options':
+          result.options.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, [FullType(String)]))! as BuiltList<Object?>);
+          break;
+        case 'resultMode':
+          result.resultMode = serializers.deserialize(value,
+                  specifiedType: const FullType(PollCreatePollRequestApplicationJson_ResultMode))!
+              as PollCreatePollRequestApplicationJson_ResultMode;
+          break;
+        case 'maxVotes':
+          result.maxVotes = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$PollVoteSerializer implements StructuredSerializer<PollVote> {
   @override
   final Iterable<Type> types = const [PollVote, _$PollVote];
@@ -12020,6 +13570,46 @@ class _$PollShowPollResponseApplicationJsonSerializer
   }
 }
 
+class _$PollVotePollRequestApplicationJsonSerializer
+    implements StructuredSerializer<PollVotePollRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [PollVotePollRequestApplicationJson, _$PollVotePollRequestApplicationJson];
+  @override
+  final String wireName = 'PollVotePollRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, PollVotePollRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'optionIds',
+      serializers.serialize(object.optionIds, specifiedType: const FullType(BuiltList, [FullType(int)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  PollVotePollRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = PollVotePollRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'optionIds':
+          result.optionIds.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, [FullType(int)]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$PollVotePollResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<PollVotePollResponseApplicationJson_Ocs> {
   @override
@@ -12196,6 +13786,51 @@ class _$PollClosePollResponseApplicationJsonSerializer
   }
 }
 
+class _$ReactionGetReactionsRequestApplicationJsonSerializer
+    implements StructuredSerializer<ReactionGetReactionsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ReactionGetReactionsRequestApplicationJson,
+    _$ReactionGetReactionsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ReactionGetReactionsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ReactionGetReactionsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.reaction;
+    if (value != null) {
+      result
+        ..add('reaction')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  ReactionGetReactionsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ReactionGetReactionsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'reaction':
+          result.reaction = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ReactionSerializer implements StructuredSerializer<Reaction> {
   @override
   final Iterable<Type> types = const [Reaction, _$Reaction];
@@ -12348,6 +13983,45 @@ class _$ReactionGetReactionsResponseApplicationJsonSerializer
   }
 }
 
+class _$ReactionReactRequestApplicationJsonSerializer
+    implements StructuredSerializer<ReactionReactRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ReactionReactRequestApplicationJson, _$ReactionReactRequestApplicationJson];
+  @override
+  final String wireName = 'ReactionReactRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ReactionReactRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'reaction',
+      serializers.serialize(object.reaction, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ReactionReactRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ReactionReactRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'reaction':
+          result.reaction = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ReactionReactResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ReactionReactResponseApplicationJson_Ocs> {
   @override
@@ -12444,6 +14118,45 @@ class _$ReactionReactResponseApplicationJsonSerializer
   }
 }
 
+class _$ReactionDeleteRequestApplicationJsonSerializer
+    implements StructuredSerializer<ReactionDeleteRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ReactionDeleteRequestApplicationJson, _$ReactionDeleteRequestApplicationJson];
+  @override
+  final String wireName = 'ReactionDeleteRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ReactionDeleteRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'reaction',
+      serializers.serialize(object.reaction, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ReactionDeleteRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ReactionDeleteRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'reaction':
+          result.reaction = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ReactionDeleteResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ReactionDeleteResponseApplicationJson_Ocs> {
   @override
@@ -12532,6 +14245,45 @@ class _$ReactionDeleteResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(ReactionDeleteResponseApplicationJson_Ocs))!
                   as ReactionDeleteResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RecordingStartRequestApplicationJsonSerializer
+    implements StructuredSerializer<RecordingStartRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [RecordingStartRequestApplicationJson, _$RecordingStartRequestApplicationJson];
+  @override
+  final String wireName = 'RecordingStartRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RecordingStartRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'status',
+      serializers.serialize(object.status, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RecordingStartRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RecordingStartRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'status':
+          result.status = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -12716,6 +14468,48 @@ class _$RecordingStopResponseApplicationJsonSerializer
   }
 }
 
+class _$RecordingNotificationDismissRequestApplicationJsonSerializer
+    implements StructuredSerializer<RecordingNotificationDismissRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RecordingNotificationDismissRequestApplicationJson,
+    _$RecordingNotificationDismissRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RecordingNotificationDismissRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RecordingNotificationDismissRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'timestamp',
+      serializers.serialize(object.timestamp, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RecordingNotificationDismissRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RecordingNotificationDismissRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'timestamp':
+          result.timestamp = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RecordingNotificationDismissResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RecordingNotificationDismissResponseApplicationJson_Ocs> {
   @override
@@ -12801,6 +14595,53 @@ class _$RecordingNotificationDismissResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RecordingNotificationDismissResponseApplicationJson_Ocs))!
               as RecordingNotificationDismissResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RecordingShareToChatRequestApplicationJsonSerializer
+    implements StructuredSerializer<RecordingShareToChatRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RecordingShareToChatRequestApplicationJson,
+    _$RecordingShareToChatRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RecordingShareToChatRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RecordingShareToChatRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'fileId',
+      serializers.serialize(object.fileId, specifiedType: const FullType(int)),
+      'timestamp',
+      serializers.serialize(object.timestamp, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RecordingShareToChatRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RecordingShareToChatRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'fileId':
+          result.fileId = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'timestamp':
+          result.timestamp = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -12991,6 +14832,45 @@ class _$RecordingBackendResponseApplicationJsonSerializer
   }
 }
 
+class _$RecordingStoreRequestApplicationJsonSerializer
+    implements StructuredSerializer<RecordingStoreRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [RecordingStoreRequestApplicationJson, _$RecordingStoreRequestApplicationJson];
+  @override
+  final String wireName = 'RecordingStoreRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RecordingStoreRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'owner',
+      serializers.serialize(object.owner, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RecordingStoreRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RecordingStoreRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'owner':
+          result.owner = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RecordingStoreResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RecordingStoreResponseApplicationJson_Ocs> {
   @override
@@ -13071,6 +14951,58 @@ class _$RecordingStoreResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(RecordingStoreResponseApplicationJson_Ocs))!
                   as RecordingStoreResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomGetRoomsRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomGetRoomsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [RoomGetRoomsRequestApplicationJson, _$RoomGetRoomsRequestApplicationJson];
+  @override
+  final String wireName = 'RoomGetRoomsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomGetRoomsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'noStatusUpdate',
+      serializers.serialize(object.noStatusUpdate,
+          specifiedType: const FullType(RoomGetRoomsRequestApplicationJson_NoStatusUpdate)),
+      'includeStatus',
+      serializers.serialize(object.includeStatus, specifiedType: const FullType(bool)),
+      'modifiedSince',
+      serializers.serialize(object.modifiedSince, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomGetRoomsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomGetRoomsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'noStatusUpdate':
+          result.noStatusUpdate = serializers.deserialize(value,
+                  specifiedType: const FullType(RoomGetRoomsRequestApplicationJson_NoStatusUpdate))!
+              as RoomGetRoomsRequestApplicationJson_NoStatusUpdate;
+          break;
+        case 'includeStatus':
+          result.includeStatus = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'modifiedSince':
+          result.modifiedSince = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -13229,6 +15161,70 @@ class _$RoomRoomGetRoomsHeadersSerializer implements StructuredSerializer<RoomRo
   }
 }
 
+class _$RoomCreateRoomRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomCreateRoomRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [RoomCreateRoomRequestApplicationJson, _$RoomCreateRoomRequestApplicationJson];
+  @override
+  final String wireName = 'RoomCreateRoomRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomCreateRoomRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'roomType',
+      serializers.serialize(object.roomType, specifiedType: const FullType(int)),
+      'invite',
+      serializers.serialize(object.invite, specifiedType: const FullType(String)),
+      'roomName',
+      serializers.serialize(object.roomName, specifiedType: const FullType(String)),
+      'source',
+      serializers.serialize(object.source, specifiedType: const FullType(String)),
+      'objectType',
+      serializers.serialize(object.objectType, specifiedType: const FullType(String)),
+      'objectId',
+      serializers.serialize(object.objectId, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomCreateRoomRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomCreateRoomRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'roomType':
+          result.roomType = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'invite':
+          result.invite = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'roomName':
+          result.roomName = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'source':
+          result.source = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'objectType':
+          result.objectType = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'objectId':
+          result.objectId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomCreateRoomResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomCreateRoomResponseApplicationJson_Ocs> {
   @override
@@ -13309,6 +15305,48 @@ class _$RoomCreateRoomResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(RoomCreateRoomResponseApplicationJson_Ocs))!
                   as RoomCreateRoomResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomGetListedRoomsRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomGetListedRoomsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomGetListedRoomsRequestApplicationJson,
+    _$RoomGetListedRoomsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomGetListedRoomsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomGetListedRoomsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'searchTerm',
+      serializers.serialize(object.searchTerm, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomGetListedRoomsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomGetListedRoomsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'searchTerm':
+          result.searchTerm = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -13948,6 +15986,48 @@ class _$RoomMakePrivateResponseApplicationJsonSerializer
   }
 }
 
+class _$RoomSetDescriptionRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetDescriptionRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomSetDescriptionRequestApplicationJson,
+    _$RoomSetDescriptionRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomSetDescriptionRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetDescriptionRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'description',
+      serializers.serialize(object.description, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetDescriptionRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetDescriptionRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'description':
+          result.description = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomSetDescriptionResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomSetDescriptionResponseApplicationJson_Ocs> {
   @override
@@ -14031,6 +16111,47 @@ class _$RoomSetDescriptionResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RoomSetDescriptionResponseApplicationJson_Ocs))!
               as RoomSetDescriptionResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomSetReadOnlyRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetReadOnlyRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [RoomSetReadOnlyRequestApplicationJson, _$RoomSetReadOnlyRequestApplicationJson];
+  @override
+  final String wireName = 'RoomSetReadOnlyRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetReadOnlyRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'state',
+      serializers.serialize(object.state, specifiedType: const FullType(RoomSetReadOnlyRequestApplicationJson_State)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetReadOnlyRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetReadOnlyRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'state':
+          result.state = serializers.deserialize(value,
+                  specifiedType: const FullType(RoomSetReadOnlyRequestApplicationJson_State))!
+              as RoomSetReadOnlyRequestApplicationJson_State;
           break;
       }
     }
@@ -14127,6 +16248,47 @@ class _$RoomSetReadOnlyResponseApplicationJsonSerializer
   }
 }
 
+class _$RoomSetListableRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetListableRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [RoomSetListableRequestApplicationJson, _$RoomSetListableRequestApplicationJson];
+  @override
+  final String wireName = 'RoomSetListableRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetListableRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'scope',
+      serializers.serialize(object.scope, specifiedType: const FullType(RoomSetListableRequestApplicationJson_Scope)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetListableRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetListableRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'scope':
+          result.scope = serializers.deserialize(value,
+                  specifiedType: const FullType(RoomSetListableRequestApplicationJson_Scope))!
+              as RoomSetListableRequestApplicationJson_Scope;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomSetListableResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomSetListableResponseApplicationJson_Ocs> {
   @override
@@ -14207,6 +16369,45 @@ class _$RoomSetListableResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(RoomSetListableResponseApplicationJson_Ocs))!
                   as RoomSetListableResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomSetPasswordRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetPasswordRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [RoomSetPasswordRequestApplicationJson, _$RoomSetPasswordRequestApplicationJson];
+  @override
+  final String wireName = 'RoomSetPasswordRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetPasswordRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'password',
+      serializers.serialize(object.password, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetPasswordRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetPasswordRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'password':
+          result.password = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -14303,6 +16504,48 @@ class _$RoomSetPasswordResponseApplicationJsonSerializer
   }
 }
 
+class _$RoomSetPermissionsRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetPermissionsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomSetPermissionsRequestApplicationJson,
+    _$RoomSetPermissionsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomSetPermissionsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetPermissionsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'permissions',
+      serializers.serialize(object.permissions, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetPermissionsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetPermissionsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'permissions':
+          result.permissions = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomSetPermissionsResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomSetPermissionsResponseApplicationJson_Ocs> {
   @override
@@ -14386,6 +16629,48 @@ class _$RoomSetPermissionsResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RoomSetPermissionsResponseApplicationJson_Ocs))!
               as RoomSetPermissionsResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomGetParticipantsRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomGetParticipantsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomGetParticipantsRequestApplicationJson,
+    _$RoomGetParticipantsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomGetParticipantsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomGetParticipantsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'includeStatus',
+      serializers.serialize(object.includeStatus, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomGetParticipantsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomGetParticipantsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'includeStatus':
+          result.includeStatus = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -14676,6 +16961,56 @@ class _$RoomRoomGetParticipantsHeadersSerializer implements StructuredSerializer
   }
 }
 
+class _$RoomAddParticipantToRoomRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomAddParticipantToRoomRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomAddParticipantToRoomRequestApplicationJson,
+    _$RoomAddParticipantToRoomRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomAddParticipantToRoomRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomAddParticipantToRoomRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'newParticipant',
+      serializers.serialize(object.newParticipant, specifiedType: const FullType(String)),
+      'source',
+      serializers.serialize(object.source,
+          specifiedType: const FullType(RoomAddParticipantToRoomRequestApplicationJson_Source)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomAddParticipantToRoomRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomAddParticipantToRoomRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'newParticipant':
+          result.newParticipant = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'source':
+          result.source = serializers.deserialize(value,
+                  specifiedType: const FullType(RoomAddParticipantToRoomRequestApplicationJson_Source))!
+              as RoomAddParticipantToRoomRequestApplicationJson_Source;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Serializer
     implements StructuredSerializer<RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0> {
   @override
@@ -14806,6 +17141,49 @@ class _$RoomAddParticipantToRoomResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RoomAddParticipantToRoomResponseApplicationJson_Ocs))!
               as RoomAddParticipantToRoomResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomGetBreakoutRoomParticipantsRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomGetBreakoutRoomParticipantsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomGetBreakoutRoomParticipantsRequestApplicationJson,
+    _$RoomGetBreakoutRoomParticipantsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomGetBreakoutRoomParticipantsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomGetBreakoutRoomParticipantsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'includeStatus',
+      serializers.serialize(object.includeStatus, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomGetBreakoutRoomParticipantsRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'includeStatus':
+          result.includeStatus = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -15048,6 +17426,48 @@ class _$RoomRemoveSelfFromRoomResponseApplicationJsonSerializer
   }
 }
 
+class _$RoomRemoveAttendeeFromRoomRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomRemoveAttendeeFromRoomRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomRemoveAttendeeFromRoomRequestApplicationJson,
+    _$RoomRemoveAttendeeFromRoomRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomRemoveAttendeeFromRoomRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomRemoveAttendeeFromRoomRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'attendeeId',
+      serializers.serialize(object.attendeeId, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomRemoveAttendeeFromRoomRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'attendeeId':
+          result.attendeeId = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs> {
   @override
@@ -15133,6 +17553,61 @@ class _$RoomRemoveAttendeeFromRoomResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs))!
               as RoomRemoveAttendeeFromRoomResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomSetAttendeePermissionsRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetAttendeePermissionsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomSetAttendeePermissionsRequestApplicationJson,
+    _$RoomSetAttendeePermissionsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomSetAttendeePermissionsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetAttendeePermissionsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'attendeeId',
+      serializers.serialize(object.attendeeId, specifiedType: const FullType(int)),
+      'method',
+      serializers.serialize(object.method,
+          specifiedType: const FullType(RoomSetAttendeePermissionsRequestApplicationJson_Method)),
+      'permissions',
+      serializers.serialize(object.permissions, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetAttendeePermissionsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetAttendeePermissionsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'attendeeId':
+          result.attendeeId = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'method':
+          result.method = serializers.deserialize(value,
+                  specifiedType: const FullType(RoomSetAttendeePermissionsRequestApplicationJson_Method))!
+              as RoomSetAttendeePermissionsRequestApplicationJson_Method;
+          break;
+        case 'permissions':
+          result.permissions = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -15234,6 +17709,57 @@ class _$RoomSetAttendeePermissionsResponseApplicationJsonSerializer
   }
 }
 
+class _$RoomSetAllAttendeesPermissionsRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetAllAttendeesPermissionsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomSetAllAttendeesPermissionsRequestApplicationJson,
+    _$RoomSetAllAttendeesPermissionsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomSetAllAttendeesPermissionsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetAllAttendeesPermissionsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'method',
+      serializers.serialize(object.method,
+          specifiedType: const FullType(RoomSetAllAttendeesPermissionsRequestApplicationJson_Method)),
+      'permissions',
+      serializers.serialize(object.permissions, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetAllAttendeesPermissionsRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'method':
+          result.method = serializers.deserialize(value,
+                  specifiedType: const FullType(RoomSetAllAttendeesPermissionsRequestApplicationJson_Method))!
+              as RoomSetAllAttendeesPermissionsRequestApplicationJson_Method;
+          break;
+        case 'permissions':
+          result.permissions = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs> {
   @override
@@ -15320,6 +17846,50 @@ class _$RoomSetAllAttendeesPermissionsResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs))!
               as RoomSetAllAttendeesPermissionsResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomJoinRoomRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomJoinRoomRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [RoomJoinRoomRequestApplicationJson, _$RoomJoinRoomRequestApplicationJson];
+  @override
+  final String wireName = 'RoomJoinRoomRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomJoinRoomRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'password',
+      serializers.serialize(object.password, specifiedType: const FullType(String)),
+      'force',
+      serializers.serialize(object.force, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomJoinRoomRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomJoinRoomRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'password':
+          result.password = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'force':
+          result.force = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
           break;
       }
     }
@@ -15546,6 +18116,51 @@ class _$RoomLeaveRoomResponseApplicationJsonSerializer
   }
 }
 
+class _$RoomResendInvitationsRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomResendInvitationsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomResendInvitationsRequestApplicationJson,
+    _$RoomResendInvitationsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomResendInvitationsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomResendInvitationsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.attendeeId;
+    if (value != null) {
+      result
+        ..add('attendeeId')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  RoomResendInvitationsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomResendInvitationsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'attendeeId':
+          result.attendeeId = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomResendInvitationsResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomResendInvitationsResponseApplicationJson_Ocs> {
   @override
@@ -15630,6 +18245,51 @@ class _$RoomResendInvitationsResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RoomResendInvitationsResponseApplicationJson_Ocs))!
               as RoomResendInvitationsResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomSetSessionStateRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetSessionStateRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomSetSessionStateRequestApplicationJson,
+    _$RoomSetSessionStateRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomSetSessionStateRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetSessionStateRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'state',
+      serializers.serialize(object.state,
+          specifiedType: const FullType(RoomSetSessionStateRequestApplicationJson_State)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetSessionStateRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetSessionStateRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'state':
+          result.state = serializers.deserialize(value,
+                  specifiedType: const FullType(RoomSetSessionStateRequestApplicationJson_State))!
+              as RoomSetSessionStateRequestApplicationJson_State;
           break;
       }
     }
@@ -15729,6 +18389,48 @@ class _$RoomSetSessionStateResponseApplicationJsonSerializer
   }
 }
 
+class _$RoomPromoteModeratorRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomPromoteModeratorRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomPromoteModeratorRequestApplicationJson,
+    _$RoomPromoteModeratorRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomPromoteModeratorRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomPromoteModeratorRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'attendeeId',
+      serializers.serialize(object.attendeeId, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomPromoteModeratorRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomPromoteModeratorRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'attendeeId':
+          result.attendeeId = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomPromoteModeratorResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomPromoteModeratorResponseApplicationJson_Ocs> {
   @override
@@ -15812,6 +18514,48 @@ class _$RoomPromoteModeratorResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RoomPromoteModeratorResponseApplicationJson_Ocs))!
               as RoomPromoteModeratorResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomDemoteModeratorRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomDemoteModeratorRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomDemoteModeratorRequestApplicationJson,
+    _$RoomDemoteModeratorRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomDemoteModeratorRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomDemoteModeratorRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'attendeeId',
+      serializers.serialize(object.attendeeId, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomDemoteModeratorRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomDemoteModeratorRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'attendeeId':
+          result.attendeeId = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -16094,6 +18838,48 @@ class _$RoomRemoveFromFavoritesResponseApplicationJsonSerializer
   }
 }
 
+class _$RoomSetNotificationLevelRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetNotificationLevelRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomSetNotificationLevelRequestApplicationJson,
+    _$RoomSetNotificationLevelRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomSetNotificationLevelRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetNotificationLevelRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'level',
+      serializers.serialize(object.level, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetNotificationLevelRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetNotificationLevelRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'level':
+          result.level = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomSetNotificationLevelResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomSetNotificationLevelResponseApplicationJson_Ocs> {
   @override
@@ -16178,6 +18964,48 @@ class _$RoomSetNotificationLevelResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RoomSetNotificationLevelResponseApplicationJson_Ocs))!
               as RoomSetNotificationLevelResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomSetNotificationCallsRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetNotificationCallsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomSetNotificationCallsRequestApplicationJson,
+    _$RoomSetNotificationCallsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomSetNotificationCallsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetNotificationCallsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'level',
+      serializers.serialize(object.level, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetNotificationCallsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetNotificationCallsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'level':
+          result.level = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -16278,6 +19106,54 @@ class _$RoomSetNotificationCallsResponseApplicationJsonSerializer
   }
 }
 
+class _$RoomSetLobbyRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetLobbyRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [RoomSetLobbyRequestApplicationJson, _$RoomSetLobbyRequestApplicationJson];
+  @override
+  final String wireName = 'RoomSetLobbyRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetLobbyRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'state',
+      serializers.serialize(object.state, specifiedType: const FullType(int)),
+    ];
+    Object? value;
+    value = object.timer;
+    if (value != null) {
+      result
+        ..add('timer')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  RoomSetLobbyRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetLobbyRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'state':
+          result.state = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+        case 'timer':
+          result.timer = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomSetLobbyResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomSetLobbyResponseApplicationJson_Ocs> {
   @override
@@ -16358,6 +19234,50 @@ class _$RoomSetLobbyResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(RoomSetLobbyResponseApplicationJson_Ocs))!
                   as RoomSetLobbyResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomSetsipEnabledRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetsipEnabledRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomSetsipEnabledRequestApplicationJson,
+    _$RoomSetsipEnabledRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomSetsipEnabledRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetsipEnabledRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'state',
+      serializers.serialize(object.state, specifiedType: const FullType(RoomSetsipEnabledRequestApplicationJson_State)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetsipEnabledRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetsipEnabledRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'state':
+          result.state = serializers.deserialize(value,
+                  specifiedType: const FullType(RoomSetsipEnabledRequestApplicationJson_State))!
+              as RoomSetsipEnabledRequestApplicationJson_State;
           break;
       }
     }
@@ -16457,6 +19377,48 @@ class _$RoomSetsipEnabledResponseApplicationJsonSerializer
   }
 }
 
+class _$RoomSetRecordingConsentRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetRecordingConsentRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomSetRecordingConsentRequestApplicationJson,
+    _$RoomSetRecordingConsentRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomSetRecordingConsentRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetRecordingConsentRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'recordingConsent',
+      serializers.serialize(object.recordingConsent, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetRecordingConsentRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetRecordingConsentRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'recordingConsent':
+          result.recordingConsent = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomSetRecordingConsentResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomSetRecordingConsentResponseApplicationJson_Ocs> {
   @override
@@ -16541,6 +19503,48 @@ class _$RoomSetRecordingConsentResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RoomSetRecordingConsentResponseApplicationJson_Ocs))!
               as RoomSetRecordingConsentResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomSetMessageExpirationRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomSetMessageExpirationRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomSetMessageExpirationRequestApplicationJson,
+    _$RoomSetMessageExpirationRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomSetMessageExpirationRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomSetMessageExpirationRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'seconds',
+      serializers.serialize(object.seconds, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomSetMessageExpirationRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomSetMessageExpirationRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'seconds':
+          result.seconds = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
       }
     }
@@ -17503,6 +20507,48 @@ class _$RoomVerifyDialInPinDeprecatedResponseApplicationJsonSerializer
   }
 }
 
+class _$RoomVerifyDialInPinRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomVerifyDialInPinRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomVerifyDialInPinRequestApplicationJson,
+    _$RoomVerifyDialInPinRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomVerifyDialInPinRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomVerifyDialInPinRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'pin',
+      serializers.serialize(object.pin, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomVerifyDialInPinRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomVerifyDialInPinRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'pin':
+          result.pin = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$RoomVerifyDialInPinResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<RoomVerifyDialInPinResponseApplicationJson_Ocs> {
   @override
@@ -17594,14 +20640,18 @@ class _$RoomVerifyDialInPinResponseApplicationJsonSerializer
   }
 }
 
-class _$RoomVerifyDialOutNumberOptionsSerializer implements StructuredSerializer<RoomVerifyDialOutNumberOptions> {
+class _$RoomVerifyDialOutNumberRequestApplicationJson_OptionsSerializer
+    implements StructuredSerializer<RoomVerifyDialOutNumberRequestApplicationJson_Options> {
   @override
-  final Iterable<Type> types = const [RoomVerifyDialOutNumberOptions, _$RoomVerifyDialOutNumberOptions];
+  final Iterable<Type> types = const [
+    RoomVerifyDialOutNumberRequestApplicationJson_Options,
+    _$RoomVerifyDialOutNumberRequestApplicationJson_Options
+  ];
   @override
-  final String wireName = 'RoomVerifyDialOutNumberOptions';
+  final String wireName = 'RoomVerifyDialOutNumberRequestApplicationJson_Options';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, RoomVerifyDialOutNumberOptions object,
+  Iterable<Object?> serialize(Serializers serializers, RoomVerifyDialOutNumberRequestApplicationJson_Options object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
@@ -17627,9 +20677,10 @@ class _$RoomVerifyDialOutNumberOptionsSerializer implements StructuredSerializer
   }
 
   @override
-  RoomVerifyDialOutNumberOptions deserialize(Serializers serializers, Iterable<Object?> serialized,
+  RoomVerifyDialOutNumberRequestApplicationJson_Options deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = RoomVerifyDialOutNumberOptionsBuilder();
+    final result = RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -17645,6 +20696,56 @@ class _$RoomVerifyDialOutNumberOptionsSerializer implements StructuredSerializer
           break;
         case 'attendeeId':
           result.attendeeId = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomVerifyDialOutNumberRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomVerifyDialOutNumberRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomVerifyDialOutNumberRequestApplicationJson,
+    _$RoomVerifyDialOutNumberRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomVerifyDialOutNumberRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomVerifyDialOutNumberRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'number',
+      serializers.serialize(object.number, specifiedType: const FullType(String)),
+      'options',
+      serializers.serialize(object.options,
+          specifiedType: const FullType(RoomVerifyDialOutNumberRequestApplicationJson_Options)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomVerifyDialOutNumberRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomVerifyDialOutNumberRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'number':
+          result.number = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'options':
+          result.options.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(RoomVerifyDialOutNumberRequestApplicationJson_Options))!
+              as RoomVerifyDialOutNumberRequestApplicationJson_Options);
           break;
       }
     }
@@ -17837,14 +20938,18 @@ class _$RoomCreateGuestByDialInResponseApplicationJsonSerializer
   }
 }
 
-class _$RoomRejectedDialOutRequestOptionsSerializer implements StructuredSerializer<RoomRejectedDialOutRequestOptions> {
+class _$RoomRejectedDialOutRequestRequestApplicationJson_OptionsSerializer
+    implements StructuredSerializer<RoomRejectedDialOutRequestRequestApplicationJson_Options> {
   @override
-  final Iterable<Type> types = const [RoomRejectedDialOutRequestOptions, _$RoomRejectedDialOutRequestOptions];
+  final Iterable<Type> types = const [
+    RoomRejectedDialOutRequestRequestApplicationJson_Options,
+    _$RoomRejectedDialOutRequestRequestApplicationJson_Options
+  ];
   @override
-  final String wireName = 'RoomRejectedDialOutRequestOptions';
+  final String wireName = 'RoomRejectedDialOutRequestRequestApplicationJson_Options';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, RoomRejectedDialOutRequestOptions object,
+  Iterable<Object?> serialize(Serializers serializers, RoomRejectedDialOutRequestRequestApplicationJson_Options object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[];
     Object? value;
@@ -17870,9 +20975,10 @@ class _$RoomRejectedDialOutRequestOptionsSerializer implements StructuredSeriali
   }
 
   @override
-  RoomRejectedDialOutRequestOptions deserialize(Serializers serializers, Iterable<Object?> serialized,
+  RoomRejectedDialOutRequestRequestApplicationJson_Options deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = RoomRejectedDialOutRequestOptionsBuilder();
+    final result = RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -17888,6 +20994,56 @@ class _$RoomRejectedDialOutRequestOptionsSerializer implements StructuredSeriali
           break;
         case 'attendeeId':
           result.attendeeId = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$RoomRejectedDialOutRequestRequestApplicationJsonSerializer
+    implements StructuredSerializer<RoomRejectedDialOutRequestRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    RoomRejectedDialOutRequestRequestApplicationJson,
+    _$RoomRejectedDialOutRequestRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'RoomRejectedDialOutRequestRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, RoomRejectedDialOutRequestRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'callId',
+      serializers.serialize(object.callId, specifiedType: const FullType(String)),
+      'options',
+      serializers.serialize(object.options,
+          specifiedType: const FullType(RoomRejectedDialOutRequestRequestApplicationJson_Options)),
+    ];
+
+    return result;
+  }
+
+  @override
+  RoomRejectedDialOutRequestRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = RoomRejectedDialOutRequestRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'callId':
+          result.callId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'options':
+          result.options.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(RoomRejectedDialOutRequestRequestApplicationJson_Options))!
+              as RoomRejectedDialOutRequestRequestApplicationJson_Options);
           break;
       }
     }
@@ -17981,6 +21137,63 @@ class _$RoomRejectedDialOutRequestResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RoomRejectedDialOutRequestResponseApplicationJson_Ocs))!
               as RoomRejectedDialOutRequestResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SettingsSetUserSettingRequestApplicationJsonSerializer
+    implements StructuredSerializer<SettingsSetUserSettingRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    SettingsSetUserSettingRequestApplicationJson,
+    _$SettingsSetUserSettingRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'SettingsSetUserSettingRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, SettingsSetUserSettingRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'key',
+      serializers.serialize(object.key,
+          specifiedType: const FullType(SettingsSetUserSettingRequestApplicationJson_Key)),
+    ];
+    Object? value;
+    value = object.value;
+    if (value != null) {
+      result
+        ..add('value')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(SettingsSetUserSettingRequestApplicationJson_Value)));
+    }
+    return result;
+  }
+
+  @override
+  SettingsSetUserSettingRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = SettingsSetUserSettingRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'key':
+          result.key = serializers.deserialize(value,
+                  specifiedType: const FullType(SettingsSetUserSettingRequestApplicationJson_Key))!
+              as SettingsSetUserSettingRequestApplicationJson_Key;
+          break;
+        case 'value':
+          result.value = serializers.deserialize(value,
+                  specifiedType: const FullType(SettingsSetUserSettingRequestApplicationJson_Value))
+              as SettingsSetUserSettingRequestApplicationJson_Value?;
           break;
       }
     }
@@ -18252,6 +21465,49 @@ class _$BotAdminListBotsResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(BotAdminListBotsResponseApplicationJson_Ocs))!
               as BotAdminListBotsResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$CertificateGetCertificateExpirationRequestApplicationJsonSerializer
+    implements StructuredSerializer<CertificateGetCertificateExpirationRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    CertificateGetCertificateExpirationRequestApplicationJson,
+    _$CertificateGetCertificateExpirationRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'CertificateGetCertificateExpirationRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, CertificateGetCertificateExpirationRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'host',
+      serializers.serialize(object.host, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  CertificateGetCertificateExpirationRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = CertificateGetCertificateExpirationRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'host':
+          result.host = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -18538,6 +21794,59 @@ class _$RecordingGetWelcomeMessageResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(RecordingGetWelcomeMessageResponseApplicationJson_Ocs))!
               as RecordingGetWelcomeMessageResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$SettingsSetsipSettingsRequestApplicationJsonSerializer
+    implements StructuredSerializer<SettingsSetsipSettingsRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    SettingsSetsipSettingsRequestApplicationJson,
+    _$SettingsSetsipSettingsRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'SettingsSetsipSettingsRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, SettingsSetsipSettingsRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'sipGroups',
+      serializers.serialize(object.sipGroups, specifiedType: const FullType(BuiltList, [FullType(String)])),
+      'dialInInfo',
+      serializers.serialize(object.dialInInfo, specifiedType: const FullType(String)),
+      'sharedSecret',
+      serializers.serialize(object.sharedSecret, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  SettingsSetsipSettingsRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = SettingsSetsipSettingsRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'sipGroups':
+          result.sipGroups.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, [FullType(String)]))! as BuiltList<Object?>);
+          break;
+        case 'dialInInfo':
+          result.dialInInfo = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'sharedSecret':
+          result.sharedSecret = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -19411,6 +22720,102 @@ class _$PublicCapabilities0Serializer implements StructuredSerializer<PublicCapa
     }
 
     return result.build();
+  }
+}
+
+abstract mixin class $AvatarGetAvatarRequestApplicationJsonInterfaceBuilder {
+  void replace($AvatarGetAvatarRequestApplicationJsonInterface other);
+  void update(void Function($AvatarGetAvatarRequestApplicationJsonInterfaceBuilder) updates);
+  bool? get darkTheme;
+  set darkTheme(bool? darkTheme);
+}
+
+class _$AvatarGetAvatarRequestApplicationJson extends AvatarGetAvatarRequestApplicationJson {
+  @override
+  final bool darkTheme;
+
+  factory _$AvatarGetAvatarRequestApplicationJson(
+          [void Function(AvatarGetAvatarRequestApplicationJsonBuilder)? updates]) =>
+      (AvatarGetAvatarRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$AvatarGetAvatarRequestApplicationJson._({required this.darkTheme}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(darkTheme, r'AvatarGetAvatarRequestApplicationJson', 'darkTheme');
+  }
+
+  @override
+  AvatarGetAvatarRequestApplicationJson rebuild(void Function(AvatarGetAvatarRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AvatarGetAvatarRequestApplicationJsonBuilder toBuilder() =>
+      AvatarGetAvatarRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AvatarGetAvatarRequestApplicationJson && darkTheme == other.darkTheme;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, darkTheme.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'AvatarGetAvatarRequestApplicationJson')..add('darkTheme', darkTheme))
+        .toString();
+  }
+}
+
+class AvatarGetAvatarRequestApplicationJsonBuilder
+    implements
+        Builder<AvatarGetAvatarRequestApplicationJson, AvatarGetAvatarRequestApplicationJsonBuilder>,
+        $AvatarGetAvatarRequestApplicationJsonInterfaceBuilder {
+  _$AvatarGetAvatarRequestApplicationJson? _$v;
+
+  bool? _darkTheme;
+  bool? get darkTheme => _$this._darkTheme;
+  set darkTheme(covariant bool? darkTheme) => _$this._darkTheme = darkTheme;
+
+  AvatarGetAvatarRequestApplicationJsonBuilder() {
+    AvatarGetAvatarRequestApplicationJson._defaults(this);
+  }
+
+  AvatarGetAvatarRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _darkTheme = $v.darkTheme;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant AvatarGetAvatarRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$AvatarGetAvatarRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(AvatarGetAvatarRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  AvatarGetAvatarRequestApplicationJson build() => _build();
+
+  _$AvatarGetAvatarRequestApplicationJson _build() {
+    AvatarGetAvatarRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$AvatarGetAvatarRequestApplicationJson._(
+            darkTheme: BuiltValueNullFieldError.checkNotNull(
+                darkTheme, r'AvatarGetAvatarRequestApplicationJson', 'darkTheme'));
+    replace(_$result);
+    return _$result;
   }
 }
 
@@ -22103,6 +25508,116 @@ class AvatarDeleteAvatarResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $AvatarEmojiAvatarRequestApplicationJsonInterfaceBuilder {
+  void replace($AvatarEmojiAvatarRequestApplicationJsonInterface other);
+  void update(void Function($AvatarEmojiAvatarRequestApplicationJsonInterfaceBuilder) updates);
+  String? get emoji;
+  set emoji(String? emoji);
+
+  String? get color;
+  set color(String? color);
+}
+
+class _$AvatarEmojiAvatarRequestApplicationJson extends AvatarEmojiAvatarRequestApplicationJson {
+  @override
+  final String emoji;
+  @override
+  final String? color;
+
+  factory _$AvatarEmojiAvatarRequestApplicationJson(
+          [void Function(AvatarEmojiAvatarRequestApplicationJsonBuilder)? updates]) =>
+      (AvatarEmojiAvatarRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$AvatarEmojiAvatarRequestApplicationJson._({required this.emoji, this.color}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(emoji, r'AvatarEmojiAvatarRequestApplicationJson', 'emoji');
+  }
+
+  @override
+  AvatarEmojiAvatarRequestApplicationJson rebuild(
+          void Function(AvatarEmojiAvatarRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AvatarEmojiAvatarRequestApplicationJsonBuilder toBuilder() =>
+      AvatarEmojiAvatarRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AvatarEmojiAvatarRequestApplicationJson && emoji == other.emoji && color == other.color;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, emoji.hashCode);
+    _$hash = $jc(_$hash, color.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'AvatarEmojiAvatarRequestApplicationJson')
+          ..add('emoji', emoji)
+          ..add('color', color))
+        .toString();
+  }
+}
+
+class AvatarEmojiAvatarRequestApplicationJsonBuilder
+    implements
+        Builder<AvatarEmojiAvatarRequestApplicationJson, AvatarEmojiAvatarRequestApplicationJsonBuilder>,
+        $AvatarEmojiAvatarRequestApplicationJsonInterfaceBuilder {
+  _$AvatarEmojiAvatarRequestApplicationJson? _$v;
+
+  String? _emoji;
+  String? get emoji => _$this._emoji;
+  set emoji(covariant String? emoji) => _$this._emoji = emoji;
+
+  String? _color;
+  String? get color => _$this._color;
+  set color(covariant String? color) => _$this._color = color;
+
+  AvatarEmojiAvatarRequestApplicationJsonBuilder() {
+    AvatarEmojiAvatarRequestApplicationJson._defaults(this);
+  }
+
+  AvatarEmojiAvatarRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _emoji = $v.emoji;
+      _color = $v.color;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant AvatarEmojiAvatarRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$AvatarEmojiAvatarRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(AvatarEmojiAvatarRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  AvatarEmojiAvatarRequestApplicationJson build() => _build();
+
+  _$AvatarEmojiAvatarRequestApplicationJson _build() {
+    AvatarEmojiAvatarRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$AvatarEmojiAvatarRequestApplicationJson._(
+            emoji: BuiltValueNullFieldError.checkNotNull(emoji, r'AvatarEmojiAvatarRequestApplicationJson', 'emoji'),
+            color: color);
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $AvatarEmojiAvatarResponseApplicationJson_OcsInterfaceBuilder {
   void replace($AvatarEmojiAvatarResponseApplicationJson_OcsInterface other);
   void update(void Function($AvatarEmojiAvatarResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -22326,6 +25841,440 @@ class AvatarEmojiAvatarResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterfaceBuilder {
+  void replace($AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterface other);
+  void update(void Function($AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterfaceBuilder) updates);
+  String? get cloudId;
+  set cloudId(String? cloudId);
+
+  bool? get darkTheme;
+  set darkTheme(bool? darkTheme);
+}
+
+class _$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson
+    extends AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson {
+  @override
+  final String cloudId;
+  @override
+  final bool darkTheme;
+
+  factory _$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson(
+          [void Function(AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder)? updates]) =>
+      (AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson._({required this.cloudId, required this.darkTheme})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        cloudId, r'AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson', 'cloudId');
+    BuiltValueNullFieldError.checkNotNull(
+        darkTheme, r'AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson', 'darkTheme');
+  }
+
+  @override
+  AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson rebuild(
+          void Function(AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder toBuilder() =>
+      AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson &&
+        cloudId == other.cloudId &&
+        darkTheme == other.darkTheme;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, cloudId.hashCode);
+    _$hash = $jc(_$hash, darkTheme.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson')
+          ..add('cloudId', cloudId)
+          ..add('darkTheme', darkTheme))
+        .toString();
+  }
+}
+
+class AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder
+    implements
+        Builder<AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson,
+            AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder>,
+        $AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonInterfaceBuilder {
+  _$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson? _$v;
+
+  String? _cloudId;
+  String? get cloudId => _$this._cloudId;
+  set cloudId(covariant String? cloudId) => _$this._cloudId = cloudId;
+
+  bool? _darkTheme;
+  bool? get darkTheme => _$this._darkTheme;
+  set darkTheme(covariant bool? darkTheme) => _$this._darkTheme = darkTheme;
+
+  AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder() {
+    AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson._defaults(this);
+  }
+
+  AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _cloudId = $v.cloudId;
+      _darkTheme = $v.darkTheme;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson build() => _build();
+
+  _$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson _build() {
+    AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson._(
+            cloudId: BuiltValueNullFieldError.checkNotNull(
+                cloudId, r'AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson', 'cloudId'),
+            darkTheme: BuiltValueNullFieldError.checkNotNull(
+                darkTheme, r'AvatarGetUserProxyAvatarWithoutRoomRequestApplicationJson', 'darkTheme'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterfaceBuilder {
+  void replace($AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterface other);
+  void update(void Function($AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterfaceBuilder) updates);
+  String? get cloudId;
+  set cloudId(String? cloudId);
+}
+
+class _$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson
+    extends AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson {
+  @override
+  final String cloudId;
+
+  factory _$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson(
+          [void Function(AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder)? updates]) =>
+      (AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson._({required this.cloudId}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        cloudId, r'AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson', 'cloudId');
+  }
+
+  @override
+  AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson rebuild(
+          void Function(AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder toBuilder() =>
+      AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson && cloudId == other.cloudId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, cloudId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson')
+          ..add('cloudId', cloudId))
+        .toString();
+  }
+}
+
+class AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder
+    implements
+        Builder<AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson,
+            AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder>,
+        $AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonInterfaceBuilder {
+  _$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson? _$v;
+
+  String? _cloudId;
+  String? get cloudId => _$this._cloudId;
+  set cloudId(covariant String? cloudId) => _$this._cloudId = cloudId;
+
+  AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder() {
+    AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson._defaults(this);
+  }
+
+  AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _cloudId = $v.cloudId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson build() => _build();
+
+  _$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson _build() {
+    AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson._(
+            cloudId: BuiltValueNullFieldError.checkNotNull(
+                cloudId, r'AvatarGetUserProxyAvatarDarkWithoutRoomRequestApplicationJson', 'cloudId'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $AvatarGetUserProxyAvatarRequestApplicationJsonInterfaceBuilder {
+  void replace($AvatarGetUserProxyAvatarRequestApplicationJsonInterface other);
+  void update(void Function($AvatarGetUserProxyAvatarRequestApplicationJsonInterfaceBuilder) updates);
+  String? get cloudId;
+  set cloudId(String? cloudId);
+
+  bool? get darkTheme;
+  set darkTheme(bool? darkTheme);
+}
+
+class _$AvatarGetUserProxyAvatarRequestApplicationJson extends AvatarGetUserProxyAvatarRequestApplicationJson {
+  @override
+  final String cloudId;
+  @override
+  final bool darkTheme;
+
+  factory _$AvatarGetUserProxyAvatarRequestApplicationJson(
+          [void Function(AvatarGetUserProxyAvatarRequestApplicationJsonBuilder)? updates]) =>
+      (AvatarGetUserProxyAvatarRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$AvatarGetUserProxyAvatarRequestApplicationJson._({required this.cloudId, required this.darkTheme}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(cloudId, r'AvatarGetUserProxyAvatarRequestApplicationJson', 'cloudId');
+    BuiltValueNullFieldError.checkNotNull(darkTheme, r'AvatarGetUserProxyAvatarRequestApplicationJson', 'darkTheme');
+  }
+
+  @override
+  AvatarGetUserProxyAvatarRequestApplicationJson rebuild(
+          void Function(AvatarGetUserProxyAvatarRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AvatarGetUserProxyAvatarRequestApplicationJsonBuilder toBuilder() =>
+      AvatarGetUserProxyAvatarRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AvatarGetUserProxyAvatarRequestApplicationJson &&
+        cloudId == other.cloudId &&
+        darkTheme == other.darkTheme;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, cloudId.hashCode);
+    _$hash = $jc(_$hash, darkTheme.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'AvatarGetUserProxyAvatarRequestApplicationJson')
+          ..add('cloudId', cloudId)
+          ..add('darkTheme', darkTheme))
+        .toString();
+  }
+}
+
+class AvatarGetUserProxyAvatarRequestApplicationJsonBuilder
+    implements
+        Builder<AvatarGetUserProxyAvatarRequestApplicationJson, AvatarGetUserProxyAvatarRequestApplicationJsonBuilder>,
+        $AvatarGetUserProxyAvatarRequestApplicationJsonInterfaceBuilder {
+  _$AvatarGetUserProxyAvatarRequestApplicationJson? _$v;
+
+  String? _cloudId;
+  String? get cloudId => _$this._cloudId;
+  set cloudId(covariant String? cloudId) => _$this._cloudId = cloudId;
+
+  bool? _darkTheme;
+  bool? get darkTheme => _$this._darkTheme;
+  set darkTheme(covariant bool? darkTheme) => _$this._darkTheme = darkTheme;
+
+  AvatarGetUserProxyAvatarRequestApplicationJsonBuilder() {
+    AvatarGetUserProxyAvatarRequestApplicationJson._defaults(this);
+  }
+
+  AvatarGetUserProxyAvatarRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _cloudId = $v.cloudId;
+      _darkTheme = $v.darkTheme;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant AvatarGetUserProxyAvatarRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$AvatarGetUserProxyAvatarRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(AvatarGetUserProxyAvatarRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  AvatarGetUserProxyAvatarRequestApplicationJson build() => _build();
+
+  _$AvatarGetUserProxyAvatarRequestApplicationJson _build() {
+    AvatarGetUserProxyAvatarRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$AvatarGetUserProxyAvatarRequestApplicationJson._(
+            cloudId: BuiltValueNullFieldError.checkNotNull(
+                cloudId, r'AvatarGetUserProxyAvatarRequestApplicationJson', 'cloudId'),
+            darkTheme: BuiltValueNullFieldError.checkNotNull(
+                darkTheme, r'AvatarGetUserProxyAvatarRequestApplicationJson', 'darkTheme'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterfaceBuilder {
+  void replace($AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterface other);
+  void update(void Function($AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterfaceBuilder) updates);
+  String? get cloudId;
+  set cloudId(String? cloudId);
+}
+
+class _$AvatarGetUserProxyAvatarDarkRequestApplicationJson extends AvatarGetUserProxyAvatarDarkRequestApplicationJson {
+  @override
+  final String cloudId;
+
+  factory _$AvatarGetUserProxyAvatarDarkRequestApplicationJson(
+          [void Function(AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder)? updates]) =>
+      (AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$AvatarGetUserProxyAvatarDarkRequestApplicationJson._({required this.cloudId}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(cloudId, r'AvatarGetUserProxyAvatarDarkRequestApplicationJson', 'cloudId');
+  }
+
+  @override
+  AvatarGetUserProxyAvatarDarkRequestApplicationJson rebuild(
+          void Function(AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder toBuilder() =>
+      AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is AvatarGetUserProxyAvatarDarkRequestApplicationJson && cloudId == other.cloudId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, cloudId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'AvatarGetUserProxyAvatarDarkRequestApplicationJson')..add('cloudId', cloudId))
+        .toString();
+  }
+}
+
+class AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder
+    implements
+        Builder<AvatarGetUserProxyAvatarDarkRequestApplicationJson,
+            AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder>,
+        $AvatarGetUserProxyAvatarDarkRequestApplicationJsonInterfaceBuilder {
+  _$AvatarGetUserProxyAvatarDarkRequestApplicationJson? _$v;
+
+  String? _cloudId;
+  String? get cloudId => _$this._cloudId;
+  set cloudId(covariant String? cloudId) => _$this._cloudId = cloudId;
+
+  AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder() {
+    AvatarGetUserProxyAvatarDarkRequestApplicationJson._defaults(this);
+  }
+
+  AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _cloudId = $v.cloudId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant AvatarGetUserProxyAvatarDarkRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$AvatarGetUserProxyAvatarDarkRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(AvatarGetUserProxyAvatarDarkRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  AvatarGetUserProxyAvatarDarkRequestApplicationJson build() => _build();
+
+  _$AvatarGetUserProxyAvatarDarkRequestApplicationJson _build() {
+    AvatarGetUserProxyAvatarDarkRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$AvatarGetUserProxyAvatarDarkRequestApplicationJson._(
+            cloudId: BuiltValueNullFieldError.checkNotNull(
+                cloudId, r'AvatarGetUserProxyAvatarDarkRequestApplicationJson', 'cloudId'));
     replace(_$result);
     return _$result;
   }
@@ -23140,6 +27089,151 @@ class BotDisableBotResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $BotSendMessageRequestApplicationJsonInterfaceBuilder {
+  void replace($BotSendMessageRequestApplicationJsonInterface other);
+  void update(void Function($BotSendMessageRequestApplicationJsonInterfaceBuilder) updates);
+  String? get message;
+  set message(String? message);
+
+  String? get referenceId;
+  set referenceId(String? referenceId);
+
+  int? get replyTo;
+  set replyTo(int? replyTo);
+
+  bool? get silent;
+  set silent(bool? silent);
+}
+
+class _$BotSendMessageRequestApplicationJson extends BotSendMessageRequestApplicationJson {
+  @override
+  final String message;
+  @override
+  final String referenceId;
+  @override
+  final int replyTo;
+  @override
+  final bool silent;
+
+  factory _$BotSendMessageRequestApplicationJson(
+          [void Function(BotSendMessageRequestApplicationJsonBuilder)? updates]) =>
+      (BotSendMessageRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$BotSendMessageRequestApplicationJson._(
+      {required this.message, required this.referenceId, required this.replyTo, required this.silent})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(message, r'BotSendMessageRequestApplicationJson', 'message');
+    BuiltValueNullFieldError.checkNotNull(referenceId, r'BotSendMessageRequestApplicationJson', 'referenceId');
+    BuiltValueNullFieldError.checkNotNull(replyTo, r'BotSendMessageRequestApplicationJson', 'replyTo');
+    BuiltValueNullFieldError.checkNotNull(silent, r'BotSendMessageRequestApplicationJson', 'silent');
+  }
+
+  @override
+  BotSendMessageRequestApplicationJson rebuild(void Function(BotSendMessageRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BotSendMessageRequestApplicationJsonBuilder toBuilder() =>
+      BotSendMessageRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BotSendMessageRequestApplicationJson &&
+        message == other.message &&
+        referenceId == other.referenceId &&
+        replyTo == other.replyTo &&
+        silent == other.silent;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, message.hashCode);
+    _$hash = $jc(_$hash, referenceId.hashCode);
+    _$hash = $jc(_$hash, replyTo.hashCode);
+    _$hash = $jc(_$hash, silent.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BotSendMessageRequestApplicationJson')
+          ..add('message', message)
+          ..add('referenceId', referenceId)
+          ..add('replyTo', replyTo)
+          ..add('silent', silent))
+        .toString();
+  }
+}
+
+class BotSendMessageRequestApplicationJsonBuilder
+    implements
+        Builder<BotSendMessageRequestApplicationJson, BotSendMessageRequestApplicationJsonBuilder>,
+        $BotSendMessageRequestApplicationJsonInterfaceBuilder {
+  _$BotSendMessageRequestApplicationJson? _$v;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(covariant String? message) => _$this._message = message;
+
+  String? _referenceId;
+  String? get referenceId => _$this._referenceId;
+  set referenceId(covariant String? referenceId) => _$this._referenceId = referenceId;
+
+  int? _replyTo;
+  int? get replyTo => _$this._replyTo;
+  set replyTo(covariant int? replyTo) => _$this._replyTo = replyTo;
+
+  bool? _silent;
+  bool? get silent => _$this._silent;
+  set silent(covariant bool? silent) => _$this._silent = silent;
+
+  BotSendMessageRequestApplicationJsonBuilder() {
+    BotSendMessageRequestApplicationJson._defaults(this);
+  }
+
+  BotSendMessageRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _message = $v.message;
+      _referenceId = $v.referenceId;
+      _replyTo = $v.replyTo;
+      _silent = $v.silent;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant BotSendMessageRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$BotSendMessageRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(BotSendMessageRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BotSendMessageRequestApplicationJson build() => _build();
+
+  _$BotSendMessageRequestApplicationJson _build() {
+    BotSendMessageRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$BotSendMessageRequestApplicationJson._(
+            message: BuiltValueNullFieldError.checkNotNull(message, r'BotSendMessageRequestApplicationJson', 'message'),
+            referenceId: BuiltValueNullFieldError.checkNotNull(
+                referenceId, r'BotSendMessageRequestApplicationJson', 'referenceId'),
+            replyTo: BuiltValueNullFieldError.checkNotNull(replyTo, r'BotSendMessageRequestApplicationJson', 'replyTo'),
+            silent: BuiltValueNullFieldError.checkNotNull(silent, r'BotSendMessageRequestApplicationJson', 'silent'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $BotSendMessageResponseApplicationJson_OcsInterfaceBuilder {
   void replace($BotSendMessageResponseApplicationJson_OcsInterface other);
   void update(void Function($BotSendMessageResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -23368,6 +27462,98 @@ class BotSendMessageResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $BotReactRequestApplicationJsonInterfaceBuilder {
+  void replace($BotReactRequestApplicationJsonInterface other);
+  void update(void Function($BotReactRequestApplicationJsonInterfaceBuilder) updates);
+  String? get reaction;
+  set reaction(String? reaction);
+}
+
+class _$BotReactRequestApplicationJson extends BotReactRequestApplicationJson {
+  @override
+  final String reaction;
+
+  factory _$BotReactRequestApplicationJson([void Function(BotReactRequestApplicationJsonBuilder)? updates]) =>
+      (BotReactRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$BotReactRequestApplicationJson._({required this.reaction}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(reaction, r'BotReactRequestApplicationJson', 'reaction');
+  }
+
+  @override
+  BotReactRequestApplicationJson rebuild(void Function(BotReactRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BotReactRequestApplicationJsonBuilder toBuilder() => BotReactRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BotReactRequestApplicationJson && reaction == other.reaction;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, reaction.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BotReactRequestApplicationJson')..add('reaction', reaction)).toString();
+  }
+}
+
+class BotReactRequestApplicationJsonBuilder
+    implements
+        Builder<BotReactRequestApplicationJson, BotReactRequestApplicationJsonBuilder>,
+        $BotReactRequestApplicationJsonInterfaceBuilder {
+  _$BotReactRequestApplicationJson? _$v;
+
+  String? _reaction;
+  String? get reaction => _$this._reaction;
+  set reaction(covariant String? reaction) => _$this._reaction = reaction;
+
+  BotReactRequestApplicationJsonBuilder() {
+    BotReactRequestApplicationJson._defaults(this);
+  }
+
+  BotReactRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _reaction = $v.reaction;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant BotReactRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$BotReactRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(BotReactRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BotReactRequestApplicationJson build() => _build();
+
+  _$BotReactRequestApplicationJson _build() {
+    BotReactRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$BotReactRequestApplicationJson._(
+            reaction: BuiltValueNullFieldError.checkNotNull(reaction, r'BotReactRequestApplicationJson', 'reaction'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $BotReactResponseApplicationJson_OcsInterfaceBuilder {
   void replace($BotReactResponseApplicationJson_OcsInterface other);
   void update(void Function($BotReactResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -23585,6 +27771,103 @@ class BotReactResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $BotDeleteReactionRequestApplicationJsonInterfaceBuilder {
+  void replace($BotDeleteReactionRequestApplicationJsonInterface other);
+  void update(void Function($BotDeleteReactionRequestApplicationJsonInterfaceBuilder) updates);
+  String? get reaction;
+  set reaction(String? reaction);
+}
+
+class _$BotDeleteReactionRequestApplicationJson extends BotDeleteReactionRequestApplicationJson {
+  @override
+  final String reaction;
+
+  factory _$BotDeleteReactionRequestApplicationJson(
+          [void Function(BotDeleteReactionRequestApplicationJsonBuilder)? updates]) =>
+      (BotDeleteReactionRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$BotDeleteReactionRequestApplicationJson._({required this.reaction}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(reaction, r'BotDeleteReactionRequestApplicationJson', 'reaction');
+  }
+
+  @override
+  BotDeleteReactionRequestApplicationJson rebuild(
+          void Function(BotDeleteReactionRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BotDeleteReactionRequestApplicationJsonBuilder toBuilder() =>
+      BotDeleteReactionRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BotDeleteReactionRequestApplicationJson && reaction == other.reaction;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, reaction.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BotDeleteReactionRequestApplicationJson')..add('reaction', reaction))
+        .toString();
+  }
+}
+
+class BotDeleteReactionRequestApplicationJsonBuilder
+    implements
+        Builder<BotDeleteReactionRequestApplicationJson, BotDeleteReactionRequestApplicationJsonBuilder>,
+        $BotDeleteReactionRequestApplicationJsonInterfaceBuilder {
+  _$BotDeleteReactionRequestApplicationJson? _$v;
+
+  String? _reaction;
+  String? get reaction => _$this._reaction;
+  set reaction(covariant String? reaction) => _$this._reaction = reaction;
+
+  BotDeleteReactionRequestApplicationJsonBuilder() {
+    BotDeleteReactionRequestApplicationJson._defaults(this);
+  }
+
+  BotDeleteReactionRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _reaction = $v.reaction;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant BotDeleteReactionRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$BotDeleteReactionRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(BotDeleteReactionRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BotDeleteReactionRequestApplicationJson build() => _build();
+
+  _$BotDeleteReactionRequestApplicationJson _build() {
+    BotDeleteReactionRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$BotDeleteReactionRequestApplicationJson._(
+            reaction: BuiltValueNullFieldError.checkNotNull(
+                reaction, r'BotDeleteReactionRequestApplicationJson', 'reaction'));
     replace(_$result);
     return _$result;
   }
@@ -23815,6 +28098,143 @@ class BotDeleteReactionResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterfaceBuilder {
+  void replace($BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterface other);
+  void update(void Function($BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterfaceBuilder) updates);
+  BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode? get mode;
+  set mode(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode? mode);
+
+  int? get amount;
+  set amount(int? amount);
+
+  String? get attendeeMap;
+  set attendeeMap(String? attendeeMap);
+}
+
+class _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson
+    extends BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson {
+  @override
+  final BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode mode;
+  @override
+  final int amount;
+  @override
+  final String attendeeMap;
+
+  factory _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson(
+          [void Function(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder)? updates]) =>
+      (BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson._(
+      {required this.mode, required this.amount, required this.attendeeMap})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(mode, r'BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson', 'mode');
+    BuiltValueNullFieldError.checkNotNull(
+        amount, r'BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson', 'amount');
+    BuiltValueNullFieldError.checkNotNull(
+        attendeeMap, r'BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson', 'attendeeMap');
+  }
+
+  @override
+  BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson rebuild(
+          void Function(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder toBuilder() =>
+      BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson &&
+        mode == other.mode &&
+        amount == other.amount &&
+        attendeeMap == other.attendeeMap;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, mode.hashCode);
+    _$hash = $jc(_$hash, amount.hashCode);
+    _$hash = $jc(_$hash, attendeeMap.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson')
+          ..add('mode', mode)
+          ..add('amount', amount)
+          ..add('attendeeMap', attendeeMap))
+        .toString();
+  }
+}
+
+class BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder
+    implements
+        Builder<BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson,
+            BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder>,
+        $BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonInterfaceBuilder {
+  _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson? _$v;
+
+  BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode? _mode;
+  BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode? get mode => _$this._mode;
+  set mode(covariant BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson_Mode? mode) => _$this._mode = mode;
+
+  int? _amount;
+  int? get amount => _$this._amount;
+  set amount(covariant int? amount) => _$this._amount = amount;
+
+  String? _attendeeMap;
+  String? get attendeeMap => _$this._attendeeMap;
+  set attendeeMap(covariant String? attendeeMap) => _$this._attendeeMap = attendeeMap;
+
+  BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder() {
+    BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson._defaults(this);
+  }
+
+  BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _mode = $v.mode;
+      _amount = $v.amount;
+      _attendeeMap = $v.attendeeMap;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(BreakoutRoomConfigureBreakoutRoomsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson build() => _build();
+
+  _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson _build() {
+    BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson._(
+            mode: BuiltValueNullFieldError.checkNotNull(
+                mode, r'BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson', 'mode'),
+            amount: BuiltValueNullFieldError.checkNotNull(
+                amount, r'BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson', 'amount'),
+            attendeeMap: BuiltValueNullFieldError.checkNotNull(
+                attendeeMap, r'BreakoutRoomConfigureBreakoutRoomsRequestApplicationJson', 'attendeeMap'));
     replace(_$result);
     return _$result;
   }
@@ -24299,6 +28719,107 @@ class BreakoutRoomRemoveBreakoutRoomsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterfaceBuilder {
+  void replace($BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterface other);
+  void update(void Function($BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterfaceBuilder) updates);
+  String? get message;
+  set message(String? message);
+}
+
+class _$BreakoutRoomBroadcastChatMessageRequestApplicationJson
+    extends BreakoutRoomBroadcastChatMessageRequestApplicationJson {
+  @override
+  final String message;
+
+  factory _$BreakoutRoomBroadcastChatMessageRequestApplicationJson(
+          [void Function(BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder)? updates]) =>
+      (BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$BreakoutRoomBroadcastChatMessageRequestApplicationJson._({required this.message}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        message, r'BreakoutRoomBroadcastChatMessageRequestApplicationJson', 'message');
+  }
+
+  @override
+  BreakoutRoomBroadcastChatMessageRequestApplicationJson rebuild(
+          void Function(BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder toBuilder() =>
+      BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BreakoutRoomBroadcastChatMessageRequestApplicationJson && message == other.message;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, message.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BreakoutRoomBroadcastChatMessageRequestApplicationJson')
+          ..add('message', message))
+        .toString();
+  }
+}
+
+class BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder
+    implements
+        Builder<BreakoutRoomBroadcastChatMessageRequestApplicationJson,
+            BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder>,
+        $BreakoutRoomBroadcastChatMessageRequestApplicationJsonInterfaceBuilder {
+  _$BreakoutRoomBroadcastChatMessageRequestApplicationJson? _$v;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(covariant String? message) => _$this._message = message;
+
+  BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder() {
+    BreakoutRoomBroadcastChatMessageRequestApplicationJson._defaults(this);
+  }
+
+  BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _message = $v.message;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant BreakoutRoomBroadcastChatMessageRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$BreakoutRoomBroadcastChatMessageRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(BreakoutRoomBroadcastChatMessageRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BreakoutRoomBroadcastChatMessageRequestApplicationJson build() => _build();
+
+  _$BreakoutRoomBroadcastChatMessageRequestApplicationJson _build() {
+    BreakoutRoomBroadcastChatMessageRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$BreakoutRoomBroadcastChatMessageRequestApplicationJson._(
+            message: BuiltValueNullFieldError.checkNotNull(
+                message, r'BreakoutRoomBroadcastChatMessageRequestApplicationJson', 'message'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterfaceBuilder {
   void replace($BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterface other);
   void update(void Function($BreakoutRoomBroadcastChatMessageResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -24533,6 +29054,106 @@ class BreakoutRoomBroadcastChatMessageResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterfaceBuilder {
+  void replace($BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterface other);
+  void update(void Function($BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterfaceBuilder) updates);
+  String? get attendeeMap;
+  set attendeeMap(String? attendeeMap);
+}
+
+class _$BreakoutRoomApplyAttendeeMapRequestApplicationJson extends BreakoutRoomApplyAttendeeMapRequestApplicationJson {
+  @override
+  final String attendeeMap;
+
+  factory _$BreakoutRoomApplyAttendeeMapRequestApplicationJson(
+          [void Function(BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder)? updates]) =>
+      (BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$BreakoutRoomApplyAttendeeMapRequestApplicationJson._({required this.attendeeMap}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        attendeeMap, r'BreakoutRoomApplyAttendeeMapRequestApplicationJson', 'attendeeMap');
+  }
+
+  @override
+  BreakoutRoomApplyAttendeeMapRequestApplicationJson rebuild(
+          void Function(BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder toBuilder() =>
+      BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BreakoutRoomApplyAttendeeMapRequestApplicationJson && attendeeMap == other.attendeeMap;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, attendeeMap.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BreakoutRoomApplyAttendeeMapRequestApplicationJson')
+          ..add('attendeeMap', attendeeMap))
+        .toString();
+  }
+}
+
+class BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder
+    implements
+        Builder<BreakoutRoomApplyAttendeeMapRequestApplicationJson,
+            BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder>,
+        $BreakoutRoomApplyAttendeeMapRequestApplicationJsonInterfaceBuilder {
+  _$BreakoutRoomApplyAttendeeMapRequestApplicationJson? _$v;
+
+  String? _attendeeMap;
+  String? get attendeeMap => _$this._attendeeMap;
+  set attendeeMap(covariant String? attendeeMap) => _$this._attendeeMap = attendeeMap;
+
+  BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder() {
+    BreakoutRoomApplyAttendeeMapRequestApplicationJson._defaults(this);
+  }
+
+  BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _attendeeMap = $v.attendeeMap;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant BreakoutRoomApplyAttendeeMapRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$BreakoutRoomApplyAttendeeMapRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(BreakoutRoomApplyAttendeeMapRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BreakoutRoomApplyAttendeeMapRequestApplicationJson build() => _build();
+
+  _$BreakoutRoomApplyAttendeeMapRequestApplicationJson _build() {
+    BreakoutRoomApplyAttendeeMapRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$BreakoutRoomApplyAttendeeMapRequestApplicationJson._(
+            attendeeMap: BuiltValueNullFieldError.checkNotNull(
+                attendeeMap, r'BreakoutRoomApplyAttendeeMapRequestApplicationJson', 'attendeeMap'));
     replace(_$result);
     return _$result;
   }
@@ -25730,6 +30351,105 @@ class BreakoutRoomStopBreakoutRoomsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterfaceBuilder {
+  void replace($BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterface other);
+  void update(void Function($BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterfaceBuilder) updates);
+  String? get target;
+  set target(String? target);
+}
+
+class _$BreakoutRoomSwitchBreakoutRoomRequestApplicationJson
+    extends BreakoutRoomSwitchBreakoutRoomRequestApplicationJson {
+  @override
+  final String target;
+
+  factory _$BreakoutRoomSwitchBreakoutRoomRequestApplicationJson(
+          [void Function(BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder)? updates]) =>
+      (BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$BreakoutRoomSwitchBreakoutRoomRequestApplicationJson._({required this.target}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(target, r'BreakoutRoomSwitchBreakoutRoomRequestApplicationJson', 'target');
+  }
+
+  @override
+  BreakoutRoomSwitchBreakoutRoomRequestApplicationJson rebuild(
+          void Function(BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder toBuilder() =>
+      BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is BreakoutRoomSwitchBreakoutRoomRequestApplicationJson && target == other.target;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, target.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'BreakoutRoomSwitchBreakoutRoomRequestApplicationJson')..add('target', target))
+        .toString();
+  }
+}
+
+class BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder
+    implements
+        Builder<BreakoutRoomSwitchBreakoutRoomRequestApplicationJson,
+            BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder>,
+        $BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonInterfaceBuilder {
+  _$BreakoutRoomSwitchBreakoutRoomRequestApplicationJson? _$v;
+
+  String? _target;
+  String? get target => _$this._target;
+  set target(covariant String? target) => _$this._target = target;
+
+  BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder() {
+    BreakoutRoomSwitchBreakoutRoomRequestApplicationJson._defaults(this);
+  }
+
+  BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _target = $v.target;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant BreakoutRoomSwitchBreakoutRoomRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$BreakoutRoomSwitchBreakoutRoomRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(BreakoutRoomSwitchBreakoutRoomRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  BreakoutRoomSwitchBreakoutRoomRequestApplicationJson build() => _build();
+
+  _$BreakoutRoomSwitchBreakoutRoomRequestApplicationJson _build() {
+    BreakoutRoomSwitchBreakoutRoomRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$BreakoutRoomSwitchBreakoutRoomRequestApplicationJson._(
+            target: BuiltValueNullFieldError.checkNotNull(
+                target, r'BreakoutRoomSwitchBreakoutRoomRequestApplicationJson', 'target'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterfaceBuilder {
   void replace($BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterface other);
   void update(void Function($BreakoutRoomSwitchBreakoutRoomResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -26369,6 +31089,101 @@ class CallGetPeersForCallResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $CallUpdateCallFlagsRequestApplicationJsonInterfaceBuilder {
+  void replace($CallUpdateCallFlagsRequestApplicationJsonInterface other);
+  void update(void Function($CallUpdateCallFlagsRequestApplicationJsonInterfaceBuilder) updates);
+  int? get flags;
+  set flags(int? flags);
+}
+
+class _$CallUpdateCallFlagsRequestApplicationJson extends CallUpdateCallFlagsRequestApplicationJson {
+  @override
+  final int flags;
+
+  factory _$CallUpdateCallFlagsRequestApplicationJson(
+          [void Function(CallUpdateCallFlagsRequestApplicationJsonBuilder)? updates]) =>
+      (CallUpdateCallFlagsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$CallUpdateCallFlagsRequestApplicationJson._({required this.flags}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(flags, r'CallUpdateCallFlagsRequestApplicationJson', 'flags');
+  }
+
+  @override
+  CallUpdateCallFlagsRequestApplicationJson rebuild(
+          void Function(CallUpdateCallFlagsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CallUpdateCallFlagsRequestApplicationJsonBuilder toBuilder() =>
+      CallUpdateCallFlagsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CallUpdateCallFlagsRequestApplicationJson && flags == other.flags;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, flags.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CallUpdateCallFlagsRequestApplicationJson')..add('flags', flags)).toString();
+  }
+}
+
+class CallUpdateCallFlagsRequestApplicationJsonBuilder
+    implements
+        Builder<CallUpdateCallFlagsRequestApplicationJson, CallUpdateCallFlagsRequestApplicationJsonBuilder>,
+        $CallUpdateCallFlagsRequestApplicationJsonInterfaceBuilder {
+  _$CallUpdateCallFlagsRequestApplicationJson? _$v;
+
+  int? _flags;
+  int? get flags => _$this._flags;
+  set flags(covariant int? flags) => _$this._flags = flags;
+
+  CallUpdateCallFlagsRequestApplicationJsonBuilder() {
+    CallUpdateCallFlagsRequestApplicationJson._defaults(this);
+  }
+
+  CallUpdateCallFlagsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _flags = $v.flags;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant CallUpdateCallFlagsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CallUpdateCallFlagsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(CallUpdateCallFlagsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CallUpdateCallFlagsRequestApplicationJson build() => _build();
+
+  _$CallUpdateCallFlagsRequestApplicationJson _build() {
+    CallUpdateCallFlagsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$CallUpdateCallFlagsRequestApplicationJson._(
+            flags: BuiltValueNullFieldError.checkNotNull(flags, r'CallUpdateCallFlagsRequestApplicationJson', 'flags'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $CallUpdateCallFlagsResponseApplicationJson_OcsInterfaceBuilder {
   void replace($CallUpdateCallFlagsResponseApplicationJson_OcsInterface other);
   void update(void Function($CallUpdateCallFlagsResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -26600,6 +31415,147 @@ class CallUpdateCallFlagsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $CallJoinCallRequestApplicationJsonInterfaceBuilder {
+  void replace($CallJoinCallRequestApplicationJsonInterface other);
+  void update(void Function($CallJoinCallRequestApplicationJsonInterfaceBuilder) updates);
+  int? get flags;
+  set flags(int? flags);
+
+  int? get forcePermissions;
+  set forcePermissions(int? forcePermissions);
+
+  bool? get silent;
+  set silent(bool? silent);
+
+  bool? get recordingConsent;
+  set recordingConsent(bool? recordingConsent);
+}
+
+class _$CallJoinCallRequestApplicationJson extends CallJoinCallRequestApplicationJson {
+  @override
+  final int? flags;
+  @override
+  final int? forcePermissions;
+  @override
+  final bool silent;
+  @override
+  final bool recordingConsent;
+
+  factory _$CallJoinCallRequestApplicationJson([void Function(CallJoinCallRequestApplicationJsonBuilder)? updates]) =>
+      (CallJoinCallRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$CallJoinCallRequestApplicationJson._(
+      {this.flags, this.forcePermissions, required this.silent, required this.recordingConsent})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(silent, r'CallJoinCallRequestApplicationJson', 'silent');
+    BuiltValueNullFieldError.checkNotNull(recordingConsent, r'CallJoinCallRequestApplicationJson', 'recordingConsent');
+  }
+
+  @override
+  CallJoinCallRequestApplicationJson rebuild(void Function(CallJoinCallRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CallJoinCallRequestApplicationJsonBuilder toBuilder() => CallJoinCallRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CallJoinCallRequestApplicationJson &&
+        flags == other.flags &&
+        forcePermissions == other.forcePermissions &&
+        silent == other.silent &&
+        recordingConsent == other.recordingConsent;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, flags.hashCode);
+    _$hash = $jc(_$hash, forcePermissions.hashCode);
+    _$hash = $jc(_$hash, silent.hashCode);
+    _$hash = $jc(_$hash, recordingConsent.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CallJoinCallRequestApplicationJson')
+          ..add('flags', flags)
+          ..add('forcePermissions', forcePermissions)
+          ..add('silent', silent)
+          ..add('recordingConsent', recordingConsent))
+        .toString();
+  }
+}
+
+class CallJoinCallRequestApplicationJsonBuilder
+    implements
+        Builder<CallJoinCallRequestApplicationJson, CallJoinCallRequestApplicationJsonBuilder>,
+        $CallJoinCallRequestApplicationJsonInterfaceBuilder {
+  _$CallJoinCallRequestApplicationJson? _$v;
+
+  int? _flags;
+  int? get flags => _$this._flags;
+  set flags(covariant int? flags) => _$this._flags = flags;
+
+  int? _forcePermissions;
+  int? get forcePermissions => _$this._forcePermissions;
+  set forcePermissions(covariant int? forcePermissions) => _$this._forcePermissions = forcePermissions;
+
+  bool? _silent;
+  bool? get silent => _$this._silent;
+  set silent(covariant bool? silent) => _$this._silent = silent;
+
+  bool? _recordingConsent;
+  bool? get recordingConsent => _$this._recordingConsent;
+  set recordingConsent(covariant bool? recordingConsent) => _$this._recordingConsent = recordingConsent;
+
+  CallJoinCallRequestApplicationJsonBuilder() {
+    CallJoinCallRequestApplicationJson._defaults(this);
+  }
+
+  CallJoinCallRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _flags = $v.flags;
+      _forcePermissions = $v.forcePermissions;
+      _silent = $v.silent;
+      _recordingConsent = $v.recordingConsent;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant CallJoinCallRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CallJoinCallRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(CallJoinCallRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CallJoinCallRequestApplicationJson build() => _build();
+
+  _$CallJoinCallRequestApplicationJson _build() {
+    CallJoinCallRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$CallJoinCallRequestApplicationJson._(
+            flags: flags,
+            forcePermissions: forcePermissions,
+            silent: BuiltValueNullFieldError.checkNotNull(silent, r'CallJoinCallRequestApplicationJson', 'silent'),
+            recordingConsent: BuiltValueNullFieldError.checkNotNull(
+                recordingConsent, r'CallJoinCallRequestApplicationJson', 'recordingConsent'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $CallJoinCallResponseApplicationJson_OcsInterfaceBuilder {
   void replace($CallJoinCallResponseApplicationJson_OcsInterface other);
   void update(void Function($CallJoinCallResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -26821,6 +31777,98 @@ class CallJoinCallResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $CallLeaveCallRequestApplicationJsonInterfaceBuilder {
+  void replace($CallLeaveCallRequestApplicationJsonInterface other);
+  void update(void Function($CallLeaveCallRequestApplicationJsonInterfaceBuilder) updates);
+  bool? get all;
+  set all(bool? all);
+}
+
+class _$CallLeaveCallRequestApplicationJson extends CallLeaveCallRequestApplicationJson {
+  @override
+  final bool all;
+
+  factory _$CallLeaveCallRequestApplicationJson([void Function(CallLeaveCallRequestApplicationJsonBuilder)? updates]) =>
+      (CallLeaveCallRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$CallLeaveCallRequestApplicationJson._({required this.all}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(all, r'CallLeaveCallRequestApplicationJson', 'all');
+  }
+
+  @override
+  CallLeaveCallRequestApplicationJson rebuild(void Function(CallLeaveCallRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CallLeaveCallRequestApplicationJsonBuilder toBuilder() => CallLeaveCallRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CallLeaveCallRequestApplicationJson && all == other.all;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, all.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CallLeaveCallRequestApplicationJson')..add('all', all)).toString();
+  }
+}
+
+class CallLeaveCallRequestApplicationJsonBuilder
+    implements
+        Builder<CallLeaveCallRequestApplicationJson, CallLeaveCallRequestApplicationJsonBuilder>,
+        $CallLeaveCallRequestApplicationJsonInterfaceBuilder {
+  _$CallLeaveCallRequestApplicationJson? _$v;
+
+  bool? _all;
+  bool? get all => _$this._all;
+  set all(covariant bool? all) => _$this._all = all;
+
+  CallLeaveCallRequestApplicationJsonBuilder() {
+    CallLeaveCallRequestApplicationJson._defaults(this);
+  }
+
+  CallLeaveCallRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _all = $v.all;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant CallLeaveCallRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CallLeaveCallRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(CallLeaveCallRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CallLeaveCallRequestApplicationJson build() => _build();
+
+  _$CallLeaveCallRequestApplicationJson _build() {
+    CallLeaveCallRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$CallLeaveCallRequestApplicationJson._(
+            all: BuiltValueNullFieldError.checkNotNull(all, r'CallLeaveCallRequestApplicationJson', 'all'));
     replace(_$result);
     return _$result;
   }
@@ -27612,6 +32660,256 @@ class CallSipDialOutResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ChatReceiveMessagesRequestApplicationJsonInterfaceBuilder {
+  void replace($ChatReceiveMessagesRequestApplicationJsonInterface other);
+  void update(void Function($ChatReceiveMessagesRequestApplicationJsonInterfaceBuilder) updates);
+  ChatReceiveMessagesRequestApplicationJson_LookIntoFuture? get lookIntoFuture;
+  set lookIntoFuture(ChatReceiveMessagesRequestApplicationJson_LookIntoFuture? lookIntoFuture);
+
+  int? get limit;
+  set limit(int? limit);
+
+  int? get lastKnownMessageId;
+  set lastKnownMessageId(int? lastKnownMessageId);
+
+  int? get lastCommonReadId;
+  set lastCommonReadId(int? lastCommonReadId);
+
+  int? get timeout;
+  set timeout(int? timeout);
+
+  ChatReceiveMessagesRequestApplicationJson_SetReadMarker? get setReadMarker;
+  set setReadMarker(ChatReceiveMessagesRequestApplicationJson_SetReadMarker? setReadMarker);
+
+  ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown? get includeLastKnown;
+  set includeLastKnown(ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown? includeLastKnown);
+
+  ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate? get noStatusUpdate;
+  set noStatusUpdate(ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate? noStatusUpdate);
+
+  ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead? get markNotificationsAsRead;
+  set markNotificationsAsRead(
+      ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead? markNotificationsAsRead);
+}
+
+class _$ChatReceiveMessagesRequestApplicationJson extends ChatReceiveMessagesRequestApplicationJson {
+  @override
+  final ChatReceiveMessagesRequestApplicationJson_LookIntoFuture lookIntoFuture;
+  @override
+  final int limit;
+  @override
+  final int lastKnownMessageId;
+  @override
+  final int lastCommonReadId;
+  @override
+  final int timeout;
+  @override
+  final ChatReceiveMessagesRequestApplicationJson_SetReadMarker setReadMarker;
+  @override
+  final ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown includeLastKnown;
+  @override
+  final ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate noStatusUpdate;
+  @override
+  final ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead markNotificationsAsRead;
+
+  factory _$ChatReceiveMessagesRequestApplicationJson(
+          [void Function(ChatReceiveMessagesRequestApplicationJsonBuilder)? updates]) =>
+      (ChatReceiveMessagesRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ChatReceiveMessagesRequestApplicationJson._(
+      {required this.lookIntoFuture,
+      required this.limit,
+      required this.lastKnownMessageId,
+      required this.lastCommonReadId,
+      required this.timeout,
+      required this.setReadMarker,
+      required this.includeLastKnown,
+      required this.noStatusUpdate,
+      required this.markNotificationsAsRead})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        lookIntoFuture, r'ChatReceiveMessagesRequestApplicationJson', 'lookIntoFuture');
+    BuiltValueNullFieldError.checkNotNull(limit, r'ChatReceiveMessagesRequestApplicationJson', 'limit');
+    BuiltValueNullFieldError.checkNotNull(
+        lastKnownMessageId, r'ChatReceiveMessagesRequestApplicationJson', 'lastKnownMessageId');
+    BuiltValueNullFieldError.checkNotNull(
+        lastCommonReadId, r'ChatReceiveMessagesRequestApplicationJson', 'lastCommonReadId');
+    BuiltValueNullFieldError.checkNotNull(timeout, r'ChatReceiveMessagesRequestApplicationJson', 'timeout');
+    BuiltValueNullFieldError.checkNotNull(setReadMarker, r'ChatReceiveMessagesRequestApplicationJson', 'setReadMarker');
+    BuiltValueNullFieldError.checkNotNull(
+        includeLastKnown, r'ChatReceiveMessagesRequestApplicationJson', 'includeLastKnown');
+    BuiltValueNullFieldError.checkNotNull(
+        noStatusUpdate, r'ChatReceiveMessagesRequestApplicationJson', 'noStatusUpdate');
+    BuiltValueNullFieldError.checkNotNull(
+        markNotificationsAsRead, r'ChatReceiveMessagesRequestApplicationJson', 'markNotificationsAsRead');
+  }
+
+  @override
+  ChatReceiveMessagesRequestApplicationJson rebuild(
+          void Function(ChatReceiveMessagesRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatReceiveMessagesRequestApplicationJsonBuilder toBuilder() =>
+      ChatReceiveMessagesRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatReceiveMessagesRequestApplicationJson &&
+        lookIntoFuture == other.lookIntoFuture &&
+        limit == other.limit &&
+        lastKnownMessageId == other.lastKnownMessageId &&
+        lastCommonReadId == other.lastCommonReadId &&
+        timeout == other.timeout &&
+        setReadMarker == other.setReadMarker &&
+        includeLastKnown == other.includeLastKnown &&
+        noStatusUpdate == other.noStatusUpdate &&
+        markNotificationsAsRead == other.markNotificationsAsRead;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, lookIntoFuture.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jc(_$hash, lastKnownMessageId.hashCode);
+    _$hash = $jc(_$hash, lastCommonReadId.hashCode);
+    _$hash = $jc(_$hash, timeout.hashCode);
+    _$hash = $jc(_$hash, setReadMarker.hashCode);
+    _$hash = $jc(_$hash, includeLastKnown.hashCode);
+    _$hash = $jc(_$hash, noStatusUpdate.hashCode);
+    _$hash = $jc(_$hash, markNotificationsAsRead.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatReceiveMessagesRequestApplicationJson')
+          ..add('lookIntoFuture', lookIntoFuture)
+          ..add('limit', limit)
+          ..add('lastKnownMessageId', lastKnownMessageId)
+          ..add('lastCommonReadId', lastCommonReadId)
+          ..add('timeout', timeout)
+          ..add('setReadMarker', setReadMarker)
+          ..add('includeLastKnown', includeLastKnown)
+          ..add('noStatusUpdate', noStatusUpdate)
+          ..add('markNotificationsAsRead', markNotificationsAsRead))
+        .toString();
+  }
+}
+
+class ChatReceiveMessagesRequestApplicationJsonBuilder
+    implements
+        Builder<ChatReceiveMessagesRequestApplicationJson, ChatReceiveMessagesRequestApplicationJsonBuilder>,
+        $ChatReceiveMessagesRequestApplicationJsonInterfaceBuilder {
+  _$ChatReceiveMessagesRequestApplicationJson? _$v;
+
+  ChatReceiveMessagesRequestApplicationJson_LookIntoFuture? _lookIntoFuture;
+  ChatReceiveMessagesRequestApplicationJson_LookIntoFuture? get lookIntoFuture => _$this._lookIntoFuture;
+  set lookIntoFuture(covariant ChatReceiveMessagesRequestApplicationJson_LookIntoFuture? lookIntoFuture) =>
+      _$this._lookIntoFuture = lookIntoFuture;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  int? _lastKnownMessageId;
+  int? get lastKnownMessageId => _$this._lastKnownMessageId;
+  set lastKnownMessageId(covariant int? lastKnownMessageId) => _$this._lastKnownMessageId = lastKnownMessageId;
+
+  int? _lastCommonReadId;
+  int? get lastCommonReadId => _$this._lastCommonReadId;
+  set lastCommonReadId(covariant int? lastCommonReadId) => _$this._lastCommonReadId = lastCommonReadId;
+
+  int? _timeout;
+  int? get timeout => _$this._timeout;
+  set timeout(covariant int? timeout) => _$this._timeout = timeout;
+
+  ChatReceiveMessagesRequestApplicationJson_SetReadMarker? _setReadMarker;
+  ChatReceiveMessagesRequestApplicationJson_SetReadMarker? get setReadMarker => _$this._setReadMarker;
+  set setReadMarker(covariant ChatReceiveMessagesRequestApplicationJson_SetReadMarker? setReadMarker) =>
+      _$this._setReadMarker = setReadMarker;
+
+  ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown? _includeLastKnown;
+  ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown? get includeLastKnown => _$this._includeLastKnown;
+  set includeLastKnown(covariant ChatReceiveMessagesRequestApplicationJson_IncludeLastKnown? includeLastKnown) =>
+      _$this._includeLastKnown = includeLastKnown;
+
+  ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate? _noStatusUpdate;
+  ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate? get noStatusUpdate => _$this._noStatusUpdate;
+  set noStatusUpdate(covariant ChatReceiveMessagesRequestApplicationJson_NoStatusUpdate? noStatusUpdate) =>
+      _$this._noStatusUpdate = noStatusUpdate;
+
+  ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead? _markNotificationsAsRead;
+  ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead? get markNotificationsAsRead =>
+      _$this._markNotificationsAsRead;
+  set markNotificationsAsRead(
+          covariant ChatReceiveMessagesRequestApplicationJson_MarkNotificationsAsRead? markNotificationsAsRead) =>
+      _$this._markNotificationsAsRead = markNotificationsAsRead;
+
+  ChatReceiveMessagesRequestApplicationJsonBuilder() {
+    ChatReceiveMessagesRequestApplicationJson._defaults(this);
+  }
+
+  ChatReceiveMessagesRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _lookIntoFuture = $v.lookIntoFuture;
+      _limit = $v.limit;
+      _lastKnownMessageId = $v.lastKnownMessageId;
+      _lastCommonReadId = $v.lastCommonReadId;
+      _timeout = $v.timeout;
+      _setReadMarker = $v.setReadMarker;
+      _includeLastKnown = $v.includeLastKnown;
+      _noStatusUpdate = $v.noStatusUpdate;
+      _markNotificationsAsRead = $v.markNotificationsAsRead;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatReceiveMessagesRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatReceiveMessagesRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ChatReceiveMessagesRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatReceiveMessagesRequestApplicationJson build() => _build();
+
+  _$ChatReceiveMessagesRequestApplicationJson _build() {
+    ChatReceiveMessagesRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ChatReceiveMessagesRequestApplicationJson._(
+            lookIntoFuture: BuiltValueNullFieldError.checkNotNull(
+                lookIntoFuture, r'ChatReceiveMessagesRequestApplicationJson', 'lookIntoFuture'),
+            limit: BuiltValueNullFieldError.checkNotNull(limit, r'ChatReceiveMessagesRequestApplicationJson', 'limit'),
+            lastKnownMessageId: BuiltValueNullFieldError.checkNotNull(
+                lastKnownMessageId, r'ChatReceiveMessagesRequestApplicationJson', 'lastKnownMessageId'),
+            lastCommonReadId: BuiltValueNullFieldError.checkNotNull(
+                lastCommonReadId, r'ChatReceiveMessagesRequestApplicationJson', 'lastCommonReadId'),
+            timeout:
+                BuiltValueNullFieldError.checkNotNull(timeout, r'ChatReceiveMessagesRequestApplicationJson', 'timeout'),
+            setReadMarker: BuiltValueNullFieldError.checkNotNull(
+                setReadMarker, r'ChatReceiveMessagesRequestApplicationJson', 'setReadMarker'),
+            includeLastKnown: BuiltValueNullFieldError.checkNotNull(
+                includeLastKnown, r'ChatReceiveMessagesRequestApplicationJson', 'includeLastKnown'),
+            noStatusUpdate: BuiltValueNullFieldError.checkNotNull(
+                noStatusUpdate, r'ChatReceiveMessagesRequestApplicationJson', 'noStatusUpdate'),
+            markNotificationsAsRead: BuiltValueNullFieldError.checkNotNull(
+                markNotificationsAsRead, r'ChatReceiveMessagesRequestApplicationJson', 'markNotificationsAsRead'));
     replace(_$result);
     return _$result;
   }
@@ -28417,6 +33715,174 @@ class ChatChatReceiveMessagesHeadersBuilder
   }
 }
 
+abstract mixin class $ChatSendMessageRequestApplicationJsonInterfaceBuilder {
+  void replace($ChatSendMessageRequestApplicationJsonInterface other);
+  void update(void Function($ChatSendMessageRequestApplicationJsonInterfaceBuilder) updates);
+  String? get message;
+  set message(String? message);
+
+  String? get actorDisplayName;
+  set actorDisplayName(String? actorDisplayName);
+
+  String? get referenceId;
+  set referenceId(String? referenceId);
+
+  int? get replyTo;
+  set replyTo(int? replyTo);
+
+  bool? get silent;
+  set silent(bool? silent);
+}
+
+class _$ChatSendMessageRequestApplicationJson extends ChatSendMessageRequestApplicationJson {
+  @override
+  final String message;
+  @override
+  final String actorDisplayName;
+  @override
+  final String referenceId;
+  @override
+  final int replyTo;
+  @override
+  final bool silent;
+
+  factory _$ChatSendMessageRequestApplicationJson(
+          [void Function(ChatSendMessageRequestApplicationJsonBuilder)? updates]) =>
+      (ChatSendMessageRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ChatSendMessageRequestApplicationJson._(
+      {required this.message,
+      required this.actorDisplayName,
+      required this.referenceId,
+      required this.replyTo,
+      required this.silent})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(message, r'ChatSendMessageRequestApplicationJson', 'message');
+    BuiltValueNullFieldError.checkNotNull(
+        actorDisplayName, r'ChatSendMessageRequestApplicationJson', 'actorDisplayName');
+    BuiltValueNullFieldError.checkNotNull(referenceId, r'ChatSendMessageRequestApplicationJson', 'referenceId');
+    BuiltValueNullFieldError.checkNotNull(replyTo, r'ChatSendMessageRequestApplicationJson', 'replyTo');
+    BuiltValueNullFieldError.checkNotNull(silent, r'ChatSendMessageRequestApplicationJson', 'silent');
+  }
+
+  @override
+  ChatSendMessageRequestApplicationJson rebuild(void Function(ChatSendMessageRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatSendMessageRequestApplicationJsonBuilder toBuilder() =>
+      ChatSendMessageRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatSendMessageRequestApplicationJson &&
+        message == other.message &&
+        actorDisplayName == other.actorDisplayName &&
+        referenceId == other.referenceId &&
+        replyTo == other.replyTo &&
+        silent == other.silent;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, message.hashCode);
+    _$hash = $jc(_$hash, actorDisplayName.hashCode);
+    _$hash = $jc(_$hash, referenceId.hashCode);
+    _$hash = $jc(_$hash, replyTo.hashCode);
+    _$hash = $jc(_$hash, silent.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatSendMessageRequestApplicationJson')
+          ..add('message', message)
+          ..add('actorDisplayName', actorDisplayName)
+          ..add('referenceId', referenceId)
+          ..add('replyTo', replyTo)
+          ..add('silent', silent))
+        .toString();
+  }
+}
+
+class ChatSendMessageRequestApplicationJsonBuilder
+    implements
+        Builder<ChatSendMessageRequestApplicationJson, ChatSendMessageRequestApplicationJsonBuilder>,
+        $ChatSendMessageRequestApplicationJsonInterfaceBuilder {
+  _$ChatSendMessageRequestApplicationJson? _$v;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(covariant String? message) => _$this._message = message;
+
+  String? _actorDisplayName;
+  String? get actorDisplayName => _$this._actorDisplayName;
+  set actorDisplayName(covariant String? actorDisplayName) => _$this._actorDisplayName = actorDisplayName;
+
+  String? _referenceId;
+  String? get referenceId => _$this._referenceId;
+  set referenceId(covariant String? referenceId) => _$this._referenceId = referenceId;
+
+  int? _replyTo;
+  int? get replyTo => _$this._replyTo;
+  set replyTo(covariant int? replyTo) => _$this._replyTo = replyTo;
+
+  bool? _silent;
+  bool? get silent => _$this._silent;
+  set silent(covariant bool? silent) => _$this._silent = silent;
+
+  ChatSendMessageRequestApplicationJsonBuilder() {
+    ChatSendMessageRequestApplicationJson._defaults(this);
+  }
+
+  ChatSendMessageRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _message = $v.message;
+      _actorDisplayName = $v.actorDisplayName;
+      _referenceId = $v.referenceId;
+      _replyTo = $v.replyTo;
+      _silent = $v.silent;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatSendMessageRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatSendMessageRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ChatSendMessageRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatSendMessageRequestApplicationJson build() => _build();
+
+  _$ChatSendMessageRequestApplicationJson _build() {
+    ChatSendMessageRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ChatSendMessageRequestApplicationJson._(
+            message:
+                BuiltValueNullFieldError.checkNotNull(message, r'ChatSendMessageRequestApplicationJson', 'message'),
+            actorDisplayName: BuiltValueNullFieldError.checkNotNull(
+                actorDisplayName, r'ChatSendMessageRequestApplicationJson', 'actorDisplayName'),
+            referenceId: BuiltValueNullFieldError.checkNotNull(
+                referenceId, r'ChatSendMessageRequestApplicationJson', 'referenceId'),
+            replyTo:
+                BuiltValueNullFieldError.checkNotNull(replyTo, r'ChatSendMessageRequestApplicationJson', 'replyTo'),
+            silent: BuiltValueNullFieldError.checkNotNull(silent, r'ChatSendMessageRequestApplicationJson', 'silent'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ChatSendMessageResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ChatSendMessageResponseApplicationJson_OcsInterface other);
   void update(void Function($ChatSendMessageResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -29046,6 +34512,101 @@ class ChatChatClearHistoryHeadersBuilder
   _$ChatChatClearHistoryHeaders _build() {
     ChatChatClearHistoryHeaders._validate(this);
     final _$result = _$v ?? _$ChatChatClearHistoryHeaders._(xChatLastCommonRead: xChatLastCommonRead);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ChatEditMessageRequestApplicationJsonInterfaceBuilder {
+  void replace($ChatEditMessageRequestApplicationJsonInterface other);
+  void update(void Function($ChatEditMessageRequestApplicationJsonInterfaceBuilder) updates);
+  String? get message;
+  set message(String? message);
+}
+
+class _$ChatEditMessageRequestApplicationJson extends ChatEditMessageRequestApplicationJson {
+  @override
+  final String message;
+
+  factory _$ChatEditMessageRequestApplicationJson(
+          [void Function(ChatEditMessageRequestApplicationJsonBuilder)? updates]) =>
+      (ChatEditMessageRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ChatEditMessageRequestApplicationJson._({required this.message}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(message, r'ChatEditMessageRequestApplicationJson', 'message');
+  }
+
+  @override
+  ChatEditMessageRequestApplicationJson rebuild(void Function(ChatEditMessageRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatEditMessageRequestApplicationJsonBuilder toBuilder() =>
+      ChatEditMessageRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatEditMessageRequestApplicationJson && message == other.message;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, message.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatEditMessageRequestApplicationJson')..add('message', message)).toString();
+  }
+}
+
+class ChatEditMessageRequestApplicationJsonBuilder
+    implements
+        Builder<ChatEditMessageRequestApplicationJson, ChatEditMessageRequestApplicationJsonBuilder>,
+        $ChatEditMessageRequestApplicationJsonInterfaceBuilder {
+  _$ChatEditMessageRequestApplicationJson? _$v;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(covariant String? message) => _$this._message = message;
+
+  ChatEditMessageRequestApplicationJsonBuilder() {
+    ChatEditMessageRequestApplicationJson._defaults(this);
+  }
+
+  ChatEditMessageRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _message = $v.message;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatEditMessageRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatEditMessageRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ChatEditMessageRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatEditMessageRequestApplicationJson build() => _build();
+
+  _$ChatEditMessageRequestApplicationJson _build() {
+    ChatEditMessageRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ChatEditMessageRequestApplicationJson._(
+            message:
+                BuiltValueNullFieldError.checkNotNull(message, r'ChatEditMessageRequestApplicationJson', 'message'));
     replace(_$result);
     return _$result;
   }
@@ -29681,6 +35242,103 @@ class ChatChatDeleteMessageHeadersBuilder
   _$ChatChatDeleteMessageHeaders _build() {
     ChatChatDeleteMessageHeaders._validate(this);
     final _$result = _$v ?? _$ChatChatDeleteMessageHeaders._(xChatLastCommonRead: xChatLastCommonRead);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ChatGetMessageContextRequestApplicationJsonInterfaceBuilder {
+  void replace($ChatGetMessageContextRequestApplicationJsonInterface other);
+  void update(void Function($ChatGetMessageContextRequestApplicationJsonInterfaceBuilder) updates);
+  int? get limit;
+  set limit(int? limit);
+}
+
+class _$ChatGetMessageContextRequestApplicationJson extends ChatGetMessageContextRequestApplicationJson {
+  @override
+  final int limit;
+
+  factory _$ChatGetMessageContextRequestApplicationJson(
+          [void Function(ChatGetMessageContextRequestApplicationJsonBuilder)? updates]) =>
+      (ChatGetMessageContextRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ChatGetMessageContextRequestApplicationJson._({required this.limit}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(limit, r'ChatGetMessageContextRequestApplicationJson', 'limit');
+  }
+
+  @override
+  ChatGetMessageContextRequestApplicationJson rebuild(
+          void Function(ChatGetMessageContextRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatGetMessageContextRequestApplicationJsonBuilder toBuilder() =>
+      ChatGetMessageContextRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatGetMessageContextRequestApplicationJson && limit == other.limit;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatGetMessageContextRequestApplicationJson')..add('limit', limit))
+        .toString();
+  }
+}
+
+class ChatGetMessageContextRequestApplicationJsonBuilder
+    implements
+        Builder<ChatGetMessageContextRequestApplicationJson, ChatGetMessageContextRequestApplicationJsonBuilder>,
+        $ChatGetMessageContextRequestApplicationJsonInterfaceBuilder {
+  _$ChatGetMessageContextRequestApplicationJson? _$v;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  ChatGetMessageContextRequestApplicationJsonBuilder() {
+    ChatGetMessageContextRequestApplicationJson._defaults(this);
+  }
+
+  ChatGetMessageContextRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _limit = $v.limit;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatGetMessageContextRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatGetMessageContextRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ChatGetMessageContextRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatGetMessageContextRequestApplicationJson build() => _build();
+
+  _$ChatGetMessageContextRequestApplicationJson _build() {
+    ChatGetMessageContextRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ChatGetMessageContextRequestApplicationJson._(
+            limit:
+                BuiltValueNullFieldError.checkNotNull(limit, r'ChatGetMessageContextRequestApplicationJson', 'limit'));
     replace(_$result);
     return _$result;
   }
@@ -30386,6 +36044,102 @@ class ChatGetReminderResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $ChatSetReminderRequestApplicationJsonInterfaceBuilder {
+  void replace($ChatSetReminderRequestApplicationJsonInterface other);
+  void update(void Function($ChatSetReminderRequestApplicationJsonInterfaceBuilder) updates);
+  int? get timestamp;
+  set timestamp(int? timestamp);
+}
+
+class _$ChatSetReminderRequestApplicationJson extends ChatSetReminderRequestApplicationJson {
+  @override
+  final int timestamp;
+
+  factory _$ChatSetReminderRequestApplicationJson(
+          [void Function(ChatSetReminderRequestApplicationJsonBuilder)? updates]) =>
+      (ChatSetReminderRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ChatSetReminderRequestApplicationJson._({required this.timestamp}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(timestamp, r'ChatSetReminderRequestApplicationJson', 'timestamp');
+  }
+
+  @override
+  ChatSetReminderRequestApplicationJson rebuild(void Function(ChatSetReminderRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatSetReminderRequestApplicationJsonBuilder toBuilder() =>
+      ChatSetReminderRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatSetReminderRequestApplicationJson && timestamp == other.timestamp;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, timestamp.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatSetReminderRequestApplicationJson')..add('timestamp', timestamp))
+        .toString();
+  }
+}
+
+class ChatSetReminderRequestApplicationJsonBuilder
+    implements
+        Builder<ChatSetReminderRequestApplicationJson, ChatSetReminderRequestApplicationJsonBuilder>,
+        $ChatSetReminderRequestApplicationJsonInterfaceBuilder {
+  _$ChatSetReminderRequestApplicationJson? _$v;
+
+  int? _timestamp;
+  int? get timestamp => _$this._timestamp;
+  set timestamp(covariant int? timestamp) => _$this._timestamp = timestamp;
+
+  ChatSetReminderRequestApplicationJsonBuilder() {
+    ChatSetReminderRequestApplicationJson._defaults(this);
+  }
+
+  ChatSetReminderRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _timestamp = $v.timestamp;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatSetReminderRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatSetReminderRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ChatSetReminderRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatSetReminderRequestApplicationJson build() => _build();
+
+  _$ChatSetReminderRequestApplicationJson _build() {
+    ChatSetReminderRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ChatSetReminderRequestApplicationJson._(
+            timestamp: BuiltValueNullFieldError.checkNotNull(
+                timestamp, r'ChatSetReminderRequestApplicationJson', 'timestamp'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ChatSetReminderResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ChatSetReminderResponseApplicationJson_OcsInterface other);
   void update(void Function($ChatSetReminderResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -30931,6 +36685,99 @@ class ChatDeleteReminderResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ChatSetReadMarkerRequestApplicationJsonInterfaceBuilder {
+  void replace($ChatSetReadMarkerRequestApplicationJsonInterface other);
+  void update(void Function($ChatSetReadMarkerRequestApplicationJsonInterfaceBuilder) updates);
+  int? get lastReadMessage;
+  set lastReadMessage(int? lastReadMessage);
+}
+
+class _$ChatSetReadMarkerRequestApplicationJson extends ChatSetReadMarkerRequestApplicationJson {
+  @override
+  final int? lastReadMessage;
+
+  factory _$ChatSetReadMarkerRequestApplicationJson(
+          [void Function(ChatSetReadMarkerRequestApplicationJsonBuilder)? updates]) =>
+      (ChatSetReadMarkerRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ChatSetReadMarkerRequestApplicationJson._({this.lastReadMessage}) : super._();
+
+  @override
+  ChatSetReadMarkerRequestApplicationJson rebuild(
+          void Function(ChatSetReadMarkerRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatSetReadMarkerRequestApplicationJsonBuilder toBuilder() =>
+      ChatSetReadMarkerRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatSetReadMarkerRequestApplicationJson && lastReadMessage == other.lastReadMessage;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, lastReadMessage.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatSetReadMarkerRequestApplicationJson')
+          ..add('lastReadMessage', lastReadMessage))
+        .toString();
+  }
+}
+
+class ChatSetReadMarkerRequestApplicationJsonBuilder
+    implements
+        Builder<ChatSetReadMarkerRequestApplicationJson, ChatSetReadMarkerRequestApplicationJsonBuilder>,
+        $ChatSetReadMarkerRequestApplicationJsonInterfaceBuilder {
+  _$ChatSetReadMarkerRequestApplicationJson? _$v;
+
+  int? _lastReadMessage;
+  int? get lastReadMessage => _$this._lastReadMessage;
+  set lastReadMessage(covariant int? lastReadMessage) => _$this._lastReadMessage = lastReadMessage;
+
+  ChatSetReadMarkerRequestApplicationJsonBuilder() {
+    ChatSetReadMarkerRequestApplicationJson._defaults(this);
+  }
+
+  ChatSetReadMarkerRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _lastReadMessage = $v.lastReadMessage;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatSetReadMarkerRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatSetReadMarkerRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ChatSetReadMarkerRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatSetReadMarkerRequestApplicationJson build() => _build();
+
+  _$ChatSetReadMarkerRequestApplicationJson _build() {
+    ChatSetReadMarkerRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$ChatSetReadMarkerRequestApplicationJson._(lastReadMessage: lastReadMessage);
     replace(_$result);
     return _$result;
   }
@@ -31570,6 +37417,133 @@ class ChatChatMarkUnreadHeadersBuilder
   }
 }
 
+abstract mixin class $ChatMentionsRequestApplicationJsonInterfaceBuilder {
+  void replace($ChatMentionsRequestApplicationJsonInterface other);
+  void update(void Function($ChatMentionsRequestApplicationJsonInterfaceBuilder) updates);
+  String? get search;
+  set search(String? search);
+
+  int? get limit;
+  set limit(int? limit);
+
+  bool? get includeStatus;
+  set includeStatus(bool? includeStatus);
+}
+
+class _$ChatMentionsRequestApplicationJson extends ChatMentionsRequestApplicationJson {
+  @override
+  final String search;
+  @override
+  final int limit;
+  @override
+  final bool includeStatus;
+
+  factory _$ChatMentionsRequestApplicationJson([void Function(ChatMentionsRequestApplicationJsonBuilder)? updates]) =>
+      (ChatMentionsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ChatMentionsRequestApplicationJson._({required this.search, required this.limit, required this.includeStatus})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(search, r'ChatMentionsRequestApplicationJson', 'search');
+    BuiltValueNullFieldError.checkNotNull(limit, r'ChatMentionsRequestApplicationJson', 'limit');
+    BuiltValueNullFieldError.checkNotNull(includeStatus, r'ChatMentionsRequestApplicationJson', 'includeStatus');
+  }
+
+  @override
+  ChatMentionsRequestApplicationJson rebuild(void Function(ChatMentionsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatMentionsRequestApplicationJsonBuilder toBuilder() => ChatMentionsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatMentionsRequestApplicationJson &&
+        search == other.search &&
+        limit == other.limit &&
+        includeStatus == other.includeStatus;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, search.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jc(_$hash, includeStatus.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatMentionsRequestApplicationJson')
+          ..add('search', search)
+          ..add('limit', limit)
+          ..add('includeStatus', includeStatus))
+        .toString();
+  }
+}
+
+class ChatMentionsRequestApplicationJsonBuilder
+    implements
+        Builder<ChatMentionsRequestApplicationJson, ChatMentionsRequestApplicationJsonBuilder>,
+        $ChatMentionsRequestApplicationJsonInterfaceBuilder {
+  _$ChatMentionsRequestApplicationJson? _$v;
+
+  String? _search;
+  String? get search => _$this._search;
+  set search(covariant String? search) => _$this._search = search;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  bool? _includeStatus;
+  bool? get includeStatus => _$this._includeStatus;
+  set includeStatus(covariant bool? includeStatus) => _$this._includeStatus = includeStatus;
+
+  ChatMentionsRequestApplicationJsonBuilder() {
+    ChatMentionsRequestApplicationJson._defaults(this);
+  }
+
+  ChatMentionsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _search = $v.search;
+      _limit = $v.limit;
+      _includeStatus = $v.includeStatus;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatMentionsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatMentionsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ChatMentionsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatMentionsRequestApplicationJson build() => _build();
+
+  _$ChatMentionsRequestApplicationJson _build() {
+    ChatMentionsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ChatMentionsRequestApplicationJson._(
+            search: BuiltValueNullFieldError.checkNotNull(search, r'ChatMentionsRequestApplicationJson', 'search'),
+            limit: BuiltValueNullFieldError.checkNotNull(limit, r'ChatMentionsRequestApplicationJson', 'limit'),
+            includeStatus: BuiltValueNullFieldError.checkNotNull(
+                includeStatus, r'ChatMentionsRequestApplicationJson', 'includeStatus'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ChatMentionSuggestionInterfaceBuilder {
   void replace($ChatMentionSuggestionInterface other);
   void update(void Function($ChatMentionSuggestionInterfaceBuilder) updates);
@@ -31997,6 +37971,142 @@ class ChatMentionsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $ChatGetObjectsSharedInRoomRequestApplicationJsonInterfaceBuilder {
+  void replace($ChatGetObjectsSharedInRoomRequestApplicationJsonInterface other);
+  void update(void Function($ChatGetObjectsSharedInRoomRequestApplicationJsonInterfaceBuilder) updates);
+  String? get objectType;
+  set objectType(String? objectType);
+
+  int? get lastKnownMessageId;
+  set lastKnownMessageId(int? lastKnownMessageId);
+
+  int? get limit;
+  set limit(int? limit);
+}
+
+class _$ChatGetObjectsSharedInRoomRequestApplicationJson extends ChatGetObjectsSharedInRoomRequestApplicationJson {
+  @override
+  final String objectType;
+  @override
+  final int lastKnownMessageId;
+  @override
+  final int limit;
+
+  factory _$ChatGetObjectsSharedInRoomRequestApplicationJson(
+          [void Function(ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder)? updates]) =>
+      (ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ChatGetObjectsSharedInRoomRequestApplicationJson._(
+      {required this.objectType, required this.lastKnownMessageId, required this.limit})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        objectType, r'ChatGetObjectsSharedInRoomRequestApplicationJson', 'objectType');
+    BuiltValueNullFieldError.checkNotNull(
+        lastKnownMessageId, r'ChatGetObjectsSharedInRoomRequestApplicationJson', 'lastKnownMessageId');
+    BuiltValueNullFieldError.checkNotNull(limit, r'ChatGetObjectsSharedInRoomRequestApplicationJson', 'limit');
+  }
+
+  @override
+  ChatGetObjectsSharedInRoomRequestApplicationJson rebuild(
+          void Function(ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder toBuilder() =>
+      ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatGetObjectsSharedInRoomRequestApplicationJson &&
+        objectType == other.objectType &&
+        lastKnownMessageId == other.lastKnownMessageId &&
+        limit == other.limit;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, objectType.hashCode);
+    _$hash = $jc(_$hash, lastKnownMessageId.hashCode);
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatGetObjectsSharedInRoomRequestApplicationJson')
+          ..add('objectType', objectType)
+          ..add('lastKnownMessageId', lastKnownMessageId)
+          ..add('limit', limit))
+        .toString();
+  }
+}
+
+class ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder
+    implements
+        Builder<ChatGetObjectsSharedInRoomRequestApplicationJson,
+            ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder>,
+        $ChatGetObjectsSharedInRoomRequestApplicationJsonInterfaceBuilder {
+  _$ChatGetObjectsSharedInRoomRequestApplicationJson? _$v;
+
+  String? _objectType;
+  String? get objectType => _$this._objectType;
+  set objectType(covariant String? objectType) => _$this._objectType = objectType;
+
+  int? _lastKnownMessageId;
+  int? get lastKnownMessageId => _$this._lastKnownMessageId;
+  set lastKnownMessageId(covariant int? lastKnownMessageId) => _$this._lastKnownMessageId = lastKnownMessageId;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder() {
+    ChatGetObjectsSharedInRoomRequestApplicationJson._defaults(this);
+  }
+
+  ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _objectType = $v.objectType;
+      _lastKnownMessageId = $v.lastKnownMessageId;
+      _limit = $v.limit;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatGetObjectsSharedInRoomRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatGetObjectsSharedInRoomRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ChatGetObjectsSharedInRoomRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatGetObjectsSharedInRoomRequestApplicationJson build() => _build();
+
+  _$ChatGetObjectsSharedInRoomRequestApplicationJson _build() {
+    ChatGetObjectsSharedInRoomRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ChatGetObjectsSharedInRoomRequestApplicationJson._(
+            objectType: BuiltValueNullFieldError.checkNotNull(
+                objectType, r'ChatGetObjectsSharedInRoomRequestApplicationJson', 'objectType'),
+            lastKnownMessageId: BuiltValueNullFieldError.checkNotNull(
+                lastKnownMessageId, r'ChatGetObjectsSharedInRoomRequestApplicationJson', 'lastKnownMessageId'),
+            limit: BuiltValueNullFieldError.checkNotNull(
+                limit, r'ChatGetObjectsSharedInRoomRequestApplicationJson', 'limit'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterface other);
   void update(void Function($ChatGetObjectsSharedInRoomResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -32324,6 +38434,176 @@ class ChatChatGetObjectsSharedInRoomHeadersBuilder
   }
 }
 
+abstract mixin class $ChatShareObjectToChatRequestApplicationJsonInterfaceBuilder {
+  void replace($ChatShareObjectToChatRequestApplicationJsonInterface other);
+  void update(void Function($ChatShareObjectToChatRequestApplicationJsonInterfaceBuilder) updates);
+  String? get objectType;
+  set objectType(String? objectType);
+
+  String? get objectId;
+  set objectId(String? objectId);
+
+  String? get metaData;
+  set metaData(String? metaData);
+
+  String? get actorDisplayName;
+  set actorDisplayName(String? actorDisplayName);
+
+  String? get referenceId;
+  set referenceId(String? referenceId);
+}
+
+class _$ChatShareObjectToChatRequestApplicationJson extends ChatShareObjectToChatRequestApplicationJson {
+  @override
+  final String objectType;
+  @override
+  final String objectId;
+  @override
+  final String metaData;
+  @override
+  final String actorDisplayName;
+  @override
+  final String referenceId;
+
+  factory _$ChatShareObjectToChatRequestApplicationJson(
+          [void Function(ChatShareObjectToChatRequestApplicationJsonBuilder)? updates]) =>
+      (ChatShareObjectToChatRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ChatShareObjectToChatRequestApplicationJson._(
+      {required this.objectType,
+      required this.objectId,
+      required this.metaData,
+      required this.actorDisplayName,
+      required this.referenceId})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(objectType, r'ChatShareObjectToChatRequestApplicationJson', 'objectType');
+    BuiltValueNullFieldError.checkNotNull(objectId, r'ChatShareObjectToChatRequestApplicationJson', 'objectId');
+    BuiltValueNullFieldError.checkNotNull(metaData, r'ChatShareObjectToChatRequestApplicationJson', 'metaData');
+    BuiltValueNullFieldError.checkNotNull(
+        actorDisplayName, r'ChatShareObjectToChatRequestApplicationJson', 'actorDisplayName');
+    BuiltValueNullFieldError.checkNotNull(referenceId, r'ChatShareObjectToChatRequestApplicationJson', 'referenceId');
+  }
+
+  @override
+  ChatShareObjectToChatRequestApplicationJson rebuild(
+          void Function(ChatShareObjectToChatRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatShareObjectToChatRequestApplicationJsonBuilder toBuilder() =>
+      ChatShareObjectToChatRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatShareObjectToChatRequestApplicationJson &&
+        objectType == other.objectType &&
+        objectId == other.objectId &&
+        metaData == other.metaData &&
+        actorDisplayName == other.actorDisplayName &&
+        referenceId == other.referenceId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, objectType.hashCode);
+    _$hash = $jc(_$hash, objectId.hashCode);
+    _$hash = $jc(_$hash, metaData.hashCode);
+    _$hash = $jc(_$hash, actorDisplayName.hashCode);
+    _$hash = $jc(_$hash, referenceId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatShareObjectToChatRequestApplicationJson')
+          ..add('objectType', objectType)
+          ..add('objectId', objectId)
+          ..add('metaData', metaData)
+          ..add('actorDisplayName', actorDisplayName)
+          ..add('referenceId', referenceId))
+        .toString();
+  }
+}
+
+class ChatShareObjectToChatRequestApplicationJsonBuilder
+    implements
+        Builder<ChatShareObjectToChatRequestApplicationJson, ChatShareObjectToChatRequestApplicationJsonBuilder>,
+        $ChatShareObjectToChatRequestApplicationJsonInterfaceBuilder {
+  _$ChatShareObjectToChatRequestApplicationJson? _$v;
+
+  String? _objectType;
+  String? get objectType => _$this._objectType;
+  set objectType(covariant String? objectType) => _$this._objectType = objectType;
+
+  String? _objectId;
+  String? get objectId => _$this._objectId;
+  set objectId(covariant String? objectId) => _$this._objectId = objectId;
+
+  String? _metaData;
+  String? get metaData => _$this._metaData;
+  set metaData(covariant String? metaData) => _$this._metaData = metaData;
+
+  String? _actorDisplayName;
+  String? get actorDisplayName => _$this._actorDisplayName;
+  set actorDisplayName(covariant String? actorDisplayName) => _$this._actorDisplayName = actorDisplayName;
+
+  String? _referenceId;
+  String? get referenceId => _$this._referenceId;
+  set referenceId(covariant String? referenceId) => _$this._referenceId = referenceId;
+
+  ChatShareObjectToChatRequestApplicationJsonBuilder() {
+    ChatShareObjectToChatRequestApplicationJson._defaults(this);
+  }
+
+  ChatShareObjectToChatRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _objectType = $v.objectType;
+      _objectId = $v.objectId;
+      _metaData = $v.metaData;
+      _actorDisplayName = $v.actorDisplayName;
+      _referenceId = $v.referenceId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatShareObjectToChatRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatShareObjectToChatRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ChatShareObjectToChatRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatShareObjectToChatRequestApplicationJson build() => _build();
+
+  _$ChatShareObjectToChatRequestApplicationJson _build() {
+    ChatShareObjectToChatRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ChatShareObjectToChatRequestApplicationJson._(
+            objectType: BuiltValueNullFieldError.checkNotNull(
+                objectType, r'ChatShareObjectToChatRequestApplicationJson', 'objectType'),
+            objectId: BuiltValueNullFieldError.checkNotNull(
+                objectId, r'ChatShareObjectToChatRequestApplicationJson', 'objectId'),
+            metaData: BuiltValueNullFieldError.checkNotNull(
+                metaData, r'ChatShareObjectToChatRequestApplicationJson', 'metaData'),
+            actorDisplayName: BuiltValueNullFieldError.checkNotNull(
+                actorDisplayName, r'ChatShareObjectToChatRequestApplicationJson', 'actorDisplayName'),
+            referenceId: BuiltValueNullFieldError.checkNotNull(
+                referenceId, r'ChatShareObjectToChatRequestApplicationJson', 'referenceId'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ChatShareObjectToChatResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ChatShareObjectToChatResponseApplicationJson_OcsInterface other);
   void update(void Function($ChatShareObjectToChatResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -32643,6 +38923,106 @@ class ChatChatShareObjectToChatHeadersBuilder
   }
 }
 
+abstract mixin class $ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterfaceBuilder {
+  void replace($ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterface other);
+  void update(void Function($ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterfaceBuilder) updates);
+  int? get limit;
+  set limit(int? limit);
+}
+
+class _$ChatGetObjectsSharedInRoomOverviewRequestApplicationJson
+    extends ChatGetObjectsSharedInRoomOverviewRequestApplicationJson {
+  @override
+  final int limit;
+
+  factory _$ChatGetObjectsSharedInRoomOverviewRequestApplicationJson(
+          [void Function(ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder)? updates]) =>
+      (ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ChatGetObjectsSharedInRoomOverviewRequestApplicationJson._({required this.limit}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(limit, r'ChatGetObjectsSharedInRoomOverviewRequestApplicationJson', 'limit');
+  }
+
+  @override
+  ChatGetObjectsSharedInRoomOverviewRequestApplicationJson rebuild(
+          void Function(ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder toBuilder() =>
+      ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ChatGetObjectsSharedInRoomOverviewRequestApplicationJson && limit == other.limit;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ChatGetObjectsSharedInRoomOverviewRequestApplicationJson')
+          ..add('limit', limit))
+        .toString();
+  }
+}
+
+class ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder
+    implements
+        Builder<ChatGetObjectsSharedInRoomOverviewRequestApplicationJson,
+            ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder>,
+        $ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonInterfaceBuilder {
+  _$ChatGetObjectsSharedInRoomOverviewRequestApplicationJson? _$v;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder() {
+    ChatGetObjectsSharedInRoomOverviewRequestApplicationJson._defaults(this);
+  }
+
+  ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _limit = $v.limit;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ChatGetObjectsSharedInRoomOverviewRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ChatGetObjectsSharedInRoomOverviewRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ChatGetObjectsSharedInRoomOverviewRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ChatGetObjectsSharedInRoomOverviewRequestApplicationJson build() => _build();
+
+  _$ChatGetObjectsSharedInRoomOverviewRequestApplicationJson _build() {
+    ChatGetObjectsSharedInRoomOverviewRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ChatGetObjectsSharedInRoomOverviewRequestApplicationJson._(
+            limit: BuiltValueNullFieldError.checkNotNull(
+                limit, r'ChatGetObjectsSharedInRoomOverviewRequestApplicationJson', 'limit'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterface other);
   void update(void Function($ChatGetObjectsSharedInRoomOverviewResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -32879,6 +39259,102 @@ class ChatGetObjectsSharedInRoomOverviewResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $SignalingGetSettingsRequestApplicationJsonInterfaceBuilder {
+  void replace($SignalingGetSettingsRequestApplicationJsonInterface other);
+  void update(void Function($SignalingGetSettingsRequestApplicationJsonInterfaceBuilder) updates);
+  String? get token;
+  set token(String? token);
+}
+
+class _$SignalingGetSettingsRequestApplicationJson extends SignalingGetSettingsRequestApplicationJson {
+  @override
+  final String token;
+
+  factory _$SignalingGetSettingsRequestApplicationJson(
+          [void Function(SignalingGetSettingsRequestApplicationJsonBuilder)? updates]) =>
+      (SignalingGetSettingsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$SignalingGetSettingsRequestApplicationJson._({required this.token}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(token, r'SignalingGetSettingsRequestApplicationJson', 'token');
+  }
+
+  @override
+  SignalingGetSettingsRequestApplicationJson rebuild(
+          void Function(SignalingGetSettingsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SignalingGetSettingsRequestApplicationJsonBuilder toBuilder() =>
+      SignalingGetSettingsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SignalingGetSettingsRequestApplicationJson && token == other.token;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, token.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SignalingGetSettingsRequestApplicationJson')..add('token', token)).toString();
+  }
+}
+
+class SignalingGetSettingsRequestApplicationJsonBuilder
+    implements
+        Builder<SignalingGetSettingsRequestApplicationJson, SignalingGetSettingsRequestApplicationJsonBuilder>,
+        $SignalingGetSettingsRequestApplicationJsonInterfaceBuilder {
+  _$SignalingGetSettingsRequestApplicationJson? _$v;
+
+  String? _token;
+  String? get token => _$this._token;
+  set token(covariant String? token) => _$this._token = token;
+
+  SignalingGetSettingsRequestApplicationJsonBuilder() {
+    SignalingGetSettingsRequestApplicationJson._defaults(this);
+  }
+
+  SignalingGetSettingsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _token = $v.token;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant SignalingGetSettingsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$SignalingGetSettingsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(SignalingGetSettingsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SignalingGetSettingsRequestApplicationJson build() => _build();
+
+  _$SignalingGetSettingsRequestApplicationJson _build() {
+    SignalingGetSettingsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$SignalingGetSettingsRequestApplicationJson._(
+            token:
+                BuiltValueNullFieldError.checkNotNull(token, r'SignalingGetSettingsRequestApplicationJson', 'token'));
     replace(_$result);
     return _$result;
   }
@@ -35596,6 +42072,105 @@ class FilesIntegrationGetRoomByShareTokenResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $PublicShareAuthCreateRoomRequestApplicationJsonInterfaceBuilder {
+  void replace($PublicShareAuthCreateRoomRequestApplicationJsonInterface other);
+  void update(void Function($PublicShareAuthCreateRoomRequestApplicationJsonInterfaceBuilder) updates);
+  String? get shareToken;
+  set shareToken(String? shareToken);
+}
+
+class _$PublicShareAuthCreateRoomRequestApplicationJson extends PublicShareAuthCreateRoomRequestApplicationJson {
+  @override
+  final String shareToken;
+
+  factory _$PublicShareAuthCreateRoomRequestApplicationJson(
+          [void Function(PublicShareAuthCreateRoomRequestApplicationJsonBuilder)? updates]) =>
+      (PublicShareAuthCreateRoomRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PublicShareAuthCreateRoomRequestApplicationJson._({required this.shareToken}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(shareToken, r'PublicShareAuthCreateRoomRequestApplicationJson', 'shareToken');
+  }
+
+  @override
+  PublicShareAuthCreateRoomRequestApplicationJson rebuild(
+          void Function(PublicShareAuthCreateRoomRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PublicShareAuthCreateRoomRequestApplicationJsonBuilder toBuilder() =>
+      PublicShareAuthCreateRoomRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PublicShareAuthCreateRoomRequestApplicationJson && shareToken == other.shareToken;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, shareToken.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PublicShareAuthCreateRoomRequestApplicationJson')
+          ..add('shareToken', shareToken))
+        .toString();
+  }
+}
+
+class PublicShareAuthCreateRoomRequestApplicationJsonBuilder
+    implements
+        Builder<PublicShareAuthCreateRoomRequestApplicationJson,
+            PublicShareAuthCreateRoomRequestApplicationJsonBuilder>,
+        $PublicShareAuthCreateRoomRequestApplicationJsonInterfaceBuilder {
+  _$PublicShareAuthCreateRoomRequestApplicationJson? _$v;
+
+  String? _shareToken;
+  String? get shareToken => _$this._shareToken;
+  set shareToken(covariant String? shareToken) => _$this._shareToken = shareToken;
+
+  PublicShareAuthCreateRoomRequestApplicationJsonBuilder() {
+    PublicShareAuthCreateRoomRequestApplicationJson._defaults(this);
+  }
+
+  PublicShareAuthCreateRoomRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _shareToken = $v.shareToken;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PublicShareAuthCreateRoomRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PublicShareAuthCreateRoomRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PublicShareAuthCreateRoomRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PublicShareAuthCreateRoomRequestApplicationJson build() => _build();
+
+  _$PublicShareAuthCreateRoomRequestApplicationJson _build() {
+    PublicShareAuthCreateRoomRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$PublicShareAuthCreateRoomRequestApplicationJson._(
+            shareToken: BuiltValueNullFieldError.checkNotNull(
+                shareToken, r'PublicShareAuthCreateRoomRequestApplicationJson', 'shareToken'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterface other);
   void update(void Function($PublicShareAuthCreateRoomResponseApplicationJson_Ocs_DataInterfaceBuilder) updates);
@@ -35968,6 +42543,103 @@ class PublicShareAuthCreateRoomResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $GuestSetDisplayNameRequestApplicationJsonInterfaceBuilder {
+  void replace($GuestSetDisplayNameRequestApplicationJsonInterface other);
+  void update(void Function($GuestSetDisplayNameRequestApplicationJsonInterfaceBuilder) updates);
+  String? get displayName;
+  set displayName(String? displayName);
+}
+
+class _$GuestSetDisplayNameRequestApplicationJson extends GuestSetDisplayNameRequestApplicationJson {
+  @override
+  final String displayName;
+
+  factory _$GuestSetDisplayNameRequestApplicationJson(
+          [void Function(GuestSetDisplayNameRequestApplicationJsonBuilder)? updates]) =>
+      (GuestSetDisplayNameRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$GuestSetDisplayNameRequestApplicationJson._({required this.displayName}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(displayName, r'GuestSetDisplayNameRequestApplicationJson', 'displayName');
+  }
+
+  @override
+  GuestSetDisplayNameRequestApplicationJson rebuild(
+          void Function(GuestSetDisplayNameRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GuestSetDisplayNameRequestApplicationJsonBuilder toBuilder() =>
+      GuestSetDisplayNameRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GuestSetDisplayNameRequestApplicationJson && displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GuestSetDisplayNameRequestApplicationJson')..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GuestSetDisplayNameRequestApplicationJsonBuilder
+    implements
+        Builder<GuestSetDisplayNameRequestApplicationJson, GuestSetDisplayNameRequestApplicationJsonBuilder>,
+        $GuestSetDisplayNameRequestApplicationJsonInterfaceBuilder {
+  _$GuestSetDisplayNameRequestApplicationJson? _$v;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(covariant String? displayName) => _$this._displayName = displayName;
+
+  GuestSetDisplayNameRequestApplicationJsonBuilder() {
+    GuestSetDisplayNameRequestApplicationJson._defaults(this);
+  }
+
+  GuestSetDisplayNameRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant GuestSetDisplayNameRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GuestSetDisplayNameRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(GuestSetDisplayNameRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GuestSetDisplayNameRequestApplicationJson build() => _build();
+
+  _$GuestSetDisplayNameRequestApplicationJson _build() {
+    GuestSetDisplayNameRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$GuestSetDisplayNameRequestApplicationJson._(
+            displayName: BuiltValueNullFieldError.checkNotNull(
+                displayName, r'GuestSetDisplayNameRequestApplicationJson', 'displayName'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $GuestSetDisplayNameResponseApplicationJson_OcsInterfaceBuilder {
   void replace($GuestSetDisplayNameResponseApplicationJson_OcsInterface other);
   void update(void Function($GuestSetDisplayNameResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -36194,6 +42866,175 @@ class GuestSetDisplayNameResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $HostedSignalingServerRequestTrialRequestApplicationJsonInterfaceBuilder {
+  void replace($HostedSignalingServerRequestTrialRequestApplicationJsonInterface other);
+  void update(void Function($HostedSignalingServerRequestTrialRequestApplicationJsonInterfaceBuilder) updates);
+  String? get url;
+  set url(String? url);
+
+  String? get name;
+  set name(String? name);
+
+  String? get email;
+  set email(String? email);
+
+  String? get language;
+  set language(String? language);
+
+  String? get country;
+  set country(String? country);
+}
+
+class _$HostedSignalingServerRequestTrialRequestApplicationJson
+    extends HostedSignalingServerRequestTrialRequestApplicationJson {
+  @override
+  final String url;
+  @override
+  final String name;
+  @override
+  final String email;
+  @override
+  final String language;
+  @override
+  final String country;
+
+  factory _$HostedSignalingServerRequestTrialRequestApplicationJson(
+          [void Function(HostedSignalingServerRequestTrialRequestApplicationJsonBuilder)? updates]) =>
+      (HostedSignalingServerRequestTrialRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$HostedSignalingServerRequestTrialRequestApplicationJson._(
+      {required this.url, required this.name, required this.email, required this.language, required this.country})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(url, r'HostedSignalingServerRequestTrialRequestApplicationJson', 'url');
+    BuiltValueNullFieldError.checkNotNull(name, r'HostedSignalingServerRequestTrialRequestApplicationJson', 'name');
+    BuiltValueNullFieldError.checkNotNull(email, r'HostedSignalingServerRequestTrialRequestApplicationJson', 'email');
+    BuiltValueNullFieldError.checkNotNull(
+        language, r'HostedSignalingServerRequestTrialRequestApplicationJson', 'language');
+    BuiltValueNullFieldError.checkNotNull(
+        country, r'HostedSignalingServerRequestTrialRequestApplicationJson', 'country');
+  }
+
+  @override
+  HostedSignalingServerRequestTrialRequestApplicationJson rebuild(
+          void Function(HostedSignalingServerRequestTrialRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  HostedSignalingServerRequestTrialRequestApplicationJsonBuilder toBuilder() =>
+      HostedSignalingServerRequestTrialRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is HostedSignalingServerRequestTrialRequestApplicationJson &&
+        url == other.url &&
+        name == other.name &&
+        email == other.email &&
+        language == other.language &&
+        country == other.country;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, url.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, email.hashCode);
+    _$hash = $jc(_$hash, language.hashCode);
+    _$hash = $jc(_$hash, country.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'HostedSignalingServerRequestTrialRequestApplicationJson')
+          ..add('url', url)
+          ..add('name', name)
+          ..add('email', email)
+          ..add('language', language)
+          ..add('country', country))
+        .toString();
+  }
+}
+
+class HostedSignalingServerRequestTrialRequestApplicationJsonBuilder
+    implements
+        Builder<HostedSignalingServerRequestTrialRequestApplicationJson,
+            HostedSignalingServerRequestTrialRequestApplicationJsonBuilder>,
+        $HostedSignalingServerRequestTrialRequestApplicationJsonInterfaceBuilder {
+  _$HostedSignalingServerRequestTrialRequestApplicationJson? _$v;
+
+  String? _url;
+  String? get url => _$this._url;
+  set url(covariant String? url) => _$this._url = url;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(covariant String? name) => _$this._name = name;
+
+  String? _email;
+  String? get email => _$this._email;
+  set email(covariant String? email) => _$this._email = email;
+
+  String? _language;
+  String? get language => _$this._language;
+  set language(covariant String? language) => _$this._language = language;
+
+  String? _country;
+  String? get country => _$this._country;
+  set country(covariant String? country) => _$this._country = country;
+
+  HostedSignalingServerRequestTrialRequestApplicationJsonBuilder() {
+    HostedSignalingServerRequestTrialRequestApplicationJson._defaults(this);
+  }
+
+  HostedSignalingServerRequestTrialRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _url = $v.url;
+      _name = $v.name;
+      _email = $v.email;
+      _language = $v.language;
+      _country = $v.country;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant HostedSignalingServerRequestTrialRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$HostedSignalingServerRequestTrialRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(HostedSignalingServerRequestTrialRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  HostedSignalingServerRequestTrialRequestApplicationJson build() => _build();
+
+  _$HostedSignalingServerRequestTrialRequestApplicationJson _build() {
+    HostedSignalingServerRequestTrialRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$HostedSignalingServerRequestTrialRequestApplicationJson._(
+            url: BuiltValueNullFieldError.checkNotNull(
+                url, r'HostedSignalingServerRequestTrialRequestApplicationJson', 'url'),
+            name: BuiltValueNullFieldError.checkNotNull(
+                name, r'HostedSignalingServerRequestTrialRequestApplicationJson', 'name'),
+            email: BuiltValueNullFieldError.checkNotNull(
+                email, r'HostedSignalingServerRequestTrialRequestApplicationJson', 'email'),
+            language: BuiltValueNullFieldError.checkNotNull(
+                language, r'HostedSignalingServerRequestTrialRequestApplicationJson', 'language'),
+            country: BuiltValueNullFieldError.checkNotNull(
+                country, r'HostedSignalingServerRequestTrialRequestApplicationJson', 'country'));
     replace(_$result);
     return _$result;
   }
@@ -36960,6 +43801,103 @@ class SignalingPullMessagesResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $SignalingSendMessagesRequestApplicationJsonInterfaceBuilder {
+  void replace($SignalingSendMessagesRequestApplicationJsonInterface other);
+  void update(void Function($SignalingSendMessagesRequestApplicationJsonInterfaceBuilder) updates);
+  String? get messages;
+  set messages(String? messages);
+}
+
+class _$SignalingSendMessagesRequestApplicationJson extends SignalingSendMessagesRequestApplicationJson {
+  @override
+  final String messages;
+
+  factory _$SignalingSendMessagesRequestApplicationJson(
+          [void Function(SignalingSendMessagesRequestApplicationJsonBuilder)? updates]) =>
+      (SignalingSendMessagesRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$SignalingSendMessagesRequestApplicationJson._({required this.messages}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(messages, r'SignalingSendMessagesRequestApplicationJson', 'messages');
+  }
+
+  @override
+  SignalingSendMessagesRequestApplicationJson rebuild(
+          void Function(SignalingSendMessagesRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SignalingSendMessagesRequestApplicationJsonBuilder toBuilder() =>
+      SignalingSendMessagesRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SignalingSendMessagesRequestApplicationJson && messages == other.messages;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, messages.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SignalingSendMessagesRequestApplicationJson')..add('messages', messages))
+        .toString();
+  }
+}
+
+class SignalingSendMessagesRequestApplicationJsonBuilder
+    implements
+        Builder<SignalingSendMessagesRequestApplicationJson, SignalingSendMessagesRequestApplicationJsonBuilder>,
+        $SignalingSendMessagesRequestApplicationJsonInterfaceBuilder {
+  _$SignalingSendMessagesRequestApplicationJson? _$v;
+
+  String? _messages;
+  String? get messages => _$this._messages;
+  set messages(covariant String? messages) => _$this._messages = messages;
+
+  SignalingSendMessagesRequestApplicationJsonBuilder() {
+    SignalingSendMessagesRequestApplicationJson._defaults(this);
+  }
+
+  SignalingSendMessagesRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _messages = $v.messages;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant SignalingSendMessagesRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$SignalingSendMessagesRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(SignalingSendMessagesRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SignalingSendMessagesRequestApplicationJson build() => _build();
+
+  _$SignalingSendMessagesRequestApplicationJson _build() {
+    SignalingSendMessagesRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$SignalingSendMessagesRequestApplicationJson._(
+            messages: BuiltValueNullFieldError.checkNotNull(
+                messages, r'SignalingSendMessagesRequestApplicationJson', 'messages'));
     replace(_$result);
     return _$result;
   }
@@ -37832,6 +44770,134 @@ class MatterbridgeGetBridgeOfRoomResponseApplicationJsonBuilder
       } catch (e) {
         throw BuiltValueNestedFieldError(
             r'MatterbridgeGetBridgeOfRoomResponseApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterfaceBuilder {
+  void replace($MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterface other);
+  void update(void Function($MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterfaceBuilder) updates);
+  bool? get enabled;
+  set enabled(bool? enabled);
+
+  ListBuilder<BuiltMap<String, JsonObject>> get parts;
+  set parts(ListBuilder<BuiltMap<String, JsonObject>>? parts);
+}
+
+class _$MatterbridgeEditBridgeOfRoomRequestApplicationJson extends MatterbridgeEditBridgeOfRoomRequestApplicationJson {
+  @override
+  final bool enabled;
+  @override
+  final BuiltList<BuiltMap<String, JsonObject>> parts;
+
+  factory _$MatterbridgeEditBridgeOfRoomRequestApplicationJson(
+          [void Function(MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder)? updates]) =>
+      (MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$MatterbridgeEditBridgeOfRoomRequestApplicationJson._({required this.enabled, required this.parts}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(enabled, r'MatterbridgeEditBridgeOfRoomRequestApplicationJson', 'enabled');
+    BuiltValueNullFieldError.checkNotNull(parts, r'MatterbridgeEditBridgeOfRoomRequestApplicationJson', 'parts');
+  }
+
+  @override
+  MatterbridgeEditBridgeOfRoomRequestApplicationJson rebuild(
+          void Function(MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder toBuilder() =>
+      MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is MatterbridgeEditBridgeOfRoomRequestApplicationJson &&
+        enabled == other.enabled &&
+        parts == other.parts;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, enabled.hashCode);
+    _$hash = $jc(_$hash, parts.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'MatterbridgeEditBridgeOfRoomRequestApplicationJson')
+          ..add('enabled', enabled)
+          ..add('parts', parts))
+        .toString();
+  }
+}
+
+class MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder
+    implements
+        Builder<MatterbridgeEditBridgeOfRoomRequestApplicationJson,
+            MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder>,
+        $MatterbridgeEditBridgeOfRoomRequestApplicationJsonInterfaceBuilder {
+  _$MatterbridgeEditBridgeOfRoomRequestApplicationJson? _$v;
+
+  bool? _enabled;
+  bool? get enabled => _$this._enabled;
+  set enabled(covariant bool? enabled) => _$this._enabled = enabled;
+
+  ListBuilder<BuiltMap<String, JsonObject>>? _parts;
+  ListBuilder<BuiltMap<String, JsonObject>> get parts => _$this._parts ??= ListBuilder<BuiltMap<String, JsonObject>>();
+  set parts(covariant ListBuilder<BuiltMap<String, JsonObject>>? parts) => _$this._parts = parts;
+
+  MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder() {
+    MatterbridgeEditBridgeOfRoomRequestApplicationJson._defaults(this);
+  }
+
+  MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _enabled = $v.enabled;
+      _parts = $v.parts.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant MatterbridgeEditBridgeOfRoomRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$MatterbridgeEditBridgeOfRoomRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(MatterbridgeEditBridgeOfRoomRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  MatterbridgeEditBridgeOfRoomRequestApplicationJson build() => _build();
+
+  _$MatterbridgeEditBridgeOfRoomRequestApplicationJson _build() {
+    MatterbridgeEditBridgeOfRoomRequestApplicationJson._validate(this);
+    _$MatterbridgeEditBridgeOfRoomRequestApplicationJson _$result;
+    try {
+      _$result = _$v ??
+          _$MatterbridgeEditBridgeOfRoomRequestApplicationJson._(
+              enabled: BuiltValueNullFieldError.checkNotNull(
+                  enabled, r'MatterbridgeEditBridgeOfRoomRequestApplicationJson', 'enabled'),
+              parts: parts.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'parts';
+        parts.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'MatterbridgeEditBridgeOfRoomRequestApplicationJson', _$failedField, e.toString());
       }
       rethrow;
     }
@@ -39153,6 +46219,166 @@ class MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $PollCreatePollRequestApplicationJsonInterfaceBuilder {
+  void replace($PollCreatePollRequestApplicationJsonInterface other);
+  void update(void Function($PollCreatePollRequestApplicationJsonInterfaceBuilder) updates);
+  String? get question;
+  set question(String? question);
+
+  ListBuilder<String> get options;
+  set options(ListBuilder<String>? options);
+
+  PollCreatePollRequestApplicationJson_ResultMode? get resultMode;
+  set resultMode(PollCreatePollRequestApplicationJson_ResultMode? resultMode);
+
+  int? get maxVotes;
+  set maxVotes(int? maxVotes);
+}
+
+class _$PollCreatePollRequestApplicationJson extends PollCreatePollRequestApplicationJson {
+  @override
+  final String question;
+  @override
+  final BuiltList<String> options;
+  @override
+  final PollCreatePollRequestApplicationJson_ResultMode resultMode;
+  @override
+  final int maxVotes;
+
+  factory _$PollCreatePollRequestApplicationJson(
+          [void Function(PollCreatePollRequestApplicationJsonBuilder)? updates]) =>
+      (PollCreatePollRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PollCreatePollRequestApplicationJson._(
+      {required this.question, required this.options, required this.resultMode, required this.maxVotes})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(question, r'PollCreatePollRequestApplicationJson', 'question');
+    BuiltValueNullFieldError.checkNotNull(options, r'PollCreatePollRequestApplicationJson', 'options');
+    BuiltValueNullFieldError.checkNotNull(resultMode, r'PollCreatePollRequestApplicationJson', 'resultMode');
+    BuiltValueNullFieldError.checkNotNull(maxVotes, r'PollCreatePollRequestApplicationJson', 'maxVotes');
+  }
+
+  @override
+  PollCreatePollRequestApplicationJson rebuild(void Function(PollCreatePollRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PollCreatePollRequestApplicationJsonBuilder toBuilder() =>
+      PollCreatePollRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PollCreatePollRequestApplicationJson &&
+        question == other.question &&
+        options == other.options &&
+        resultMode == other.resultMode &&
+        maxVotes == other.maxVotes;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, question.hashCode);
+    _$hash = $jc(_$hash, options.hashCode);
+    _$hash = $jc(_$hash, resultMode.hashCode);
+    _$hash = $jc(_$hash, maxVotes.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PollCreatePollRequestApplicationJson')
+          ..add('question', question)
+          ..add('options', options)
+          ..add('resultMode', resultMode)
+          ..add('maxVotes', maxVotes))
+        .toString();
+  }
+}
+
+class PollCreatePollRequestApplicationJsonBuilder
+    implements
+        Builder<PollCreatePollRequestApplicationJson, PollCreatePollRequestApplicationJsonBuilder>,
+        $PollCreatePollRequestApplicationJsonInterfaceBuilder {
+  _$PollCreatePollRequestApplicationJson? _$v;
+
+  String? _question;
+  String? get question => _$this._question;
+  set question(covariant String? question) => _$this._question = question;
+
+  ListBuilder<String>? _options;
+  ListBuilder<String> get options => _$this._options ??= ListBuilder<String>();
+  set options(covariant ListBuilder<String>? options) => _$this._options = options;
+
+  PollCreatePollRequestApplicationJson_ResultMode? _resultMode;
+  PollCreatePollRequestApplicationJson_ResultMode? get resultMode => _$this._resultMode;
+  set resultMode(covariant PollCreatePollRequestApplicationJson_ResultMode? resultMode) =>
+      _$this._resultMode = resultMode;
+
+  int? _maxVotes;
+  int? get maxVotes => _$this._maxVotes;
+  set maxVotes(covariant int? maxVotes) => _$this._maxVotes = maxVotes;
+
+  PollCreatePollRequestApplicationJsonBuilder() {
+    PollCreatePollRequestApplicationJson._defaults(this);
+  }
+
+  PollCreatePollRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _question = $v.question;
+      _options = $v.options.toBuilder();
+      _resultMode = $v.resultMode;
+      _maxVotes = $v.maxVotes;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PollCreatePollRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PollCreatePollRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PollCreatePollRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PollCreatePollRequestApplicationJson build() => _build();
+
+  _$PollCreatePollRequestApplicationJson _build() {
+    PollCreatePollRequestApplicationJson._validate(this);
+    _$PollCreatePollRequestApplicationJson _$result;
+    try {
+      _$result = _$v ??
+          _$PollCreatePollRequestApplicationJson._(
+              question:
+                  BuiltValueNullFieldError.checkNotNull(question, r'PollCreatePollRequestApplicationJson', 'question'),
+              options: options.build(),
+              resultMode: BuiltValueNullFieldError.checkNotNull(
+                  resultMode, r'PollCreatePollRequestApplicationJson', 'resultMode'),
+              maxVotes:
+                  BuiltValueNullFieldError.checkNotNull(maxVotes, r'PollCreatePollRequestApplicationJson', 'maxVotes'));
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'options';
+        options.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'PollCreatePollRequestApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $PollVoteInterfaceBuilder {
   void replace($PollVoteInterface other);
   void update(void Function($PollVoteInterfaceBuilder) updates);
@@ -40041,6 +47267,108 @@ class PollShowPollResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $PollVotePollRequestApplicationJsonInterfaceBuilder {
+  void replace($PollVotePollRequestApplicationJsonInterface other);
+  void update(void Function($PollVotePollRequestApplicationJsonInterfaceBuilder) updates);
+  ListBuilder<int> get optionIds;
+  set optionIds(ListBuilder<int>? optionIds);
+}
+
+class _$PollVotePollRequestApplicationJson extends PollVotePollRequestApplicationJson {
+  @override
+  final BuiltList<int> optionIds;
+
+  factory _$PollVotePollRequestApplicationJson([void Function(PollVotePollRequestApplicationJsonBuilder)? updates]) =>
+      (PollVotePollRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$PollVotePollRequestApplicationJson._({required this.optionIds}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(optionIds, r'PollVotePollRequestApplicationJson', 'optionIds');
+  }
+
+  @override
+  PollVotePollRequestApplicationJson rebuild(void Function(PollVotePollRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  PollVotePollRequestApplicationJsonBuilder toBuilder() => PollVotePollRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is PollVotePollRequestApplicationJson && optionIds == other.optionIds;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, optionIds.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'PollVotePollRequestApplicationJson')..add('optionIds', optionIds)).toString();
+  }
+}
+
+class PollVotePollRequestApplicationJsonBuilder
+    implements
+        Builder<PollVotePollRequestApplicationJson, PollVotePollRequestApplicationJsonBuilder>,
+        $PollVotePollRequestApplicationJsonInterfaceBuilder {
+  _$PollVotePollRequestApplicationJson? _$v;
+
+  ListBuilder<int>? _optionIds;
+  ListBuilder<int> get optionIds => _$this._optionIds ??= ListBuilder<int>();
+  set optionIds(covariant ListBuilder<int>? optionIds) => _$this._optionIds = optionIds;
+
+  PollVotePollRequestApplicationJsonBuilder() {
+    PollVotePollRequestApplicationJson._defaults(this);
+  }
+
+  PollVotePollRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _optionIds = $v.optionIds.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant PollVotePollRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$PollVotePollRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(PollVotePollRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  PollVotePollRequestApplicationJson build() => _build();
+
+  _$PollVotePollRequestApplicationJson _build() {
+    PollVotePollRequestApplicationJson._validate(this);
+    _$PollVotePollRequestApplicationJson _$result;
+    try {
+      _$result = _$v ?? _$PollVotePollRequestApplicationJson._(optionIds: optionIds.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'optionIds';
+        optionIds.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'PollVotePollRequestApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $PollVotePollResponseApplicationJson_OcsInterfaceBuilder {
   void replace($PollVotePollResponseApplicationJson_OcsInterface other);
   void update(void Function($PollVotePollResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -40493,6 +47821,98 @@ class PollClosePollResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $ReactionGetReactionsRequestApplicationJsonInterfaceBuilder {
+  void replace($ReactionGetReactionsRequestApplicationJsonInterface other);
+  void update(void Function($ReactionGetReactionsRequestApplicationJsonInterfaceBuilder) updates);
+  String? get reaction;
+  set reaction(String? reaction);
+}
+
+class _$ReactionGetReactionsRequestApplicationJson extends ReactionGetReactionsRequestApplicationJson {
+  @override
+  final String? reaction;
+
+  factory _$ReactionGetReactionsRequestApplicationJson(
+          [void Function(ReactionGetReactionsRequestApplicationJsonBuilder)? updates]) =>
+      (ReactionGetReactionsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ReactionGetReactionsRequestApplicationJson._({this.reaction}) : super._();
+
+  @override
+  ReactionGetReactionsRequestApplicationJson rebuild(
+          void Function(ReactionGetReactionsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ReactionGetReactionsRequestApplicationJsonBuilder toBuilder() =>
+      ReactionGetReactionsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ReactionGetReactionsRequestApplicationJson && reaction == other.reaction;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, reaction.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ReactionGetReactionsRequestApplicationJson')..add('reaction', reaction))
+        .toString();
+  }
+}
+
+class ReactionGetReactionsRequestApplicationJsonBuilder
+    implements
+        Builder<ReactionGetReactionsRequestApplicationJson, ReactionGetReactionsRequestApplicationJsonBuilder>,
+        $ReactionGetReactionsRequestApplicationJsonInterfaceBuilder {
+  _$ReactionGetReactionsRequestApplicationJson? _$v;
+
+  String? _reaction;
+  String? get reaction => _$this._reaction;
+  set reaction(covariant String? reaction) => _$this._reaction = reaction;
+
+  ReactionGetReactionsRequestApplicationJsonBuilder() {
+    ReactionGetReactionsRequestApplicationJson._defaults(this);
+  }
+
+  ReactionGetReactionsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _reaction = $v.reaction;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ReactionGetReactionsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ReactionGetReactionsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ReactionGetReactionsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ReactionGetReactionsRequestApplicationJson build() => _build();
+
+  _$ReactionGetReactionsRequestApplicationJson _build() {
+    ReactionGetReactionsRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$ReactionGetReactionsRequestApplicationJson._(reaction: reaction);
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ReactionInterfaceBuilder {
   void replace($ReactionInterface other);
   void update(void Function($ReactionInterfaceBuilder) updates);
@@ -40860,6 +48280,99 @@ class ReactionGetReactionsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $ReactionReactRequestApplicationJsonInterfaceBuilder {
+  void replace($ReactionReactRequestApplicationJsonInterface other);
+  void update(void Function($ReactionReactRequestApplicationJsonInterfaceBuilder) updates);
+  String? get reaction;
+  set reaction(String? reaction);
+}
+
+class _$ReactionReactRequestApplicationJson extends ReactionReactRequestApplicationJson {
+  @override
+  final String reaction;
+
+  factory _$ReactionReactRequestApplicationJson([void Function(ReactionReactRequestApplicationJsonBuilder)? updates]) =>
+      (ReactionReactRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ReactionReactRequestApplicationJson._({required this.reaction}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(reaction, r'ReactionReactRequestApplicationJson', 'reaction');
+  }
+
+  @override
+  ReactionReactRequestApplicationJson rebuild(void Function(ReactionReactRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ReactionReactRequestApplicationJsonBuilder toBuilder() => ReactionReactRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ReactionReactRequestApplicationJson && reaction == other.reaction;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, reaction.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ReactionReactRequestApplicationJson')..add('reaction', reaction)).toString();
+  }
+}
+
+class ReactionReactRequestApplicationJsonBuilder
+    implements
+        Builder<ReactionReactRequestApplicationJson, ReactionReactRequestApplicationJsonBuilder>,
+        $ReactionReactRequestApplicationJsonInterfaceBuilder {
+  _$ReactionReactRequestApplicationJson? _$v;
+
+  String? _reaction;
+  String? get reaction => _$this._reaction;
+  set reaction(covariant String? reaction) => _$this._reaction = reaction;
+
+  ReactionReactRequestApplicationJsonBuilder() {
+    ReactionReactRequestApplicationJson._defaults(this);
+  }
+
+  ReactionReactRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _reaction = $v.reaction;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ReactionReactRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ReactionReactRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ReactionReactRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ReactionReactRequestApplicationJson build() => _build();
+
+  _$ReactionReactRequestApplicationJson _build() {
+    ReactionReactRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ReactionReactRequestApplicationJson._(
+            reaction:
+                BuiltValueNullFieldError.checkNotNull(reaction, r'ReactionReactRequestApplicationJson', 'reaction'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ReactionReactResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ReactionReactResponseApplicationJson_OcsInterface other);
   void update(void Function($ReactionReactResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -41087,6 +48600,101 @@ class ReactionReactResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $ReactionDeleteRequestApplicationJsonInterfaceBuilder {
+  void replace($ReactionDeleteRequestApplicationJsonInterface other);
+  void update(void Function($ReactionDeleteRequestApplicationJsonInterfaceBuilder) updates);
+  String? get reaction;
+  set reaction(String? reaction);
+}
+
+class _$ReactionDeleteRequestApplicationJson extends ReactionDeleteRequestApplicationJson {
+  @override
+  final String reaction;
+
+  factory _$ReactionDeleteRequestApplicationJson(
+          [void Function(ReactionDeleteRequestApplicationJsonBuilder)? updates]) =>
+      (ReactionDeleteRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ReactionDeleteRequestApplicationJson._({required this.reaction}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(reaction, r'ReactionDeleteRequestApplicationJson', 'reaction');
+  }
+
+  @override
+  ReactionDeleteRequestApplicationJson rebuild(void Function(ReactionDeleteRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ReactionDeleteRequestApplicationJsonBuilder toBuilder() =>
+      ReactionDeleteRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ReactionDeleteRequestApplicationJson && reaction == other.reaction;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, reaction.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ReactionDeleteRequestApplicationJson')..add('reaction', reaction)).toString();
+  }
+}
+
+class ReactionDeleteRequestApplicationJsonBuilder
+    implements
+        Builder<ReactionDeleteRequestApplicationJson, ReactionDeleteRequestApplicationJsonBuilder>,
+        $ReactionDeleteRequestApplicationJsonInterfaceBuilder {
+  _$ReactionDeleteRequestApplicationJson? _$v;
+
+  String? _reaction;
+  String? get reaction => _$this._reaction;
+  set reaction(covariant String? reaction) => _$this._reaction = reaction;
+
+  ReactionDeleteRequestApplicationJsonBuilder() {
+    ReactionDeleteRequestApplicationJson._defaults(this);
+  }
+
+  ReactionDeleteRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _reaction = $v.reaction;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ReactionDeleteRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ReactionDeleteRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ReactionDeleteRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ReactionDeleteRequestApplicationJson build() => _build();
+
+  _$ReactionDeleteRequestApplicationJson _build() {
+    ReactionDeleteRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ReactionDeleteRequestApplicationJson._(
+            reaction:
+                BuiltValueNullFieldError.checkNotNull(reaction, r'ReactionDeleteRequestApplicationJson', 'reaction'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ReactionDeleteResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ReactionDeleteResponseApplicationJson_OcsInterface other);
   void update(void Function($ReactionDeleteResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -41309,6 +48917,100 @@ class ReactionDeleteResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RecordingStartRequestApplicationJsonInterfaceBuilder {
+  void replace($RecordingStartRequestApplicationJsonInterface other);
+  void update(void Function($RecordingStartRequestApplicationJsonInterfaceBuilder) updates);
+  int? get status;
+  set status(int? status);
+}
+
+class _$RecordingStartRequestApplicationJson extends RecordingStartRequestApplicationJson {
+  @override
+  final int status;
+
+  factory _$RecordingStartRequestApplicationJson(
+          [void Function(RecordingStartRequestApplicationJsonBuilder)? updates]) =>
+      (RecordingStartRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RecordingStartRequestApplicationJson._({required this.status}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(status, r'RecordingStartRequestApplicationJson', 'status');
+  }
+
+  @override
+  RecordingStartRequestApplicationJson rebuild(void Function(RecordingStartRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RecordingStartRequestApplicationJsonBuilder toBuilder() =>
+      RecordingStartRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RecordingStartRequestApplicationJson && status == other.status;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, status.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RecordingStartRequestApplicationJson')..add('status', status)).toString();
+  }
+}
+
+class RecordingStartRequestApplicationJsonBuilder
+    implements
+        Builder<RecordingStartRequestApplicationJson, RecordingStartRequestApplicationJsonBuilder>,
+        $RecordingStartRequestApplicationJsonInterfaceBuilder {
+  _$RecordingStartRequestApplicationJson? _$v;
+
+  int? _status;
+  int? get status => _$this._status;
+  set status(covariant int? status) => _$this._status = status;
+
+  RecordingStartRequestApplicationJsonBuilder() {
+    RecordingStartRequestApplicationJson._defaults(this);
+  }
+
+  RecordingStartRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _status = $v.status;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RecordingStartRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RecordingStartRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RecordingStartRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RecordingStartRequestApplicationJson build() => _build();
+
+  _$RecordingStartRequestApplicationJson _build() {
+    RecordingStartRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RecordingStartRequestApplicationJson._(
+            status: BuiltValueNullFieldError.checkNotNull(status, r'RecordingStartRequestApplicationJson', 'status'));
     replace(_$result);
     return _$result;
   }
@@ -41770,6 +49472,106 @@ class RecordingStopResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RecordingNotificationDismissRequestApplicationJsonInterfaceBuilder {
+  void replace($RecordingNotificationDismissRequestApplicationJsonInterface other);
+  void update(void Function($RecordingNotificationDismissRequestApplicationJsonInterfaceBuilder) updates);
+  int? get timestamp;
+  set timestamp(int? timestamp);
+}
+
+class _$RecordingNotificationDismissRequestApplicationJson extends RecordingNotificationDismissRequestApplicationJson {
+  @override
+  final int timestamp;
+
+  factory _$RecordingNotificationDismissRequestApplicationJson(
+          [void Function(RecordingNotificationDismissRequestApplicationJsonBuilder)? updates]) =>
+      (RecordingNotificationDismissRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RecordingNotificationDismissRequestApplicationJson._({required this.timestamp}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        timestamp, r'RecordingNotificationDismissRequestApplicationJson', 'timestamp');
+  }
+
+  @override
+  RecordingNotificationDismissRequestApplicationJson rebuild(
+          void Function(RecordingNotificationDismissRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RecordingNotificationDismissRequestApplicationJsonBuilder toBuilder() =>
+      RecordingNotificationDismissRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RecordingNotificationDismissRequestApplicationJson && timestamp == other.timestamp;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, timestamp.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RecordingNotificationDismissRequestApplicationJson')
+          ..add('timestamp', timestamp))
+        .toString();
+  }
+}
+
+class RecordingNotificationDismissRequestApplicationJsonBuilder
+    implements
+        Builder<RecordingNotificationDismissRequestApplicationJson,
+            RecordingNotificationDismissRequestApplicationJsonBuilder>,
+        $RecordingNotificationDismissRequestApplicationJsonInterfaceBuilder {
+  _$RecordingNotificationDismissRequestApplicationJson? _$v;
+
+  int? _timestamp;
+  int? get timestamp => _$this._timestamp;
+  set timestamp(covariant int? timestamp) => _$this._timestamp = timestamp;
+
+  RecordingNotificationDismissRequestApplicationJsonBuilder() {
+    RecordingNotificationDismissRequestApplicationJson._defaults(this);
+  }
+
+  RecordingNotificationDismissRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _timestamp = $v.timestamp;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RecordingNotificationDismissRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RecordingNotificationDismissRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RecordingNotificationDismissRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RecordingNotificationDismissRequestApplicationJson build() => _build();
+
+  _$RecordingNotificationDismissRequestApplicationJson _build() {
+    RecordingNotificationDismissRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RecordingNotificationDismissRequestApplicationJson._(
+            timestamp: BuiltValueNullFieldError.checkNotNull(
+                timestamp, r'RecordingNotificationDismissRequestApplicationJson', 'timestamp'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RecordingNotificationDismissResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RecordingNotificationDismissResponseApplicationJson_OcsInterface other);
   void update(void Function($RecordingNotificationDismissResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -42002,6 +49804,121 @@ class RecordingNotificationDismissResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RecordingShareToChatRequestApplicationJsonInterfaceBuilder {
+  void replace($RecordingShareToChatRequestApplicationJsonInterface other);
+  void update(void Function($RecordingShareToChatRequestApplicationJsonInterfaceBuilder) updates);
+  int? get fileId;
+  set fileId(int? fileId);
+
+  int? get timestamp;
+  set timestamp(int? timestamp);
+}
+
+class _$RecordingShareToChatRequestApplicationJson extends RecordingShareToChatRequestApplicationJson {
+  @override
+  final int fileId;
+  @override
+  final int timestamp;
+
+  factory _$RecordingShareToChatRequestApplicationJson(
+          [void Function(RecordingShareToChatRequestApplicationJsonBuilder)? updates]) =>
+      (RecordingShareToChatRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RecordingShareToChatRequestApplicationJson._({required this.fileId, required this.timestamp}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(fileId, r'RecordingShareToChatRequestApplicationJson', 'fileId');
+    BuiltValueNullFieldError.checkNotNull(timestamp, r'RecordingShareToChatRequestApplicationJson', 'timestamp');
+  }
+
+  @override
+  RecordingShareToChatRequestApplicationJson rebuild(
+          void Function(RecordingShareToChatRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RecordingShareToChatRequestApplicationJsonBuilder toBuilder() =>
+      RecordingShareToChatRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RecordingShareToChatRequestApplicationJson &&
+        fileId == other.fileId &&
+        timestamp == other.timestamp;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, fileId.hashCode);
+    _$hash = $jc(_$hash, timestamp.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RecordingShareToChatRequestApplicationJson')
+          ..add('fileId', fileId)
+          ..add('timestamp', timestamp))
+        .toString();
+  }
+}
+
+class RecordingShareToChatRequestApplicationJsonBuilder
+    implements
+        Builder<RecordingShareToChatRequestApplicationJson, RecordingShareToChatRequestApplicationJsonBuilder>,
+        $RecordingShareToChatRequestApplicationJsonInterfaceBuilder {
+  _$RecordingShareToChatRequestApplicationJson? _$v;
+
+  int? _fileId;
+  int? get fileId => _$this._fileId;
+  set fileId(covariant int? fileId) => _$this._fileId = fileId;
+
+  int? _timestamp;
+  int? get timestamp => _$this._timestamp;
+  set timestamp(covariant int? timestamp) => _$this._timestamp = timestamp;
+
+  RecordingShareToChatRequestApplicationJsonBuilder() {
+    RecordingShareToChatRequestApplicationJson._defaults(this);
+  }
+
+  RecordingShareToChatRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _fileId = $v.fileId;
+      _timestamp = $v.timestamp;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RecordingShareToChatRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RecordingShareToChatRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RecordingShareToChatRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RecordingShareToChatRequestApplicationJson build() => _build();
+
+  _$RecordingShareToChatRequestApplicationJson _build() {
+    RecordingShareToChatRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RecordingShareToChatRequestApplicationJson._(
+            fileId:
+                BuiltValueNullFieldError.checkNotNull(fileId, r'RecordingShareToChatRequestApplicationJson', 'fileId'),
+            timestamp: BuiltValueNullFieldError.checkNotNull(
+                timestamp, r'RecordingShareToChatRequestApplicationJson', 'timestamp'));
     replace(_$result);
     return _$result;
   }
@@ -42469,6 +50386,100 @@ class RecordingBackendResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RecordingStoreRequestApplicationJsonInterfaceBuilder {
+  void replace($RecordingStoreRequestApplicationJsonInterface other);
+  void update(void Function($RecordingStoreRequestApplicationJsonInterfaceBuilder) updates);
+  String? get owner;
+  set owner(String? owner);
+}
+
+class _$RecordingStoreRequestApplicationJson extends RecordingStoreRequestApplicationJson {
+  @override
+  final String owner;
+
+  factory _$RecordingStoreRequestApplicationJson(
+          [void Function(RecordingStoreRequestApplicationJsonBuilder)? updates]) =>
+      (RecordingStoreRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RecordingStoreRequestApplicationJson._({required this.owner}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(owner, r'RecordingStoreRequestApplicationJson', 'owner');
+  }
+
+  @override
+  RecordingStoreRequestApplicationJson rebuild(void Function(RecordingStoreRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RecordingStoreRequestApplicationJsonBuilder toBuilder() =>
+      RecordingStoreRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RecordingStoreRequestApplicationJson && owner == other.owner;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, owner.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RecordingStoreRequestApplicationJson')..add('owner', owner)).toString();
+  }
+}
+
+class RecordingStoreRequestApplicationJsonBuilder
+    implements
+        Builder<RecordingStoreRequestApplicationJson, RecordingStoreRequestApplicationJsonBuilder>,
+        $RecordingStoreRequestApplicationJsonInterfaceBuilder {
+  _$RecordingStoreRequestApplicationJson? _$v;
+
+  String? _owner;
+  String? get owner => _$this._owner;
+  set owner(covariant String? owner) => _$this._owner = owner;
+
+  RecordingStoreRequestApplicationJsonBuilder() {
+    RecordingStoreRequestApplicationJson._defaults(this);
+  }
+
+  RecordingStoreRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _owner = $v.owner;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RecordingStoreRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RecordingStoreRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RecordingStoreRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RecordingStoreRequestApplicationJson build() => _build();
+
+  _$RecordingStoreRequestApplicationJson _build() {
+    RecordingStoreRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RecordingStoreRequestApplicationJson._(
+            owner: BuiltValueNullFieldError.checkNotNull(owner, r'RecordingStoreRequestApplicationJson', 'owner'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RecordingStoreResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RecordingStoreResponseApplicationJson_OcsInterface other);
   void update(void Function($RecordingStoreResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -42692,6 +50703,137 @@ class RecordingStoreResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomGetRoomsRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomGetRoomsRequestApplicationJsonInterface other);
+  void update(void Function($RoomGetRoomsRequestApplicationJsonInterfaceBuilder) updates);
+  RoomGetRoomsRequestApplicationJson_NoStatusUpdate? get noStatusUpdate;
+  set noStatusUpdate(RoomGetRoomsRequestApplicationJson_NoStatusUpdate? noStatusUpdate);
+
+  bool? get includeStatus;
+  set includeStatus(bool? includeStatus);
+
+  int? get modifiedSince;
+  set modifiedSince(int? modifiedSince);
+}
+
+class _$RoomGetRoomsRequestApplicationJson extends RoomGetRoomsRequestApplicationJson {
+  @override
+  final RoomGetRoomsRequestApplicationJson_NoStatusUpdate noStatusUpdate;
+  @override
+  final bool includeStatus;
+  @override
+  final int modifiedSince;
+
+  factory _$RoomGetRoomsRequestApplicationJson([void Function(RoomGetRoomsRequestApplicationJsonBuilder)? updates]) =>
+      (RoomGetRoomsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomGetRoomsRequestApplicationJson._(
+      {required this.noStatusUpdate, required this.includeStatus, required this.modifiedSince})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(noStatusUpdate, r'RoomGetRoomsRequestApplicationJson', 'noStatusUpdate');
+    BuiltValueNullFieldError.checkNotNull(includeStatus, r'RoomGetRoomsRequestApplicationJson', 'includeStatus');
+    BuiltValueNullFieldError.checkNotNull(modifiedSince, r'RoomGetRoomsRequestApplicationJson', 'modifiedSince');
+  }
+
+  @override
+  RoomGetRoomsRequestApplicationJson rebuild(void Function(RoomGetRoomsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomGetRoomsRequestApplicationJsonBuilder toBuilder() => RoomGetRoomsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomGetRoomsRequestApplicationJson &&
+        noStatusUpdate == other.noStatusUpdate &&
+        includeStatus == other.includeStatus &&
+        modifiedSince == other.modifiedSince;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, noStatusUpdate.hashCode);
+    _$hash = $jc(_$hash, includeStatus.hashCode);
+    _$hash = $jc(_$hash, modifiedSince.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomGetRoomsRequestApplicationJson')
+          ..add('noStatusUpdate', noStatusUpdate)
+          ..add('includeStatus', includeStatus)
+          ..add('modifiedSince', modifiedSince))
+        .toString();
+  }
+}
+
+class RoomGetRoomsRequestApplicationJsonBuilder
+    implements
+        Builder<RoomGetRoomsRequestApplicationJson, RoomGetRoomsRequestApplicationJsonBuilder>,
+        $RoomGetRoomsRequestApplicationJsonInterfaceBuilder {
+  _$RoomGetRoomsRequestApplicationJson? _$v;
+
+  RoomGetRoomsRequestApplicationJson_NoStatusUpdate? _noStatusUpdate;
+  RoomGetRoomsRequestApplicationJson_NoStatusUpdate? get noStatusUpdate => _$this._noStatusUpdate;
+  set noStatusUpdate(covariant RoomGetRoomsRequestApplicationJson_NoStatusUpdate? noStatusUpdate) =>
+      _$this._noStatusUpdate = noStatusUpdate;
+
+  bool? _includeStatus;
+  bool? get includeStatus => _$this._includeStatus;
+  set includeStatus(covariant bool? includeStatus) => _$this._includeStatus = includeStatus;
+
+  int? _modifiedSince;
+  int? get modifiedSince => _$this._modifiedSince;
+  set modifiedSince(covariant int? modifiedSince) => _$this._modifiedSince = modifiedSince;
+
+  RoomGetRoomsRequestApplicationJsonBuilder() {
+    RoomGetRoomsRequestApplicationJson._defaults(this);
+  }
+
+  RoomGetRoomsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _noStatusUpdate = $v.noStatusUpdate;
+      _includeStatus = $v.includeStatus;
+      _modifiedSince = $v.modifiedSince;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomGetRoomsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomGetRoomsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomGetRoomsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomGetRoomsRequestApplicationJson build() => _build();
+
+  _$RoomGetRoomsRequestApplicationJson _build() {
+    RoomGetRoomsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomGetRoomsRequestApplicationJson._(
+            noStatusUpdate: BuiltValueNullFieldError.checkNotNull(
+                noStatusUpdate, r'RoomGetRoomsRequestApplicationJson', 'noStatusUpdate'),
+            includeStatus: BuiltValueNullFieldError.checkNotNull(
+                includeStatus, r'RoomGetRoomsRequestApplicationJson', 'includeStatus'),
+            modifiedSince: BuiltValueNullFieldError.checkNotNull(
+                modifiedSince, r'RoomGetRoomsRequestApplicationJson', 'modifiedSince'));
     replace(_$result);
     return _$result;
   }
@@ -43047,6 +51189,189 @@ class RoomRoomGetRoomsHeadersBuilder
   }
 }
 
+abstract mixin class $RoomCreateRoomRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomCreateRoomRequestApplicationJsonInterface other);
+  void update(void Function($RoomCreateRoomRequestApplicationJsonInterfaceBuilder) updates);
+  int? get roomType;
+  set roomType(int? roomType);
+
+  String? get invite;
+  set invite(String? invite);
+
+  String? get roomName;
+  set roomName(String? roomName);
+
+  String? get source;
+  set source(String? source);
+
+  String? get objectType;
+  set objectType(String? objectType);
+
+  String? get objectId;
+  set objectId(String? objectId);
+}
+
+class _$RoomCreateRoomRequestApplicationJson extends RoomCreateRoomRequestApplicationJson {
+  @override
+  final int roomType;
+  @override
+  final String invite;
+  @override
+  final String roomName;
+  @override
+  final String source;
+  @override
+  final String objectType;
+  @override
+  final String objectId;
+
+  factory _$RoomCreateRoomRequestApplicationJson(
+          [void Function(RoomCreateRoomRequestApplicationJsonBuilder)? updates]) =>
+      (RoomCreateRoomRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomCreateRoomRequestApplicationJson._(
+      {required this.roomType,
+      required this.invite,
+      required this.roomName,
+      required this.source,
+      required this.objectType,
+      required this.objectId})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(roomType, r'RoomCreateRoomRequestApplicationJson', 'roomType');
+    BuiltValueNullFieldError.checkNotNull(invite, r'RoomCreateRoomRequestApplicationJson', 'invite');
+    BuiltValueNullFieldError.checkNotNull(roomName, r'RoomCreateRoomRequestApplicationJson', 'roomName');
+    BuiltValueNullFieldError.checkNotNull(source, r'RoomCreateRoomRequestApplicationJson', 'source');
+    BuiltValueNullFieldError.checkNotNull(objectType, r'RoomCreateRoomRequestApplicationJson', 'objectType');
+    BuiltValueNullFieldError.checkNotNull(objectId, r'RoomCreateRoomRequestApplicationJson', 'objectId');
+  }
+
+  @override
+  RoomCreateRoomRequestApplicationJson rebuild(void Function(RoomCreateRoomRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomCreateRoomRequestApplicationJsonBuilder toBuilder() =>
+      RoomCreateRoomRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomCreateRoomRequestApplicationJson &&
+        roomType == other.roomType &&
+        invite == other.invite &&
+        roomName == other.roomName &&
+        source == other.source &&
+        objectType == other.objectType &&
+        objectId == other.objectId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, roomType.hashCode);
+    _$hash = $jc(_$hash, invite.hashCode);
+    _$hash = $jc(_$hash, roomName.hashCode);
+    _$hash = $jc(_$hash, source.hashCode);
+    _$hash = $jc(_$hash, objectType.hashCode);
+    _$hash = $jc(_$hash, objectId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomCreateRoomRequestApplicationJson')
+          ..add('roomType', roomType)
+          ..add('invite', invite)
+          ..add('roomName', roomName)
+          ..add('source', source)
+          ..add('objectType', objectType)
+          ..add('objectId', objectId))
+        .toString();
+  }
+}
+
+class RoomCreateRoomRequestApplicationJsonBuilder
+    implements
+        Builder<RoomCreateRoomRequestApplicationJson, RoomCreateRoomRequestApplicationJsonBuilder>,
+        $RoomCreateRoomRequestApplicationJsonInterfaceBuilder {
+  _$RoomCreateRoomRequestApplicationJson? _$v;
+
+  int? _roomType;
+  int? get roomType => _$this._roomType;
+  set roomType(covariant int? roomType) => _$this._roomType = roomType;
+
+  String? _invite;
+  String? get invite => _$this._invite;
+  set invite(covariant String? invite) => _$this._invite = invite;
+
+  String? _roomName;
+  String? get roomName => _$this._roomName;
+  set roomName(covariant String? roomName) => _$this._roomName = roomName;
+
+  String? _source;
+  String? get source => _$this._source;
+  set source(covariant String? source) => _$this._source = source;
+
+  String? _objectType;
+  String? get objectType => _$this._objectType;
+  set objectType(covariant String? objectType) => _$this._objectType = objectType;
+
+  String? _objectId;
+  String? get objectId => _$this._objectId;
+  set objectId(covariant String? objectId) => _$this._objectId = objectId;
+
+  RoomCreateRoomRequestApplicationJsonBuilder() {
+    RoomCreateRoomRequestApplicationJson._defaults(this);
+  }
+
+  RoomCreateRoomRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _roomType = $v.roomType;
+      _invite = $v.invite;
+      _roomName = $v.roomName;
+      _source = $v.source;
+      _objectType = $v.objectType;
+      _objectId = $v.objectId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomCreateRoomRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomCreateRoomRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomCreateRoomRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomCreateRoomRequestApplicationJson build() => _build();
+
+  _$RoomCreateRoomRequestApplicationJson _build() {
+    RoomCreateRoomRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomCreateRoomRequestApplicationJson._(
+            roomType:
+                BuiltValueNullFieldError.checkNotNull(roomType, r'RoomCreateRoomRequestApplicationJson', 'roomType'),
+            invite: BuiltValueNullFieldError.checkNotNull(invite, r'RoomCreateRoomRequestApplicationJson', 'invite'),
+            roomName:
+                BuiltValueNullFieldError.checkNotNull(roomName, r'RoomCreateRoomRequestApplicationJson', 'roomName'),
+            source: BuiltValueNullFieldError.checkNotNull(source, r'RoomCreateRoomRequestApplicationJson', 'source'),
+            objectType: BuiltValueNullFieldError.checkNotNull(
+                objectType, r'RoomCreateRoomRequestApplicationJson', 'objectType'),
+            objectId:
+                BuiltValueNullFieldError.checkNotNull(objectId, r'RoomCreateRoomRequestApplicationJson', 'objectId'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomCreateRoomResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomCreateRoomResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomCreateRoomResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -43269,6 +51594,103 @@ class RoomCreateRoomResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomGetListedRoomsRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomGetListedRoomsRequestApplicationJsonInterface other);
+  void update(void Function($RoomGetListedRoomsRequestApplicationJsonInterfaceBuilder) updates);
+  String? get searchTerm;
+  set searchTerm(String? searchTerm);
+}
+
+class _$RoomGetListedRoomsRequestApplicationJson extends RoomGetListedRoomsRequestApplicationJson {
+  @override
+  final String searchTerm;
+
+  factory _$RoomGetListedRoomsRequestApplicationJson(
+          [void Function(RoomGetListedRoomsRequestApplicationJsonBuilder)? updates]) =>
+      (RoomGetListedRoomsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomGetListedRoomsRequestApplicationJson._({required this.searchTerm}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(searchTerm, r'RoomGetListedRoomsRequestApplicationJson', 'searchTerm');
+  }
+
+  @override
+  RoomGetListedRoomsRequestApplicationJson rebuild(
+          void Function(RoomGetListedRoomsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomGetListedRoomsRequestApplicationJsonBuilder toBuilder() =>
+      RoomGetListedRoomsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomGetListedRoomsRequestApplicationJson && searchTerm == other.searchTerm;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, searchTerm.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomGetListedRoomsRequestApplicationJson')..add('searchTerm', searchTerm))
+        .toString();
+  }
+}
+
+class RoomGetListedRoomsRequestApplicationJsonBuilder
+    implements
+        Builder<RoomGetListedRoomsRequestApplicationJson, RoomGetListedRoomsRequestApplicationJsonBuilder>,
+        $RoomGetListedRoomsRequestApplicationJsonInterfaceBuilder {
+  _$RoomGetListedRoomsRequestApplicationJson? _$v;
+
+  String? _searchTerm;
+  String? get searchTerm => _$this._searchTerm;
+  set searchTerm(covariant String? searchTerm) => _$this._searchTerm = searchTerm;
+
+  RoomGetListedRoomsRequestApplicationJsonBuilder() {
+    RoomGetListedRoomsRequestApplicationJson._defaults(this);
+  }
+
+  RoomGetListedRoomsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _searchTerm = $v.searchTerm;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomGetListedRoomsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomGetListedRoomsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomGetListedRoomsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomGetListedRoomsRequestApplicationJson build() => _build();
+
+  _$RoomGetListedRoomsRequestApplicationJson _build() {
+    RoomGetListedRoomsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomGetListedRoomsRequestApplicationJson._(
+            searchTerm: BuiltValueNullFieldError.checkNotNull(
+                searchTerm, r'RoomGetListedRoomsRequestApplicationJson', 'searchTerm'));
     replace(_$result);
     return _$result;
   }
@@ -44837,6 +53259,103 @@ class RoomMakePrivateResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RoomSetDescriptionRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetDescriptionRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetDescriptionRequestApplicationJsonInterfaceBuilder) updates);
+  String? get description;
+  set description(String? description);
+}
+
+class _$RoomSetDescriptionRequestApplicationJson extends RoomSetDescriptionRequestApplicationJson {
+  @override
+  final String description;
+
+  factory _$RoomSetDescriptionRequestApplicationJson(
+          [void Function(RoomSetDescriptionRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetDescriptionRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetDescriptionRequestApplicationJson._({required this.description}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(description, r'RoomSetDescriptionRequestApplicationJson', 'description');
+  }
+
+  @override
+  RoomSetDescriptionRequestApplicationJson rebuild(
+          void Function(RoomSetDescriptionRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetDescriptionRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetDescriptionRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetDescriptionRequestApplicationJson && description == other.description;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetDescriptionRequestApplicationJson')..add('description', description))
+        .toString();
+  }
+}
+
+class RoomSetDescriptionRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetDescriptionRequestApplicationJson, RoomSetDescriptionRequestApplicationJsonBuilder>,
+        $RoomSetDescriptionRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetDescriptionRequestApplicationJson? _$v;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(covariant String? description) => _$this._description = description;
+
+  RoomSetDescriptionRequestApplicationJsonBuilder() {
+    RoomSetDescriptionRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetDescriptionRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _description = $v.description;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetDescriptionRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetDescriptionRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetDescriptionRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetDescriptionRequestApplicationJson build() => _build();
+
+  _$RoomSetDescriptionRequestApplicationJson _build() {
+    RoomSetDescriptionRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetDescriptionRequestApplicationJson._(
+            description: BuiltValueNullFieldError.checkNotNull(
+                description, r'RoomSetDescriptionRequestApplicationJson', 'description'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomSetDescriptionResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomSetDescriptionResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomSetDescriptionResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -45062,6 +53581,100 @@ class RoomSetDescriptionResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomSetReadOnlyRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetReadOnlyRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetReadOnlyRequestApplicationJsonInterfaceBuilder) updates);
+  RoomSetReadOnlyRequestApplicationJson_State? get state;
+  set state(RoomSetReadOnlyRequestApplicationJson_State? state);
+}
+
+class _$RoomSetReadOnlyRequestApplicationJson extends RoomSetReadOnlyRequestApplicationJson {
+  @override
+  final RoomSetReadOnlyRequestApplicationJson_State state;
+
+  factory _$RoomSetReadOnlyRequestApplicationJson(
+          [void Function(RoomSetReadOnlyRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetReadOnlyRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetReadOnlyRequestApplicationJson._({required this.state}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(state, r'RoomSetReadOnlyRequestApplicationJson', 'state');
+  }
+
+  @override
+  RoomSetReadOnlyRequestApplicationJson rebuild(void Function(RoomSetReadOnlyRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetReadOnlyRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetReadOnlyRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetReadOnlyRequestApplicationJson && state == other.state;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, state.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetReadOnlyRequestApplicationJson')..add('state', state)).toString();
+  }
+}
+
+class RoomSetReadOnlyRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetReadOnlyRequestApplicationJson, RoomSetReadOnlyRequestApplicationJsonBuilder>,
+        $RoomSetReadOnlyRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetReadOnlyRequestApplicationJson? _$v;
+
+  RoomSetReadOnlyRequestApplicationJson_State? _state;
+  RoomSetReadOnlyRequestApplicationJson_State? get state => _$this._state;
+  set state(covariant RoomSetReadOnlyRequestApplicationJson_State? state) => _$this._state = state;
+
+  RoomSetReadOnlyRequestApplicationJsonBuilder() {
+    RoomSetReadOnlyRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetReadOnlyRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _state = $v.state;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetReadOnlyRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetReadOnlyRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetReadOnlyRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetReadOnlyRequestApplicationJson build() => _build();
+
+  _$RoomSetReadOnlyRequestApplicationJson _build() {
+    RoomSetReadOnlyRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetReadOnlyRequestApplicationJson._(
+            state: BuiltValueNullFieldError.checkNotNull(state, r'RoomSetReadOnlyRequestApplicationJson', 'state'));
     replace(_$result);
     return _$result;
   }
@@ -45296,6 +53909,100 @@ class RoomSetReadOnlyResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RoomSetListableRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetListableRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetListableRequestApplicationJsonInterfaceBuilder) updates);
+  RoomSetListableRequestApplicationJson_Scope? get scope;
+  set scope(RoomSetListableRequestApplicationJson_Scope? scope);
+}
+
+class _$RoomSetListableRequestApplicationJson extends RoomSetListableRequestApplicationJson {
+  @override
+  final RoomSetListableRequestApplicationJson_Scope scope;
+
+  factory _$RoomSetListableRequestApplicationJson(
+          [void Function(RoomSetListableRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetListableRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetListableRequestApplicationJson._({required this.scope}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(scope, r'RoomSetListableRequestApplicationJson', 'scope');
+  }
+
+  @override
+  RoomSetListableRequestApplicationJson rebuild(void Function(RoomSetListableRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetListableRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetListableRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetListableRequestApplicationJson && scope == other.scope;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, scope.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetListableRequestApplicationJson')..add('scope', scope)).toString();
+  }
+}
+
+class RoomSetListableRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetListableRequestApplicationJson, RoomSetListableRequestApplicationJsonBuilder>,
+        $RoomSetListableRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetListableRequestApplicationJson? _$v;
+
+  RoomSetListableRequestApplicationJson_Scope? _scope;
+  RoomSetListableRequestApplicationJson_Scope? get scope => _$this._scope;
+  set scope(covariant RoomSetListableRequestApplicationJson_Scope? scope) => _$this._scope = scope;
+
+  RoomSetListableRequestApplicationJsonBuilder() {
+    RoomSetListableRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetListableRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _scope = $v.scope;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetListableRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetListableRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetListableRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetListableRequestApplicationJson build() => _build();
+
+  _$RoomSetListableRequestApplicationJson _build() {
+    RoomSetListableRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetListableRequestApplicationJson._(
+            scope: BuiltValueNullFieldError.checkNotNull(scope, r'RoomSetListableRequestApplicationJson', 'scope'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomSetListableResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomSetListableResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomSetListableResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -45520,6 +54227,102 @@ class RoomSetListableResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomSetPasswordRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetPasswordRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetPasswordRequestApplicationJsonInterfaceBuilder) updates);
+  String? get password;
+  set password(String? password);
+}
+
+class _$RoomSetPasswordRequestApplicationJson extends RoomSetPasswordRequestApplicationJson {
+  @override
+  final String password;
+
+  factory _$RoomSetPasswordRequestApplicationJson(
+          [void Function(RoomSetPasswordRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetPasswordRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetPasswordRequestApplicationJson._({required this.password}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(password, r'RoomSetPasswordRequestApplicationJson', 'password');
+  }
+
+  @override
+  RoomSetPasswordRequestApplicationJson rebuild(void Function(RoomSetPasswordRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetPasswordRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetPasswordRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetPasswordRequestApplicationJson && password == other.password;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, password.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetPasswordRequestApplicationJson')..add('password', password))
+        .toString();
+  }
+}
+
+class RoomSetPasswordRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetPasswordRequestApplicationJson, RoomSetPasswordRequestApplicationJsonBuilder>,
+        $RoomSetPasswordRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetPasswordRequestApplicationJson? _$v;
+
+  String? _password;
+  String? get password => _$this._password;
+  set password(covariant String? password) => _$this._password = password;
+
+  RoomSetPasswordRequestApplicationJsonBuilder() {
+    RoomSetPasswordRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetPasswordRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _password = $v.password;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetPasswordRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetPasswordRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetPasswordRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetPasswordRequestApplicationJson build() => _build();
+
+  _$RoomSetPasswordRequestApplicationJson _build() {
+    RoomSetPasswordRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetPasswordRequestApplicationJson._(
+            password:
+                BuiltValueNullFieldError.checkNotNull(password, r'RoomSetPasswordRequestApplicationJson', 'password'));
     replace(_$result);
     return _$result;
   }
@@ -45754,6 +54557,103 @@ class RoomSetPasswordResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RoomSetPermissionsRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetPermissionsRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetPermissionsRequestApplicationJsonInterfaceBuilder) updates);
+  int? get permissions;
+  set permissions(int? permissions);
+}
+
+class _$RoomSetPermissionsRequestApplicationJson extends RoomSetPermissionsRequestApplicationJson {
+  @override
+  final int permissions;
+
+  factory _$RoomSetPermissionsRequestApplicationJson(
+          [void Function(RoomSetPermissionsRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetPermissionsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetPermissionsRequestApplicationJson._({required this.permissions}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(permissions, r'RoomSetPermissionsRequestApplicationJson', 'permissions');
+  }
+
+  @override
+  RoomSetPermissionsRequestApplicationJson rebuild(
+          void Function(RoomSetPermissionsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetPermissionsRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetPermissionsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetPermissionsRequestApplicationJson && permissions == other.permissions;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, permissions.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetPermissionsRequestApplicationJson')..add('permissions', permissions))
+        .toString();
+  }
+}
+
+class RoomSetPermissionsRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetPermissionsRequestApplicationJson, RoomSetPermissionsRequestApplicationJsonBuilder>,
+        $RoomSetPermissionsRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetPermissionsRequestApplicationJson? _$v;
+
+  int? _permissions;
+  int? get permissions => _$this._permissions;
+  set permissions(covariant int? permissions) => _$this._permissions = permissions;
+
+  RoomSetPermissionsRequestApplicationJsonBuilder() {
+    RoomSetPermissionsRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetPermissionsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _permissions = $v.permissions;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetPermissionsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetPermissionsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetPermissionsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetPermissionsRequestApplicationJson build() => _build();
+
+  _$RoomSetPermissionsRequestApplicationJson _build() {
+    RoomSetPermissionsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetPermissionsRequestApplicationJson._(
+            permissions: BuiltValueNullFieldError.checkNotNull(
+                permissions, r'RoomSetPermissionsRequestApplicationJson', 'permissions'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomSetPermissionsResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomSetPermissionsResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomSetPermissionsResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -45977,6 +54877,104 @@ class RoomSetPermissionsResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomGetParticipantsRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomGetParticipantsRequestApplicationJsonInterface other);
+  void update(void Function($RoomGetParticipantsRequestApplicationJsonInterfaceBuilder) updates);
+  bool? get includeStatus;
+  set includeStatus(bool? includeStatus);
+}
+
+class _$RoomGetParticipantsRequestApplicationJson extends RoomGetParticipantsRequestApplicationJson {
+  @override
+  final bool includeStatus;
+
+  factory _$RoomGetParticipantsRequestApplicationJson(
+          [void Function(RoomGetParticipantsRequestApplicationJsonBuilder)? updates]) =>
+      (RoomGetParticipantsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomGetParticipantsRequestApplicationJson._({required this.includeStatus}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(includeStatus, r'RoomGetParticipantsRequestApplicationJson', 'includeStatus');
+  }
+
+  @override
+  RoomGetParticipantsRequestApplicationJson rebuild(
+          void Function(RoomGetParticipantsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomGetParticipantsRequestApplicationJsonBuilder toBuilder() =>
+      RoomGetParticipantsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomGetParticipantsRequestApplicationJson && includeStatus == other.includeStatus;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, includeStatus.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomGetParticipantsRequestApplicationJson')
+          ..add('includeStatus', includeStatus))
+        .toString();
+  }
+}
+
+class RoomGetParticipantsRequestApplicationJsonBuilder
+    implements
+        Builder<RoomGetParticipantsRequestApplicationJson, RoomGetParticipantsRequestApplicationJsonBuilder>,
+        $RoomGetParticipantsRequestApplicationJsonInterfaceBuilder {
+  _$RoomGetParticipantsRequestApplicationJson? _$v;
+
+  bool? _includeStatus;
+  bool? get includeStatus => _$this._includeStatus;
+  set includeStatus(covariant bool? includeStatus) => _$this._includeStatus = includeStatus;
+
+  RoomGetParticipantsRequestApplicationJsonBuilder() {
+    RoomGetParticipantsRequestApplicationJson._defaults(this);
+  }
+
+  RoomGetParticipantsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _includeStatus = $v.includeStatus;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomGetParticipantsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomGetParticipantsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomGetParticipantsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomGetParticipantsRequestApplicationJson build() => _build();
+
+  _$RoomGetParticipantsRequestApplicationJson _build() {
+    RoomGetParticipantsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomGetParticipantsRequestApplicationJson._(
+            includeStatus: BuiltValueNullFieldError.checkNotNull(
+                includeStatus, r'RoomGetParticipantsRequestApplicationJson', 'includeStatus'));
     replace(_$result);
     return _$result;
   }
@@ -46688,6 +55686,122 @@ class RoomRoomGetParticipantsHeadersBuilder
   }
 }
 
+abstract mixin class $RoomAddParticipantToRoomRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomAddParticipantToRoomRequestApplicationJsonInterface other);
+  void update(void Function($RoomAddParticipantToRoomRequestApplicationJsonInterfaceBuilder) updates);
+  String? get newParticipant;
+  set newParticipant(String? newParticipant);
+
+  RoomAddParticipantToRoomRequestApplicationJson_Source? get source;
+  set source(RoomAddParticipantToRoomRequestApplicationJson_Source? source);
+}
+
+class _$RoomAddParticipantToRoomRequestApplicationJson extends RoomAddParticipantToRoomRequestApplicationJson {
+  @override
+  final String newParticipant;
+  @override
+  final RoomAddParticipantToRoomRequestApplicationJson_Source source;
+
+  factory _$RoomAddParticipantToRoomRequestApplicationJson(
+          [void Function(RoomAddParticipantToRoomRequestApplicationJsonBuilder)? updates]) =>
+      (RoomAddParticipantToRoomRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomAddParticipantToRoomRequestApplicationJson._({required this.newParticipant, required this.source}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        newParticipant, r'RoomAddParticipantToRoomRequestApplicationJson', 'newParticipant');
+    BuiltValueNullFieldError.checkNotNull(source, r'RoomAddParticipantToRoomRequestApplicationJson', 'source');
+  }
+
+  @override
+  RoomAddParticipantToRoomRequestApplicationJson rebuild(
+          void Function(RoomAddParticipantToRoomRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomAddParticipantToRoomRequestApplicationJsonBuilder toBuilder() =>
+      RoomAddParticipantToRoomRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomAddParticipantToRoomRequestApplicationJson &&
+        newParticipant == other.newParticipant &&
+        source == other.source;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, newParticipant.hashCode);
+    _$hash = $jc(_$hash, source.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomAddParticipantToRoomRequestApplicationJson')
+          ..add('newParticipant', newParticipant)
+          ..add('source', source))
+        .toString();
+  }
+}
+
+class RoomAddParticipantToRoomRequestApplicationJsonBuilder
+    implements
+        Builder<RoomAddParticipantToRoomRequestApplicationJson, RoomAddParticipantToRoomRequestApplicationJsonBuilder>,
+        $RoomAddParticipantToRoomRequestApplicationJsonInterfaceBuilder {
+  _$RoomAddParticipantToRoomRequestApplicationJson? _$v;
+
+  String? _newParticipant;
+  String? get newParticipant => _$this._newParticipant;
+  set newParticipant(covariant String? newParticipant) => _$this._newParticipant = newParticipant;
+
+  RoomAddParticipantToRoomRequestApplicationJson_Source? _source;
+  RoomAddParticipantToRoomRequestApplicationJson_Source? get source => _$this._source;
+  set source(covariant RoomAddParticipantToRoomRequestApplicationJson_Source? source) => _$this._source = source;
+
+  RoomAddParticipantToRoomRequestApplicationJsonBuilder() {
+    RoomAddParticipantToRoomRequestApplicationJson._defaults(this);
+  }
+
+  RoomAddParticipantToRoomRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _newParticipant = $v.newParticipant;
+      _source = $v.source;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomAddParticipantToRoomRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomAddParticipantToRoomRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomAddParticipantToRoomRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomAddParticipantToRoomRequestApplicationJson build() => _build();
+
+  _$RoomAddParticipantToRoomRequestApplicationJson _build() {
+    RoomAddParticipantToRoomRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomAddParticipantToRoomRequestApplicationJson._(
+            newParticipant: BuiltValueNullFieldError.checkNotNull(
+                newParticipant, r'RoomAddParticipantToRoomRequestApplicationJson', 'newParticipant'),
+            source: BuiltValueNullFieldError.checkNotNull(
+                source, r'RoomAddParticipantToRoomRequestApplicationJson', 'source'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0InterfaceBuilder {
   void replace($RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0Interface other);
   void update(void Function($RoomAddParticipantToRoomResponseApplicationJson_Ocs_Data0InterfaceBuilder) updates);
@@ -47022,6 +56136,107 @@ class RoomAddParticipantToRoomResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterface other);
+  void update(void Function($RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterfaceBuilder) updates);
+  bool? get includeStatus;
+  set includeStatus(bool? includeStatus);
+}
+
+class _$RoomGetBreakoutRoomParticipantsRequestApplicationJson
+    extends RoomGetBreakoutRoomParticipantsRequestApplicationJson {
+  @override
+  final bool includeStatus;
+
+  factory _$RoomGetBreakoutRoomParticipantsRequestApplicationJson(
+          [void Function(RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder)? updates]) =>
+      (RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomGetBreakoutRoomParticipantsRequestApplicationJson._({required this.includeStatus}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        includeStatus, r'RoomGetBreakoutRoomParticipantsRequestApplicationJson', 'includeStatus');
+  }
+
+  @override
+  RoomGetBreakoutRoomParticipantsRequestApplicationJson rebuild(
+          void Function(RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder toBuilder() =>
+      RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomGetBreakoutRoomParticipantsRequestApplicationJson && includeStatus == other.includeStatus;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, includeStatus.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomGetBreakoutRoomParticipantsRequestApplicationJson')
+          ..add('includeStatus', includeStatus))
+        .toString();
+  }
+}
+
+class RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder
+    implements
+        Builder<RoomGetBreakoutRoomParticipantsRequestApplicationJson,
+            RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder>,
+        $RoomGetBreakoutRoomParticipantsRequestApplicationJsonInterfaceBuilder {
+  _$RoomGetBreakoutRoomParticipantsRequestApplicationJson? _$v;
+
+  bool? _includeStatus;
+  bool? get includeStatus => _$this._includeStatus;
+  set includeStatus(covariant bool? includeStatus) => _$this._includeStatus = includeStatus;
+
+  RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder() {
+    RoomGetBreakoutRoomParticipantsRequestApplicationJson._defaults(this);
+  }
+
+  RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _includeStatus = $v.includeStatus;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomGetBreakoutRoomParticipantsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomGetBreakoutRoomParticipantsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomGetBreakoutRoomParticipantsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomGetBreakoutRoomParticipantsRequestApplicationJson build() => _build();
+
+  _$RoomGetBreakoutRoomParticipantsRequestApplicationJson _build() {
+    RoomGetBreakoutRoomParticipantsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomGetBreakoutRoomParticipantsRequestApplicationJson._(
+            includeStatus: BuiltValueNullFieldError.checkNotNull(
+                includeStatus, r'RoomGetBreakoutRoomParticipantsRequestApplicationJson', 'includeStatus'));
     replace(_$result);
     return _$result;
   }
@@ -47606,6 +56821,106 @@ class RoomRemoveSelfFromRoomResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RoomRemoveAttendeeFromRoomRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomRemoveAttendeeFromRoomRequestApplicationJsonInterface other);
+  void update(void Function($RoomRemoveAttendeeFromRoomRequestApplicationJsonInterfaceBuilder) updates);
+  int? get attendeeId;
+  set attendeeId(int? attendeeId);
+}
+
+class _$RoomRemoveAttendeeFromRoomRequestApplicationJson extends RoomRemoveAttendeeFromRoomRequestApplicationJson {
+  @override
+  final int attendeeId;
+
+  factory _$RoomRemoveAttendeeFromRoomRequestApplicationJson(
+          [void Function(RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder)? updates]) =>
+      (RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomRemoveAttendeeFromRoomRequestApplicationJson._({required this.attendeeId}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        attendeeId, r'RoomRemoveAttendeeFromRoomRequestApplicationJson', 'attendeeId');
+  }
+
+  @override
+  RoomRemoveAttendeeFromRoomRequestApplicationJson rebuild(
+          void Function(RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder toBuilder() =>
+      RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomRemoveAttendeeFromRoomRequestApplicationJson && attendeeId == other.attendeeId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, attendeeId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomRemoveAttendeeFromRoomRequestApplicationJson')
+          ..add('attendeeId', attendeeId))
+        .toString();
+  }
+}
+
+class RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder
+    implements
+        Builder<RoomRemoveAttendeeFromRoomRequestApplicationJson,
+            RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder>,
+        $RoomRemoveAttendeeFromRoomRequestApplicationJsonInterfaceBuilder {
+  _$RoomRemoveAttendeeFromRoomRequestApplicationJson? _$v;
+
+  int? _attendeeId;
+  int? get attendeeId => _$this._attendeeId;
+  set attendeeId(covariant int? attendeeId) => _$this._attendeeId = attendeeId;
+
+  RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder() {
+    RoomRemoveAttendeeFromRoomRequestApplicationJson._defaults(this);
+  }
+
+  RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _attendeeId = $v.attendeeId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomRemoveAttendeeFromRoomRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomRemoveAttendeeFromRoomRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomRemoveAttendeeFromRoomRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomRemoveAttendeeFromRoomRequestApplicationJson build() => _build();
+
+  _$RoomRemoveAttendeeFromRoomRequestApplicationJson _build() {
+    RoomRemoveAttendeeFromRoomRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomRemoveAttendeeFromRoomRequestApplicationJson._(
+            attendeeId: BuiltValueNullFieldError.checkNotNull(
+                attendeeId, r'RoomRemoveAttendeeFromRoomRequestApplicationJson', 'attendeeId'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomRemoveAttendeeFromRoomResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -47837,6 +57152,142 @@ class RoomRemoveAttendeeFromRoomResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomSetAttendeePermissionsRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetAttendeePermissionsRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetAttendeePermissionsRequestApplicationJsonInterfaceBuilder) updates);
+  int? get attendeeId;
+  set attendeeId(int? attendeeId);
+
+  RoomSetAttendeePermissionsRequestApplicationJson_Method? get method;
+  set method(RoomSetAttendeePermissionsRequestApplicationJson_Method? method);
+
+  int? get permissions;
+  set permissions(int? permissions);
+}
+
+class _$RoomSetAttendeePermissionsRequestApplicationJson extends RoomSetAttendeePermissionsRequestApplicationJson {
+  @override
+  final int attendeeId;
+  @override
+  final RoomSetAttendeePermissionsRequestApplicationJson_Method method;
+  @override
+  final int permissions;
+
+  factory _$RoomSetAttendeePermissionsRequestApplicationJson(
+          [void Function(RoomSetAttendeePermissionsRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetAttendeePermissionsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetAttendeePermissionsRequestApplicationJson._(
+      {required this.attendeeId, required this.method, required this.permissions})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        attendeeId, r'RoomSetAttendeePermissionsRequestApplicationJson', 'attendeeId');
+    BuiltValueNullFieldError.checkNotNull(method, r'RoomSetAttendeePermissionsRequestApplicationJson', 'method');
+    BuiltValueNullFieldError.checkNotNull(
+        permissions, r'RoomSetAttendeePermissionsRequestApplicationJson', 'permissions');
+  }
+
+  @override
+  RoomSetAttendeePermissionsRequestApplicationJson rebuild(
+          void Function(RoomSetAttendeePermissionsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetAttendeePermissionsRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetAttendeePermissionsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetAttendeePermissionsRequestApplicationJson &&
+        attendeeId == other.attendeeId &&
+        method == other.method &&
+        permissions == other.permissions;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, attendeeId.hashCode);
+    _$hash = $jc(_$hash, method.hashCode);
+    _$hash = $jc(_$hash, permissions.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetAttendeePermissionsRequestApplicationJson')
+          ..add('attendeeId', attendeeId)
+          ..add('method', method)
+          ..add('permissions', permissions))
+        .toString();
+  }
+}
+
+class RoomSetAttendeePermissionsRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetAttendeePermissionsRequestApplicationJson,
+            RoomSetAttendeePermissionsRequestApplicationJsonBuilder>,
+        $RoomSetAttendeePermissionsRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetAttendeePermissionsRequestApplicationJson? _$v;
+
+  int? _attendeeId;
+  int? get attendeeId => _$this._attendeeId;
+  set attendeeId(covariant int? attendeeId) => _$this._attendeeId = attendeeId;
+
+  RoomSetAttendeePermissionsRequestApplicationJson_Method? _method;
+  RoomSetAttendeePermissionsRequestApplicationJson_Method? get method => _$this._method;
+  set method(covariant RoomSetAttendeePermissionsRequestApplicationJson_Method? method) => _$this._method = method;
+
+  int? _permissions;
+  int? get permissions => _$this._permissions;
+  set permissions(covariant int? permissions) => _$this._permissions = permissions;
+
+  RoomSetAttendeePermissionsRequestApplicationJsonBuilder() {
+    RoomSetAttendeePermissionsRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetAttendeePermissionsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _attendeeId = $v.attendeeId;
+      _method = $v.method;
+      _permissions = $v.permissions;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetAttendeePermissionsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetAttendeePermissionsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetAttendeePermissionsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetAttendeePermissionsRequestApplicationJson build() => _build();
+
+  _$RoomSetAttendeePermissionsRequestApplicationJson _build() {
+    RoomSetAttendeePermissionsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetAttendeePermissionsRequestApplicationJson._(
+            attendeeId: BuiltValueNullFieldError.checkNotNull(
+                attendeeId, r'RoomSetAttendeePermissionsRequestApplicationJson', 'attendeeId'),
+            method: BuiltValueNullFieldError.checkNotNull(
+                method, r'RoomSetAttendeePermissionsRequestApplicationJson', 'method'),
+            permissions: BuiltValueNullFieldError.checkNotNull(
+                permissions, r'RoomSetAttendeePermissionsRequestApplicationJson', 'permissions'));
     replace(_$result);
     return _$result;
   }
@@ -48078,6 +57529,125 @@ class RoomSetAttendeePermissionsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RoomSetAllAttendeesPermissionsRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetAllAttendeesPermissionsRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetAllAttendeesPermissionsRequestApplicationJsonInterfaceBuilder) updates);
+  RoomSetAllAttendeesPermissionsRequestApplicationJson_Method? get method;
+  set method(RoomSetAllAttendeesPermissionsRequestApplicationJson_Method? method);
+
+  int? get permissions;
+  set permissions(int? permissions);
+}
+
+class _$RoomSetAllAttendeesPermissionsRequestApplicationJson
+    extends RoomSetAllAttendeesPermissionsRequestApplicationJson {
+  @override
+  final RoomSetAllAttendeesPermissionsRequestApplicationJson_Method method;
+  @override
+  final int permissions;
+
+  factory _$RoomSetAllAttendeesPermissionsRequestApplicationJson(
+          [void Function(RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetAllAttendeesPermissionsRequestApplicationJson._({required this.method, required this.permissions})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(method, r'RoomSetAllAttendeesPermissionsRequestApplicationJson', 'method');
+    BuiltValueNullFieldError.checkNotNull(
+        permissions, r'RoomSetAllAttendeesPermissionsRequestApplicationJson', 'permissions');
+  }
+
+  @override
+  RoomSetAllAttendeesPermissionsRequestApplicationJson rebuild(
+          void Function(RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetAllAttendeesPermissionsRequestApplicationJson &&
+        method == other.method &&
+        permissions == other.permissions;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, method.hashCode);
+    _$hash = $jc(_$hash, permissions.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetAllAttendeesPermissionsRequestApplicationJson')
+          ..add('method', method)
+          ..add('permissions', permissions))
+        .toString();
+  }
+}
+
+class RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetAllAttendeesPermissionsRequestApplicationJson,
+            RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder>,
+        $RoomSetAllAttendeesPermissionsRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetAllAttendeesPermissionsRequestApplicationJson? _$v;
+
+  RoomSetAllAttendeesPermissionsRequestApplicationJson_Method? _method;
+  RoomSetAllAttendeesPermissionsRequestApplicationJson_Method? get method => _$this._method;
+  set method(covariant RoomSetAllAttendeesPermissionsRequestApplicationJson_Method? method) => _$this._method = method;
+
+  int? _permissions;
+  int? get permissions => _$this._permissions;
+  set permissions(covariant int? permissions) => _$this._permissions = permissions;
+
+  RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder() {
+    RoomSetAllAttendeesPermissionsRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _method = $v.method;
+      _permissions = $v.permissions;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetAllAttendeesPermissionsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetAllAttendeesPermissionsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetAllAttendeesPermissionsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetAllAttendeesPermissionsRequestApplicationJson build() => _build();
+
+  _$RoomSetAllAttendeesPermissionsRequestApplicationJson _build() {
+    RoomSetAllAttendeesPermissionsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetAllAttendeesPermissionsRequestApplicationJson._(
+            method: BuiltValueNullFieldError.checkNotNull(
+                method, r'RoomSetAllAttendeesPermissionsRequestApplicationJson', 'method'),
+            permissions: BuiltValueNullFieldError.checkNotNull(
+                permissions, r'RoomSetAllAttendeesPermissionsRequestApplicationJson', 'permissions'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomSetAllAttendeesPermissionsResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -48311,6 +57881,115 @@ class RoomSetAllAttendeesPermissionsResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomJoinRoomRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomJoinRoomRequestApplicationJsonInterface other);
+  void update(void Function($RoomJoinRoomRequestApplicationJsonInterfaceBuilder) updates);
+  String? get password;
+  set password(String? password);
+
+  bool? get force;
+  set force(bool? force);
+}
+
+class _$RoomJoinRoomRequestApplicationJson extends RoomJoinRoomRequestApplicationJson {
+  @override
+  final String password;
+  @override
+  final bool force;
+
+  factory _$RoomJoinRoomRequestApplicationJson([void Function(RoomJoinRoomRequestApplicationJsonBuilder)? updates]) =>
+      (RoomJoinRoomRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomJoinRoomRequestApplicationJson._({required this.password, required this.force}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(password, r'RoomJoinRoomRequestApplicationJson', 'password');
+    BuiltValueNullFieldError.checkNotNull(force, r'RoomJoinRoomRequestApplicationJson', 'force');
+  }
+
+  @override
+  RoomJoinRoomRequestApplicationJson rebuild(void Function(RoomJoinRoomRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomJoinRoomRequestApplicationJsonBuilder toBuilder() => RoomJoinRoomRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomJoinRoomRequestApplicationJson && password == other.password && force == other.force;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, password.hashCode);
+    _$hash = $jc(_$hash, force.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomJoinRoomRequestApplicationJson')
+          ..add('password', password)
+          ..add('force', force))
+        .toString();
+  }
+}
+
+class RoomJoinRoomRequestApplicationJsonBuilder
+    implements
+        Builder<RoomJoinRoomRequestApplicationJson, RoomJoinRoomRequestApplicationJsonBuilder>,
+        $RoomJoinRoomRequestApplicationJsonInterfaceBuilder {
+  _$RoomJoinRoomRequestApplicationJson? _$v;
+
+  String? _password;
+  String? get password => _$this._password;
+  set password(covariant String? password) => _$this._password = password;
+
+  bool? _force;
+  bool? get force => _$this._force;
+  set force(covariant bool? force) => _$this._force = force;
+
+  RoomJoinRoomRequestApplicationJsonBuilder() {
+    RoomJoinRoomRequestApplicationJson._defaults(this);
+  }
+
+  RoomJoinRoomRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _password = $v.password;
+      _force = $v.force;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomJoinRoomRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomJoinRoomRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomJoinRoomRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomJoinRoomRequestApplicationJson build() => _build();
+
+  _$RoomJoinRoomRequestApplicationJson _build() {
+    RoomJoinRoomRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomJoinRoomRequestApplicationJson._(
+            password:
+                BuiltValueNullFieldError.checkNotNull(password, r'RoomJoinRoomRequestApplicationJson', 'password'),
+            force: BuiltValueNullFieldError.checkNotNull(force, r'RoomJoinRoomRequestApplicationJson', 'force'));
     replace(_$result);
     return _$result;
   }
@@ -48860,6 +58539,98 @@ class RoomLeaveRoomResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RoomResendInvitationsRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomResendInvitationsRequestApplicationJsonInterface other);
+  void update(void Function($RoomResendInvitationsRequestApplicationJsonInterfaceBuilder) updates);
+  int? get attendeeId;
+  set attendeeId(int? attendeeId);
+}
+
+class _$RoomResendInvitationsRequestApplicationJson extends RoomResendInvitationsRequestApplicationJson {
+  @override
+  final int? attendeeId;
+
+  factory _$RoomResendInvitationsRequestApplicationJson(
+          [void Function(RoomResendInvitationsRequestApplicationJsonBuilder)? updates]) =>
+      (RoomResendInvitationsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomResendInvitationsRequestApplicationJson._({this.attendeeId}) : super._();
+
+  @override
+  RoomResendInvitationsRequestApplicationJson rebuild(
+          void Function(RoomResendInvitationsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomResendInvitationsRequestApplicationJsonBuilder toBuilder() =>
+      RoomResendInvitationsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomResendInvitationsRequestApplicationJson && attendeeId == other.attendeeId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, attendeeId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomResendInvitationsRequestApplicationJson')..add('attendeeId', attendeeId))
+        .toString();
+  }
+}
+
+class RoomResendInvitationsRequestApplicationJsonBuilder
+    implements
+        Builder<RoomResendInvitationsRequestApplicationJson, RoomResendInvitationsRequestApplicationJsonBuilder>,
+        $RoomResendInvitationsRequestApplicationJsonInterfaceBuilder {
+  _$RoomResendInvitationsRequestApplicationJson? _$v;
+
+  int? _attendeeId;
+  int? get attendeeId => _$this._attendeeId;
+  set attendeeId(covariant int? attendeeId) => _$this._attendeeId = attendeeId;
+
+  RoomResendInvitationsRequestApplicationJsonBuilder() {
+    RoomResendInvitationsRequestApplicationJson._defaults(this);
+  }
+
+  RoomResendInvitationsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _attendeeId = $v.attendeeId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomResendInvitationsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomResendInvitationsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomResendInvitationsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomResendInvitationsRequestApplicationJson build() => _build();
+
+  _$RoomResendInvitationsRequestApplicationJson _build() {
+    RoomResendInvitationsRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$RoomResendInvitationsRequestApplicationJson._(attendeeId: attendeeId);
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomResendInvitationsResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomResendInvitationsResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomResendInvitationsResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -49087,6 +58858,101 @@ class RoomResendInvitationsResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomSetSessionStateRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetSessionStateRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetSessionStateRequestApplicationJsonInterfaceBuilder) updates);
+  RoomSetSessionStateRequestApplicationJson_State? get state;
+  set state(RoomSetSessionStateRequestApplicationJson_State? state);
+}
+
+class _$RoomSetSessionStateRequestApplicationJson extends RoomSetSessionStateRequestApplicationJson {
+  @override
+  final RoomSetSessionStateRequestApplicationJson_State state;
+
+  factory _$RoomSetSessionStateRequestApplicationJson(
+          [void Function(RoomSetSessionStateRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetSessionStateRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetSessionStateRequestApplicationJson._({required this.state}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(state, r'RoomSetSessionStateRequestApplicationJson', 'state');
+  }
+
+  @override
+  RoomSetSessionStateRequestApplicationJson rebuild(
+          void Function(RoomSetSessionStateRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetSessionStateRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetSessionStateRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetSessionStateRequestApplicationJson && state == other.state;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, state.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetSessionStateRequestApplicationJson')..add('state', state)).toString();
+  }
+}
+
+class RoomSetSessionStateRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetSessionStateRequestApplicationJson, RoomSetSessionStateRequestApplicationJsonBuilder>,
+        $RoomSetSessionStateRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetSessionStateRequestApplicationJson? _$v;
+
+  RoomSetSessionStateRequestApplicationJson_State? _state;
+  RoomSetSessionStateRequestApplicationJson_State? get state => _$this._state;
+  set state(covariant RoomSetSessionStateRequestApplicationJson_State? state) => _$this._state = state;
+
+  RoomSetSessionStateRequestApplicationJsonBuilder() {
+    RoomSetSessionStateRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetSessionStateRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _state = $v.state;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetSessionStateRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetSessionStateRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetSessionStateRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetSessionStateRequestApplicationJson build() => _build();
+
+  _$RoomSetSessionStateRequestApplicationJson _build() {
+    RoomSetSessionStateRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetSessionStateRequestApplicationJson._(
+            state: BuiltValueNullFieldError.checkNotNull(state, r'RoomSetSessionStateRequestApplicationJson', 'state'));
     replace(_$result);
     return _$result;
   }
@@ -49321,6 +59187,103 @@ class RoomSetSessionStateResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RoomPromoteModeratorRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomPromoteModeratorRequestApplicationJsonInterface other);
+  void update(void Function($RoomPromoteModeratorRequestApplicationJsonInterfaceBuilder) updates);
+  int? get attendeeId;
+  set attendeeId(int? attendeeId);
+}
+
+class _$RoomPromoteModeratorRequestApplicationJson extends RoomPromoteModeratorRequestApplicationJson {
+  @override
+  final int attendeeId;
+
+  factory _$RoomPromoteModeratorRequestApplicationJson(
+          [void Function(RoomPromoteModeratorRequestApplicationJsonBuilder)? updates]) =>
+      (RoomPromoteModeratorRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomPromoteModeratorRequestApplicationJson._({required this.attendeeId}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(attendeeId, r'RoomPromoteModeratorRequestApplicationJson', 'attendeeId');
+  }
+
+  @override
+  RoomPromoteModeratorRequestApplicationJson rebuild(
+          void Function(RoomPromoteModeratorRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomPromoteModeratorRequestApplicationJsonBuilder toBuilder() =>
+      RoomPromoteModeratorRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomPromoteModeratorRequestApplicationJson && attendeeId == other.attendeeId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, attendeeId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomPromoteModeratorRequestApplicationJson')..add('attendeeId', attendeeId))
+        .toString();
+  }
+}
+
+class RoomPromoteModeratorRequestApplicationJsonBuilder
+    implements
+        Builder<RoomPromoteModeratorRequestApplicationJson, RoomPromoteModeratorRequestApplicationJsonBuilder>,
+        $RoomPromoteModeratorRequestApplicationJsonInterfaceBuilder {
+  _$RoomPromoteModeratorRequestApplicationJson? _$v;
+
+  int? _attendeeId;
+  int? get attendeeId => _$this._attendeeId;
+  set attendeeId(covariant int? attendeeId) => _$this._attendeeId = attendeeId;
+
+  RoomPromoteModeratorRequestApplicationJsonBuilder() {
+    RoomPromoteModeratorRequestApplicationJson._defaults(this);
+  }
+
+  RoomPromoteModeratorRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _attendeeId = $v.attendeeId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomPromoteModeratorRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomPromoteModeratorRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomPromoteModeratorRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomPromoteModeratorRequestApplicationJson build() => _build();
+
+  _$RoomPromoteModeratorRequestApplicationJson _build() {
+    RoomPromoteModeratorRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomPromoteModeratorRequestApplicationJson._(
+            attendeeId: BuiltValueNullFieldError.checkNotNull(
+                attendeeId, r'RoomPromoteModeratorRequestApplicationJson', 'attendeeId'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomPromoteModeratorResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomPromoteModeratorResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomPromoteModeratorResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -49548,6 +59511,103 @@ class RoomPromoteModeratorResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomDemoteModeratorRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomDemoteModeratorRequestApplicationJsonInterface other);
+  void update(void Function($RoomDemoteModeratorRequestApplicationJsonInterfaceBuilder) updates);
+  int? get attendeeId;
+  set attendeeId(int? attendeeId);
+}
+
+class _$RoomDemoteModeratorRequestApplicationJson extends RoomDemoteModeratorRequestApplicationJson {
+  @override
+  final int attendeeId;
+
+  factory _$RoomDemoteModeratorRequestApplicationJson(
+          [void Function(RoomDemoteModeratorRequestApplicationJsonBuilder)? updates]) =>
+      (RoomDemoteModeratorRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomDemoteModeratorRequestApplicationJson._({required this.attendeeId}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(attendeeId, r'RoomDemoteModeratorRequestApplicationJson', 'attendeeId');
+  }
+
+  @override
+  RoomDemoteModeratorRequestApplicationJson rebuild(
+          void Function(RoomDemoteModeratorRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomDemoteModeratorRequestApplicationJsonBuilder toBuilder() =>
+      RoomDemoteModeratorRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomDemoteModeratorRequestApplicationJson && attendeeId == other.attendeeId;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, attendeeId.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomDemoteModeratorRequestApplicationJson')..add('attendeeId', attendeeId))
+        .toString();
+  }
+}
+
+class RoomDemoteModeratorRequestApplicationJsonBuilder
+    implements
+        Builder<RoomDemoteModeratorRequestApplicationJson, RoomDemoteModeratorRequestApplicationJsonBuilder>,
+        $RoomDemoteModeratorRequestApplicationJsonInterfaceBuilder {
+  _$RoomDemoteModeratorRequestApplicationJson? _$v;
+
+  int? _attendeeId;
+  int? get attendeeId => _$this._attendeeId;
+  set attendeeId(covariant int? attendeeId) => _$this._attendeeId = attendeeId;
+
+  RoomDemoteModeratorRequestApplicationJsonBuilder() {
+    RoomDemoteModeratorRequestApplicationJson._defaults(this);
+  }
+
+  RoomDemoteModeratorRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _attendeeId = $v.attendeeId;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomDemoteModeratorRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomDemoteModeratorRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomDemoteModeratorRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomDemoteModeratorRequestApplicationJson build() => _build();
+
+  _$RoomDemoteModeratorRequestApplicationJson _build() {
+    RoomDemoteModeratorRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomDemoteModeratorRequestApplicationJson._(
+            attendeeId: BuiltValueNullFieldError.checkNotNull(
+                attendeeId, r'RoomDemoteModeratorRequestApplicationJson', 'attendeeId'));
     replace(_$result);
     return _$result;
   }
@@ -50247,6 +60307,103 @@ class RoomRemoveFromFavoritesResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RoomSetNotificationLevelRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetNotificationLevelRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetNotificationLevelRequestApplicationJsonInterfaceBuilder) updates);
+  int? get level;
+  set level(int? level);
+}
+
+class _$RoomSetNotificationLevelRequestApplicationJson extends RoomSetNotificationLevelRequestApplicationJson {
+  @override
+  final int level;
+
+  factory _$RoomSetNotificationLevelRequestApplicationJson(
+          [void Function(RoomSetNotificationLevelRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetNotificationLevelRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetNotificationLevelRequestApplicationJson._({required this.level}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(level, r'RoomSetNotificationLevelRequestApplicationJson', 'level');
+  }
+
+  @override
+  RoomSetNotificationLevelRequestApplicationJson rebuild(
+          void Function(RoomSetNotificationLevelRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetNotificationLevelRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetNotificationLevelRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetNotificationLevelRequestApplicationJson && level == other.level;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, level.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetNotificationLevelRequestApplicationJson')..add('level', level))
+        .toString();
+  }
+}
+
+class RoomSetNotificationLevelRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetNotificationLevelRequestApplicationJson, RoomSetNotificationLevelRequestApplicationJsonBuilder>,
+        $RoomSetNotificationLevelRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetNotificationLevelRequestApplicationJson? _$v;
+
+  int? _level;
+  int? get level => _$this._level;
+  set level(covariant int? level) => _$this._level = level;
+
+  RoomSetNotificationLevelRequestApplicationJsonBuilder() {
+    RoomSetNotificationLevelRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetNotificationLevelRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _level = $v.level;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetNotificationLevelRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetNotificationLevelRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetNotificationLevelRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetNotificationLevelRequestApplicationJson build() => _build();
+
+  _$RoomSetNotificationLevelRequestApplicationJson _build() {
+    RoomSetNotificationLevelRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetNotificationLevelRequestApplicationJson._(
+            level: BuiltValueNullFieldError.checkNotNull(
+                level, r'RoomSetNotificationLevelRequestApplicationJson', 'level'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomSetNotificationLevelResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomSetNotificationLevelResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomSetNotificationLevelResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -50478,6 +60635,103 @@ class RoomSetNotificationLevelResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomSetNotificationCallsRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetNotificationCallsRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetNotificationCallsRequestApplicationJsonInterfaceBuilder) updates);
+  int? get level;
+  set level(int? level);
+}
+
+class _$RoomSetNotificationCallsRequestApplicationJson extends RoomSetNotificationCallsRequestApplicationJson {
+  @override
+  final int level;
+
+  factory _$RoomSetNotificationCallsRequestApplicationJson(
+          [void Function(RoomSetNotificationCallsRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetNotificationCallsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetNotificationCallsRequestApplicationJson._({required this.level}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(level, r'RoomSetNotificationCallsRequestApplicationJson', 'level');
+  }
+
+  @override
+  RoomSetNotificationCallsRequestApplicationJson rebuild(
+          void Function(RoomSetNotificationCallsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetNotificationCallsRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetNotificationCallsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetNotificationCallsRequestApplicationJson && level == other.level;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, level.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetNotificationCallsRequestApplicationJson')..add('level', level))
+        .toString();
+  }
+}
+
+class RoomSetNotificationCallsRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetNotificationCallsRequestApplicationJson, RoomSetNotificationCallsRequestApplicationJsonBuilder>,
+        $RoomSetNotificationCallsRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetNotificationCallsRequestApplicationJson? _$v;
+
+  int? _level;
+  int? get level => _$this._level;
+  set level(covariant int? level) => _$this._level = level;
+
+  RoomSetNotificationCallsRequestApplicationJsonBuilder() {
+    RoomSetNotificationCallsRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetNotificationCallsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _level = $v.level;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetNotificationCallsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetNotificationCallsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetNotificationCallsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetNotificationCallsRequestApplicationJson build() => _build();
+
+  _$RoomSetNotificationCallsRequestApplicationJson _build() {
+    RoomSetNotificationCallsRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetNotificationCallsRequestApplicationJson._(
+            level: BuiltValueNullFieldError.checkNotNull(
+                level, r'RoomSetNotificationCallsRequestApplicationJson', 'level'));
     replace(_$result);
     return _$result;
   }
@@ -50719,6 +60973,113 @@ class RoomSetNotificationCallsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RoomSetLobbyRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetLobbyRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetLobbyRequestApplicationJsonInterfaceBuilder) updates);
+  int? get state;
+  set state(int? state);
+
+  int? get timer;
+  set timer(int? timer);
+}
+
+class _$RoomSetLobbyRequestApplicationJson extends RoomSetLobbyRequestApplicationJson {
+  @override
+  final int state;
+  @override
+  final int? timer;
+
+  factory _$RoomSetLobbyRequestApplicationJson([void Function(RoomSetLobbyRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetLobbyRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetLobbyRequestApplicationJson._({required this.state, this.timer}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(state, r'RoomSetLobbyRequestApplicationJson', 'state');
+  }
+
+  @override
+  RoomSetLobbyRequestApplicationJson rebuild(void Function(RoomSetLobbyRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetLobbyRequestApplicationJsonBuilder toBuilder() => RoomSetLobbyRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetLobbyRequestApplicationJson && state == other.state && timer == other.timer;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, state.hashCode);
+    _$hash = $jc(_$hash, timer.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetLobbyRequestApplicationJson')
+          ..add('state', state)
+          ..add('timer', timer))
+        .toString();
+  }
+}
+
+class RoomSetLobbyRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetLobbyRequestApplicationJson, RoomSetLobbyRequestApplicationJsonBuilder>,
+        $RoomSetLobbyRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetLobbyRequestApplicationJson? _$v;
+
+  int? _state;
+  int? get state => _$this._state;
+  set state(covariant int? state) => _$this._state = state;
+
+  int? _timer;
+  int? get timer => _$this._timer;
+  set timer(covariant int? timer) => _$this._timer = timer;
+
+  RoomSetLobbyRequestApplicationJsonBuilder() {
+    RoomSetLobbyRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetLobbyRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _state = $v.state;
+      _timer = $v.timer;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetLobbyRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetLobbyRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetLobbyRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetLobbyRequestApplicationJson build() => _build();
+
+  _$RoomSetLobbyRequestApplicationJson _build() {
+    RoomSetLobbyRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetLobbyRequestApplicationJson._(
+            state: BuiltValueNullFieldError.checkNotNull(state, r'RoomSetLobbyRequestApplicationJson', 'state'),
+            timer: timer);
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomSetLobbyResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomSetLobbyResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomSetLobbyResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -50939,6 +61300,101 @@ class RoomSetLobbyResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomSetsipEnabledRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetsipEnabledRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetsipEnabledRequestApplicationJsonInterfaceBuilder) updates);
+  RoomSetsipEnabledRequestApplicationJson_State? get state;
+  set state(RoomSetsipEnabledRequestApplicationJson_State? state);
+}
+
+class _$RoomSetsipEnabledRequestApplicationJson extends RoomSetsipEnabledRequestApplicationJson {
+  @override
+  final RoomSetsipEnabledRequestApplicationJson_State state;
+
+  factory _$RoomSetsipEnabledRequestApplicationJson(
+          [void Function(RoomSetsipEnabledRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetsipEnabledRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetsipEnabledRequestApplicationJson._({required this.state}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(state, r'RoomSetsipEnabledRequestApplicationJson', 'state');
+  }
+
+  @override
+  RoomSetsipEnabledRequestApplicationJson rebuild(
+          void Function(RoomSetsipEnabledRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetsipEnabledRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetsipEnabledRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetsipEnabledRequestApplicationJson && state == other.state;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, state.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetsipEnabledRequestApplicationJson')..add('state', state)).toString();
+  }
+}
+
+class RoomSetsipEnabledRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetsipEnabledRequestApplicationJson, RoomSetsipEnabledRequestApplicationJsonBuilder>,
+        $RoomSetsipEnabledRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetsipEnabledRequestApplicationJson? _$v;
+
+  RoomSetsipEnabledRequestApplicationJson_State? _state;
+  RoomSetsipEnabledRequestApplicationJson_State? get state => _$this._state;
+  set state(covariant RoomSetsipEnabledRequestApplicationJson_State? state) => _$this._state = state;
+
+  RoomSetsipEnabledRequestApplicationJsonBuilder() {
+    RoomSetsipEnabledRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetsipEnabledRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _state = $v.state;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetsipEnabledRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetsipEnabledRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetsipEnabledRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetsipEnabledRequestApplicationJson build() => _build();
+
+  _$RoomSetsipEnabledRequestApplicationJson _build() {
+    RoomSetsipEnabledRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetsipEnabledRequestApplicationJson._(
+            state: BuiltValueNullFieldError.checkNotNull(state, r'RoomSetsipEnabledRequestApplicationJson', 'state'));
     replace(_$result);
     return _$result;
   }
@@ -51172,6 +61628,105 @@ class RoomSetsipEnabledResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RoomSetRecordingConsentRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetRecordingConsentRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetRecordingConsentRequestApplicationJsonInterfaceBuilder) updates);
+  int? get recordingConsent;
+  set recordingConsent(int? recordingConsent);
+}
+
+class _$RoomSetRecordingConsentRequestApplicationJson extends RoomSetRecordingConsentRequestApplicationJson {
+  @override
+  final int recordingConsent;
+
+  factory _$RoomSetRecordingConsentRequestApplicationJson(
+          [void Function(RoomSetRecordingConsentRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetRecordingConsentRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetRecordingConsentRequestApplicationJson._({required this.recordingConsent}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        recordingConsent, r'RoomSetRecordingConsentRequestApplicationJson', 'recordingConsent');
+  }
+
+  @override
+  RoomSetRecordingConsentRequestApplicationJson rebuild(
+          void Function(RoomSetRecordingConsentRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetRecordingConsentRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetRecordingConsentRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetRecordingConsentRequestApplicationJson && recordingConsent == other.recordingConsent;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, recordingConsent.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetRecordingConsentRequestApplicationJson')
+          ..add('recordingConsent', recordingConsent))
+        .toString();
+  }
+}
+
+class RoomSetRecordingConsentRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetRecordingConsentRequestApplicationJson, RoomSetRecordingConsentRequestApplicationJsonBuilder>,
+        $RoomSetRecordingConsentRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetRecordingConsentRequestApplicationJson? _$v;
+
+  int? _recordingConsent;
+  int? get recordingConsent => _$this._recordingConsent;
+  set recordingConsent(covariant int? recordingConsent) => _$this._recordingConsent = recordingConsent;
+
+  RoomSetRecordingConsentRequestApplicationJsonBuilder() {
+    RoomSetRecordingConsentRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetRecordingConsentRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _recordingConsent = $v.recordingConsent;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetRecordingConsentRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetRecordingConsentRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetRecordingConsentRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetRecordingConsentRequestApplicationJson build() => _build();
+
+  _$RoomSetRecordingConsentRequestApplicationJson _build() {
+    RoomSetRecordingConsentRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetRecordingConsentRequestApplicationJson._(
+            recordingConsent: BuiltValueNullFieldError.checkNotNull(
+                recordingConsent, r'RoomSetRecordingConsentRequestApplicationJson', 'recordingConsent'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomSetRecordingConsentResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomSetRecordingConsentResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomSetRecordingConsentResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -51398,6 +61953,103 @@ class RoomSetRecordingConsentResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomSetMessageExpirationRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomSetMessageExpirationRequestApplicationJsonInterface other);
+  void update(void Function($RoomSetMessageExpirationRequestApplicationJsonInterfaceBuilder) updates);
+  int? get seconds;
+  set seconds(int? seconds);
+}
+
+class _$RoomSetMessageExpirationRequestApplicationJson extends RoomSetMessageExpirationRequestApplicationJson {
+  @override
+  final int seconds;
+
+  factory _$RoomSetMessageExpirationRequestApplicationJson(
+          [void Function(RoomSetMessageExpirationRequestApplicationJsonBuilder)? updates]) =>
+      (RoomSetMessageExpirationRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomSetMessageExpirationRequestApplicationJson._({required this.seconds}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(seconds, r'RoomSetMessageExpirationRequestApplicationJson', 'seconds');
+  }
+
+  @override
+  RoomSetMessageExpirationRequestApplicationJson rebuild(
+          void Function(RoomSetMessageExpirationRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomSetMessageExpirationRequestApplicationJsonBuilder toBuilder() =>
+      RoomSetMessageExpirationRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomSetMessageExpirationRequestApplicationJson && seconds == other.seconds;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, seconds.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomSetMessageExpirationRequestApplicationJson')..add('seconds', seconds))
+        .toString();
+  }
+}
+
+class RoomSetMessageExpirationRequestApplicationJsonBuilder
+    implements
+        Builder<RoomSetMessageExpirationRequestApplicationJson, RoomSetMessageExpirationRequestApplicationJsonBuilder>,
+        $RoomSetMessageExpirationRequestApplicationJsonInterfaceBuilder {
+  _$RoomSetMessageExpirationRequestApplicationJson? _$v;
+
+  int? _seconds;
+  int? get seconds => _$this._seconds;
+  set seconds(covariant int? seconds) => _$this._seconds = seconds;
+
+  RoomSetMessageExpirationRequestApplicationJsonBuilder() {
+    RoomSetMessageExpirationRequestApplicationJson._defaults(this);
+  }
+
+  RoomSetMessageExpirationRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _seconds = $v.seconds;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomSetMessageExpirationRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomSetMessageExpirationRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomSetMessageExpirationRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomSetMessageExpirationRequestApplicationJson build() => _build();
+
+  _$RoomSetMessageExpirationRequestApplicationJson _build() {
+    RoomSetMessageExpirationRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomSetMessageExpirationRequestApplicationJson._(
+            seconds: BuiltValueNullFieldError.checkNotNull(
+                seconds, r'RoomSetMessageExpirationRequestApplicationJson', 'seconds'));
     replace(_$result);
     return _$result;
   }
@@ -53850,6 +64502,101 @@ class RoomVerifyDialInPinDeprecatedResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $RoomVerifyDialInPinRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomVerifyDialInPinRequestApplicationJsonInterface other);
+  void update(void Function($RoomVerifyDialInPinRequestApplicationJsonInterfaceBuilder) updates);
+  String? get pin;
+  set pin(String? pin);
+}
+
+class _$RoomVerifyDialInPinRequestApplicationJson extends RoomVerifyDialInPinRequestApplicationJson {
+  @override
+  final String pin;
+
+  factory _$RoomVerifyDialInPinRequestApplicationJson(
+          [void Function(RoomVerifyDialInPinRequestApplicationJsonBuilder)? updates]) =>
+      (RoomVerifyDialInPinRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomVerifyDialInPinRequestApplicationJson._({required this.pin}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(pin, r'RoomVerifyDialInPinRequestApplicationJson', 'pin');
+  }
+
+  @override
+  RoomVerifyDialInPinRequestApplicationJson rebuild(
+          void Function(RoomVerifyDialInPinRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomVerifyDialInPinRequestApplicationJsonBuilder toBuilder() =>
+      RoomVerifyDialInPinRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomVerifyDialInPinRequestApplicationJson && pin == other.pin;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, pin.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomVerifyDialInPinRequestApplicationJson')..add('pin', pin)).toString();
+  }
+}
+
+class RoomVerifyDialInPinRequestApplicationJsonBuilder
+    implements
+        Builder<RoomVerifyDialInPinRequestApplicationJson, RoomVerifyDialInPinRequestApplicationJsonBuilder>,
+        $RoomVerifyDialInPinRequestApplicationJsonInterfaceBuilder {
+  _$RoomVerifyDialInPinRequestApplicationJson? _$v;
+
+  String? _pin;
+  String? get pin => _$this._pin;
+  set pin(covariant String? pin) => _$this._pin = pin;
+
+  RoomVerifyDialInPinRequestApplicationJsonBuilder() {
+    RoomVerifyDialInPinRequestApplicationJson._defaults(this);
+  }
+
+  RoomVerifyDialInPinRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _pin = $v.pin;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomVerifyDialInPinRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomVerifyDialInPinRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomVerifyDialInPinRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomVerifyDialInPinRequestApplicationJson build() => _build();
+
+  _$RoomVerifyDialInPinRequestApplicationJson _build() {
+    RoomVerifyDialInPinRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$RoomVerifyDialInPinRequestApplicationJson._(
+            pin: BuiltValueNullFieldError.checkNotNull(pin, r'RoomVerifyDialInPinRequestApplicationJson', 'pin'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $RoomVerifyDialInPinResponseApplicationJson_OcsInterfaceBuilder {
   void replace($RoomVerifyDialInPinResponseApplicationJson_OcsInterface other);
   void update(void Function($RoomVerifyDialInPinResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -54079,9 +64826,9 @@ class RoomVerifyDialInPinResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $RoomVerifyDialOutNumberOptionsInterfaceBuilder {
-  void replace($RoomVerifyDialOutNumberOptionsInterface other);
-  void update(void Function($RoomVerifyDialOutNumberOptionsInterfaceBuilder) updates);
+abstract mixin class $RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterfaceBuilder {
+  void replace($RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterface other);
+  void update(void Function($RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterfaceBuilder) updates);
   String? get actorId;
   set actorId(String? actorId);
 
@@ -54092,7 +64839,8 @@ abstract mixin class $RoomVerifyDialOutNumberOptionsInterfaceBuilder {
   set attendeeId(int? attendeeId);
 }
 
-class _$RoomVerifyDialOutNumberOptions extends RoomVerifyDialOutNumberOptions {
+class _$RoomVerifyDialOutNumberRequestApplicationJson_Options
+    extends RoomVerifyDialOutNumberRequestApplicationJson_Options {
   @override
   final String? actorId;
   @override
@@ -54100,22 +64848,26 @@ class _$RoomVerifyDialOutNumberOptions extends RoomVerifyDialOutNumberOptions {
   @override
   final int? attendeeId;
 
-  factory _$RoomVerifyDialOutNumberOptions([void Function(RoomVerifyDialOutNumberOptionsBuilder)? updates]) =>
-      (RoomVerifyDialOutNumberOptionsBuilder()..update(updates))._build();
+  factory _$RoomVerifyDialOutNumberRequestApplicationJson_Options(
+          [void Function(RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder)? updates]) =>
+      (RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder()..update(updates))._build();
 
-  _$RoomVerifyDialOutNumberOptions._({this.actorId, this.actorType, this.attendeeId}) : super._();
+  _$RoomVerifyDialOutNumberRequestApplicationJson_Options._({this.actorId, this.actorType, this.attendeeId})
+      : super._();
 
   @override
-  RoomVerifyDialOutNumberOptions rebuild(void Function(RoomVerifyDialOutNumberOptionsBuilder) updates) =>
+  RoomVerifyDialOutNumberRequestApplicationJson_Options rebuild(
+          void Function(RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  RoomVerifyDialOutNumberOptionsBuilder toBuilder() => RoomVerifyDialOutNumberOptionsBuilder()..replace(this);
+  RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder toBuilder() =>
+      RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is RoomVerifyDialOutNumberOptions &&
+    return other is RoomVerifyDialOutNumberRequestApplicationJson_Options &&
         actorId == other.actorId &&
         actorType == other.actorType &&
         attendeeId == other.attendeeId;
@@ -54133,7 +64885,7 @@ class _$RoomVerifyDialOutNumberOptions extends RoomVerifyDialOutNumberOptions {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'RoomVerifyDialOutNumberOptions')
+    return (newBuiltValueToStringHelper(r'RoomVerifyDialOutNumberRequestApplicationJson_Options')
           ..add('actorId', actorId)
           ..add('actorType', actorType)
           ..add('attendeeId', attendeeId))
@@ -54141,11 +64893,12 @@ class _$RoomVerifyDialOutNumberOptions extends RoomVerifyDialOutNumberOptions {
   }
 }
 
-class RoomVerifyDialOutNumberOptionsBuilder
+class RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder
     implements
-        Builder<RoomVerifyDialOutNumberOptions, RoomVerifyDialOutNumberOptionsBuilder>,
-        $RoomVerifyDialOutNumberOptionsInterfaceBuilder {
-  _$RoomVerifyDialOutNumberOptions? _$v;
+        Builder<RoomVerifyDialOutNumberRequestApplicationJson_Options,
+            RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder>,
+        $RoomVerifyDialOutNumberRequestApplicationJson_OptionsInterfaceBuilder {
+  _$RoomVerifyDialOutNumberRequestApplicationJson_Options? _$v;
 
   String? _actorId;
   String? get actorId => _$this._actorId;
@@ -54159,11 +64912,11 @@ class RoomVerifyDialOutNumberOptionsBuilder
   int? get attendeeId => _$this._attendeeId;
   set attendeeId(covariant int? attendeeId) => _$this._attendeeId = attendeeId;
 
-  RoomVerifyDialOutNumberOptionsBuilder() {
-    RoomVerifyDialOutNumberOptions._defaults(this);
+  RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder() {
+    RoomVerifyDialOutNumberRequestApplicationJson_Options._defaults(this);
   }
 
-  RoomVerifyDialOutNumberOptionsBuilder get _$this {
+  RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _actorId = $v.actorId;
@@ -54175,23 +64928,150 @@ class RoomVerifyDialOutNumberOptionsBuilder
   }
 
   @override
-  void replace(covariant RoomVerifyDialOutNumberOptions other) {
+  void replace(covariant RoomVerifyDialOutNumberRequestApplicationJson_Options other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$RoomVerifyDialOutNumberOptions;
+    _$v = other as _$RoomVerifyDialOutNumberRequestApplicationJson_Options;
   }
 
   @override
-  void update(void Function(RoomVerifyDialOutNumberOptionsBuilder)? updates) {
+  void update(void Function(RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  RoomVerifyDialOutNumberOptions build() => _build();
+  RoomVerifyDialOutNumberRequestApplicationJson_Options build() => _build();
 
-  _$RoomVerifyDialOutNumberOptions _build() {
-    RoomVerifyDialOutNumberOptions._validate(this);
-    final _$result =
-        _$v ?? _$RoomVerifyDialOutNumberOptions._(actorId: actorId, actorType: actorType, attendeeId: attendeeId);
+  _$RoomVerifyDialOutNumberRequestApplicationJson_Options _build() {
+    RoomVerifyDialOutNumberRequestApplicationJson_Options._validate(this);
+    final _$result = _$v ??
+        _$RoomVerifyDialOutNumberRequestApplicationJson_Options._(
+            actorId: actorId, actorType: actorType, attendeeId: attendeeId);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomVerifyDialOutNumberRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomVerifyDialOutNumberRequestApplicationJsonInterface other);
+  void update(void Function($RoomVerifyDialOutNumberRequestApplicationJsonInterfaceBuilder) updates);
+  String? get number;
+  set number(String? number);
+
+  RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder get options;
+  set options(RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder? options);
+}
+
+class _$RoomVerifyDialOutNumberRequestApplicationJson extends RoomVerifyDialOutNumberRequestApplicationJson {
+  @override
+  final String number;
+  @override
+  final RoomVerifyDialOutNumberRequestApplicationJson_Options options;
+
+  factory _$RoomVerifyDialOutNumberRequestApplicationJson(
+          [void Function(RoomVerifyDialOutNumberRequestApplicationJsonBuilder)? updates]) =>
+      (RoomVerifyDialOutNumberRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomVerifyDialOutNumberRequestApplicationJson._({required this.number, required this.options}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(number, r'RoomVerifyDialOutNumberRequestApplicationJson', 'number');
+    BuiltValueNullFieldError.checkNotNull(options, r'RoomVerifyDialOutNumberRequestApplicationJson', 'options');
+  }
+
+  @override
+  RoomVerifyDialOutNumberRequestApplicationJson rebuild(
+          void Function(RoomVerifyDialOutNumberRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomVerifyDialOutNumberRequestApplicationJsonBuilder toBuilder() =>
+      RoomVerifyDialOutNumberRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomVerifyDialOutNumberRequestApplicationJson && number == other.number && options == other.options;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, number.hashCode);
+    _$hash = $jc(_$hash, options.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomVerifyDialOutNumberRequestApplicationJson')
+          ..add('number', number)
+          ..add('options', options))
+        .toString();
+  }
+}
+
+class RoomVerifyDialOutNumberRequestApplicationJsonBuilder
+    implements
+        Builder<RoomVerifyDialOutNumberRequestApplicationJson, RoomVerifyDialOutNumberRequestApplicationJsonBuilder>,
+        $RoomVerifyDialOutNumberRequestApplicationJsonInterfaceBuilder {
+  _$RoomVerifyDialOutNumberRequestApplicationJson? _$v;
+
+  String? _number;
+  String? get number => _$this._number;
+  set number(covariant String? number) => _$this._number = number;
+
+  RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder? _options;
+  RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder get options =>
+      _$this._options ??= RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder();
+  set options(covariant RoomVerifyDialOutNumberRequestApplicationJson_OptionsBuilder? options) =>
+      _$this._options = options;
+
+  RoomVerifyDialOutNumberRequestApplicationJsonBuilder() {
+    RoomVerifyDialOutNumberRequestApplicationJson._defaults(this);
+  }
+
+  RoomVerifyDialOutNumberRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _number = $v.number;
+      _options = $v.options.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomVerifyDialOutNumberRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomVerifyDialOutNumberRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomVerifyDialOutNumberRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomVerifyDialOutNumberRequestApplicationJson build() => _build();
+
+  _$RoomVerifyDialOutNumberRequestApplicationJson _build() {
+    RoomVerifyDialOutNumberRequestApplicationJson._validate(this);
+    _$RoomVerifyDialOutNumberRequestApplicationJson _$result;
+    try {
+      _$result = _$v ??
+          _$RoomVerifyDialOutNumberRequestApplicationJson._(
+              number: BuiltValueNullFieldError.checkNotNull(
+                  number, r'RoomVerifyDialOutNumberRequestApplicationJson', 'number'),
+              options: options.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'options';
+        options.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'RoomVerifyDialOutNumberRequestApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -54659,9 +65539,9 @@ class RoomCreateGuestByDialInResponseApplicationJsonBuilder
   }
 }
 
-abstract mixin class $RoomRejectedDialOutRequestOptionsInterfaceBuilder {
-  void replace($RoomRejectedDialOutRequestOptionsInterface other);
-  void update(void Function($RoomRejectedDialOutRequestOptionsInterfaceBuilder) updates);
+abstract mixin class $RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterfaceBuilder {
+  void replace($RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterface other);
+  void update(void Function($RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterfaceBuilder) updates);
   String? get actorId;
   set actorId(String? actorId);
 
@@ -54672,7 +65552,8 @@ abstract mixin class $RoomRejectedDialOutRequestOptionsInterfaceBuilder {
   set attendeeId(int? attendeeId);
 }
 
-class _$RoomRejectedDialOutRequestOptions extends RoomRejectedDialOutRequestOptions {
+class _$RoomRejectedDialOutRequestRequestApplicationJson_Options
+    extends RoomRejectedDialOutRequestRequestApplicationJson_Options {
   @override
   final String? actorId;
   @override
@@ -54680,22 +65561,26 @@ class _$RoomRejectedDialOutRequestOptions extends RoomRejectedDialOutRequestOpti
   @override
   final int? attendeeId;
 
-  factory _$RoomRejectedDialOutRequestOptions([void Function(RoomRejectedDialOutRequestOptionsBuilder)? updates]) =>
-      (RoomRejectedDialOutRequestOptionsBuilder()..update(updates))._build();
+  factory _$RoomRejectedDialOutRequestRequestApplicationJson_Options(
+          [void Function(RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder)? updates]) =>
+      (RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder()..update(updates))._build();
 
-  _$RoomRejectedDialOutRequestOptions._({this.actorId, this.actorType, this.attendeeId}) : super._();
+  _$RoomRejectedDialOutRequestRequestApplicationJson_Options._({this.actorId, this.actorType, this.attendeeId})
+      : super._();
 
   @override
-  RoomRejectedDialOutRequestOptions rebuild(void Function(RoomRejectedDialOutRequestOptionsBuilder) updates) =>
+  RoomRejectedDialOutRequestRequestApplicationJson_Options rebuild(
+          void Function(RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  RoomRejectedDialOutRequestOptionsBuilder toBuilder() => RoomRejectedDialOutRequestOptionsBuilder()..replace(this);
+  RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder toBuilder() =>
+      RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is RoomRejectedDialOutRequestOptions &&
+    return other is RoomRejectedDialOutRequestRequestApplicationJson_Options &&
         actorId == other.actorId &&
         actorType == other.actorType &&
         attendeeId == other.attendeeId;
@@ -54713,7 +65598,7 @@ class _$RoomRejectedDialOutRequestOptions extends RoomRejectedDialOutRequestOpti
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'RoomRejectedDialOutRequestOptions')
+    return (newBuiltValueToStringHelper(r'RoomRejectedDialOutRequestRequestApplicationJson_Options')
           ..add('actorId', actorId)
           ..add('actorType', actorType)
           ..add('attendeeId', attendeeId))
@@ -54721,11 +65606,12 @@ class _$RoomRejectedDialOutRequestOptions extends RoomRejectedDialOutRequestOpti
   }
 }
 
-class RoomRejectedDialOutRequestOptionsBuilder
+class RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder
     implements
-        Builder<RoomRejectedDialOutRequestOptions, RoomRejectedDialOutRequestOptionsBuilder>,
-        $RoomRejectedDialOutRequestOptionsInterfaceBuilder {
-  _$RoomRejectedDialOutRequestOptions? _$v;
+        Builder<RoomRejectedDialOutRequestRequestApplicationJson_Options,
+            RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder>,
+        $RoomRejectedDialOutRequestRequestApplicationJson_OptionsInterfaceBuilder {
+  _$RoomRejectedDialOutRequestRequestApplicationJson_Options? _$v;
 
   String? _actorId;
   String? get actorId => _$this._actorId;
@@ -54739,11 +65625,11 @@ class RoomRejectedDialOutRequestOptionsBuilder
   int? get attendeeId => _$this._attendeeId;
   set attendeeId(covariant int? attendeeId) => _$this._attendeeId = attendeeId;
 
-  RoomRejectedDialOutRequestOptionsBuilder() {
-    RoomRejectedDialOutRequestOptions._defaults(this);
+  RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder() {
+    RoomRejectedDialOutRequestRequestApplicationJson_Options._defaults(this);
   }
 
-  RoomRejectedDialOutRequestOptionsBuilder get _$this {
+  RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _actorId = $v.actorId;
@@ -54755,23 +65641,154 @@ class RoomRejectedDialOutRequestOptionsBuilder
   }
 
   @override
-  void replace(covariant RoomRejectedDialOutRequestOptions other) {
+  void replace(covariant RoomRejectedDialOutRequestRequestApplicationJson_Options other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$RoomRejectedDialOutRequestOptions;
+    _$v = other as _$RoomRejectedDialOutRequestRequestApplicationJson_Options;
   }
 
   @override
-  void update(void Function(RoomRejectedDialOutRequestOptionsBuilder)? updates) {
+  void update(void Function(RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  RoomRejectedDialOutRequestOptions build() => _build();
+  RoomRejectedDialOutRequestRequestApplicationJson_Options build() => _build();
 
-  _$RoomRejectedDialOutRequestOptions _build() {
-    RoomRejectedDialOutRequestOptions._validate(this);
-    final _$result =
-        _$v ?? _$RoomRejectedDialOutRequestOptions._(actorId: actorId, actorType: actorType, attendeeId: attendeeId);
+  _$RoomRejectedDialOutRequestRequestApplicationJson_Options _build() {
+    RoomRejectedDialOutRequestRequestApplicationJson_Options._validate(this);
+    final _$result = _$v ??
+        _$RoomRejectedDialOutRequestRequestApplicationJson_Options._(
+            actorId: actorId, actorType: actorType, attendeeId: attendeeId);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $RoomRejectedDialOutRequestRequestApplicationJsonInterfaceBuilder {
+  void replace($RoomRejectedDialOutRequestRequestApplicationJsonInterface other);
+  void update(void Function($RoomRejectedDialOutRequestRequestApplicationJsonInterfaceBuilder) updates);
+  String? get callId;
+  set callId(String? callId);
+
+  RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder get options;
+  set options(RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder? options);
+}
+
+class _$RoomRejectedDialOutRequestRequestApplicationJson extends RoomRejectedDialOutRequestRequestApplicationJson {
+  @override
+  final String callId;
+  @override
+  final RoomRejectedDialOutRequestRequestApplicationJson_Options options;
+
+  factory _$RoomRejectedDialOutRequestRequestApplicationJson(
+          [void Function(RoomRejectedDialOutRequestRequestApplicationJsonBuilder)? updates]) =>
+      (RoomRejectedDialOutRequestRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$RoomRejectedDialOutRequestRequestApplicationJson._({required this.callId, required this.options}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(callId, r'RoomRejectedDialOutRequestRequestApplicationJson', 'callId');
+    BuiltValueNullFieldError.checkNotNull(options, r'RoomRejectedDialOutRequestRequestApplicationJson', 'options');
+  }
+
+  @override
+  RoomRejectedDialOutRequestRequestApplicationJson rebuild(
+          void Function(RoomRejectedDialOutRequestRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  RoomRejectedDialOutRequestRequestApplicationJsonBuilder toBuilder() =>
+      RoomRejectedDialOutRequestRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is RoomRejectedDialOutRequestRequestApplicationJson &&
+        callId == other.callId &&
+        options == other.options;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, callId.hashCode);
+    _$hash = $jc(_$hash, options.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'RoomRejectedDialOutRequestRequestApplicationJson')
+          ..add('callId', callId)
+          ..add('options', options))
+        .toString();
+  }
+}
+
+class RoomRejectedDialOutRequestRequestApplicationJsonBuilder
+    implements
+        Builder<RoomRejectedDialOutRequestRequestApplicationJson,
+            RoomRejectedDialOutRequestRequestApplicationJsonBuilder>,
+        $RoomRejectedDialOutRequestRequestApplicationJsonInterfaceBuilder {
+  _$RoomRejectedDialOutRequestRequestApplicationJson? _$v;
+
+  String? _callId;
+  String? get callId => _$this._callId;
+  set callId(covariant String? callId) => _$this._callId = callId;
+
+  RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder? _options;
+  RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder get options =>
+      _$this._options ??= RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder();
+  set options(covariant RoomRejectedDialOutRequestRequestApplicationJson_OptionsBuilder? options) =>
+      _$this._options = options;
+
+  RoomRejectedDialOutRequestRequestApplicationJsonBuilder() {
+    RoomRejectedDialOutRequestRequestApplicationJson._defaults(this);
+  }
+
+  RoomRejectedDialOutRequestRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _callId = $v.callId;
+      _options = $v.options.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant RoomRejectedDialOutRequestRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$RoomRejectedDialOutRequestRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(RoomRejectedDialOutRequestRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  RoomRejectedDialOutRequestRequestApplicationJson build() => _build();
+
+  _$RoomRejectedDialOutRequestRequestApplicationJson _build() {
+    RoomRejectedDialOutRequestRequestApplicationJson._validate(this);
+    _$RoomRejectedDialOutRequestRequestApplicationJson _$result;
+    try {
+      _$result = _$v ??
+          _$RoomRejectedDialOutRequestRequestApplicationJson._(
+              callId: BuiltValueNullFieldError.checkNotNull(
+                  callId, r'RoomRejectedDialOutRequestRequestApplicationJson', 'callId'),
+              options: options.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'options';
+        options.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'RoomRejectedDialOutRequestRequestApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
     replace(_$result);
     return _$result;
   }
@@ -55008,6 +66025,117 @@ class RoomRejectedDialOutRequestResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $SettingsSetUserSettingRequestApplicationJsonInterfaceBuilder {
+  void replace($SettingsSetUserSettingRequestApplicationJsonInterface other);
+  void update(void Function($SettingsSetUserSettingRequestApplicationJsonInterfaceBuilder) updates);
+  SettingsSetUserSettingRequestApplicationJson_Key? get key;
+  set key(SettingsSetUserSettingRequestApplicationJson_Key? key);
+
+  SettingsSetUserSettingRequestApplicationJson_Value? get value;
+  set value(SettingsSetUserSettingRequestApplicationJson_Value? value);
+}
+
+class _$SettingsSetUserSettingRequestApplicationJson extends SettingsSetUserSettingRequestApplicationJson {
+  @override
+  final SettingsSetUserSettingRequestApplicationJson_Key key;
+  @override
+  final SettingsSetUserSettingRequestApplicationJson_Value? value;
+
+  factory _$SettingsSetUserSettingRequestApplicationJson(
+          [void Function(SettingsSetUserSettingRequestApplicationJsonBuilder)? updates]) =>
+      (SettingsSetUserSettingRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$SettingsSetUserSettingRequestApplicationJson._({required this.key, this.value}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(key, r'SettingsSetUserSettingRequestApplicationJson', 'key');
+  }
+
+  @override
+  SettingsSetUserSettingRequestApplicationJson rebuild(
+          void Function(SettingsSetUserSettingRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SettingsSetUserSettingRequestApplicationJsonBuilder toBuilder() =>
+      SettingsSetUserSettingRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    final dynamic _$dynamicOther = other;
+    return other is SettingsSetUserSettingRequestApplicationJson && key == other.key && value == _$dynamicOther.value;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, key.hashCode);
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SettingsSetUserSettingRequestApplicationJson')
+          ..add('key', key)
+          ..add('value', value))
+        .toString();
+  }
+}
+
+class SettingsSetUserSettingRequestApplicationJsonBuilder
+    implements
+        Builder<SettingsSetUserSettingRequestApplicationJson, SettingsSetUserSettingRequestApplicationJsonBuilder>,
+        $SettingsSetUserSettingRequestApplicationJsonInterfaceBuilder {
+  _$SettingsSetUserSettingRequestApplicationJson? _$v;
+
+  SettingsSetUserSettingRequestApplicationJson_Key? _key;
+  SettingsSetUserSettingRequestApplicationJson_Key? get key => _$this._key;
+  set key(covariant SettingsSetUserSettingRequestApplicationJson_Key? key) => _$this._key = key;
+
+  SettingsSetUserSettingRequestApplicationJson_Value? _value;
+  SettingsSetUserSettingRequestApplicationJson_Value? get value => _$this._value;
+  set value(covariant SettingsSetUserSettingRequestApplicationJson_Value? value) => _$this._value = value;
+
+  SettingsSetUserSettingRequestApplicationJsonBuilder() {
+    SettingsSetUserSettingRequestApplicationJson._defaults(this);
+  }
+
+  SettingsSetUserSettingRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _key = $v.key;
+      _value = $v.value;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant SettingsSetUserSettingRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$SettingsSetUserSettingRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(SettingsSetUserSettingRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SettingsSetUserSettingRequestApplicationJson build() => _build();
+
+  _$SettingsSetUserSettingRequestApplicationJson _build() {
+    SettingsSetUserSettingRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$SettingsSetUserSettingRequestApplicationJson._(
+            key: BuiltValueNullFieldError.checkNotNull(key, r'SettingsSetUserSettingRequestApplicationJson', 'key'),
+            value: value);
     replace(_$result);
     return _$result;
   }
@@ -55710,6 +66838,106 @@ class BotAdminListBotsResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $CertificateGetCertificateExpirationRequestApplicationJsonInterfaceBuilder {
+  void replace($CertificateGetCertificateExpirationRequestApplicationJsonInterface other);
+  void update(void Function($CertificateGetCertificateExpirationRequestApplicationJsonInterfaceBuilder) updates);
+  String? get host;
+  set host(String? host);
+}
+
+class _$CertificateGetCertificateExpirationRequestApplicationJson
+    extends CertificateGetCertificateExpirationRequestApplicationJson {
+  @override
+  final String host;
+
+  factory _$CertificateGetCertificateExpirationRequestApplicationJson(
+          [void Function(CertificateGetCertificateExpirationRequestApplicationJsonBuilder)? updates]) =>
+      (CertificateGetCertificateExpirationRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$CertificateGetCertificateExpirationRequestApplicationJson._({required this.host}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(host, r'CertificateGetCertificateExpirationRequestApplicationJson', 'host');
+  }
+
+  @override
+  CertificateGetCertificateExpirationRequestApplicationJson rebuild(
+          void Function(CertificateGetCertificateExpirationRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  CertificateGetCertificateExpirationRequestApplicationJsonBuilder toBuilder() =>
+      CertificateGetCertificateExpirationRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is CertificateGetCertificateExpirationRequestApplicationJson && host == other.host;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, host.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'CertificateGetCertificateExpirationRequestApplicationJson')
+          ..add('host', host))
+        .toString();
+  }
+}
+
+class CertificateGetCertificateExpirationRequestApplicationJsonBuilder
+    implements
+        Builder<CertificateGetCertificateExpirationRequestApplicationJson,
+            CertificateGetCertificateExpirationRequestApplicationJsonBuilder>,
+        $CertificateGetCertificateExpirationRequestApplicationJsonInterfaceBuilder {
+  _$CertificateGetCertificateExpirationRequestApplicationJson? _$v;
+
+  String? _host;
+  String? get host => _$this._host;
+  set host(covariant String? host) => _$this._host = host;
+
+  CertificateGetCertificateExpirationRequestApplicationJsonBuilder() {
+    CertificateGetCertificateExpirationRequestApplicationJson._defaults(this);
+  }
+
+  CertificateGetCertificateExpirationRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _host = $v.host;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant CertificateGetCertificateExpirationRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$CertificateGetCertificateExpirationRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(CertificateGetCertificateExpirationRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  CertificateGetCertificateExpirationRequestApplicationJson build() => _build();
+
+  _$CertificateGetCertificateExpirationRequestApplicationJson _build() {
+    CertificateGetCertificateExpirationRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$CertificateGetCertificateExpirationRequestApplicationJson._(
+            host: BuiltValueNullFieldError.checkNotNull(
+                host, r'CertificateGetCertificateExpirationRequestApplicationJson', 'host'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterfaceBuilder {
   void replace($CertificateGetCertificateExpirationResponseApplicationJson_Ocs_DataInterface other);
   void update(
@@ -56380,6 +67608,151 @@ class RecordingGetWelcomeMessageResponseApplicationJsonBuilder
       } catch (e) {
         throw BuiltValueNestedFieldError(
             r'RecordingGetWelcomeMessageResponseApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $SettingsSetsipSettingsRequestApplicationJsonInterfaceBuilder {
+  void replace($SettingsSetsipSettingsRequestApplicationJsonInterface other);
+  void update(void Function($SettingsSetsipSettingsRequestApplicationJsonInterfaceBuilder) updates);
+  ListBuilder<String> get sipGroups;
+  set sipGroups(ListBuilder<String>? sipGroups);
+
+  String? get dialInInfo;
+  set dialInInfo(String? dialInInfo);
+
+  String? get sharedSecret;
+  set sharedSecret(String? sharedSecret);
+}
+
+class _$SettingsSetsipSettingsRequestApplicationJson extends SettingsSetsipSettingsRequestApplicationJson {
+  @override
+  final BuiltList<String> sipGroups;
+  @override
+  final String dialInInfo;
+  @override
+  final String sharedSecret;
+
+  factory _$SettingsSetsipSettingsRequestApplicationJson(
+          [void Function(SettingsSetsipSettingsRequestApplicationJsonBuilder)? updates]) =>
+      (SettingsSetsipSettingsRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$SettingsSetsipSettingsRequestApplicationJson._(
+      {required this.sipGroups, required this.dialInInfo, required this.sharedSecret})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(sipGroups, r'SettingsSetsipSettingsRequestApplicationJson', 'sipGroups');
+    BuiltValueNullFieldError.checkNotNull(dialInInfo, r'SettingsSetsipSettingsRequestApplicationJson', 'dialInInfo');
+    BuiltValueNullFieldError.checkNotNull(
+        sharedSecret, r'SettingsSetsipSettingsRequestApplicationJson', 'sharedSecret');
+  }
+
+  @override
+  SettingsSetsipSettingsRequestApplicationJson rebuild(
+          void Function(SettingsSetsipSettingsRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  SettingsSetsipSettingsRequestApplicationJsonBuilder toBuilder() =>
+      SettingsSetsipSettingsRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is SettingsSetsipSettingsRequestApplicationJson &&
+        sipGroups == other.sipGroups &&
+        dialInInfo == other.dialInInfo &&
+        sharedSecret == other.sharedSecret;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, sipGroups.hashCode);
+    _$hash = $jc(_$hash, dialInInfo.hashCode);
+    _$hash = $jc(_$hash, sharedSecret.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'SettingsSetsipSettingsRequestApplicationJson')
+          ..add('sipGroups', sipGroups)
+          ..add('dialInInfo', dialInInfo)
+          ..add('sharedSecret', sharedSecret))
+        .toString();
+  }
+}
+
+class SettingsSetsipSettingsRequestApplicationJsonBuilder
+    implements
+        Builder<SettingsSetsipSettingsRequestApplicationJson, SettingsSetsipSettingsRequestApplicationJsonBuilder>,
+        $SettingsSetsipSettingsRequestApplicationJsonInterfaceBuilder {
+  _$SettingsSetsipSettingsRequestApplicationJson? _$v;
+
+  ListBuilder<String>? _sipGroups;
+  ListBuilder<String> get sipGroups => _$this._sipGroups ??= ListBuilder<String>();
+  set sipGroups(covariant ListBuilder<String>? sipGroups) => _$this._sipGroups = sipGroups;
+
+  String? _dialInInfo;
+  String? get dialInInfo => _$this._dialInInfo;
+  set dialInInfo(covariant String? dialInInfo) => _$this._dialInInfo = dialInInfo;
+
+  String? _sharedSecret;
+  String? get sharedSecret => _$this._sharedSecret;
+  set sharedSecret(covariant String? sharedSecret) => _$this._sharedSecret = sharedSecret;
+
+  SettingsSetsipSettingsRequestApplicationJsonBuilder() {
+    SettingsSetsipSettingsRequestApplicationJson._defaults(this);
+  }
+
+  SettingsSetsipSettingsRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _sipGroups = $v.sipGroups.toBuilder();
+      _dialInInfo = $v.dialInInfo;
+      _sharedSecret = $v.sharedSecret;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant SettingsSetsipSettingsRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$SettingsSetsipSettingsRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(SettingsSetsipSettingsRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  SettingsSetsipSettingsRequestApplicationJson build() => _build();
+
+  _$SettingsSetsipSettingsRequestApplicationJson _build() {
+    SettingsSetsipSettingsRequestApplicationJson._validate(this);
+    _$SettingsSetsipSettingsRequestApplicationJson _$result;
+    try {
+      _$result = _$v ??
+          _$SettingsSetsipSettingsRequestApplicationJson._(
+              sipGroups: sipGroups.build(),
+              dialInInfo: BuiltValueNullFieldError.checkNotNull(
+                  dialInInfo, r'SettingsSetsipSettingsRequestApplicationJson', 'dialInInfo'),
+              sharedSecret: BuiltValueNullFieldError.checkNotNull(
+                  sharedSecret, r'SettingsSetsipSettingsRequestApplicationJson', 'sharedSecret'));
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'sipGroups';
+        sipGroups.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'SettingsSetsipSettingsRequestApplicationJson', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/packages/nextcloud/lib/src/api/spreed.openapi.json
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.json
@@ -1602,20 +1602,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "darkTheme",
-                        "in": "query",
-                        "description": "Theme used for background",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "darkTheme": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Theme used for background"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -1760,25 +1764,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "emoji"
+                                ],
+                                "properties": {
+                                    "emoji": {
+                                        "type": "string",
+                                        "description": "Emoji"
+                                    },
+                                    "color": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Color of the emoji"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "emoji",
-                        "in": "query",
-                        "description": "Emoji",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "color",
-                        "in": "query",
-                        "description": "Color of the emoji",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2338,44 +2348,46 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "mode",
+                                    "amount"
+                                ],
+                                "properties": {
+                                    "mode": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "enum": [
+                                            0,
+                                            1,
+                                            2,
+                                            3
+                                        ],
+                                        "description": "Mode of the breakout rooms"
+                                    },
+                                    "amount": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Number of breakout rooms - Constants {@see BreakoutRoom::MINIMUM_ROOM_AMOUNT} and {@see BreakoutRoom::MAXIMUM_ROOM_AMOUNT}",
+                                        "minimum": 1,
+                                        "maximum": 20
+                                    },
+                                    "attendeeMap": {
+                                        "type": "string",
+                                        "default": "[]",
+                                        "description": "Mapping of the attendees to breakout rooms"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "mode",
-                        "in": "query",
-                        "description": "Mode of the breakout rooms",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "enum": [
-                                0,
-                                1,
-                                2,
-                                3
-                            ]
-                        }
-                    },
-                    {
-                        "name": "amount",
-                        "in": "query",
-                        "description": "Number of breakout rooms - Constants {@see BreakoutRoom::MINIMUM_ROOM_AMOUNT} and {@see BreakoutRoom::MAXIMUM_ROOM_AMOUNT}",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 1,
-                            "maximum": 20
-                        }
-                    },
-                    {
-                        "name": "attendeeMap",
-                        "in": "query",
-                        "description": "Mapping of the attendees to breakout rooms",
-                        "schema": {
-                            "type": "string",
-                            "default": "[]"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2578,16 +2590,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "message",
-                        "in": "query",
-                        "description": "Message to broadcast",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "message"
+                                ],
+                                "properties": {
+                                    "message": {
+                                        "type": "string",
+                                        "description": "Message to broadcast"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -2748,16 +2770,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "attendeeMap",
-                        "in": "query",
-                        "description": "JSON encoded mapping of the attendees to breakout rooms `array<int, int>`",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "attendeeMap"
+                                ],
+                                "properties": {
+                                    "attendeeMap": {
+                                        "type": "string",
+                                        "description": "JSON encoded mapping of the attendees to breakout rooms `array<int, int>`"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -3362,16 +3394,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "target",
-                        "in": "query",
-                        "description": "Target breakout room",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "target"
+                                ],
+                                "properties": {
+                                    "target": {
+                                        "type": "string",
+                                        "description": "Target breakout room"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -3576,57 +3618,45 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "flags": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "In-Call flags",
+                                        "minimum": 0,
+                                        "maximum": 15
+                                    },
+                                    "forcePermissions": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "In-call permissions",
+                                        "minimum": 0,
+                                        "maximum": 255
+                                    },
+                                    "silent": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Join the call silently"
+                                    },
+                                    "recordingConsent": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "When the user ticked a checkbox and agreed with being recorded\n (Only needed when the `config => call => recording-consent` capability is set to {@see RecordingService::CONSENT_REQUIRED_YES}\n  or the capability is {@see RecordingService::CONSENT_REQUIRED_OPTIONAL}\n  and the conversation `recordingConsent` value is {@see RecordingService::CONSENT_REQUIRED_YES} )"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "flags",
-                        "in": "query",
-                        "description": "In-Call flags",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true,
-                            "minimum": 0,
-                            "maximum": 15
-                        }
-                    },
-                    {
-                        "name": "forcePermissions",
-                        "in": "query",
-                        "description": "In-call permissions",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true,
-                            "minimum": 0,
-                            "maximum": 255
-                        }
-                    },
-                    {
-                        "name": "silent",
-                        "in": "query",
-                        "description": "Join the call silently",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "recordingConsent",
-                        "in": "query",
-                        "description": "When the user ticked a checkbox and agreed with being recorded (Only needed when the `config => call => recording-consent` capability is set to {@see RecordingService::CONSENT_REQUIRED_YES} or the capability is {@see RecordingService::CONSENT_REQUIRED_OPTIONAL} and the conversation `recordingConsent` value is {@see RecordingService::CONSENT_REQUIRED_YES} )",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -3768,19 +3798,29 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "flags",
-                        "in": "query",
-                        "description": "New flags",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0,
-                            "maximum": 15
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "flags"
+                                ],
+                                "properties": {
+                                    "flags": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "New flags",
+                                        "minimum": 0,
+                                        "maximum": 15
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -3915,20 +3955,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "all",
-                        "in": "query",
-                        "description": "whether to also terminate the call for all participants",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "all": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "whether to also terminate the call for all participants"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -4400,121 +4444,99 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "lookIntoFuture"
+                                ],
+                                "properties": {
+                                    "lookIntoFuture": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "enum": [
+                                            0,
+                                            1
+                                        ],
+                                        "description": "Polling for new messages (1) or getting the history of the chat (0)"
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 100,
+                                        "description": "Number of chat messages to receive (100 by default, 200 at most)"
+                                    },
+                                    "lastKnownMessageId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "description": "The last known message (serves as offset)",
+                                        "minimum": 0
+                                    },
+                                    "lastCommonReadId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "description": "The last known common read message\n                             (so the response is 200 instead of 304 when\n                             it changes even when there are no messages)",
+                                        "minimum": 0
+                                    },
+                                    "timeout": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 30,
+                                        "description": "Number of seconds to wait for new messages (30 by default, 30 at most)",
+                                        "minimum": 0,
+                                        "maximum": 30
+                                    },
+                                    "setReadMarker": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 1,
+                                        "enum": [
+                                            0,
+                                            1
+                                        ],
+                                        "description": "Automatically set the last read marker when 1,\n                          if your client does this itself via chat/{token}/read set to 0"
+                                    },
+                                    "includeLastKnown": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "enum": [
+                                            0,
+                                            1
+                                        ],
+                                        "description": "Include the $lastKnownMessageId in the messages when 1 (default 0)"
+                                    },
+                                    "noStatusUpdate": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "enum": [
+                                            0,
+                                            1
+                                        ],
+                                        "description": "When the user status should not be automatically set to online set to 1 (default 0)"
+                                    },
+                                    "markNotificationsAsRead": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 1,
+                                        "enum": [
+                                            0,
+                                            1
+                                        ],
+                                        "description": "Set to 0 when notifications should not be marked as read (default 1)"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "lookIntoFuture",
-                        "in": "query",
-                        "description": "Polling for new messages (1) or getting the history of the chat (0)",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Number of chat messages to receive (100 by default, 200 at most)",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 100
-                        }
-                    },
-                    {
-                        "name": "lastKnownMessageId",
-                        "in": "query",
-                        "description": "The last known message (serves as offset)",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0,
-                            "minimum": 0
-                        }
-                    },
-                    {
-                        "name": "lastCommonReadId",
-                        "in": "query",
-                        "description": "The last known common read message (so the response is 200 instead of 304 when it changes even when there are no messages)",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0,
-                            "minimum": 0
-                        }
-                    },
-                    {
-                        "name": "timeout",
-                        "in": "query",
-                        "description": "Number of seconds to wait for new messages (30 by default, 30 at most)",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 30,
-                            "minimum": 0,
-                            "maximum": 30
-                        }
-                    },
-                    {
-                        "name": "setReadMarker",
-                        "in": "query",
-                        "description": "Automatically set the last read marker when 1, if your client does this itself via chat/{token}/read set to 0",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 1,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "includeLastKnown",
-                        "in": "query",
-                        "description": "Include the $lastKnownMessageId in the messages when 1 (default 0)",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "noStatusUpdate",
-                        "in": "query",
-                        "description": "When the user status should not be automatically set to online set to 1 (default 0)",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "markNotificationsAsRead",
-                        "in": "query",
-                        "description": "Set to 0 when notifications should not be marked as read (default 1)",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 1,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -4614,58 +4636,48 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "message"
+                                ],
+                                "properties": {
+                                    "message": {
+                                        "type": "string",
+                                        "description": "the message to send"
+                                    },
+                                    "actorDisplayName": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "for guests"
+                                    },
+                                    "referenceId": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "for the message to be able to later identify it again"
+                                    },
+                                    "replyTo": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "description": "Parent id which this message is a reply to",
+                                        "minimum": 0
+                                    },
+                                    "silent": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "If sent silent the chat message will not create any notifications"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "message",
-                        "in": "query",
-                        "description": "the message to send",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "actorDisplayName",
-                        "in": "query",
-                        "description": "for guests",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "referenceId",
-                        "in": "query",
-                        "description": "for the message to be able to later identify it again",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "replyTo",
-                        "in": "query",
-                        "description": "Parent id which this message is a reply to",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0,
-                            "minimum": 0
-                        }
-                    },
-                    {
-                        "name": "silent",
-                        "in": "query",
-                        "description": "If sent silent the chat message will not create any notifications",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -5268,16 +5280,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "message",
-                        "in": "query",
-                        "description": "the message to send",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "message"
+                                ],
+                                "properties": {
+                                    "message": {
+                                        "type": "string",
+                                        "description": "the message to send"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -5565,19 +5587,27 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Number of chat messages to receive in both directions (50 by default, 100 at most, might return 201 messages)",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 50,
-                            "minimum": 1,
-                            "maximum": 100
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 50,
+                                        "description": "Number of chat messages to receive in both directions (50 by default, 100 at most, might return 201 messages)",
+                                        "minimum": 1,
+                                        "maximum": 100
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -5688,18 +5718,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "timestamp",
-                        "in": "query",
-                        "description": "Timestamp of the reminder",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "timestamp"
+                                ],
+                                "properties": {
+                                    "timestamp": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Timestamp of the reminder",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -6085,18 +6125,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "lastReadMessage",
-                        "in": "query",
-                        "description": "ID if the last read message (Optional only with `chat-read-last` capability)",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true,
-                            "minimum": 0
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "lastReadMessage": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "ID if the last read message (Optional only with `chat-read-last` capability)",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -6274,39 +6322,37 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "search"
+                                ],
+                                "properties": {
+                                    "search": {
+                                        "type": "string",
+                                        "description": "Text to search for"
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 20,
+                                        "description": "Maximum number of results"
+                                    },
+                                    "includeStatus": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Include the user statuses"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "search",
-                        "in": "query",
-                        "description": "Text to search for",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Maximum number of results",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 20
-                        }
-                    },
-                    {
-                        "name": "includeStatus",
-                        "in": "query",
-                        "description": "Include the user statuses",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -6393,52 +6439,46 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "objectType",
+                                    "objectId"
+                                ],
+                                "properties": {
+                                    "objectType": {
+                                        "type": "string",
+                                        "description": "Type of the object"
+                                    },
+                                    "objectId": {
+                                        "type": "string",
+                                        "description": "ID of the object"
+                                    },
+                                    "metaData": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Additional metadata"
+                                    },
+                                    "actorDisplayName": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Guest name"
+                                    },
+                                    "referenceId": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Reference ID"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "objectType",
-                        "in": "query",
-                        "description": "Type of the object",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "objectId",
-                        "in": "query",
-                        "description": "ID of the object",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "metaData",
-                        "in": "query",
-                        "description": "Additional metadata",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "actorDisplayName",
-                        "in": "query",
-                        "description": "Guest name",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "referenceId",
-                        "in": "query",
-                        "description": "Reference ID",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -6611,39 +6651,41 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "objectType"
+                                ],
+                                "properties": {
+                                    "objectType": {
+                                        "type": "string",
+                                        "description": "Type of the objects"
+                                    },
+                                    "lastKnownMessageId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "description": "ID of the last known message",
+                                        "minimum": 0
+                                    },
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 100,
+                                        "description": "Maximum number of objects",
+                                        "minimum": 1,
+                                        "maximum": 200
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "objectType",
-                        "in": "query",
-                        "description": "Type of the objects",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "lastKnownMessageId",
-                        "in": "query",
-                        "description": "ID of the last known message",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0,
-                            "minimum": 0
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Maximum number of objects",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 100,
-                            "minimum": 1,
-                            "maximum": 200
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -6736,19 +6778,27 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Maximum number of objects",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 7,
-                            "minimum": 1,
-                            "maximum": 20
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 7,
+                                        "description": "Maximum number of objects",
+                                        "minimum": 1,
+                                        "maximum": 20
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -7142,16 +7192,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "displayName",
-                        "in": "query",
-                        "description": "New display name",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "displayName"
+                                ],
+                                "properties": {
+                                    "displayName": {
+                                        "type": "string",
+                                        "description": "New display name"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -7367,34 +7427,31 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "enabled",
-                        "in": "query",
-                        "description": "If the bridge should be enabled",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "parts",
-                        "in": "query",
-                        "description": "New parts",
-                        "schema": {
-                            "type": "string",
-                            "contentMediaType": "application/json",
-                            "contentSchema": {
-                                "$ref": "#/components/schemas/MatterbridgeConfigFields",
-                                "default": [],
-                                "description": "New parts"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "enabled"
+                                ],
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean",
+                                        "description": "If the bridge should be enabled"
+                                    },
+                                    "parts": {
+                                        "$ref": "#/components/schemas/MatterbridgeConfigFields",
+                                        "default": [],
+                                        "description": "New parts"
+                                    }
+                                }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -7715,52 +7772,50 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "question",
-                        "in": "query",
-                        "description": "Question of the poll",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "options[]",
-                        "in": "query",
-                        "description": "Options of the poll",
-                        "required": true,
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "question",
+                                    "options",
+                                    "resultMode",
+                                    "maxVotes"
+                                ],
+                                "properties": {
+                                    "question": {
+                                        "type": "string",
+                                        "description": "Question of the poll"
+                                    },
+                                    "options": {
+                                        "type": "array",
+                                        "description": "Options of the poll",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "resultMode": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "enum": [
+                                            0,
+                                            1
+                                        ],
+                                        "description": "Mode how the results will be shown"
+                                    },
+                                    "maxVotes": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Number of maximum votes per voter"
+                                    }
+                                }
                             }
                         }
-                    },
-                    {
-                        "name": "resultMode",
-                        "in": "query",
-                        "description": "Mode how the results will be shown",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "maxVotes",
-                        "in": "query",
-                        "description": "Number of maximum votes per voter",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -7991,20 +8046,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "optionIds[]",
-                        "in": "query",
-                        "description": "IDs of the selected options",
-                        "schema": {
-                            "type": "array",
-                            "default": [],
-                            "items": {
-                                "type": "integer",
-                                "format": "int64"
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "optionIds": {
+                                        "type": "array",
+                                        "default": [],
+                                        "description": "IDs of the selected options",
+                                        "items": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                        }
+                                    }
+                                }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -8359,16 +8422,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "shareToken",
-                        "in": "query",
-                        "description": "Token of the file share",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "shareToken"
+                                ],
+                                "properties": {
+                                    "shareToken": {
+                                        "type": "string",
+                                        "description": "Token of the file share"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -8486,16 +8559,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "reaction",
-                        "in": "query",
-                        "description": "Emoji to add",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "reaction"
+                                ],
+                                "properties": {
+                                    "reaction": {
+                                        "type": "string",
+                                        "description": "Emoji to add"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -8685,16 +8768,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "reaction",
-                        "in": "query",
-                        "description": "Emoji to remove",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "reaction"
+                                ],
+                                "properties": {
+                                    "reaction": {
+                                        "type": "string",
+                                        "description": "Emoji to remove"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -8848,16 +8941,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "reaction",
-                        "in": "query",
-                        "description": "Emoji to filter",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "reaction": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Emoji to filter"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -8984,17 +9085,27 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "status",
-                        "in": "query",
-                        "description": "Type of the recording",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "status"
+                                ],
+                                "properties": {
+                                    "status": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Type of the recording"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -9228,18 +9339,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "timestamp",
-                        "in": "query",
-                        "description": "Timestamp of the notification to be dismissed",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "timestamp"
+                                ],
+                                "properties": {
+                                    "timestamp": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Timestamp of the notification to be dismissed",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -9357,29 +9478,35 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "fileId",
+                                    "timestamp"
+                                ],
+                                "properties": {
+                                    "fileId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "ID of the file",
+                                        "minimum": 0
+                                    },
+                                    "timestamp": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Timestamp of the notification to be dismissed",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "fileId",
-                        "in": "query",
-                        "description": "ID of the file",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0
-                        }
-                    },
-                    {
-                        "name": "timestamp",
-                        "in": "query",
-                        "description": "Timestamp of the notification to be dismissed",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -9497,45 +9624,41 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "noStatusUpdate": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "enum": [
+                                            0,
+                                            1
+                                        ],
+                                        "description": "When the user status should not be automatically set to online set to 1 (default 0)"
+                                    },
+                                    "includeStatus": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Include the user status"
+                                    },
+                                    "modifiedSince": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "description": "Filter rooms modified after a timestamp",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "noStatusUpdate",
-                        "in": "query",
-                        "description": "When the user status should not be automatically set to online set to 1 (default 0)",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "includeStatus",
-                        "in": "query",
-                        "description": "Include the user status",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "modifiedSince",
-                        "in": "query",
-                        "description": "Filter rooms modified after a timestamp",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0,
-                            "minimum": 0
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -9626,62 +9749,52 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "roomType"
+                                ],
+                                "properties": {
+                                    "roomType": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Type of the room"
+                                    },
+                                    "invite": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "User, group, \u2026 ID to invite"
+                                    },
+                                    "roomName": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Name of the room"
+                                    },
+                                    "source": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Source of the invite ID ('circles' to create a room with a circle, etc.)"
+                                    },
+                                    "objectType": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Type of the object"
+                                    },
+                                    "objectId": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "ID of the object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "roomType",
-                        "in": "query",
-                        "description": "Type of the room",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "invite",
-                        "in": "query",
-                        "description": "User, group, \u2026 ID to invite",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "roomName",
-                        "in": "query",
-                        "description": "Name of the room",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "source",
-                        "in": "query",
-                        "description": "Source of the invite ID ('circles' to create a room with a circle, etc.)",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "objectType",
-                        "in": "query",
-                        "description": "Type of the object",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "objectId",
-                        "in": "query",
-                        "description": "ID of the object",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -9875,16 +9988,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "searchTerm",
-                        "in": "query",
-                        "description": "search term",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "searchTerm": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "search term"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -10531,16 +10652,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "description",
-                        "in": "query",
-                        "description": "New description",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "description"
+                                ],
+                                "properties": {
+                                    "description": {
+                                        "type": "string",
+                                        "description": "New description"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -10648,21 +10779,31 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "state",
-                        "in": "query",
-                        "description": "New read-only state",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "state"
+                                ],
+                                "properties": {
+                                    "state": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "enum": [
+                                            0,
+                                            1
+                                        ],
+                                        "description": "New read-only state"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -10770,22 +10911,32 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "scope",
-                        "in": "query",
-                        "description": "Scope where the room is listable",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "enum": [
-                                0,
-                                1,
-                                2
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "scope"
+                                ],
+                                "properties": {
+                                    "scope": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "enum": [
+                                            0,
+                                            1,
+                                            2
+                                        ],
+                                        "description": "Scope where the room is listable"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -10894,16 +11045,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "password",
-                        "in": "query",
-                        "description": "New password",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "password"
+                                ],
+                                "properties": {
+                                    "password": {
+                                        "type": "string",
+                                        "description": "New password"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -11047,19 +11208,29 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "permissions",
-                        "in": "query",
-                        "description": "New permissions",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0,
-                            "maximum": 255
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "permissions"
+                                ],
+                                "properties": {
+                                    "permissions": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "New permissions",
+                                        "minimum": 0,
+                                        "maximum": 255
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -11184,20 +11355,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "includeStatus",
-                        "in": "query",
-                        "description": "Include the user statuses",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "includeStatus": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Include the user statuses"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -11315,33 +11490,39 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "newParticipant"
+                                ],
+                                "properties": {
+                                    "newParticipant": {
+                                        "type": "string",
+                                        "description": "New participant"
+                                    },
+                                    "source": {
+                                        "type": "string",
+                                        "default": "users",
+                                        "enum": [
+                                            "users",
+                                            "groups",
+                                            "circles",
+                                            "emails",
+                                            "federated_users",
+                                            "phones"
+                                        ],
+                                        "description": "Source of the participant"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "newParticipant",
-                        "in": "query",
-                        "description": "New participant",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "source",
-                        "in": "query",
-                        "description": "Source of the participant",
-                        "schema": {
-                            "type": "string",
-                            "default": "users",
-                            "enum": [
-                                "users",
-                                "groups",
-                                "circles",
-                                "emails",
-                                "federated_users",
-                                "phones"
-                            ]
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -11532,20 +11713,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "includeStatus",
-                        "in": "query",
-                        "description": "Include the user statuses",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "includeStatus": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Include the user statuses"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -11840,18 +12025,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "attendeeId",
-                        "in": "query",
-                        "description": "ID of the attendee",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "attendeeId"
+                                ],
+                                "properties": {
+                                    "attendeeId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "ID of the attendee",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -12016,44 +12211,46 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "attendeeId",
+                                    "method",
+                                    "permissions"
+                                ],
+                                "properties": {
+                                    "attendeeId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "ID of the attendee",
+                                        "minimum": 0
+                                    },
+                                    "method": {
+                                        "type": "string",
+                                        "enum": [
+                                            "set",
+                                            "remove",
+                                            "add"
+                                        ],
+                                        "description": "Method of updating permissions ('set', 'remove', 'add')"
+                                    },
+                                    "permissions": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "New permissions",
+                                        "minimum": 0,
+                                        "maximum": 255
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "attendeeId",
-                        "in": "query",
-                        "description": "ID of the attendee",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0
-                        }
-                    },
-                    {
-                        "name": "method",
-                        "in": "query",
-                        "description": "Method of updating permissions ('set', 'remove', 'add')",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "set",
-                                "remove",
-                                "add"
-                            ]
-                        }
-                    },
-                    {
-                        "name": "permissions",
-                        "in": "query",
-                        "description": "New permissions",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0,
-                            "maximum": 255
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -12218,33 +12415,39 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "method",
+                                    "permissions"
+                                ],
+                                "properties": {
+                                    "method": {
+                                        "type": "string",
+                                        "enum": [
+                                            "set",
+                                            "remove",
+                                            "add"
+                                        ],
+                                        "description": "Method of updating permissions ('set', 'remove', 'add')"
+                                    },
+                                    "permissions": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "New permissions",
+                                        "minimum": 0,
+                                        "maximum": 255
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "method",
-                        "in": "query",
-                        "description": "Method of updating permissions ('set', 'remove', 'add')",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "set",
-                                "remove",
-                                "add"
-                            ]
-                        }
-                    },
-                    {
-                        "name": "permissions",
-                        "in": "query",
-                        "description": "New permissions",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0,
-                            "maximum": 255
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -12355,29 +12558,29 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "password": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Password of the room"
+                                    },
+                                    "force": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "Create a new session if necessary"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "password",
-                        "in": "query",
-                        "description": "Password of the room",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "force",
-                        "in": "query",
-                        "description": "Create a new session if necessary",
-                        "schema": {
-                            "type": "integer",
-                            "default": 1,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -12651,18 +12854,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "attendeeId",
-                        "in": "query",
-                        "description": "ID of the attendee",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true,
-                            "minimum": 0
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "attendeeId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "ID of the attendee",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -12771,21 +12982,31 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "state",
-                        "in": "query",
-                        "description": "of the room",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "state"
+                                ],
+                                "properties": {
+                                    "state": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "enum": [
+                                            0,
+                                            1
+                                        ],
+                                        "description": "of the room"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -12924,18 +13145,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "attendeeId",
-                        "in": "query",
-                        "description": "ID of the attendee",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "attendeeId"
+                                ],
+                                "properties": {
+                                    "attendeeId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "ID of the attendee",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -13098,18 +13329,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "attendeeId",
-                        "in": "query",
-                        "description": "ID of the attendee",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "attendeeId"
+                                ],
+                                "properties": {
+                                    "attendeeId": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "ID of the attendee",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -13431,17 +13672,27 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "level",
-                        "in": "query",
-                        "description": "New level",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "level"
+                                ],
+                                "properties": {
+                                    "level": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "New level"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -13549,17 +13800,27 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "level",
-                        "in": "query",
-                        "description": "New level",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "level"
+                                ],
+                                "properties": {
+                                    "level": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "New level"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -13667,28 +13928,34 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "state"
+                                ],
+                                "properties": {
+                                    "state": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "New state"
+                                    },
+                                    "timer": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Timer when the lobby will be removed",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "state",
-                        "in": "query",
-                        "description": "New state",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "timer",
-                        "in": "query",
-                        "description": "Timer when the lobby will be removed",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true,
-                            "minimum": 0
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -13798,22 +14065,32 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "state",
-                        "in": "query",
-                        "description": "New state",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "enum": [
-                                0,
-                                1,
-                                2
-                            ]
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "state"
+                                ],
+                                "properties": {
+                                    "state": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "enum": [
+                                            0,
+                                            1,
+                                            2
+                                        ],
+                                        "description": "New state"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -14007,17 +14284,27 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "recordingConsent",
-                        "in": "query",
-                        "description": "New consent setting for the conversation (Only {@see RecordingService::CONSENT_REQUIRED_NO} and {@see RecordingService::CONSENT_REQUIRED_YES} are allowed here.)",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "recordingConsent"
+                                ],
+                                "properties": {
+                                    "recordingConsent": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "New consent setting for the conversation\n  (Only {@see RecordingService::CONSENT_REQUIRED_NO} and {@see RecordingService::CONSENT_REQUIRED_YES} are allowed here.)"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -14166,18 +14453,28 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "seconds",
-                        "in": "query",
-                        "description": "New time",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "minimum": 0
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "seconds"
+                                ],
+                                "properties": {
+                                    "seconds": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "New time",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -14396,39 +14693,45 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "key",
-                        "in": "query",
-                        "description": "Key to update",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": [
-                                "attachment_folder",
-                                "read_status_privacy",
-                                "typing_privacy",
-                                "play_sounds"
-                            ]
-                        }
-                    },
-                    {
-                        "name": "value",
-                        "in": "query",
-                        "description": "New value for the key",
-                        "schema": {
-                            "nullable": true,
-                            "oneOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "integer",
-                                    "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "key"
+                                ],
+                                "properties": {
+                                    "key": {
+                                        "type": "string",
+                                        "enum": [
+                                            "attachment_folder",
+                                            "read_status_privacy",
+                                            "typing_privacy",
+                                            "play_sounds"
+                                        ],
+                                        "description": "Key to update"
+                                    },
+                                    "value": {
+                                        "nullable": true,
+                                        "description": "New value for the key",
+                                        "oneOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "integer",
+                                                "format": "int64"
+                                            }
+                                        ]
+                                    }
                                 }
-                            ]
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -14529,16 +14832,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "token",
-                        "in": "query",
-                        "description": "Token of the room",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "Token of the room"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -14668,16 +14979,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "messages",
-                        "in": "query",
-                        "description": "JSON encoded messages",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "messages"
+                                ],
+                                "properties": {
+                                    "messages": {
+                                        "type": "string",
+                                        "description": "JSON encoded messages"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -15217,29 +15538,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "cloudId"
+                                ],
+                                "properties": {
+                                    "cloudId": {
+                                        "type": "string",
+                                        "description": "Federation CloudID to get the avatar for"
+                                    },
+                                    "darkTheme": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Theme used for background"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "cloudId",
-                        "in": "query",
-                        "description": "Federation CloudID to get the avatar for",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "darkTheme",
-                        "in": "query",
-                        "description": "Theme used for background",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -15307,16 +15630,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "cloudId",
-                        "in": "query",
-                        "description": "Federation CloudID to get the avatar for",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "cloudId"
+                                ],
+                                "properties": {
+                                    "cloudId": {
+                                        "type": "string",
+                                        "description": "Federation CloudID to get the avatar for"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -15385,29 +15718,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "cloudId"
+                                ],
+                                "properties": {
+                                    "cloudId": {
+                                        "type": "string",
+                                        "description": "Federation CloudID to get the avatar for"
+                                    },
+                                    "darkTheme": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Theme used for background"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "cloudId",
-                        "in": "query",
-                        "description": "Federation CloudID to get the avatar for",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "darkTheme",
-                        "in": "query",
-                        "description": "Theme used for background",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -15485,16 +15820,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "cloudId",
-                        "in": "query",
-                        "description": "Federation CloudID to get the avatar for",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "cloudId"
+                                ],
+                                "properties": {
+                                    "cloudId": {
+                                        "type": "string",
+                                        "description": "Federation CloudID to get the avatar for"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -16116,48 +16461,42 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "message"
+                                ],
+                                "properties": {
+                                    "message": {
+                                        "type": "string",
+                                        "description": "The message to send"
+                                    },
+                                    "referenceId": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "For the message to be able to later identify it again"
+                                    },
+                                    "replyTo": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "default": 0,
+                                        "description": "Parent id which this message is a reply to"
+                                    },
+                                    "silent": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "If sent silent the chat message will not create any notifications"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "message",
-                        "in": "query",
-                        "description": "The message to send",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "referenceId",
-                        "in": "query",
-                        "description": "For the message to be able to later identify it again",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "replyTo",
-                        "in": "query",
-                        "description": "Parent id which this message is a reply to",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "default": 0
-                        }
-                    },
-                    {
-                        "name": "silent",
-                        "in": "query",
-                        "description": "If sent silent the chat message will not create any notifications",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -16323,16 +16662,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "reaction",
-                        "in": "query",
-                        "description": "Reaction to add",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "reaction"
+                                ],
+                                "properties": {
+                                    "reaction": {
+                                        "type": "string",
+                                        "description": "Reaction to add"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -16534,16 +16883,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "reaction",
-                        "in": "query",
-                        "description": "Reaction to delete",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "reaction"
+                                ],
+                                "properties": {
+                                    "reaction": {
+                                        "type": "string",
+                                        "description": "Reaction to delete"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -16796,16 +17155,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "host",
-                        "in": "query",
-                        "description": "Host to check",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "host"
+                                ],
+                                "properties": {
+                                    "host": {
+                                        "type": "string",
+                                        "description": "Host to check"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -16927,52 +17296,46 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "url",
+                                    "name",
+                                    "email",
+                                    "language",
+                                    "country"
+                                ],
+                                "properties": {
+                                    "url": {
+                                        "type": "string",
+                                        "description": "Server URL"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Display name of the user"
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "description": "Email of the user"
+                                    },
+                                    "language": {
+                                        "type": "string",
+                                        "description": "Language of the user"
+                                    },
+                                    "country": {
+                                        "type": "string",
+                                        "description": "Country of the user"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "url",
-                        "in": "query",
-                        "description": "Server URL",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "name",
-                        "in": "query",
-                        "description": "Display name of the user",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "email",
-                        "in": "query",
-                        "description": "Email of the user",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "language",
-                        "in": "query",
-                        "description": "Language of the user",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "country",
-                        "in": "query",
-                        "description": "Country of the user",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -17640,37 +18003,37 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "sipGroups[]",
-                        "in": "query",
-                        "description": "New SIP groups",
-                        "schema": {
-                            "type": "array",
-                            "default": [],
-                            "items": {
-                                "type": "string"
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "sipGroups": {
+                                        "type": "array",
+                                        "default": [],
+                                        "description": "New SIP groups",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "dialInInfo": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "New dial info"
+                                    },
+                                    "sharedSecret": {
+                                        "type": "string",
+                                        "default": "",
+                                        "description": "New shared secret"
+                                    }
+                                }
                             }
                         }
-                    },
-                    {
-                        "name": "dialInInfo",
-                        "in": "query",
-                        "description": "New dial info",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
-                    {
-                        "name": "sharedSecret",
-                        "in": "query",
-                        "description": "New shared secret",
-                        "schema": {
-                            "type": "string",
-                            "default": ""
-                        }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -18133,16 +18496,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "owner",
-                        "in": "query",
-                        "description": "User that will own the recording file",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "owner"
+                                ],
+                                "properties": {
+                                    "owner": {
+                                        "type": "string",
+                                        "description": "User that will own the recording file"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -18492,16 +18865,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "pin",
-                        "in": "query",
-                        "description": "PIN the participant used to dial-in",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "pin"
+                                ],
+                                "properties": {
+                                    "pin": {
+                                        "type": "string",
+                                        "description": "PIN the participant used to dial-in"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -18668,42 +19051,43 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "number",
-                        "in": "query",
-                        "description": "E164 formatted phone number",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "options",
-                        "in": "query",
-                        "description": "Additional details to verify the validity of the request",
-                        "schema": {
-                            "type": "string",
-                            "contentMediaType": "application/json",
-                            "contentSchema": {
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
                                 "type": "object",
-                                "default": [],
-                                "description": "Additional details to verify the validity of the request",
+                                "required": [
+                                    "number"
+                                ],
                                 "properties": {
-                                    "actorId": {
-                                        "type": "string"
+                                    "number": {
+                                        "type": "string",
+                                        "description": "E164 formatted phone number"
                                     },
-                                    "actorType": {
-                                        "$ref": "#/components/schemas/ActorType"
-                                    },
-                                    "attendeeId": {
-                                        "type": "integer",
-                                        "format": "int64"
+                                    "options": {
+                                        "type": "object",
+                                        "default": [],
+                                        "description": "Additional details to verify the validity of the request",
+                                        "properties": {
+                                            "actorId": {
+                                                "type": "string"
+                                            },
+                                            "actorType": {
+                                                "$ref": "#/components/schemas/ActorType"
+                                            },
+                                            "attendeeId": {
+                                                "type": "integer",
+                                                "format": "int64"
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",
@@ -19037,42 +19421,43 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "callId",
-                        "in": "query",
-                        "description": "The call ID provided by the SIP bridge earlier to uniquely identify the call to terminate",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "options",
-                        "in": "query",
-                        "description": "Additional details to verify the validity of the request",
-                        "schema": {
-                            "type": "string",
-                            "contentMediaType": "application/json",
-                            "contentSchema": {
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
                                 "type": "object",
-                                "default": [],
-                                "description": "Additional details to verify the validity of the request",
+                                "required": [
+                                    "callId"
+                                ],
                                 "properties": {
-                                    "actorId": {
-                                        "type": "string"
+                                    "callId": {
+                                        "type": "string",
+                                        "description": "The call ID provided by the SIP bridge earlier to uniquely identify the call to terminate"
                                     },
-                                    "actorType": {
-                                        "$ref": "#/components/schemas/ActorType"
-                                    },
-                                    "attendeeId": {
-                                        "type": "integer",
-                                        "format": "int64"
+                                    "options": {
+                                        "type": "object",
+                                        "default": [],
+                                        "description": "Additional details to verify the validity of the request",
+                                        "properties": {
+                                            "actorId": {
+                                                "type": "string"
+                                            },
+                                            "actorType": {
+                                                "$ref": "#/components/schemas/ActorType"
+                                            },
+                                            "attendeeId": {
+                                                "type": "integer",
+                                                "format": "int64"
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",

--- a/packages/nextcloud/lib/src/api/theming.openapi.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.dart
@@ -16,6 +16,7 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:built_collection/built_collection.dart';
@@ -350,8 +351,6 @@ class $ThemingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [plain] Let the browser decide the CSS priority. Defaults to `0`.
-  ///   * [withCustomCss] Include custom CSS. Defaults to `0`.
   ///   * [themeId] ID of the theme.
   ///
   /// Status codes:
@@ -364,26 +363,13 @@ class $ThemingClient {
   @_i2.experimental
   _i3.Request $getThemeStylesheet_Request({
     required String themeId,
-    ThemingGetThemeStylesheetPlain? plain,
-    ThemingGetThemeStylesheetWithCustomCss? withCustomCss,
+    ThemingGetThemeStylesheetRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __themeId = _$jsonSerializers.serialize(themeId, specifiedType: const FullType(String));
     _parameters['themeId'] = __themeId;
 
-    var __plain = _$jsonSerializers.serialize(plain, specifiedType: const FullType(ThemingGetThemeStylesheetPlain));
-    __plain ??= 0;
-    _parameters['plain'] = __plain;
-
-    var __withCustomCss = _$jsonSerializers.serialize(
-      withCustomCss,
-      specifiedType: const FullType(ThemingGetThemeStylesheetWithCustomCss),
-    );
-    __withCustomCss ??= 0;
-    _parameters['withCustomCss'] = __withCustomCss;
-
-    final _path =
-        _i4.UriTemplate('/index.php/apps/theming/theme/{themeId}.css{?plain*,withCustomCss*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/apps/theming/theme/{themeId}.css').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'text/css';
@@ -402,6 +388,20 @@ class $ThemingClient {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(ThemingGetThemeStylesheetRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ThemingGetThemeStylesheetRequestApplicationJson(),
+              specifiedType: const FullType(ThemingGetThemeStylesheetRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -411,8 +411,6 @@ class $ThemingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [plain] Let the browser decide the CSS priority. Defaults to `0`.
-  ///   * [withCustomCss] Include custom CSS. Defaults to `0`.
   ///   * [themeId] ID of the theme.
   ///
   /// Status codes:
@@ -424,13 +422,11 @@ class $ThemingClient {
   ///  * [$getThemeStylesheet_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<String, void>> getThemeStylesheet({
     required String themeId,
-    ThemingGetThemeStylesheetPlain? plain,
-    ThemingGetThemeStylesheetWithCustomCss? withCustomCss,
+    ThemingGetThemeStylesheetRequestApplicationJson? $body,
   }) async {
     final _request = $getThemeStylesheet_Request(
       themeId: themeId,
-      plain: plain,
-      withCustomCss: withCustomCss,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -455,7 +451,6 @@ class $ThemingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [useSvg] Return image as SVG. Defaults to `1`.
   ///   * [key] Key of the image.
   ///
   /// Status codes:
@@ -469,17 +464,13 @@ class $ThemingClient {
   @_i2.experimental
   _i3.Request $getImage_Request({
     required String key,
-    ThemingGetImageUseSvg? useSvg,
+    ThemingGetImageRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
     _parameters['key'] = __key;
 
-    var __useSvg = _$jsonSerializers.serialize(useSvg, specifiedType: const FullType(ThemingGetImageUseSvg));
-    __useSvg ??= 1;
-    _parameters['useSvg'] = __useSvg;
-
-    final _path = _i4.UriTemplate('/index.php/apps/theming/image/{key}{?useSvg*}').expand(_parameters);
+    final _path = _i4.UriTemplate('/index.php/apps/theming/image/{key}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = '*/*';
@@ -498,6 +489,17 @@ class $ThemingClient {
     }
 
 // coverage:ignore-end
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(ThemingGetImageRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ThemingGetImageRequestApplicationJson(),
+              specifiedType: const FullType(ThemingGetImageRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -507,7 +509,6 @@ class $ThemingClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [useSvg] Return image as SVG. Defaults to `1`.
   ///   * [key] Key of the image.
   ///
   /// Status codes:
@@ -520,11 +521,11 @@ class $ThemingClient {
   ///  * [$getImage_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Uint8List, void>> getImage({
     required String key,
-    ThemingGetImageUseSvg? useSvg,
+    ThemingGetImageRequestApplicationJson? $body,
   }) async {
     final _request = $getImage_Request(
       key: key,
-      useSvg: useSvg,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -889,199 +890,156 @@ class $UserThemeClient {
   }
 }
 
-class ThemingGetThemeStylesheetPlain extends EnumClass {
-  const ThemingGetThemeStylesheetPlain._(super.name);
+@BuiltValue(instantiable: false)
+sealed class $ThemingGetThemeStylesheetRequestApplicationJsonInterface {
+  static final _$plain = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ThemingGetThemeStylesheetPlain $0 = _$themingGetThemeStylesheetPlain$0;
+  static final _$withCustomCss = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ThemingGetThemeStylesheetPlain $1 = _$themingGetThemeStylesheetPlain$1;
+  /// Let the browser decide the CSS priority.
+  bool get plain;
 
-  /// Returns a set with all values this enum contains.
+  /// Include custom CSS.
+  bool get withCustomCss;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ThemingGetThemeStylesheetRequestApplicationJsonInterfaceBuilder].
+  $ThemingGetThemeStylesheetRequestApplicationJsonInterface rebuild(
+    void Function($ThemingGetThemeStylesheetRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ThemingGetThemeStylesheetRequestApplicationJsonInterfaceBuilder].
+  $ThemingGetThemeStylesheetRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ThemingGetThemeStylesheetRequestApplicationJsonInterfaceBuilder b) {
+    b.plain = _$plain;
+    b.withCustomCss = _$withCustomCss;
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ThemingGetThemeStylesheetRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ThemingGetThemeStylesheetRequestApplicationJson
+    implements
+        $ThemingGetThemeStylesheetRequestApplicationJsonInterface,
+        Built<ThemingGetThemeStylesheetRequestApplicationJson, ThemingGetThemeStylesheetRequestApplicationJsonBuilder> {
+  /// Creates a new ThemingGetThemeStylesheetRequestApplicationJson object using the builder pattern.
+  factory ThemingGetThemeStylesheetRequestApplicationJson([
+    void Function(ThemingGetThemeStylesheetRequestApplicationJsonBuilder)? b,
+  ]) = _$ThemingGetThemeStylesheetRequestApplicationJson;
+
   // coverage:ignore-start
-  static BuiltSet<ThemingGetThemeStylesheetPlain> get values => _$themingGetThemeStylesheetPlainValues;
+  const ThemingGetThemeStylesheetRequestApplicationJson._();
   // coverage:ignore-end
 
-  /// Returns the enum value associated to the [name].
-  static ThemingGetThemeStylesheetPlain valueOf(String name) => _$valueOfThemingGetThemeStylesheetPlain(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for ThemingGetThemeStylesheetPlain.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ThemingGetThemeStylesheetPlain> get serializer =>
-      const _$ThemingGetThemeStylesheetPlainSerializer();
-}
-
-class _$ThemingGetThemeStylesheetPlainSerializer implements PrimitiveSerializer<ThemingGetThemeStylesheetPlain> {
-  const _$ThemingGetThemeStylesheetPlainSerializer();
-
-  static const Map<ThemingGetThemeStylesheetPlain, Object> _toWire = <ThemingGetThemeStylesheetPlain, Object>{
-    ThemingGetThemeStylesheetPlain.$0: 0,
-    ThemingGetThemeStylesheetPlain.$1: 1,
-  };
-
-  static const Map<Object, ThemingGetThemeStylesheetPlain> _fromWire = <Object, ThemingGetThemeStylesheetPlain>{
-    0: ThemingGetThemeStylesheetPlain.$0,
-    1: ThemingGetThemeStylesheetPlain.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [ThemingGetThemeStylesheetPlain];
-
-  @override
-  String get wireName => 'ThemingGetThemeStylesheetPlain';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    ThemingGetThemeStylesheetPlain object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  ThemingGetThemeStylesheetPlain deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-class ThemingGetThemeStylesheetWithCustomCss extends EnumClass {
-  const ThemingGetThemeStylesheetWithCustomCss._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ThemingGetThemeStylesheetWithCustomCss $0 = _$themingGetThemeStylesheetWithCustomCss$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ThemingGetThemeStylesheetWithCustomCss $1 = _$themingGetThemeStylesheetWithCustomCss$1;
-
-  /// Returns a set with all values this enum contains.
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
   // coverage:ignore-start
-  static BuiltSet<ThemingGetThemeStylesheetWithCustomCss> get values => _$themingGetThemeStylesheetWithCustomCssValues;
+  factory ThemingGetThemeStylesheetRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
   // coverage:ignore-end
 
-  /// Returns the enum value associated to the [name].
-  static ThemingGetThemeStylesheetWithCustomCss valueOf(String name) =>
-      _$valueOfThemingGetThemeStylesheetWithCustomCss(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for ThemingGetThemeStylesheetWithCustomCss.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ThemingGetThemeStylesheetWithCustomCss> get serializer =>
-      const _$ThemingGetThemeStylesheetWithCustomCssSerializer();
-}
-
-class _$ThemingGetThemeStylesheetWithCustomCssSerializer
-    implements PrimitiveSerializer<ThemingGetThemeStylesheetWithCustomCss> {
-  const _$ThemingGetThemeStylesheetWithCustomCssSerializer();
-
-  static const Map<ThemingGetThemeStylesheetWithCustomCss, Object> _toWire =
-      <ThemingGetThemeStylesheetWithCustomCss, Object>{
-    ThemingGetThemeStylesheetWithCustomCss.$0: 0,
-    ThemingGetThemeStylesheetWithCustomCss.$1: 1,
-  };
-
-  static const Map<Object, ThemingGetThemeStylesheetWithCustomCss> _fromWire =
-      <Object, ThemingGetThemeStylesheetWithCustomCss>{
-    0: ThemingGetThemeStylesheetWithCustomCss.$0,
-    1: ThemingGetThemeStylesheetWithCustomCss.$1,
-  };
-
-  @override
-  Iterable<Type> get types => const [ThemingGetThemeStylesheetWithCustomCss];
-
-  @override
-  String get wireName => 'ThemingGetThemeStylesheetWithCustomCss';
-
-  @override
-  Object serialize(
-    Serializers serializers,
-    ThemingGetThemeStylesheetWithCustomCss object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
-
-  @override
-  ThemingGetThemeStylesheetWithCustomCss deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
-}
-
-class ThemingGetImageUseSvg extends EnumClass {
-  const ThemingGetImageUseSvg._(super.name);
-
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ThemingGetImageUseSvg $0 = _$themingGetImageUseSvg$0;
-
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ThemingGetImageUseSvg $1 = _$themingGetImageUseSvg$1;
-
-  /// Returns a set with all values this enum contains.
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
   // coverage:ignore-start
-  static BuiltSet<ThemingGetImageUseSvg> get values => _$themingGetImageUseSvgValues;
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
   // coverage:ignore-end
 
-  /// Returns the enum value associated to the [name].
-  static ThemingGetImageUseSvg valueOf(String name) => _$valueOfThemingGetImageUseSvg(name);
+  /// Serializer for ThemingGetThemeStylesheetRequestApplicationJson.
+  static Serializer<ThemingGetThemeStylesheetRequestApplicationJson> get serializer =>
+      _$themingGetThemeStylesheetRequestApplicationJsonSerializer;
 
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ThemingGetThemeStylesheetRequestApplicationJsonBuilder b) {
+    $ThemingGetThemeStylesheetRequestApplicationJsonInterface._defaults(b);
+  }
 
-  /// Serializer for ThemingGetImageUseSvg.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ThemingGetImageUseSvg> get serializer => const _$ThemingGetImageUseSvgSerializer();
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ThemingGetThemeStylesheetRequestApplicationJsonBuilder b) {
+    $ThemingGetThemeStylesheetRequestApplicationJsonInterface._validate(b);
+  }
 }
 
-class _$ThemingGetImageUseSvgSerializer implements PrimitiveSerializer<ThemingGetImageUseSvg> {
-  const _$ThemingGetImageUseSvgSerializer();
+@BuiltValue(instantiable: false)
+sealed class $ThemingGetImageRequestApplicationJsonInterface {
+  static final _$useSvg = _$jsonSerializers.deserialize(
+    true,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  static const Map<ThemingGetImageUseSvg, Object> _toWire = <ThemingGetImageUseSvg, Object>{
-    ThemingGetImageUseSvg.$0: 0,
-    ThemingGetImageUseSvg.$1: 1,
-  };
+  /// Return image as SVG.
+  bool get useSvg;
 
-  static const Map<Object, ThemingGetImageUseSvg> _fromWire = <Object, ThemingGetImageUseSvg>{
-    0: ThemingGetImageUseSvg.$0,
-    1: ThemingGetImageUseSvg.$1,
-  };
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ThemingGetImageRequestApplicationJsonInterfaceBuilder].
+  $ThemingGetImageRequestApplicationJsonInterface rebuild(
+    void Function($ThemingGetImageRequestApplicationJsonInterfaceBuilder) updates,
+  );
 
-  @override
-  Iterable<Type> get types => const [ThemingGetImageUseSvg];
+  /// Converts the instance to a builder [$ThemingGetImageRequestApplicationJsonInterfaceBuilder].
+  $ThemingGetImageRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ThemingGetImageRequestApplicationJsonInterfaceBuilder b) {
+    b.useSvg = _$useSvg;
+  }
 
-  @override
-  String get wireName => 'ThemingGetImageUseSvg';
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ThemingGetImageRequestApplicationJsonInterfaceBuilder b) {}
+}
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    ThemingGetImageUseSvg object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+abstract class ThemingGetImageRequestApplicationJson
+    implements
+        $ThemingGetImageRequestApplicationJsonInterface,
+        Built<ThemingGetImageRequestApplicationJson, ThemingGetImageRequestApplicationJsonBuilder> {
+  /// Creates a new ThemingGetImageRequestApplicationJson object using the builder pattern.
+  factory ThemingGetImageRequestApplicationJson([void Function(ThemingGetImageRequestApplicationJsonBuilder)? b]) =
+      _$ThemingGetImageRequestApplicationJson;
 
-  @override
-  ThemingGetImageUseSvg deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  // coverage:ignore-start
+  const ThemingGetImageRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ThemingGetImageRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ThemingGetImageRequestApplicationJson.
+  static Serializer<ThemingGetImageRequestApplicationJson> get serializer =>
+      _$themingGetImageRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ThemingGetImageRequestApplicationJsonBuilder b) {
+    $ThemingGetImageRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ThemingGetImageRequestApplicationJsonBuilder b) {
+    $ThemingGetImageRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -1684,9 +1642,16 @@ abstract class PublicCapabilities
 @_i2.visibleForTesting
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
-      ..add(ThemingGetThemeStylesheetPlain.serializer)
-      ..add(ThemingGetThemeStylesheetWithCustomCss.serializer)
-      ..add(ThemingGetImageUseSvg.serializer)
+      ..addBuilderFactory(
+        const FullType(ThemingGetThemeStylesheetRequestApplicationJson),
+        ThemingGetThemeStylesheetRequestApplicationJsonBuilder.new,
+      )
+      ..add(ThemingGetThemeStylesheetRequestApplicationJson.serializer)
+      ..addBuilderFactory(
+        const FullType(ThemingGetImageRequestApplicationJson),
+        ThemingGetImageRequestApplicationJsonBuilder.new,
+      )
+      ..add(ThemingGetImageRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ThemingGetManifestResponseApplicationJson),
         ThemingGetManifestResponseApplicationJsonBuilder.new,

--- a/packages/nextcloud/lib/src/api/theming.openapi.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.dart
@@ -92,9 +92,9 @@ class $IconClient {
   @_i2.experimental
   _i3.Request $getFavicon_Request({String? app}) {
     final _parameters = <String, Object?>{};
-    var $app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
-    $app ??= 'core';
-    _parameters['app'] = $app;
+    var __app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
+    __app ??= 'core';
+    _parameters['app'] = __app;
 
     final _path = _i4.UriTemplate('/index.php/apps/theming/favicon/{app}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -174,9 +174,9 @@ class $IconClient {
   @_i2.experimental
   _i3.Request $getTouchIcon_Request({String? app}) {
     final _parameters = <String, Object?>{};
-    var $app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
-    $app ??= 'core';
-    _parameters['app'] = $app;
+    var __app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
+    __app ??= 'core';
+    _parameters['app'] = __app;
 
     final _path = _i4.UriTemplate('/index.php/apps/theming/icon/{app}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -260,16 +260,16 @@ class $IconClient {
     required String image,
   }) {
     final _parameters = <String, Object?>{};
-    final $app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
-    _parameters['app'] = $app;
+    final __app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
+    _parameters['app'] = __app;
 
-    final $image = _$jsonSerializers.serialize(image, specifiedType: const FullType(String));
+    final __image = _$jsonSerializers.serialize(image, specifiedType: const FullType(String));
     _i6.checkString(
-      $image,
+      __image,
       'image',
       pattern: RegExp(r'^.+$'),
     );
-    _parameters['image'] = $image;
+    _parameters['image'] = __image;
 
     final _path = _i4.UriTemplate('/index.php/apps/theming/img/{app}/{image}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -368,19 +368,19 @@ class $ThemingClient {
     ThemingGetThemeStylesheetWithCustomCss? withCustomCss,
   }) {
     final _parameters = <String, Object?>{};
-    final $themeId = _$jsonSerializers.serialize(themeId, specifiedType: const FullType(String));
-    _parameters['themeId'] = $themeId;
+    final __themeId = _$jsonSerializers.serialize(themeId, specifiedType: const FullType(String));
+    _parameters['themeId'] = __themeId;
 
-    var $plain = _$jsonSerializers.serialize(plain, specifiedType: const FullType(ThemingGetThemeStylesheetPlain));
-    $plain ??= 0;
-    _parameters['plain'] = $plain;
+    var __plain = _$jsonSerializers.serialize(plain, specifiedType: const FullType(ThemingGetThemeStylesheetPlain));
+    __plain ??= 0;
+    _parameters['plain'] = __plain;
 
-    var $withCustomCss = _$jsonSerializers.serialize(
+    var __withCustomCss = _$jsonSerializers.serialize(
       withCustomCss,
       specifiedType: const FullType(ThemingGetThemeStylesheetWithCustomCss),
     );
-    $withCustomCss ??= 0;
-    _parameters['withCustomCss'] = $withCustomCss;
+    __withCustomCss ??= 0;
+    _parameters['withCustomCss'] = __withCustomCss;
 
     final _path =
         _i4.UriTemplate('/index.php/apps/theming/theme/{themeId}.css{?plain*,withCustomCss*}').expand(_parameters);
@@ -472,12 +472,12 @@ class $ThemingClient {
     ThemingGetImageUseSvg? useSvg,
   }) {
     final _parameters = <String, Object?>{};
-    final $key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
-    _parameters['key'] = $key;
+    final __key = _$jsonSerializers.serialize(key, specifiedType: const FullType(String));
+    _parameters['key'] = __key;
 
-    var $useSvg = _$jsonSerializers.serialize(useSvg, specifiedType: const FullType(ThemingGetImageUseSvg));
-    $useSvg ??= 1;
-    _parameters['useSvg'] = $useSvg;
+    var __useSvg = _$jsonSerializers.serialize(useSvg, specifiedType: const FullType(ThemingGetImageUseSvg));
+    __useSvg ??= 1;
+    _parameters['useSvg'] = __useSvg;
 
     final _path = _i4.UriTemplate('/index.php/apps/theming/image/{key}{?useSvg*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -562,9 +562,9 @@ class $ThemingClient {
   @_i2.experimental
   _i3.Request $getManifest_Request({String? app}) {
     final _parameters = <String, Object?>{};
-    var $app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
-    $app ??= 'core';
-    _parameters['app'] = $app;
+    var __app = _$jsonSerializers.serialize(app, specifiedType: const FullType(String));
+    __app ??= 'core';
+    _parameters['app'] = __app;
 
     final _path = _i4.UriTemplate('/index.php/apps/theming/manifest/{app}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -725,8 +725,8 @@ class $UserThemeClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $themeId = _$jsonSerializers.serialize(themeId, specifiedType: const FullType(String));
-    _parameters['themeId'] = $themeId;
+    final __themeId = _$jsonSerializers.serialize(themeId, specifiedType: const FullType(String));
+    _parameters['themeId'] = __themeId;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/theming/api/v1/theme/{themeId}/enable').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -749,9 +749,9 @@ class $UserThemeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -823,8 +823,8 @@ class $UserThemeClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $themeId = _$jsonSerializers.serialize(themeId, specifiedType: const FullType(String));
-    _parameters['themeId'] = $themeId;
+    final __themeId = _$jsonSerializers.serialize(themeId, specifiedType: const FullType(String));
+    _parameters['themeId'] = __themeId;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/theming/api/v1/theme/{themeId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -847,9 +847,9 @@ class $UserThemeClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/theming.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.g.dart
@@ -6,68 +6,11 @@ part of 'theming.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-const ThemingGetThemeStylesheetPlain _$themingGetThemeStylesheetPlain$0 = ThemingGetThemeStylesheetPlain._('\$0');
-const ThemingGetThemeStylesheetPlain _$themingGetThemeStylesheetPlain$1 = ThemingGetThemeStylesheetPlain._('\$1');
-
-ThemingGetThemeStylesheetPlain _$valueOfThemingGetThemeStylesheetPlain(String name) {
-  switch (name) {
-    case '\$0':
-      return _$themingGetThemeStylesheetPlain$0;
-    case '\$1':
-      return _$themingGetThemeStylesheetPlain$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ThemingGetThemeStylesheetPlain> _$themingGetThemeStylesheetPlainValues =
-    BuiltSet<ThemingGetThemeStylesheetPlain>(const <ThemingGetThemeStylesheetPlain>[
-  _$themingGetThemeStylesheetPlain$0,
-  _$themingGetThemeStylesheetPlain$1,
-]);
-
-const ThemingGetThemeStylesheetWithCustomCss _$themingGetThemeStylesheetWithCustomCss$0 =
-    ThemingGetThemeStylesheetWithCustomCss._('\$0');
-const ThemingGetThemeStylesheetWithCustomCss _$themingGetThemeStylesheetWithCustomCss$1 =
-    ThemingGetThemeStylesheetWithCustomCss._('\$1');
-
-ThemingGetThemeStylesheetWithCustomCss _$valueOfThemingGetThemeStylesheetWithCustomCss(String name) {
-  switch (name) {
-    case '\$0':
-      return _$themingGetThemeStylesheetWithCustomCss$0;
-    case '\$1':
-      return _$themingGetThemeStylesheetWithCustomCss$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ThemingGetThemeStylesheetWithCustomCss> _$themingGetThemeStylesheetWithCustomCssValues =
-    BuiltSet<ThemingGetThemeStylesheetWithCustomCss>(const <ThemingGetThemeStylesheetWithCustomCss>[
-  _$themingGetThemeStylesheetWithCustomCss$0,
-  _$themingGetThemeStylesheetWithCustomCss$1,
-]);
-
-const ThemingGetImageUseSvg _$themingGetImageUseSvg$0 = ThemingGetImageUseSvg._('\$0');
-const ThemingGetImageUseSvg _$themingGetImageUseSvg$1 = ThemingGetImageUseSvg._('\$1');
-
-ThemingGetImageUseSvg _$valueOfThemingGetImageUseSvg(String name) {
-  switch (name) {
-    case '\$0':
-      return _$themingGetImageUseSvg$0;
-    case '\$1':
-      return _$themingGetImageUseSvg$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ThemingGetImageUseSvg> _$themingGetImageUseSvgValues =
-    BuiltSet<ThemingGetImageUseSvg>(const <ThemingGetImageUseSvg>[
-  _$themingGetImageUseSvg$0,
-  _$themingGetImageUseSvg$1,
-]);
-
+Serializer<ThemingGetThemeStylesheetRequestApplicationJson>
+    _$themingGetThemeStylesheetRequestApplicationJsonSerializer =
+    _$ThemingGetThemeStylesheetRequestApplicationJsonSerializer();
+Serializer<ThemingGetImageRequestApplicationJson> _$themingGetImageRequestApplicationJsonSerializer =
+    _$ThemingGetImageRequestApplicationJsonSerializer();
 Serializer<ThemingGetManifestResponseApplicationJson_Icons> _$themingGetManifestResponseApplicationJsonIconsSerializer =
     _$ThemingGetManifestResponseApplicationJson_IconsSerializer();
 Serializer<ThemingGetManifestResponseApplicationJson> _$themingGetManifestResponseApplicationJsonSerializer =
@@ -84,6 +27,92 @@ Serializer<UserThemeDisableThemeResponseApplicationJson> _$userThemeDisableTheme
     _$UserThemeDisableThemeResponseApplicationJsonSerializer();
 Serializer<PublicCapabilities_Theming> _$publicCapabilitiesThemingSerializer = _$PublicCapabilities_ThemingSerializer();
 Serializer<PublicCapabilities> _$publicCapabilitiesSerializer = _$PublicCapabilitiesSerializer();
+
+class _$ThemingGetThemeStylesheetRequestApplicationJsonSerializer
+    implements StructuredSerializer<ThemingGetThemeStylesheetRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ThemingGetThemeStylesheetRequestApplicationJson,
+    _$ThemingGetThemeStylesheetRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ThemingGetThemeStylesheetRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ThemingGetThemeStylesheetRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'plain',
+      serializers.serialize(object.plain, specifiedType: const FullType(bool)),
+      'withCustomCss',
+      serializers.serialize(object.withCustomCss, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ThemingGetThemeStylesheetRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ThemingGetThemeStylesheetRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'plain':
+          result.plain = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+        case 'withCustomCss':
+          result.withCustomCss = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ThemingGetImageRequestApplicationJsonSerializer
+    implements StructuredSerializer<ThemingGetImageRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ThemingGetImageRequestApplicationJson, _$ThemingGetImageRequestApplicationJson];
+  @override
+  final String wireName = 'ThemingGetImageRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ThemingGetImageRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'useSvg',
+      serializers.serialize(object.useSvg, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ThemingGetImageRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ThemingGetImageRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'useSvg':
+          result.useSvg = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
 
 class _$ThemingGetManifestResponseApplicationJson_IconsSerializer
     implements StructuredSerializer<ThemingGetManifestResponseApplicationJson_Icons> {
@@ -610,6 +639,217 @@ class _$PublicCapabilitiesSerializer implements StructuredSerializer<PublicCapab
     }
 
     return result.build();
+  }
+}
+
+abstract mixin class $ThemingGetThemeStylesheetRequestApplicationJsonInterfaceBuilder {
+  void replace($ThemingGetThemeStylesheetRequestApplicationJsonInterface other);
+  void update(void Function($ThemingGetThemeStylesheetRequestApplicationJsonInterfaceBuilder) updates);
+  bool? get plain;
+  set plain(bool? plain);
+
+  bool? get withCustomCss;
+  set withCustomCss(bool? withCustomCss);
+}
+
+class _$ThemingGetThemeStylesheetRequestApplicationJson extends ThemingGetThemeStylesheetRequestApplicationJson {
+  @override
+  final bool plain;
+  @override
+  final bool withCustomCss;
+
+  factory _$ThemingGetThemeStylesheetRequestApplicationJson(
+          [void Function(ThemingGetThemeStylesheetRequestApplicationJsonBuilder)? updates]) =>
+      (ThemingGetThemeStylesheetRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ThemingGetThemeStylesheetRequestApplicationJson._({required this.plain, required this.withCustomCss}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(plain, r'ThemingGetThemeStylesheetRequestApplicationJson', 'plain');
+    BuiltValueNullFieldError.checkNotNull(
+        withCustomCss, r'ThemingGetThemeStylesheetRequestApplicationJson', 'withCustomCss');
+  }
+
+  @override
+  ThemingGetThemeStylesheetRequestApplicationJson rebuild(
+          void Function(ThemingGetThemeStylesheetRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ThemingGetThemeStylesheetRequestApplicationJsonBuilder toBuilder() =>
+      ThemingGetThemeStylesheetRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ThemingGetThemeStylesheetRequestApplicationJson &&
+        plain == other.plain &&
+        withCustomCss == other.withCustomCss;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, plain.hashCode);
+    _$hash = $jc(_$hash, withCustomCss.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ThemingGetThemeStylesheetRequestApplicationJson')
+          ..add('plain', plain)
+          ..add('withCustomCss', withCustomCss))
+        .toString();
+  }
+}
+
+class ThemingGetThemeStylesheetRequestApplicationJsonBuilder
+    implements
+        Builder<ThemingGetThemeStylesheetRequestApplicationJson,
+            ThemingGetThemeStylesheetRequestApplicationJsonBuilder>,
+        $ThemingGetThemeStylesheetRequestApplicationJsonInterfaceBuilder {
+  _$ThemingGetThemeStylesheetRequestApplicationJson? _$v;
+
+  bool? _plain;
+  bool? get plain => _$this._plain;
+  set plain(covariant bool? plain) => _$this._plain = plain;
+
+  bool? _withCustomCss;
+  bool? get withCustomCss => _$this._withCustomCss;
+  set withCustomCss(covariant bool? withCustomCss) => _$this._withCustomCss = withCustomCss;
+
+  ThemingGetThemeStylesheetRequestApplicationJsonBuilder() {
+    ThemingGetThemeStylesheetRequestApplicationJson._defaults(this);
+  }
+
+  ThemingGetThemeStylesheetRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _plain = $v.plain;
+      _withCustomCss = $v.withCustomCss;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ThemingGetThemeStylesheetRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ThemingGetThemeStylesheetRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ThemingGetThemeStylesheetRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ThemingGetThemeStylesheetRequestApplicationJson build() => _build();
+
+  _$ThemingGetThemeStylesheetRequestApplicationJson _build() {
+    ThemingGetThemeStylesheetRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ThemingGetThemeStylesheetRequestApplicationJson._(
+            plain: BuiltValueNullFieldError.checkNotNull(
+                plain, r'ThemingGetThemeStylesheetRequestApplicationJson', 'plain'),
+            withCustomCss: BuiltValueNullFieldError.checkNotNull(
+                withCustomCss, r'ThemingGetThemeStylesheetRequestApplicationJson', 'withCustomCss'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ThemingGetImageRequestApplicationJsonInterfaceBuilder {
+  void replace($ThemingGetImageRequestApplicationJsonInterface other);
+  void update(void Function($ThemingGetImageRequestApplicationJsonInterfaceBuilder) updates);
+  bool? get useSvg;
+  set useSvg(bool? useSvg);
+}
+
+class _$ThemingGetImageRequestApplicationJson extends ThemingGetImageRequestApplicationJson {
+  @override
+  final bool useSvg;
+
+  factory _$ThemingGetImageRequestApplicationJson(
+          [void Function(ThemingGetImageRequestApplicationJsonBuilder)? updates]) =>
+      (ThemingGetImageRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ThemingGetImageRequestApplicationJson._({required this.useSvg}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(useSvg, r'ThemingGetImageRequestApplicationJson', 'useSvg');
+  }
+
+  @override
+  ThemingGetImageRequestApplicationJson rebuild(void Function(ThemingGetImageRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ThemingGetImageRequestApplicationJsonBuilder toBuilder() =>
+      ThemingGetImageRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ThemingGetImageRequestApplicationJson && useSvg == other.useSvg;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, useSvg.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ThemingGetImageRequestApplicationJson')..add('useSvg', useSvg)).toString();
+  }
+}
+
+class ThemingGetImageRequestApplicationJsonBuilder
+    implements
+        Builder<ThemingGetImageRequestApplicationJson, ThemingGetImageRequestApplicationJsonBuilder>,
+        $ThemingGetImageRequestApplicationJsonInterfaceBuilder {
+  _$ThemingGetImageRequestApplicationJson? _$v;
+
+  bool? _useSvg;
+  bool? get useSvg => _$this._useSvg;
+  set useSvg(covariant bool? useSvg) => _$this._useSvg = useSvg;
+
+  ThemingGetImageRequestApplicationJsonBuilder() {
+    ThemingGetImageRequestApplicationJson._defaults(this);
+  }
+
+  ThemingGetImageRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _useSvg = $v.useSvg;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ThemingGetImageRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ThemingGetImageRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ThemingGetImageRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ThemingGetImageRequestApplicationJson build() => _build();
+
+  _$ThemingGetImageRequestApplicationJson _build() {
+    ThemingGetImageRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ThemingGetImageRequestApplicationJson._(
+            useSvg: BuiltValueNullFieldError.checkNotNull(useSvg, r'ThemingGetImageRequestApplicationJson', 'useSvg'));
+    replace(_$result);
+    return _$result;
   }
 }
 

--- a/packages/nextcloud/lib/src/api/theming.openapi.json
+++ b/packages/nextcloud/lib/src/api/theming.openapi.json
@@ -135,33 +135,29 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "plain": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Let the browser decide the CSS priority"
+                                    },
+                                    "withCustomCss": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Include custom CSS"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "plain",
-                        "in": "query",
-                        "description": "Let the browser decide the CSS priority",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "withCustomCss",
-                        "in": "query",
-                        "description": "Include custom CSS",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
                     {
                         "name": "themeId",
                         "in": "path",
@@ -213,20 +209,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "useSvg",
-                        "in": "query",
-                        "description": "Return image as SVG",
-                        "schema": {
-                            "type": "integer",
-                            "default": 1,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "useSvg": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "Return image as SVG"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "key",
                         "in": "path",

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
@@ -90,12 +90,12 @@ class $ApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $newVersion = _$jsonSerializers.serialize(newVersion, specifiedType: const FullType(String));
-    _parameters['newVersion'] = $newVersion;
+    final __newVersion = _$jsonSerializers.serialize(newVersion, specifiedType: const FullType(String));
+    _parameters['newVersion'] = __newVersion;
 
-    var $apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ApiGetAppListApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    var __apiVersion = _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ApiGetAppListApiVersion));
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/updatenotification/api/{apiVersion}/applist/{newVersion}')
         .expand(_parameters);
@@ -119,9 +119,9 @@ class $ApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -202,16 +202,16 @@ class $ApiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
-    _parameters['appId'] = $appId;
+    final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
+    _parameters['appId'] = __appId;
 
-    final $version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
-    _parameters['version'] = $version;
+    final __version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
+    _parameters['version'] = __version;
 
-    var $apiVersion =
+    var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ApiGetAppChangelogEntryApiVersion));
-    $apiVersion ??= 'v1';
-    _parameters['apiVersion'] = $apiVersion;
+    __apiVersion ??= 'v1';
+    _parameters['apiVersion'] = __apiVersion;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/updatenotification/api/{apiVersion}/changelog/{appId}{?version*}')
         .expand(_parameters);
@@ -235,9 +235,9 @@ class $ApiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
@@ -16,6 +16,8 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
+
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
@@ -182,7 +184,6 @@ class $ApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [version] The version to search the changelog entry for (defaults to the latest installed).
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [appId] App to search changelog entry for.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -197,24 +198,21 @@ class $ApiClient {
   @_i2.experimental
   _i3.Request $getAppChangelogEntry_Request({
     required String appId,
-    String? version,
     ApiGetAppChangelogEntryApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    ApiGetAppChangelogEntryRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __appId = _$jsonSerializers.serialize(appId, specifiedType: const FullType(String));
     _parameters['appId'] = __appId;
-
-    final __version = _$jsonSerializers.serialize(version, specifiedType: const FullType(String));
-    _parameters['version'] = __version;
 
     var __apiVersion =
         _$jsonSerializers.serialize(apiVersion, specifiedType: const FullType(ApiGetAppChangelogEntryApiVersion));
     __apiVersion ??= 'v1';
     _parameters['apiVersion'] = __apiVersion;
 
-    final _path = _i4.UriTemplate('/ocs/v2.php/apps/updatenotification/api/{apiVersion}/changelog/{appId}{?version*}')
-        .expand(_parameters);
+    final _path =
+        _i4.UriTemplate('/ocs/v2.php/apps/updatenotification/api/{apiVersion}/changelog/{appId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -239,6 +237,20 @@ class $ApiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(ApiGetAppChangelogEntryRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ApiGetAppChangelogEntryRequestApplicationJson(),
+              specifiedType: const FullType(ApiGetAppChangelogEntryRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -250,7 +262,6 @@ class $ApiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [version] The version to search the changelog entry for (defaults to the latest installed).
   ///   * [apiVersion] Defaults to `"v1"`.
   ///   * [appId] App to search changelog entry for.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
@@ -264,15 +275,15 @@ class $ApiClient {
   ///  * [$getAppChangelogEntry_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ApiGetAppChangelogEntryResponseApplicationJson, void>> getAppChangelogEntry({
     required String appId,
-    String? version,
     ApiGetAppChangelogEntryApiVersion? apiVersion,
     bool? oCSAPIRequest,
+    ApiGetAppChangelogEntryRequestApplicationJson? $body,
   }) async {
     final _request = $getAppChangelogEntry_Request(
       appId: appId,
-      version: version,
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -701,6 +712,70 @@ class _$ApiGetAppChangelogEntryApiVersionSerializer implements PrimitiveSerializ
 }
 
 @BuiltValue(instantiable: false)
+sealed class $ApiGetAppChangelogEntryRequestApplicationJsonInterface {
+  /// The version to search the changelog entry for (defaults to the latest installed).
+  String? get version;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ApiGetAppChangelogEntryRequestApplicationJsonInterfaceBuilder].
+  $ApiGetAppChangelogEntryRequestApplicationJsonInterface rebuild(
+    void Function($ApiGetAppChangelogEntryRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ApiGetAppChangelogEntryRequestApplicationJsonInterfaceBuilder].
+  $ApiGetAppChangelogEntryRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ApiGetAppChangelogEntryRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ApiGetAppChangelogEntryRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ApiGetAppChangelogEntryRequestApplicationJson
+    implements
+        $ApiGetAppChangelogEntryRequestApplicationJsonInterface,
+        Built<ApiGetAppChangelogEntryRequestApplicationJson, ApiGetAppChangelogEntryRequestApplicationJsonBuilder> {
+  /// Creates a new ApiGetAppChangelogEntryRequestApplicationJson object using the builder pattern.
+  factory ApiGetAppChangelogEntryRequestApplicationJson([
+    void Function(ApiGetAppChangelogEntryRequestApplicationJsonBuilder)? b,
+  ]) = _$ApiGetAppChangelogEntryRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ApiGetAppChangelogEntryRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ApiGetAppChangelogEntryRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ApiGetAppChangelogEntryRequestApplicationJson.
+  static Serializer<ApiGetAppChangelogEntryRequestApplicationJson> get serializer =>
+      _$apiGetAppChangelogEntryRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ApiGetAppChangelogEntryRequestApplicationJsonBuilder b) {
+    $ApiGetAppChangelogEntryRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ApiGetAppChangelogEntryRequestApplicationJsonBuilder b) {
+    $ApiGetAppChangelogEntryRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $ApiGetAppChangelogEntryResponseApplicationJson_Ocs_DataInterface {
   String get appName;
   String get content;
@@ -924,6 +999,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(App.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(App)]), ListBuilder<App>.new)
       ..add(ApiGetAppChangelogEntryApiVersion.serializer)
+      ..addBuilderFactory(
+        const FullType(ApiGetAppChangelogEntryRequestApplicationJson),
+        ApiGetAppChangelogEntryRequestApplicationJsonBuilder.new,
+      )
+      ..add(ApiGetAppChangelogEntryRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ApiGetAppChangelogEntryResponseApplicationJson),
         ApiGetAppChangelogEntryResponseApplicationJsonBuilder.new,

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.g.dart
@@ -47,6 +47,8 @@ Serializer<ApiGetAppListResponseApplicationJson_Ocs> _$apiGetAppListResponseAppl
     _$ApiGetAppListResponseApplicationJson_OcsSerializer();
 Serializer<ApiGetAppListResponseApplicationJson> _$apiGetAppListResponseApplicationJsonSerializer =
     _$ApiGetAppListResponseApplicationJsonSerializer();
+Serializer<ApiGetAppChangelogEntryRequestApplicationJson> _$apiGetAppChangelogEntryRequestApplicationJsonSerializer =
+    _$ApiGetAppChangelogEntryRequestApplicationJsonSerializer();
 Serializer<ApiGetAppChangelogEntryResponseApplicationJson_Ocs_Data>
     _$apiGetAppChangelogEntryResponseApplicationJsonOcsDataSerializer =
     _$ApiGetAppChangelogEntryResponseApplicationJson_Ocs_DataSerializer();
@@ -299,6 +301,51 @@ class _$ApiGetAppListResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(ApiGetAppListResponseApplicationJson_Ocs))!
                   as ApiGetAppListResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ApiGetAppChangelogEntryRequestApplicationJsonSerializer
+    implements StructuredSerializer<ApiGetAppChangelogEntryRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    ApiGetAppChangelogEntryRequestApplicationJson,
+    _$ApiGetAppChangelogEntryRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'ApiGetAppChangelogEntryRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ApiGetAppChangelogEntryRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.version;
+    if (value != null) {
+      result
+        ..add('version')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  ApiGetAppChangelogEntryRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ApiGetAppChangelogEntryRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'version':
+          result.version = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -1054,6 +1101,98 @@ class ApiGetAppListResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ApiGetAppChangelogEntryRequestApplicationJsonInterfaceBuilder {
+  void replace($ApiGetAppChangelogEntryRequestApplicationJsonInterface other);
+  void update(void Function($ApiGetAppChangelogEntryRequestApplicationJsonInterfaceBuilder) updates);
+  String? get version;
+  set version(String? version);
+}
+
+class _$ApiGetAppChangelogEntryRequestApplicationJson extends ApiGetAppChangelogEntryRequestApplicationJson {
+  @override
+  final String? version;
+
+  factory _$ApiGetAppChangelogEntryRequestApplicationJson(
+          [void Function(ApiGetAppChangelogEntryRequestApplicationJsonBuilder)? updates]) =>
+      (ApiGetAppChangelogEntryRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ApiGetAppChangelogEntryRequestApplicationJson._({this.version}) : super._();
+
+  @override
+  ApiGetAppChangelogEntryRequestApplicationJson rebuild(
+          void Function(ApiGetAppChangelogEntryRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ApiGetAppChangelogEntryRequestApplicationJsonBuilder toBuilder() =>
+      ApiGetAppChangelogEntryRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ApiGetAppChangelogEntryRequestApplicationJson && version == other.version;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, version.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ApiGetAppChangelogEntryRequestApplicationJson')..add('version', version))
+        .toString();
+  }
+}
+
+class ApiGetAppChangelogEntryRequestApplicationJsonBuilder
+    implements
+        Builder<ApiGetAppChangelogEntryRequestApplicationJson, ApiGetAppChangelogEntryRequestApplicationJsonBuilder>,
+        $ApiGetAppChangelogEntryRequestApplicationJsonInterfaceBuilder {
+  _$ApiGetAppChangelogEntryRequestApplicationJson? _$v;
+
+  String? _version;
+  String? get version => _$this._version;
+  set version(covariant String? version) => _$this._version = version;
+
+  ApiGetAppChangelogEntryRequestApplicationJsonBuilder() {
+    ApiGetAppChangelogEntryRequestApplicationJson._defaults(this);
+  }
+
+  ApiGetAppChangelogEntryRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _version = $v.version;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ApiGetAppChangelogEntryRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ApiGetAppChangelogEntryRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ApiGetAppChangelogEntryRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ApiGetAppChangelogEntryRequestApplicationJson build() => _build();
+
+  _$ApiGetAppChangelogEntryRequestApplicationJson _build() {
+    ApiGetAppChangelogEntryRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$ApiGetAppChangelogEntryRequestApplicationJson._(version: version);
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.json
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.json
@@ -221,16 +221,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "version",
-                        "in": "query",
-                        "description": "The version to search the changelog entry for (defaults to the latest installed)",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "version": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "The version to search the changelog entry for (defaults to the latest installed)"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "apiVersion",
                         "in": "path",

--- a/packages/nextcloud/lib/src/api/uppush.openapi.dart
+++ b/packages/nextcloud/lib/src/api/uppush.openapi.dart
@@ -141,8 +141,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $setKeepalive_Request({required int keepalive}) {
     final _parameters = <String, Object?>{};
-    final $keepalive = _$jsonSerializers.serialize(keepalive, specifiedType: const FullType(int));
-    _parameters['keepalive'] = $keepalive;
+    final __keepalive = _$jsonSerializers.serialize(keepalive, specifiedType: const FullType(int));
+    _parameters['keepalive'] = __keepalive;
 
     final _path = _i5.UriTemplate('/index.php/apps/uppush/keepalive{?keepalive*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -224,8 +224,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $createDevice_Request({required String deviceName}) {
     final _parameters = <String, Object?>{};
-    final $deviceName = _$jsonSerializers.serialize(deviceName, specifiedType: const FullType(String));
-    _parameters['deviceName'] = $deviceName;
+    final __deviceName = _$jsonSerializers.serialize(deviceName, specifiedType: const FullType(String));
+    _parameters['deviceName'] = __deviceName;
 
     final _path = _i5.UriTemplate('/index.php/apps/uppush/device{?deviceName*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -305,8 +305,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $syncDevice_Request({required String deviceId}) {
     final _parameters = <String, Object?>{};
-    final $deviceId = _$jsonSerializers.serialize(deviceId, specifiedType: const FullType(String));
-    _parameters['deviceId'] = $deviceId;
+    final __deviceId = _$jsonSerializers.serialize(deviceId, specifiedType: const FullType(String));
+    _parameters['deviceId'] = __deviceId;
 
     final _path = _i5.UriTemplate('/index.php/apps/uppush/device/{deviceId}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -381,8 +381,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $deleteDevice_Request({required String deviceId}) {
     final _parameters = <String, Object?>{};
-    final $deviceId = _$jsonSerializers.serialize(deviceId, specifiedType: const FullType(String));
-    _parameters['deviceId'] = $deviceId;
+    final __deviceId = _$jsonSerializers.serialize(deviceId, specifiedType: const FullType(String));
+    _parameters['deviceId'] = __deviceId;
 
     final _path = _i5.UriTemplate('/index.php/apps/uppush/device/{deviceId}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -464,11 +464,11 @@ class $Client extends _i1.DynamiteClient {
     required String appName,
   }) {
     final _parameters = <String, Object?>{};
-    final $deviceId = _$jsonSerializers.serialize(deviceId, specifiedType: const FullType(String));
-    _parameters['deviceId'] = $deviceId;
+    final __deviceId = _$jsonSerializers.serialize(deviceId, specifiedType: const FullType(String));
+    _parameters['deviceId'] = __deviceId;
 
-    final $appName = _$jsonSerializers.serialize(appName, specifiedType: const FullType(String));
-    _parameters['appName'] = $appName;
+    final __appName = _$jsonSerializers.serialize(appName, specifiedType: const FullType(String));
+    _parameters['appName'] = __appName;
 
     final _path = _i5.UriTemplate('/index.php/apps/uppush/app{?deviceId*,appName*}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -548,8 +548,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $deleteApp_Request({required String token}) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _parameters['token'] = $token;
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    _parameters['token'] = __token;
 
     final _path = _i5.UriTemplate('/index.php/apps/uppush/app/{token}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -622,8 +622,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $unifiedpushDiscovery_Request({required String token}) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _parameters['token'] = $token;
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    _parameters['token'] = __token;
 
     final _path = _i5.UriTemplate('/index.php/apps/uppush/push/{token}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');
@@ -698,8 +698,8 @@ class $Client extends _i1.DynamiteClient {
   @_i2.experimental
   _i3.Request $push_Request({required String token}) {
     final _parameters = <String, Object?>{};
-    final $token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
-    _parameters['token'] = $token;
+    final __token = _$jsonSerializers.serialize(token, specifiedType: const FullType(String));
+    _parameters['token'] = __token;
 
     final _path = _i5.UriTemplate('/index.php/apps/uppush/push/{token}').expand(_parameters);
     final _uri = Uri.parse('$baseURL$_path');

--- a/packages/nextcloud/lib/src/api/user_ldap.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_ldap.openapi.dart
@@ -105,9 +105,9 @@ class $ConfigapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -177,13 +177,13 @@ class $ConfigapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $configID = _$jsonSerializers.serialize(configID, specifiedType: const FullType(String));
-    _parameters['configID'] = $configID;
+    final __configID = _$jsonSerializers.serialize(configID, specifiedType: const FullType(String));
+    _parameters['configID'] = __configID;
 
-    var $showPassword =
+    var __showPassword =
         _$jsonSerializers.serialize(showPassword, specifiedType: const FullType(ConfigapiShowShowPassword));
-    $showPassword ??= 0;
-    _parameters['showPassword'] = $showPassword;
+    __showPassword ??= 0;
+    _parameters['showPassword'] = __showPassword;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/apps/user_ldap/api/v1/config/{configID}{?showPassword*}').expand(_parameters);
@@ -207,9 +207,9 @@ class $ConfigapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -289,16 +289,16 @@ class $ConfigapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $configData = _$jsonSerializers.serialize(
+    final __configData = _$jsonSerializers.serialize(
       configData,
       specifiedType: const FullType(ContentString, [
         FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
       ]),
     );
-    _parameters['configData'] = $configData;
+    _parameters['configData'] = __configData;
 
-    final $configID = _$jsonSerializers.serialize(configID, specifiedType: const FullType(String));
-    _parameters['configID'] = $configID;
+    final __configID = _$jsonSerializers.serialize(configID, specifiedType: const FullType(String));
+    _parameters['configID'] = __configID;
 
     final _path =
         _i6.UriTemplate('/ocs/v2.php/apps/user_ldap/api/v1/config/{configID}{?configData*}').expand(_parameters);
@@ -322,9 +322,9 @@ class $ConfigapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -401,8 +401,8 @@ class $ConfigapiClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $configID = _$jsonSerializers.serialize(configID, specifiedType: const FullType(String));
-    _parameters['configID'] = $configID;
+    final __configID = _$jsonSerializers.serialize(configID, specifiedType: const FullType(String));
+    _parameters['configID'] = __configID;
 
     final _path = _i6.UriTemplate('/ocs/v2.php/apps/user_ldap/api/v1/config/{configID}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -425,9 +425,9 @@ class $ConfigapiClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/user_ldap.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_ldap.openapi.dart
@@ -16,6 +16,8 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
+
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/json_object.dart';
@@ -24,7 +26,6 @@ import 'package:built_value/standard_json_plugin.dart' as _i8;
 import 'package:collection/collection.dart' as _i4;
 import 'package:dynamite_runtime/built_value.dart' as _i7;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/models.dart';
 import 'package:dynamite_runtime/utils.dart' as _i5;
 import 'package:http/http.dart' as _i3;
 import 'package:meta/meta.dart' as _i2;
@@ -159,7 +160,6 @@ class $ConfigapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [showPassword] Whether to show the password. Defaults to `0`.
   ///   * [configID] ID of the config.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -173,20 +173,14 @@ class $ConfigapiClient {
   @_i2.experimental
   _i3.Request $$show_Request({
     required String configID,
-    ConfigapiShowShowPassword? showPassword,
     bool? oCSAPIRequest,
+    ConfigapiShowRequestApplicationJson? $body,
   }) {
     final _parameters = <String, Object?>{};
     final __configID = _$jsonSerializers.serialize(configID, specifiedType: const FullType(String));
     _parameters['configID'] = __configID;
 
-    var __showPassword =
-        _$jsonSerializers.serialize(showPassword, specifiedType: const FullType(ConfigapiShowShowPassword));
-    __showPassword ??= 0;
-    _parameters['showPassword'] = __showPassword;
-
-    final _path =
-        _i6.UriTemplate('/ocs/v2.php/apps/user_ldap/api/v1/config/{configID}{?showPassword*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/apps/user_ldap/api/v1/config/{configID}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -211,6 +205,17 @@ class $ConfigapiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(ConfigapiShowRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              ConfigapiShowRequestApplicationJson(),
+              specifiedType: const FullType(ConfigapiShowRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -223,7 +228,6 @@ class $ConfigapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [showPassword] Whether to show the password. Defaults to `0`.
   ///   * [configID] ID of the config.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -236,13 +240,13 @@ class $ConfigapiClient {
   ///  * [$$show_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ConfigapiShowResponseApplicationJson, void>> $show({
     required String configID,
-    ConfigapiShowShowPassword? showPassword,
     bool? oCSAPIRequest,
+    ConfigapiShowRequestApplicationJson? $body,
   }) async {
     final _request = $$show_Request(
       configID: configID,
-      showPassword: showPassword,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -270,7 +274,6 @@ class $ConfigapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [configData] New config.
   ///   * [configID] ID of the config.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -284,24 +287,15 @@ class $ConfigapiClient {
   ///  * [$modify_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $modify_Request({
-    required ContentString<BuiltMap<String, JsonObject>> configData,
     required String configID,
+    required ConfigapiModifyRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final __configData = _$jsonSerializers.serialize(
-      configData,
-      specifiedType: const FullType(ContentString, [
-        FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
-      ]),
-    );
-    _parameters['configData'] = __configData;
-
     final __configID = _$jsonSerializers.serialize(configID, specifiedType: const FullType(String));
     _parameters['configID'] = __configID;
 
-    final _path =
-        _i6.UriTemplate('/ocs/v2.php/apps/user_ldap/api/v1/config/{configID}{?configData*}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/apps/user_ldap/api/v1/config/{configID}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
@@ -326,6 +320,10 @@ class $ConfigapiClient {
     __oCSAPIRequest ??= true;
     _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(ConfigapiModifyRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -337,7 +335,6 @@ class $ConfigapiClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [configData] New config.
   ///   * [configID] ID of the config.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
@@ -350,14 +347,14 @@ class $ConfigapiClient {
   ///  * [$modify_Request] for the request send by this method.
   ///  * [$modify_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ConfigapiModifyResponseApplicationJson, void>> modify({
-    required ContentString<BuiltMap<String, JsonObject>> configData,
     required String configID,
+    required ConfigapiModifyRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $modify_Request(
-      configData: configData,
       configID: configID,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -715,67 +712,75 @@ abstract class ConfigapiCreateResponseApplicationJson
   }
 }
 
-class ConfigapiShowShowPassword extends EnumClass {
-  const ConfigapiShowShowPassword._(super.name);
+@BuiltValue(instantiable: false)
+sealed class $ConfigapiShowRequestApplicationJsonInterface {
+  static final _$showPassword = _$jsonSerializers.deserialize(
+    false,
+    specifiedType: const FullType(bool),
+  )! as bool;
 
-  /// `0`
-  @BuiltValueEnumConst(wireName: '0')
-  static const ConfigapiShowShowPassword $0 = _$configapiShowShowPassword$0;
+  /// Whether to show the password.
+  bool get showPassword;
 
-  /// `1`
-  @BuiltValueEnumConst(wireName: '1')
-  static const ConfigapiShowShowPassword $1 = _$configapiShowShowPassword$1;
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ConfigapiShowRequestApplicationJsonInterfaceBuilder].
+  $ConfigapiShowRequestApplicationJsonInterface rebuild(
+    void Function($ConfigapiShowRequestApplicationJsonInterfaceBuilder) updates,
+  );
 
-  /// Returns a set with all values this enum contains.
-  // coverage:ignore-start
-  static BuiltSet<ConfigapiShowShowPassword> get values => _$configapiShowShowPasswordValues;
-  // coverage:ignore-end
+  /// Converts the instance to a builder [$ConfigapiShowRequestApplicationJsonInterfaceBuilder].
+  $ConfigapiShowRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ConfigapiShowRequestApplicationJsonInterfaceBuilder b) {
+    b.showPassword = _$showPassword;
+  }
 
-  /// Returns the enum value associated to the [name].
-  static ConfigapiShowShowPassword valueOf(String name) => _$valueOfConfigapiShowShowPassword(name);
-
-  /// Returns the serialized value of this enum value.
-  int get value => _$jsonSerializers.serializeWith(serializer, this)! as int;
-
-  /// Serializer for ConfigapiShowShowPassword.
-  @BuiltValueSerializer(custom: true)
-  static Serializer<ConfigapiShowShowPassword> get serializer => const _$ConfigapiShowShowPasswordSerializer();
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ConfigapiShowRequestApplicationJsonInterfaceBuilder b) {}
 }
 
-class _$ConfigapiShowShowPasswordSerializer implements PrimitiveSerializer<ConfigapiShowShowPassword> {
-  const _$ConfigapiShowShowPasswordSerializer();
+abstract class ConfigapiShowRequestApplicationJson
+    implements
+        $ConfigapiShowRequestApplicationJsonInterface,
+        Built<ConfigapiShowRequestApplicationJson, ConfigapiShowRequestApplicationJsonBuilder> {
+  /// Creates a new ConfigapiShowRequestApplicationJson object using the builder pattern.
+  factory ConfigapiShowRequestApplicationJson([void Function(ConfigapiShowRequestApplicationJsonBuilder)? b]) =
+      _$ConfigapiShowRequestApplicationJson;
 
-  static const Map<ConfigapiShowShowPassword, Object> _toWire = <ConfigapiShowShowPassword, Object>{
-    ConfigapiShowShowPassword.$0: 0,
-    ConfigapiShowShowPassword.$1: 1,
-  };
+  // coverage:ignore-start
+  const ConfigapiShowRequestApplicationJson._();
+  // coverage:ignore-end
 
-  static const Map<Object, ConfigapiShowShowPassword> _fromWire = <Object, ConfigapiShowShowPassword>{
-    0: ConfigapiShowShowPassword.$0,
-    1: ConfigapiShowShowPassword.$1,
-  };
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ConfigapiShowRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
 
-  @override
-  Iterable<Type> get types => const [ConfigapiShowShowPassword];
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
 
-  @override
-  String get wireName => 'ConfigapiShowShowPassword';
+  /// Serializer for ConfigapiShowRequestApplicationJson.
+  static Serializer<ConfigapiShowRequestApplicationJson> get serializer =>
+      _$configapiShowRequestApplicationJsonSerializer;
 
-  @override
-  Object serialize(
-    Serializers serializers,
-    ConfigapiShowShowPassword object, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _toWire[object]!;
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ConfigapiShowRequestApplicationJsonBuilder b) {
+    $ConfigapiShowRequestApplicationJsonInterface._defaults(b);
+  }
 
-  @override
-  ConfigapiShowShowPassword deserialize(
-    Serializers serializers,
-    Object serialized, {
-    FullType specifiedType = FullType.unspecified,
-  }) =>
-      _fromWire[serialized]!;
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ConfigapiShowRequestApplicationJsonBuilder b) {
+    $ConfigapiShowRequestApplicationJsonInterface._validate(b);
+  }
 }
 
 @BuiltValue(instantiable: false)
@@ -901,6 +906,69 @@ abstract class ConfigapiShowResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(ConfigapiShowResponseApplicationJsonBuilder b) {
     $ConfigapiShowResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $ConfigapiModifyRequestApplicationJsonInterface {
+  /// New config.
+  BuiltMap<String, JsonObject> get configData;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$ConfigapiModifyRequestApplicationJsonInterfaceBuilder].
+  $ConfigapiModifyRequestApplicationJsonInterface rebuild(
+    void Function($ConfigapiModifyRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$ConfigapiModifyRequestApplicationJsonInterfaceBuilder].
+  $ConfigapiModifyRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($ConfigapiModifyRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($ConfigapiModifyRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class ConfigapiModifyRequestApplicationJson
+    implements
+        $ConfigapiModifyRequestApplicationJsonInterface,
+        Built<ConfigapiModifyRequestApplicationJson, ConfigapiModifyRequestApplicationJsonBuilder> {
+  /// Creates a new ConfigapiModifyRequestApplicationJson object using the builder pattern.
+  factory ConfigapiModifyRequestApplicationJson([void Function(ConfigapiModifyRequestApplicationJsonBuilder)? b]) =
+      _$ConfigapiModifyRequestApplicationJson;
+
+  // coverage:ignore-start
+  const ConfigapiModifyRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory ConfigapiModifyRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for ConfigapiModifyRequestApplicationJson.
+  static Serializer<ConfigapiModifyRequestApplicationJson> get serializer =>
+      _$configapiModifyRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(ConfigapiModifyRequestApplicationJsonBuilder b) {
+    $ConfigapiModifyRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(ConfigapiModifyRequestApplicationJsonBuilder b) {
+    $ConfigapiModifyRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -1181,7 +1249,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         ConfigapiCreateResponseApplicationJson_Ocs_DataBuilder.new,
       )
       ..add(ConfigapiCreateResponseApplicationJson_Ocs_Data.serializer)
-      ..add(ConfigapiShowShowPassword.serializer)
+      ..addBuilderFactory(
+        const FullType(ConfigapiShowRequestApplicationJson),
+        ConfigapiShowRequestApplicationJsonBuilder.new,
+      )
+      ..add(ConfigapiShowRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ConfigapiShowResponseApplicationJson),
         ConfigapiShowResponseApplicationJsonBuilder.new,
@@ -1197,12 +1269,10 @@ final Serializers _$serializers = (Serializers().toBuilder()
         MapBuilder<String, JsonObject>.new,
       )
       ..addBuilderFactory(
-        const FullType(ContentString, [
-          FullType(BuiltMap, [FullType(String), FullType(JsonObject)]),
-        ]),
-        ContentStringBuilder<BuiltMap<String, JsonObject>>.new,
+        const FullType(ConfigapiModifyRequestApplicationJson),
+        ConfigapiModifyRequestApplicationJsonBuilder.new,
       )
-      ..add(ContentString.serializer)
+      ..add(ConfigapiModifyRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(ConfigapiModifyResponseApplicationJson),
         ConfigapiModifyResponseApplicationJsonBuilder.new,

--- a/packages/nextcloud/lib/src/api/user_ldap.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/user_ldap.openapi.g.dart
@@ -6,26 +6,6 @@ part of 'user_ldap.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-const ConfigapiShowShowPassword _$configapiShowShowPassword$0 = ConfigapiShowShowPassword._('\$0');
-const ConfigapiShowShowPassword _$configapiShowShowPassword$1 = ConfigapiShowShowPassword._('\$1');
-
-ConfigapiShowShowPassword _$valueOfConfigapiShowShowPassword(String name) {
-  switch (name) {
-    case '\$0':
-      return _$configapiShowShowPassword$0;
-    case '\$1':
-      return _$configapiShowShowPassword$1;
-    default:
-      throw ArgumentError(name);
-  }
-}
-
-final BuiltSet<ConfigapiShowShowPassword> _$configapiShowShowPasswordValues =
-    BuiltSet<ConfigapiShowShowPassword>(const <ConfigapiShowShowPassword>[
-  _$configapiShowShowPassword$0,
-  _$configapiShowShowPassword$1,
-]);
-
 Serializer<OCSMeta> _$oCSMetaSerializer = _$OCSMetaSerializer();
 Serializer<ConfigapiCreateResponseApplicationJson_Ocs_Data> _$configapiCreateResponseApplicationJsonOcsDataSerializer =
     _$ConfigapiCreateResponseApplicationJson_Ocs_DataSerializer();
@@ -33,10 +13,14 @@ Serializer<ConfigapiCreateResponseApplicationJson_Ocs> _$configapiCreateResponse
     _$ConfigapiCreateResponseApplicationJson_OcsSerializer();
 Serializer<ConfigapiCreateResponseApplicationJson> _$configapiCreateResponseApplicationJsonSerializer =
     _$ConfigapiCreateResponseApplicationJsonSerializer();
+Serializer<ConfigapiShowRequestApplicationJson> _$configapiShowRequestApplicationJsonSerializer =
+    _$ConfigapiShowRequestApplicationJsonSerializer();
 Serializer<ConfigapiShowResponseApplicationJson_Ocs> _$configapiShowResponseApplicationJsonOcsSerializer =
     _$ConfigapiShowResponseApplicationJson_OcsSerializer();
 Serializer<ConfigapiShowResponseApplicationJson> _$configapiShowResponseApplicationJsonSerializer =
     _$ConfigapiShowResponseApplicationJsonSerializer();
+Serializer<ConfigapiModifyRequestApplicationJson> _$configapiModifyRequestApplicationJsonSerializer =
+    _$ConfigapiModifyRequestApplicationJsonSerializer();
 Serializer<ConfigapiModifyResponseApplicationJson_Ocs> _$configapiModifyResponseApplicationJsonOcsSerializer =
     _$ConfigapiModifyResponseApplicationJson_OcsSerializer();
 Serializer<ConfigapiModifyResponseApplicationJson> _$configapiModifyResponseApplicationJsonSerializer =
@@ -249,6 +233,45 @@ class _$ConfigapiCreateResponseApplicationJsonSerializer
   }
 }
 
+class _$ConfigapiShowRequestApplicationJsonSerializer
+    implements StructuredSerializer<ConfigapiShowRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ConfigapiShowRequestApplicationJson, _$ConfigapiShowRequestApplicationJson];
+  @override
+  final String wireName = 'ConfigapiShowRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ConfigapiShowRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'showPassword',
+      serializers.serialize(object.showPassword, specifiedType: const FullType(bool)),
+    ];
+
+    return result;
+  }
+
+  @override
+  ConfigapiShowRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ConfigapiShowRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'showPassword':
+          result.showPassword = serializers.deserialize(value, specifiedType: const FullType(bool))! as bool;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$ConfigapiShowResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<ConfigapiShowResponseApplicationJson_Ocs> {
   @override
@@ -331,6 +354,47 @@ class _$ConfigapiShowResponseApplicationJsonSerializer
           result.ocs.replace(
               serializers.deserialize(value, specifiedType: const FullType(ConfigapiShowResponseApplicationJson_Ocs))!
                   as ConfigapiShowResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ConfigapiModifyRequestApplicationJsonSerializer
+    implements StructuredSerializer<ConfigapiModifyRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [ConfigapiModifyRequestApplicationJson, _$ConfigapiModifyRequestApplicationJson];
+  @override
+  final String wireName = 'ConfigapiModifyRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ConfigapiModifyRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'configData',
+      serializers.serialize(object.configData,
+          specifiedType: const FullType(BuiltMap, [FullType(String), FullType(JsonObject)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  ConfigapiModifyRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = ConfigapiModifyRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'configData':
+          result.configData.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltMap, [FullType(String), FullType(JsonObject)]))!);
           break;
       }
     }
@@ -990,6 +1054,100 @@ class ConfigapiCreateResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $ConfigapiShowRequestApplicationJsonInterfaceBuilder {
+  void replace($ConfigapiShowRequestApplicationJsonInterface other);
+  void update(void Function($ConfigapiShowRequestApplicationJsonInterfaceBuilder) updates);
+  bool? get showPassword;
+  set showPassword(bool? showPassword);
+}
+
+class _$ConfigapiShowRequestApplicationJson extends ConfigapiShowRequestApplicationJson {
+  @override
+  final bool showPassword;
+
+  factory _$ConfigapiShowRequestApplicationJson([void Function(ConfigapiShowRequestApplicationJsonBuilder)? updates]) =>
+      (ConfigapiShowRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ConfigapiShowRequestApplicationJson._({required this.showPassword}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(showPassword, r'ConfigapiShowRequestApplicationJson', 'showPassword');
+  }
+
+  @override
+  ConfigapiShowRequestApplicationJson rebuild(void Function(ConfigapiShowRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ConfigapiShowRequestApplicationJsonBuilder toBuilder() => ConfigapiShowRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ConfigapiShowRequestApplicationJson && showPassword == other.showPassword;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, showPassword.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ConfigapiShowRequestApplicationJson')..add('showPassword', showPassword))
+        .toString();
+  }
+}
+
+class ConfigapiShowRequestApplicationJsonBuilder
+    implements
+        Builder<ConfigapiShowRequestApplicationJson, ConfigapiShowRequestApplicationJsonBuilder>,
+        $ConfigapiShowRequestApplicationJsonInterfaceBuilder {
+  _$ConfigapiShowRequestApplicationJson? _$v;
+
+  bool? _showPassword;
+  bool? get showPassword => _$this._showPassword;
+  set showPassword(covariant bool? showPassword) => _$this._showPassword = showPassword;
+
+  ConfigapiShowRequestApplicationJsonBuilder() {
+    ConfigapiShowRequestApplicationJson._defaults(this);
+  }
+
+  ConfigapiShowRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _showPassword = $v.showPassword;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ConfigapiShowRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ConfigapiShowRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ConfigapiShowRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ConfigapiShowRequestApplicationJson build() => _build();
+
+  _$ConfigapiShowRequestApplicationJson _build() {
+    ConfigapiShowRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$ConfigapiShowRequestApplicationJson._(
+            showPassword: BuiltValueNullFieldError.checkNotNull(
+                showPassword, r'ConfigapiShowRequestApplicationJson', 'showPassword'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $ConfigapiShowResponseApplicationJson_OcsInterfaceBuilder {
   void replace($ConfigapiShowResponseApplicationJson_OcsInterface other);
   void update(void Function($ConfigapiShowResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -1209,6 +1367,111 @@ class ConfigapiShowResponseApplicationJsonBuilder
         ocs.build();
       } catch (e) {
         throw BuiltValueNestedFieldError(r'ConfigapiShowResponseApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $ConfigapiModifyRequestApplicationJsonInterfaceBuilder {
+  void replace($ConfigapiModifyRequestApplicationJsonInterface other);
+  void update(void Function($ConfigapiModifyRequestApplicationJsonInterfaceBuilder) updates);
+  MapBuilder<String, JsonObject> get configData;
+  set configData(MapBuilder<String, JsonObject>? configData);
+}
+
+class _$ConfigapiModifyRequestApplicationJson extends ConfigapiModifyRequestApplicationJson {
+  @override
+  final BuiltMap<String, JsonObject> configData;
+
+  factory _$ConfigapiModifyRequestApplicationJson(
+          [void Function(ConfigapiModifyRequestApplicationJsonBuilder)? updates]) =>
+      (ConfigapiModifyRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$ConfigapiModifyRequestApplicationJson._({required this.configData}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(configData, r'ConfigapiModifyRequestApplicationJson', 'configData');
+  }
+
+  @override
+  ConfigapiModifyRequestApplicationJson rebuild(void Function(ConfigapiModifyRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ConfigapiModifyRequestApplicationJsonBuilder toBuilder() =>
+      ConfigapiModifyRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ConfigapiModifyRequestApplicationJson && configData == other.configData;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, configData.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ConfigapiModifyRequestApplicationJson')..add('configData', configData))
+        .toString();
+  }
+}
+
+class ConfigapiModifyRequestApplicationJsonBuilder
+    implements
+        Builder<ConfigapiModifyRequestApplicationJson, ConfigapiModifyRequestApplicationJsonBuilder>,
+        $ConfigapiModifyRequestApplicationJsonInterfaceBuilder {
+  _$ConfigapiModifyRequestApplicationJson? _$v;
+
+  MapBuilder<String, JsonObject>? _configData;
+  MapBuilder<String, JsonObject> get configData => _$this._configData ??= MapBuilder<String, JsonObject>();
+  set configData(covariant MapBuilder<String, JsonObject>? configData) => _$this._configData = configData;
+
+  ConfigapiModifyRequestApplicationJsonBuilder() {
+    ConfigapiModifyRequestApplicationJson._defaults(this);
+  }
+
+  ConfigapiModifyRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _configData = $v.configData.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant ConfigapiModifyRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ConfigapiModifyRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(ConfigapiModifyRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ConfigapiModifyRequestApplicationJson build() => _build();
+
+  _$ConfigapiModifyRequestApplicationJson _build() {
+    ConfigapiModifyRequestApplicationJson._validate(this);
+    _$ConfigapiModifyRequestApplicationJson _$result;
+    try {
+      _$result = _$v ?? _$ConfigapiModifyRequestApplicationJson._(configData: configData.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'configData';
+        configData.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'ConfigapiModifyRequestApplicationJson', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/packages/nextcloud/lib/src/api/user_ldap.openapi.json
+++ b/packages/nextcloud/lib/src/api/user_ldap.openapi.json
@@ -134,20 +134,24 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "showPassword",
-                        "in": "query",
-                        "description": "Whether to show the password",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
-                            ]
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "showPassword": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether to show the password"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "configID",
                         "in": "path",
@@ -247,24 +251,29 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "configData",
-                        "in": "query",
-                        "description": "New config",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "contentMediaType": "application/json",
-                            "contentSchema": {
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
                                 "type": "object",
-                                "description": "New config",
-                                "additionalProperties": {
-                                    "type": "object"
+                                "required": [
+                                    "configData"
+                                ],
+                                "properties": {
+                                    "configData": {
+                                        "type": "object",
+                                        "description": "New config",
+                                        "additionalProperties": {
+                                            "type": "object"
+                                        }
+                                    }
                                 }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "configID",
                         "in": "path",

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -16,18 +16,20 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
+
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/json_object.dart';
 import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart' as _i8;
-import 'package:collection/collection.dart' as _i5;
+import 'package:collection/collection.dart' as _i4;
 import 'package:dynamite_runtime/built_value.dart' as _i7;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i6;
+import 'package:dynamite_runtime/utils.dart' as _i5;
 import 'package:http/http.dart' as _i3;
 import 'package:meta/meta.dart' as _i2;
-import 'package:uri/uri.dart' as _i4;
+import 'package:uri/uri.dart' as _i6;
 
 part 'user_status.openapi.g.dart';
 
@@ -78,7 +80,6 @@ class $HeartbeatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [status] Only online, away.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -92,19 +93,15 @@ class $HeartbeatClient {
   ///  * [$heartbeat_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $heartbeat_Request({
-    required String status,
+    required HeartbeatHeartbeatRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __status = _$jsonSerializers.serialize(status, specifiedType: const FullType(String));
-    _parameters['status'] = __status;
-
-    final _path = _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/heartbeat{?status*}').expand(_parameters);
+    const _path = '/ocs/v2.php/apps/user_status/api/v1/heartbeat';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -122,8 +119,12 @@ class $HeartbeatClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(HeartbeatHeartbeatRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -133,7 +134,6 @@ class $HeartbeatClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [status] Only online, away.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -146,12 +146,12 @@ class $HeartbeatClient {
   ///  * [$heartbeat_Request] for the request send by this method.
   ///  * [$heartbeat_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<HeartbeatHeartbeatResponseApplicationJson, void>> heartbeat({
-    required String status,
+    required HeartbeatHeartbeatRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $heartbeat_Request(
-      status: status,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -200,7 +200,7 @@ class $PredefinedStatusClient {
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -218,7 +218,7 @@ class $PredefinedStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -274,8 +274,6 @@ class $StatusesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [limit] Maximum number of statuses to find.
-  ///   * [offset] Offset for finding statuses.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -286,23 +284,15 @@ class $StatusesClient {
   ///  * [$findAll_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $findAll_Request({
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    StatusesFindAllRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = __limit;
-
-    final __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    _parameters['offset'] = __offset;
-
-    final _path = _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/statuses{?limit*,offset*}').expand(_parameters);
+    const _path = '/ocs/v2.php/apps/user_status/api/v1/statuses';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -320,8 +310,19 @@ class $StatusesClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize($body, specifiedType: const FullType(StatusesFindAllRequestApplicationJson)),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              StatusesFindAllRequestApplicationJson(),
+              specifiedType: const FullType(StatusesFindAllRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -331,8 +332,6 @@ class $StatusesClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [limit] Maximum number of statuses to find.
-  ///   * [offset] Offset for finding statuses.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -342,14 +341,12 @@ class $StatusesClient {
   ///  * [$findAll_Request] for the request send by this method.
   ///  * [$findAll_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<StatusesFindAllResponseApplicationJson, void>> findAll({
-    int? limit,
-    int? offset,
     bool? oCSAPIRequest,
+    StatusesFindAllRequestApplicationJson? $body,
   }) async {
     final _request = $findAll_Request(
-      limit: limit,
-      offset: offset,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -394,12 +391,12 @@ class $StatusesClient {
     final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
     _parameters['userId'] = __userId;
 
-    final _path = _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/statuses/{userId}').expand(_parameters);
+    final _path = _i6.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/statuses/{userId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -417,7 +414,7 @@ class $StatusesClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -494,7 +491,7 @@ class $UserStatusClient {
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -512,7 +509,7 @@ class $UserStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -563,7 +560,6 @@ class $UserStatusClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [statusType] The new status type.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -575,20 +571,15 @@ class $UserStatusClient {
   ///  * [$setStatus_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setStatus_Request({
-    required String statusType,
+    required UserStatusSetStatusRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __statusType = _$jsonSerializers.serialize(statusType, specifiedType: const FullType(String));
-    _parameters['statusType'] = __statusType;
-
-    final _path =
-        _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/status{?statusType*}').expand(_parameters);
+    const _path = '/ocs/v2.php/apps/user_status/api/v1/user_status/status';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -606,8 +597,12 @@ class $UserStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(UserStatusSetStatusRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -617,7 +612,6 @@ class $UserStatusClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [statusType] The new status type.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -628,12 +622,12 @@ class $UserStatusClient {
   ///  * [$setStatus_Request] for the request send by this method.
   ///  * [$setStatus_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UserStatusSetStatusResponseApplicationJson, void>> setStatus({
-    required String statusType,
+    required UserStatusSetStatusRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setStatus_Request(
-      statusType: statusType,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -660,8 +654,6 @@ class $UserStatusClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [messageId] ID of the predefined message.
-  ///   * [clearAt] When the message should be cleared.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -673,25 +665,15 @@ class $UserStatusClient {
   ///  * [$setPredefinedMessage_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setPredefinedMessage_Request({
-    required String messageId,
-    int? clearAt,
+    required UserStatusSetPredefinedMessageRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(String));
-    _parameters['messageId'] = __messageId;
-
-    final __clearAt = _$jsonSerializers.serialize(clearAt, specifiedType: const FullType(int));
-    _parameters['clearAt'] = __clearAt;
-
-    final _path =
-        _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/message/predefined{?messageId*,clearAt*}')
-            .expand(_parameters);
+    const _path = '/ocs/v2.php/apps/user_status/api/v1/user_status/message/predefined';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -709,8 +691,15 @@ class $UserStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(UserStatusSetPredefinedMessageRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -720,8 +709,6 @@ class $UserStatusClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [messageId] ID of the predefined message.
-  ///   * [clearAt] When the message should be cleared.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -732,14 +719,12 @@ class $UserStatusClient {
   ///  * [$setPredefinedMessage_Request] for the request send by this method.
   ///  * [$setPredefinedMessage_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UserStatusSetPredefinedMessageResponseApplicationJson, void>> setPredefinedMessage({
-    required String messageId,
-    int? clearAt,
+    required UserStatusSetPredefinedMessageRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setPredefinedMessage_Request(
-      messageId: messageId,
-      clearAt: clearAt,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -766,9 +751,6 @@ class $UserStatusClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [statusIcon] Icon of the status.
-  ///   * [message] Message of the status.
-  ///   * [clearAt] When the message should be cleared.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -780,29 +762,15 @@ class $UserStatusClient {
   ///  * [$setCustomMessage_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setCustomMessage_Request({
-    String? statusIcon,
-    String? message,
-    int? clearAt,
     bool? oCSAPIRequest,
+    UserStatusSetCustomMessageRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    final __statusIcon = _$jsonSerializers.serialize(statusIcon, specifiedType: const FullType(String));
-    _parameters['statusIcon'] = __statusIcon;
-
-    final __message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
-    _parameters['message'] = __message;
-
-    final __clearAt = _$jsonSerializers.serialize(clearAt, specifiedType: const FullType(int));
-    _parameters['clearAt'] = __clearAt;
-
-    final _path = _i4.UriTemplate(
-      '/ocs/v2.php/apps/user_status/api/v1/user_status/message/custom{?statusIcon*,message*,clearAt*}',
-    ).expand(_parameters);
+    const _path = '/ocs/v2.php/apps/user_status/api/v1/user_status/message/custom';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -820,8 +788,22 @@ class $UserStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(UserStatusSetCustomMessageRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              UserStatusSetCustomMessageRequestApplicationJson(),
+              specifiedType: const FullType(UserStatusSetCustomMessageRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -831,9 +813,6 @@ class $UserStatusClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [statusIcon] Icon of the status.
-  ///   * [message] Message of the status.
-  ///   * [clearAt] When the message should be cleared.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -844,16 +823,12 @@ class $UserStatusClient {
   ///  * [$setCustomMessage_Request] for the request send by this method.
   ///  * [$setCustomMessage_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<UserStatusSetCustomMessageResponseApplicationJson, void>> setCustomMessage({
-    String? statusIcon,
-    String? message,
-    int? clearAt,
     bool? oCSAPIRequest,
+    UserStatusSetCustomMessageRequestApplicationJson? $body,
   }) async {
     final _request = $setCustomMessage_Request(
-      statusIcon: statusIcon,
-      message: message,
-      clearAt: clearAt,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -895,7 +870,7 @@ class $UserStatusClient {
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -913,7 +888,7 @@ class $UserStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -982,12 +957,12 @@ class $UserStatusClient {
     _parameters['messageId'] = __messageId;
 
     final _path =
-        _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/revert/{messageId}').expand(_parameters);
+        _i6.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/revert/{messageId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('delete', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -1005,7 +980,7 @@ class $UserStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -1040,6 +1015,70 @@ class $UserStatusClient {
     final _rawResponse =
         _i1.ResponseConverter<UserStatusRevertStatusResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $HeartbeatHeartbeatRequestApplicationJsonInterface {
+  /// Only online, away.
+  String get status;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$HeartbeatHeartbeatRequestApplicationJsonInterfaceBuilder].
+  $HeartbeatHeartbeatRequestApplicationJsonInterface rebuild(
+    void Function($HeartbeatHeartbeatRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$HeartbeatHeartbeatRequestApplicationJsonInterfaceBuilder].
+  $HeartbeatHeartbeatRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($HeartbeatHeartbeatRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($HeartbeatHeartbeatRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class HeartbeatHeartbeatRequestApplicationJson
+    implements
+        $HeartbeatHeartbeatRequestApplicationJsonInterface,
+        Built<HeartbeatHeartbeatRequestApplicationJson, HeartbeatHeartbeatRequestApplicationJsonBuilder> {
+  /// Creates a new HeartbeatHeartbeatRequestApplicationJson object using the builder pattern.
+  factory HeartbeatHeartbeatRequestApplicationJson([
+    void Function(HeartbeatHeartbeatRequestApplicationJsonBuilder)? b,
+  ]) = _$HeartbeatHeartbeatRequestApplicationJson;
+
+  // coverage:ignore-start
+  const HeartbeatHeartbeatRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory HeartbeatHeartbeatRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for HeartbeatHeartbeatRequestApplicationJson.
+  static Serializer<HeartbeatHeartbeatRequestApplicationJson> get serializer =>
+      _$heartbeatHeartbeatRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(HeartbeatHeartbeatRequestApplicationJsonBuilder b) {
+    $HeartbeatHeartbeatRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(HeartbeatHeartbeatRequestApplicationJsonBuilder b) {
+    $HeartbeatHeartbeatRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -1799,6 +1838,72 @@ abstract class PredefinedStatusFindAllResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $StatusesFindAllRequestApplicationJsonInterface {
+  /// Maximum number of statuses to find.
+  int? get limit;
+
+  /// Offset for finding statuses.
+  int? get offset;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$StatusesFindAllRequestApplicationJsonInterfaceBuilder].
+  $StatusesFindAllRequestApplicationJsonInterface rebuild(
+    void Function($StatusesFindAllRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$StatusesFindAllRequestApplicationJsonInterfaceBuilder].
+  $StatusesFindAllRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($StatusesFindAllRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($StatusesFindAllRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class StatusesFindAllRequestApplicationJson
+    implements
+        $StatusesFindAllRequestApplicationJsonInterface,
+        Built<StatusesFindAllRequestApplicationJson, StatusesFindAllRequestApplicationJsonBuilder> {
+  /// Creates a new StatusesFindAllRequestApplicationJson object using the builder pattern.
+  factory StatusesFindAllRequestApplicationJson([void Function(StatusesFindAllRequestApplicationJsonBuilder)? b]) =
+      _$StatusesFindAllRequestApplicationJson;
+
+  // coverage:ignore-start
+  const StatusesFindAllRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory StatusesFindAllRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for StatusesFindAllRequestApplicationJson.
+  static Serializer<StatusesFindAllRequestApplicationJson> get serializer =>
+      _$statusesFindAllRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(StatusesFindAllRequestApplicationJsonBuilder b) {
+    $StatusesFindAllRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(StatusesFindAllRequestApplicationJsonBuilder b) {
+    $StatusesFindAllRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $StatusesFindAllResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   BuiltList<Public> get data;
@@ -2177,6 +2282,70 @@ abstract class UserStatusGetStatusResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $UserStatusSetStatusRequestApplicationJsonInterface {
+  /// The new status type.
+  String get statusType;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusSetStatusRequestApplicationJsonInterfaceBuilder].
+  $UserStatusSetStatusRequestApplicationJsonInterface rebuild(
+    void Function($UserStatusSetStatusRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusSetStatusRequestApplicationJsonInterfaceBuilder].
+  $UserStatusSetStatusRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusSetStatusRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusSetStatusRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UserStatusSetStatusRequestApplicationJson
+    implements
+        $UserStatusSetStatusRequestApplicationJsonInterface,
+        Built<UserStatusSetStatusRequestApplicationJson, UserStatusSetStatusRequestApplicationJsonBuilder> {
+  /// Creates a new UserStatusSetStatusRequestApplicationJson object using the builder pattern.
+  factory UserStatusSetStatusRequestApplicationJson([
+    void Function(UserStatusSetStatusRequestApplicationJsonBuilder)? b,
+  ]) = _$UserStatusSetStatusRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UserStatusSetStatusRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UserStatusSetStatusRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UserStatusSetStatusRequestApplicationJson.
+  static Serializer<UserStatusSetStatusRequestApplicationJson> get serializer =>
+      _$userStatusSetStatusRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusSetStatusRequestApplicationJsonBuilder b) {
+    $UserStatusSetStatusRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusSetStatusRequestApplicationJsonBuilder b) {
+    $UserStatusSetStatusRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $UserStatusSetStatusResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Private get data;
@@ -2300,6 +2469,74 @@ abstract class UserStatusSetStatusResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(UserStatusSetStatusResponseApplicationJsonBuilder b) {
     $UserStatusSetStatusResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $UserStatusSetPredefinedMessageRequestApplicationJsonInterface {
+  /// ID of the predefined message.
+  String get messageId;
+
+  /// When the message should be cleared.
+  int? get clearAt;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusSetPredefinedMessageRequestApplicationJsonInterfaceBuilder].
+  $UserStatusSetPredefinedMessageRequestApplicationJsonInterface rebuild(
+    void Function($UserStatusSetPredefinedMessageRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusSetPredefinedMessageRequestApplicationJsonInterfaceBuilder].
+  $UserStatusSetPredefinedMessageRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusSetPredefinedMessageRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusSetPredefinedMessageRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UserStatusSetPredefinedMessageRequestApplicationJson
+    implements
+        $UserStatusSetPredefinedMessageRequestApplicationJsonInterface,
+        Built<UserStatusSetPredefinedMessageRequestApplicationJson,
+            UserStatusSetPredefinedMessageRequestApplicationJsonBuilder> {
+  /// Creates a new UserStatusSetPredefinedMessageRequestApplicationJson object using the builder pattern.
+  factory UserStatusSetPredefinedMessageRequestApplicationJson([
+    void Function(UserStatusSetPredefinedMessageRequestApplicationJsonBuilder)? b,
+  ]) = _$UserStatusSetPredefinedMessageRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UserStatusSetPredefinedMessageRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UserStatusSetPredefinedMessageRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UserStatusSetPredefinedMessageRequestApplicationJson.
+  static Serializer<UserStatusSetPredefinedMessageRequestApplicationJson> get serializer =>
+      _$userStatusSetPredefinedMessageRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusSetPredefinedMessageRequestApplicationJsonBuilder b) {
+    $UserStatusSetPredefinedMessageRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusSetPredefinedMessageRequestApplicationJsonBuilder b) {
+    $UserStatusSetPredefinedMessageRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -2429,6 +2666,77 @@ abstract class UserStatusSetPredefinedMessageResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(UserStatusSetPredefinedMessageResponseApplicationJsonBuilder b) {
     $UserStatusSetPredefinedMessageResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $UserStatusSetCustomMessageRequestApplicationJsonInterface {
+  /// Icon of the status.
+  String? get statusIcon;
+
+  /// Message of the status.
+  String? get message;
+
+  /// When the message should be cleared.
+  int? get clearAt;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$UserStatusSetCustomMessageRequestApplicationJsonInterfaceBuilder].
+  $UserStatusSetCustomMessageRequestApplicationJsonInterface rebuild(
+    void Function($UserStatusSetCustomMessageRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$UserStatusSetCustomMessageRequestApplicationJsonInterfaceBuilder].
+  $UserStatusSetCustomMessageRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($UserStatusSetCustomMessageRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($UserStatusSetCustomMessageRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class UserStatusSetCustomMessageRequestApplicationJson
+    implements
+        $UserStatusSetCustomMessageRequestApplicationJsonInterface,
+        Built<UserStatusSetCustomMessageRequestApplicationJson,
+            UserStatusSetCustomMessageRequestApplicationJsonBuilder> {
+  /// Creates a new UserStatusSetCustomMessageRequestApplicationJson object using the builder pattern.
+  factory UserStatusSetCustomMessageRequestApplicationJson([
+    void Function(UserStatusSetCustomMessageRequestApplicationJsonBuilder)? b,
+  ]) = _$UserStatusSetCustomMessageRequestApplicationJson;
+
+  // coverage:ignore-start
+  const UserStatusSetCustomMessageRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory UserStatusSetCustomMessageRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for UserStatusSetCustomMessageRequestApplicationJson.
+  static Serializer<UserStatusSetCustomMessageRequestApplicationJson> get serializer =>
+      _$userStatusSetCustomMessageRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(UserStatusSetCustomMessageRequestApplicationJsonBuilder b) {
+    $UserStatusSetCustomMessageRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(UserStatusSetCustomMessageRequestApplicationJsonBuilder b) {
+    $UserStatusSetCustomMessageRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -2971,13 +3279,13 @@ extension $557344b3ba734aacc7109e5420fcb6c5Extension on _$557344b3ba734aacc7109e
   List<String> get _names => const ['clearAtTimeType', r'$int'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i6.validateOneOf(
+  void validateOneOf() => _i5.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i6.validateAnyOf(
+  void validateAnyOf() => _i5.validateAnyOf(
         _values,
         _names,
       );
@@ -3053,13 +3361,13 @@ extension $d77829de8b7590d2e16cdb714800f5beExtension on _$d77829de8b7590d2e16cdb
   List<String> get _names => const ['builtListNever', 'private'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i6.validateOneOf(
+  void validateOneOf() => _i5.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i6.validateAnyOf(
+  void validateAnyOf() => _i5.validateAnyOf(
         _values,
         _names,
       );
@@ -3135,6 +3443,11 @@ class _$d77829de8b7590d2e16cdb714800f5beSerializer implements PrimitiveSerialize
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
+        const FullType(HeartbeatHeartbeatRequestApplicationJson),
+        HeartbeatHeartbeatRequestApplicationJsonBuilder.new,
+      )
+      ..add(HeartbeatHeartbeatRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(HeartbeatHeartbeatResponseApplicationJson),
         HeartbeatHeartbeatResponseApplicationJsonBuilder.new,
       )
@@ -3170,6 +3483,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add($557344b3ba734aacc7109e5420fcb6c5Extension._serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(Predefined)]), ListBuilder<Predefined>.new)
       ..addBuilderFactory(
+        const FullType(StatusesFindAllRequestApplicationJson),
+        StatusesFindAllRequestApplicationJsonBuilder.new,
+      )
+      ..add(StatusesFindAllRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(StatusesFindAllResponseApplicationJson),
         StatusesFindAllResponseApplicationJsonBuilder.new,
       )
@@ -3201,6 +3519,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(UserStatusGetStatusResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(
+        const FullType(UserStatusSetStatusRequestApplicationJson),
+        UserStatusSetStatusRequestApplicationJsonBuilder.new,
+      )
+      ..add(UserStatusSetStatusRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(UserStatusSetStatusResponseApplicationJson),
         UserStatusSetStatusResponseApplicationJsonBuilder.new,
       )
@@ -3211,6 +3534,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       )
       ..add(UserStatusSetStatusResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(
+        const FullType(UserStatusSetPredefinedMessageRequestApplicationJson),
+        UserStatusSetPredefinedMessageRequestApplicationJsonBuilder.new,
+      )
+      ..add(UserStatusSetPredefinedMessageRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(UserStatusSetPredefinedMessageResponseApplicationJson),
         UserStatusSetPredefinedMessageResponseApplicationJsonBuilder.new,
       )
@@ -3220,6 +3548,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
         UserStatusSetPredefinedMessageResponseApplicationJson_OcsBuilder.new,
       )
       ..add(UserStatusSetPredefinedMessageResponseApplicationJson_Ocs.serializer)
+      ..addBuilderFactory(
+        const FullType(UserStatusSetCustomMessageRequestApplicationJson),
+        UserStatusSetCustomMessageRequestApplicationJsonBuilder.new,
+      )
+      ..add(UserStatusSetCustomMessageRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(UserStatusSetCustomMessageResponseApplicationJson),
         UserStatusSetCustomMessageResponseApplicationJsonBuilder.new,

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -96,8 +96,8 @@ class $HeartbeatClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $status = _$jsonSerializers.serialize(status, specifiedType: const FullType(String));
-    _parameters['status'] = $status;
+    final __status = _$jsonSerializers.serialize(status, specifiedType: const FullType(String));
+    _parameters['status'] = __status;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/heartbeat{?status*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -120,9 +120,9 @@ class $HeartbeatClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -216,9 +216,9 @@ class $PredefinedStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -291,11 +291,11 @@ class $StatusesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
-    _parameters['limit'] = $limit;
+    final __limit = _$jsonSerializers.serialize(limit, specifiedType: const FullType(int));
+    _parameters['limit'] = __limit;
 
-    final $offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
-    _parameters['offset'] = $offset;
+    final __offset = _$jsonSerializers.serialize(offset, specifiedType: const FullType(int));
+    _parameters['offset'] = __offset;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/statuses{?limit*,offset*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -318,9 +318,9 @@ class $StatusesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -391,8 +391,8 @@ class $StatusesClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
-    _parameters['userId'] = $userId;
+    final __userId = _$jsonSerializers.serialize(userId, specifiedType: const FullType(String));
+    _parameters['userId'] = __userId;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/statuses/{userId}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -415,9 +415,9 @@ class $StatusesClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -510,9 +510,9 @@ class $UserStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -579,8 +579,8 @@ class $UserStatusClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $statusType = _$jsonSerializers.serialize(statusType, specifiedType: const FullType(String));
-    _parameters['statusType'] = $statusType;
+    final __statusType = _$jsonSerializers.serialize(statusType, specifiedType: const FullType(String));
+    _parameters['statusType'] = __statusType;
 
     final _path =
         _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/status{?statusType*}').expand(_parameters);
@@ -604,9 +604,9 @@ class $UserStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -678,11 +678,11 @@ class $UserStatusClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(String));
-    _parameters['messageId'] = $messageId;
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(String));
+    _parameters['messageId'] = __messageId;
 
-    final $clearAt = _$jsonSerializers.serialize(clearAt, specifiedType: const FullType(int));
-    _parameters['clearAt'] = $clearAt;
+    final __clearAt = _$jsonSerializers.serialize(clearAt, specifiedType: const FullType(int));
+    _parameters['clearAt'] = __clearAt;
 
     final _path =
         _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/message/predefined{?messageId*,clearAt*}')
@@ -707,9 +707,9 @@ class $UserStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -786,14 +786,14 @@ class $UserStatusClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $statusIcon = _$jsonSerializers.serialize(statusIcon, specifiedType: const FullType(String));
-    _parameters['statusIcon'] = $statusIcon;
+    final __statusIcon = _$jsonSerializers.serialize(statusIcon, specifiedType: const FullType(String));
+    _parameters['statusIcon'] = __statusIcon;
 
-    final $message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
-    _parameters['message'] = $message;
+    final __message = _$jsonSerializers.serialize(message, specifiedType: const FullType(String));
+    _parameters['message'] = __message;
 
-    final $clearAt = _$jsonSerializers.serialize(clearAt, specifiedType: const FullType(int));
-    _parameters['clearAt'] = $clearAt;
+    final __clearAt = _$jsonSerializers.serialize(clearAt, specifiedType: const FullType(int));
+    _parameters['clearAt'] = __clearAt;
 
     final _path = _i4.UriTemplate(
       '/ocs/v2.php/apps/user_status/api/v1/user_status/message/custom{?statusIcon*,message*,clearAt*}',
@@ -818,9 +818,9 @@ class $UserStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -911,9 +911,9 @@ class $UserStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -978,8 +978,8 @@ class $UserStatusClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(String));
-    _parameters['messageId'] = $messageId;
+    final __messageId = _$jsonSerializers.serialize(messageId, specifiedType: const FullType(String));
+    _parameters['messageId'] = __messageId;
 
     final _path =
         _i4.UriTemplate('/ocs/v2.php/apps/user_status/api/v1/user_status/revert/{messageId}').expand(_parameters);
@@ -1003,9 +1003,9 @@ class $UserStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/user_status.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.g.dart
@@ -79,6 +79,8 @@ final BuiltSet<ClearAtTimeType> _$clearAtTimeTypeValues = BuiltSet<ClearAtTimeTy
   _$clearAtTimeTypeWeek,
 ]);
 
+Serializer<HeartbeatHeartbeatRequestApplicationJson> _$heartbeatHeartbeatRequestApplicationJsonSerializer =
+    _$HeartbeatHeartbeatRequestApplicationJsonSerializer();
 Serializer<OCSMeta> _$oCSMetaSerializer = _$OCSMetaSerializer();
 Serializer<Public> _$publicSerializer = _$PublicSerializer();
 Serializer<Private> _$privateSerializer = _$PrivateSerializer();
@@ -93,6 +95,8 @@ Serializer<PredefinedStatusFindAllResponseApplicationJson_Ocs>
     _$PredefinedStatusFindAllResponseApplicationJson_OcsSerializer();
 Serializer<PredefinedStatusFindAllResponseApplicationJson> _$predefinedStatusFindAllResponseApplicationJsonSerializer =
     _$PredefinedStatusFindAllResponseApplicationJsonSerializer();
+Serializer<StatusesFindAllRequestApplicationJson> _$statusesFindAllRequestApplicationJsonSerializer =
+    _$StatusesFindAllRequestApplicationJsonSerializer();
 Serializer<StatusesFindAllResponseApplicationJson_Ocs> _$statusesFindAllResponseApplicationJsonOcsSerializer =
     _$StatusesFindAllResponseApplicationJson_OcsSerializer();
 Serializer<StatusesFindAllResponseApplicationJson> _$statusesFindAllResponseApplicationJsonSerializer =
@@ -105,16 +109,24 @@ Serializer<UserStatusGetStatusResponseApplicationJson_Ocs> _$userStatusGetStatus
     _$UserStatusGetStatusResponseApplicationJson_OcsSerializer();
 Serializer<UserStatusGetStatusResponseApplicationJson> _$userStatusGetStatusResponseApplicationJsonSerializer =
     _$UserStatusGetStatusResponseApplicationJsonSerializer();
+Serializer<UserStatusSetStatusRequestApplicationJson> _$userStatusSetStatusRequestApplicationJsonSerializer =
+    _$UserStatusSetStatusRequestApplicationJsonSerializer();
 Serializer<UserStatusSetStatusResponseApplicationJson_Ocs> _$userStatusSetStatusResponseApplicationJsonOcsSerializer =
     _$UserStatusSetStatusResponseApplicationJson_OcsSerializer();
 Serializer<UserStatusSetStatusResponseApplicationJson> _$userStatusSetStatusResponseApplicationJsonSerializer =
     _$UserStatusSetStatusResponseApplicationJsonSerializer();
+Serializer<UserStatusSetPredefinedMessageRequestApplicationJson>
+    _$userStatusSetPredefinedMessageRequestApplicationJsonSerializer =
+    _$UserStatusSetPredefinedMessageRequestApplicationJsonSerializer();
 Serializer<UserStatusSetPredefinedMessageResponseApplicationJson_Ocs>
     _$userStatusSetPredefinedMessageResponseApplicationJsonOcsSerializer =
     _$UserStatusSetPredefinedMessageResponseApplicationJson_OcsSerializer();
 Serializer<UserStatusSetPredefinedMessageResponseApplicationJson>
     _$userStatusSetPredefinedMessageResponseApplicationJsonSerializer =
     _$UserStatusSetPredefinedMessageResponseApplicationJsonSerializer();
+Serializer<UserStatusSetCustomMessageRequestApplicationJson>
+    _$userStatusSetCustomMessageRequestApplicationJsonSerializer =
+    _$UserStatusSetCustomMessageRequestApplicationJsonSerializer();
 Serializer<UserStatusSetCustomMessageResponseApplicationJson_Ocs>
     _$userStatusSetCustomMessageResponseApplicationJsonOcsSerializer =
     _$UserStatusSetCustomMessageResponseApplicationJson_OcsSerializer();
@@ -133,6 +145,48 @@ Serializer<UserStatusRevertStatusResponseApplicationJson> _$userStatusRevertStat
     _$UserStatusRevertStatusResponseApplicationJsonSerializer();
 Serializer<Capabilities_UserStatus> _$capabilitiesUserStatusSerializer = _$Capabilities_UserStatusSerializer();
 Serializer<Capabilities> _$capabilitiesSerializer = _$CapabilitiesSerializer();
+
+class _$HeartbeatHeartbeatRequestApplicationJsonSerializer
+    implements StructuredSerializer<HeartbeatHeartbeatRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    HeartbeatHeartbeatRequestApplicationJson,
+    _$HeartbeatHeartbeatRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'HeartbeatHeartbeatRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, HeartbeatHeartbeatRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'status',
+      serializers.serialize(object.status, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  HeartbeatHeartbeatRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = HeartbeatHeartbeatRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'status':
+          result.status = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
 
 class _$OCSMetaSerializer implements StructuredSerializer<OCSMeta> {
   @override
@@ -655,6 +709,57 @@ class _$PredefinedStatusFindAllResponseApplicationJsonSerializer
   }
 }
 
+class _$StatusesFindAllRequestApplicationJsonSerializer
+    implements StructuredSerializer<StatusesFindAllRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [StatusesFindAllRequestApplicationJson, _$StatusesFindAllRequestApplicationJson];
+  @override
+  final String wireName = 'StatusesFindAllRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, StatusesFindAllRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.limit;
+    if (value != null) {
+      result
+        ..add('limit')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.offset;
+    if (value != null) {
+      result
+        ..add('offset')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  StatusesFindAllRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = StatusesFindAllRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'limit':
+          result.limit = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'offset':
+          result.offset = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$StatusesFindAllResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<StatusesFindAllResponseApplicationJson_Ocs> {
   @override
@@ -923,6 +1028,48 @@ class _$UserStatusGetStatusResponseApplicationJsonSerializer
   }
 }
 
+class _$UserStatusSetStatusRequestApplicationJsonSerializer
+    implements StructuredSerializer<UserStatusSetStatusRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    UserStatusSetStatusRequestApplicationJson,
+    _$UserStatusSetStatusRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'UserStatusSetStatusRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UserStatusSetStatusRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'statusType',
+      serializers.serialize(object.statusType, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  UserStatusSetStatusRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UserStatusSetStatusRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'statusType':
+          result.statusType = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$UserStatusSetStatusResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<UserStatusSetStatusResponseApplicationJson_Ocs> {
   @override
@@ -1006,6 +1153,58 @@ class _$UserStatusSetStatusResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(UserStatusSetStatusResponseApplicationJson_Ocs))!
               as UserStatusSetStatusResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UserStatusSetPredefinedMessageRequestApplicationJsonSerializer
+    implements StructuredSerializer<UserStatusSetPredefinedMessageRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    UserStatusSetPredefinedMessageRequestApplicationJson,
+    _$UserStatusSetPredefinedMessageRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'UserStatusSetPredefinedMessageRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UserStatusSetPredefinedMessageRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'messageId',
+      serializers.serialize(object.messageId, specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.clearAt;
+    if (value != null) {
+      result
+        ..add('clearAt')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  UserStatusSetPredefinedMessageRequestApplicationJson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UserStatusSetPredefinedMessageRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'messageId':
+          result.messageId = serializers.deserialize(value, specifiedType: const FullType(String))! as String;
+          break;
+        case 'clearAt':
+          result.clearAt = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
           break;
       }
     }
@@ -1100,6 +1299,69 @@ class _$UserStatusSetPredefinedMessageResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(UserStatusSetPredefinedMessageResponseApplicationJson_Ocs))!
               as UserStatusSetPredefinedMessageResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UserStatusSetCustomMessageRequestApplicationJsonSerializer
+    implements StructuredSerializer<UserStatusSetCustomMessageRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    UserStatusSetCustomMessageRequestApplicationJson,
+    _$UserStatusSetCustomMessageRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'UserStatusSetCustomMessageRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UserStatusSetCustomMessageRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.statusIcon;
+    if (value != null) {
+      result
+        ..add('statusIcon')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.message;
+    if (value != null) {
+      result
+        ..add('message')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.clearAt;
+    if (value != null) {
+      result
+        ..add('clearAt')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  UserStatusSetCustomMessageRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = UserStatusSetCustomMessageRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'statusIcon':
+          result.statusIcon = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'message':
+          result.message = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'clearAt':
+          result.clearAt = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
           break;
       }
     }
@@ -1472,6 +1734,102 @@ class _$CapabilitiesSerializer implements StructuredSerializer<Capabilities> {
     }
 
     return result.build();
+  }
+}
+
+abstract mixin class $HeartbeatHeartbeatRequestApplicationJsonInterfaceBuilder {
+  void replace($HeartbeatHeartbeatRequestApplicationJsonInterface other);
+  void update(void Function($HeartbeatHeartbeatRequestApplicationJsonInterfaceBuilder) updates);
+  String? get status;
+  set status(String? status);
+}
+
+class _$HeartbeatHeartbeatRequestApplicationJson extends HeartbeatHeartbeatRequestApplicationJson {
+  @override
+  final String status;
+
+  factory _$HeartbeatHeartbeatRequestApplicationJson(
+          [void Function(HeartbeatHeartbeatRequestApplicationJsonBuilder)? updates]) =>
+      (HeartbeatHeartbeatRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$HeartbeatHeartbeatRequestApplicationJson._({required this.status}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(status, r'HeartbeatHeartbeatRequestApplicationJson', 'status');
+  }
+
+  @override
+  HeartbeatHeartbeatRequestApplicationJson rebuild(
+          void Function(HeartbeatHeartbeatRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  HeartbeatHeartbeatRequestApplicationJsonBuilder toBuilder() =>
+      HeartbeatHeartbeatRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is HeartbeatHeartbeatRequestApplicationJson && status == other.status;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, status.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'HeartbeatHeartbeatRequestApplicationJson')..add('status', status)).toString();
+  }
+}
+
+class HeartbeatHeartbeatRequestApplicationJsonBuilder
+    implements
+        Builder<HeartbeatHeartbeatRequestApplicationJson, HeartbeatHeartbeatRequestApplicationJsonBuilder>,
+        $HeartbeatHeartbeatRequestApplicationJsonInterfaceBuilder {
+  _$HeartbeatHeartbeatRequestApplicationJson? _$v;
+
+  String? _status;
+  String? get status => _$this._status;
+  set status(covariant String? status) => _$this._status = status;
+
+  HeartbeatHeartbeatRequestApplicationJsonBuilder() {
+    HeartbeatHeartbeatRequestApplicationJson._defaults(this);
+  }
+
+  HeartbeatHeartbeatRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _status = $v.status;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant HeartbeatHeartbeatRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$HeartbeatHeartbeatRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(HeartbeatHeartbeatRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  HeartbeatHeartbeatRequestApplicationJson build() => _build();
+
+  _$HeartbeatHeartbeatRequestApplicationJson _build() {
+    HeartbeatHeartbeatRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$HeartbeatHeartbeatRequestApplicationJson._(
+            status:
+                BuiltValueNullFieldError.checkNotNull(status, r'HeartbeatHeartbeatRequestApplicationJson', 'status'));
+    replace(_$result);
+    return _$result;
   }
 }
 
@@ -2696,6 +3054,110 @@ class PredefinedStatusFindAllResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $StatusesFindAllRequestApplicationJsonInterfaceBuilder {
+  void replace($StatusesFindAllRequestApplicationJsonInterface other);
+  void update(void Function($StatusesFindAllRequestApplicationJsonInterfaceBuilder) updates);
+  int? get limit;
+  set limit(int? limit);
+
+  int? get offset;
+  set offset(int? offset);
+}
+
+class _$StatusesFindAllRequestApplicationJson extends StatusesFindAllRequestApplicationJson {
+  @override
+  final int? limit;
+  @override
+  final int? offset;
+
+  factory _$StatusesFindAllRequestApplicationJson(
+          [void Function(StatusesFindAllRequestApplicationJsonBuilder)? updates]) =>
+      (StatusesFindAllRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$StatusesFindAllRequestApplicationJson._({this.limit, this.offset}) : super._();
+
+  @override
+  StatusesFindAllRequestApplicationJson rebuild(void Function(StatusesFindAllRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  StatusesFindAllRequestApplicationJsonBuilder toBuilder() =>
+      StatusesFindAllRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is StatusesFindAllRequestApplicationJson && limit == other.limit && offset == other.offset;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, limit.hashCode);
+    _$hash = $jc(_$hash, offset.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'StatusesFindAllRequestApplicationJson')
+          ..add('limit', limit)
+          ..add('offset', offset))
+        .toString();
+  }
+}
+
+class StatusesFindAllRequestApplicationJsonBuilder
+    implements
+        Builder<StatusesFindAllRequestApplicationJson, StatusesFindAllRequestApplicationJsonBuilder>,
+        $StatusesFindAllRequestApplicationJsonInterfaceBuilder {
+  _$StatusesFindAllRequestApplicationJson? _$v;
+
+  int? _limit;
+  int? get limit => _$this._limit;
+  set limit(covariant int? limit) => _$this._limit = limit;
+
+  int? _offset;
+  int? get offset => _$this._offset;
+  set offset(covariant int? offset) => _$this._offset = offset;
+
+  StatusesFindAllRequestApplicationJsonBuilder() {
+    StatusesFindAllRequestApplicationJson._defaults(this);
+  }
+
+  StatusesFindAllRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _limit = $v.limit;
+      _offset = $v.offset;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant StatusesFindAllRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$StatusesFindAllRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(StatusesFindAllRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  StatusesFindAllRequestApplicationJson build() => _build();
+
+  _$StatusesFindAllRequestApplicationJson _build() {
+    StatusesFindAllRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$StatusesFindAllRequestApplicationJson._(limit: limit, offset: offset);
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $StatusesFindAllResponseApplicationJson_OcsInterfaceBuilder {
   void replace($StatusesFindAllResponseApplicationJson_OcsInterface other);
   void update(void Function($StatusesFindAllResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -3378,6 +3840,103 @@ class UserStatusGetStatusResponseApplicationJsonBuilder
   }
 }
 
+abstract mixin class $UserStatusSetStatusRequestApplicationJsonInterfaceBuilder {
+  void replace($UserStatusSetStatusRequestApplicationJsonInterface other);
+  void update(void Function($UserStatusSetStatusRequestApplicationJsonInterfaceBuilder) updates);
+  String? get statusType;
+  set statusType(String? statusType);
+}
+
+class _$UserStatusSetStatusRequestApplicationJson extends UserStatusSetStatusRequestApplicationJson {
+  @override
+  final String statusType;
+
+  factory _$UserStatusSetStatusRequestApplicationJson(
+          [void Function(UserStatusSetStatusRequestApplicationJsonBuilder)? updates]) =>
+      (UserStatusSetStatusRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UserStatusSetStatusRequestApplicationJson._({required this.statusType}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(statusType, r'UserStatusSetStatusRequestApplicationJson', 'statusType');
+  }
+
+  @override
+  UserStatusSetStatusRequestApplicationJson rebuild(
+          void Function(UserStatusSetStatusRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UserStatusSetStatusRequestApplicationJsonBuilder toBuilder() =>
+      UserStatusSetStatusRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UserStatusSetStatusRequestApplicationJson && statusType == other.statusType;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, statusType.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UserStatusSetStatusRequestApplicationJson')..add('statusType', statusType))
+        .toString();
+  }
+}
+
+class UserStatusSetStatusRequestApplicationJsonBuilder
+    implements
+        Builder<UserStatusSetStatusRequestApplicationJson, UserStatusSetStatusRequestApplicationJsonBuilder>,
+        $UserStatusSetStatusRequestApplicationJsonInterfaceBuilder {
+  _$UserStatusSetStatusRequestApplicationJson? _$v;
+
+  String? _statusType;
+  String? get statusType => _$this._statusType;
+  set statusType(covariant String? statusType) => _$this._statusType = statusType;
+
+  UserStatusSetStatusRequestApplicationJsonBuilder() {
+    UserStatusSetStatusRequestApplicationJson._defaults(this);
+  }
+
+  UserStatusSetStatusRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _statusType = $v.statusType;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UserStatusSetStatusRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UserStatusSetStatusRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UserStatusSetStatusRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UserStatusSetStatusRequestApplicationJson build() => _build();
+
+  _$UserStatusSetStatusRequestApplicationJson _build() {
+    UserStatusSetStatusRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UserStatusSetStatusRequestApplicationJson._(
+            statusType: BuiltValueNullFieldError.checkNotNull(
+                statusType, r'UserStatusSetStatusRequestApplicationJson', 'statusType'));
+    replace(_$result);
+    return _$result;
+  }
+}
+
 abstract mixin class $UserStatusSetStatusResponseApplicationJson_OcsInterfaceBuilder {
   void replace($UserStatusSetStatusResponseApplicationJson_OcsInterface other);
   void update(void Function($UserStatusSetStatusResponseApplicationJson_OcsInterfaceBuilder) updates);
@@ -3602,6 +4161,122 @@ class UserStatusSetStatusResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $UserStatusSetPredefinedMessageRequestApplicationJsonInterfaceBuilder {
+  void replace($UserStatusSetPredefinedMessageRequestApplicationJsonInterface other);
+  void update(void Function($UserStatusSetPredefinedMessageRequestApplicationJsonInterfaceBuilder) updates);
+  String? get messageId;
+  set messageId(String? messageId);
+
+  int? get clearAt;
+  set clearAt(int? clearAt);
+}
+
+class _$UserStatusSetPredefinedMessageRequestApplicationJson
+    extends UserStatusSetPredefinedMessageRequestApplicationJson {
+  @override
+  final String messageId;
+  @override
+  final int? clearAt;
+
+  factory _$UserStatusSetPredefinedMessageRequestApplicationJson(
+          [void Function(UserStatusSetPredefinedMessageRequestApplicationJsonBuilder)? updates]) =>
+      (UserStatusSetPredefinedMessageRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UserStatusSetPredefinedMessageRequestApplicationJson._({required this.messageId, this.clearAt}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        messageId, r'UserStatusSetPredefinedMessageRequestApplicationJson', 'messageId');
+  }
+
+  @override
+  UserStatusSetPredefinedMessageRequestApplicationJson rebuild(
+          void Function(UserStatusSetPredefinedMessageRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UserStatusSetPredefinedMessageRequestApplicationJsonBuilder toBuilder() =>
+      UserStatusSetPredefinedMessageRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UserStatusSetPredefinedMessageRequestApplicationJson &&
+        messageId == other.messageId &&
+        clearAt == other.clearAt;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, messageId.hashCode);
+    _$hash = $jc(_$hash, clearAt.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UserStatusSetPredefinedMessageRequestApplicationJson')
+          ..add('messageId', messageId)
+          ..add('clearAt', clearAt))
+        .toString();
+  }
+}
+
+class UserStatusSetPredefinedMessageRequestApplicationJsonBuilder
+    implements
+        Builder<UserStatusSetPredefinedMessageRequestApplicationJson,
+            UserStatusSetPredefinedMessageRequestApplicationJsonBuilder>,
+        $UserStatusSetPredefinedMessageRequestApplicationJsonInterfaceBuilder {
+  _$UserStatusSetPredefinedMessageRequestApplicationJson? _$v;
+
+  String? _messageId;
+  String? get messageId => _$this._messageId;
+  set messageId(covariant String? messageId) => _$this._messageId = messageId;
+
+  int? _clearAt;
+  int? get clearAt => _$this._clearAt;
+  set clearAt(covariant int? clearAt) => _$this._clearAt = clearAt;
+
+  UserStatusSetPredefinedMessageRequestApplicationJsonBuilder() {
+    UserStatusSetPredefinedMessageRequestApplicationJson._defaults(this);
+  }
+
+  UserStatusSetPredefinedMessageRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _messageId = $v.messageId;
+      _clearAt = $v.clearAt;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UserStatusSetPredefinedMessageRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UserStatusSetPredefinedMessageRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UserStatusSetPredefinedMessageRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UserStatusSetPredefinedMessageRequestApplicationJson build() => _build();
+
+  _$UserStatusSetPredefinedMessageRequestApplicationJson _build() {
+    UserStatusSetPredefinedMessageRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UserStatusSetPredefinedMessageRequestApplicationJson._(
+            messageId: BuiltValueNullFieldError.checkNotNull(
+                messageId, r'UserStatusSetPredefinedMessageRequestApplicationJson', 'messageId'),
+            clearAt: clearAt);
     replace(_$result);
     return _$result;
   }
@@ -3840,6 +4515,129 @@ class UserStatusSetPredefinedMessageResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $UserStatusSetCustomMessageRequestApplicationJsonInterfaceBuilder {
+  void replace($UserStatusSetCustomMessageRequestApplicationJsonInterface other);
+  void update(void Function($UserStatusSetCustomMessageRequestApplicationJsonInterfaceBuilder) updates);
+  String? get statusIcon;
+  set statusIcon(String? statusIcon);
+
+  String? get message;
+  set message(String? message);
+
+  int? get clearAt;
+  set clearAt(int? clearAt);
+}
+
+class _$UserStatusSetCustomMessageRequestApplicationJson extends UserStatusSetCustomMessageRequestApplicationJson {
+  @override
+  final String? statusIcon;
+  @override
+  final String? message;
+  @override
+  final int? clearAt;
+
+  factory _$UserStatusSetCustomMessageRequestApplicationJson(
+          [void Function(UserStatusSetCustomMessageRequestApplicationJsonBuilder)? updates]) =>
+      (UserStatusSetCustomMessageRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$UserStatusSetCustomMessageRequestApplicationJson._({this.statusIcon, this.message, this.clearAt}) : super._();
+
+  @override
+  UserStatusSetCustomMessageRequestApplicationJson rebuild(
+          void Function(UserStatusSetCustomMessageRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UserStatusSetCustomMessageRequestApplicationJsonBuilder toBuilder() =>
+      UserStatusSetCustomMessageRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UserStatusSetCustomMessageRequestApplicationJson &&
+        statusIcon == other.statusIcon &&
+        message == other.message &&
+        clearAt == other.clearAt;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, statusIcon.hashCode);
+    _$hash = $jc(_$hash, message.hashCode);
+    _$hash = $jc(_$hash, clearAt.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UserStatusSetCustomMessageRequestApplicationJson')
+          ..add('statusIcon', statusIcon)
+          ..add('message', message)
+          ..add('clearAt', clearAt))
+        .toString();
+  }
+}
+
+class UserStatusSetCustomMessageRequestApplicationJsonBuilder
+    implements
+        Builder<UserStatusSetCustomMessageRequestApplicationJson,
+            UserStatusSetCustomMessageRequestApplicationJsonBuilder>,
+        $UserStatusSetCustomMessageRequestApplicationJsonInterfaceBuilder {
+  _$UserStatusSetCustomMessageRequestApplicationJson? _$v;
+
+  String? _statusIcon;
+  String? get statusIcon => _$this._statusIcon;
+  set statusIcon(covariant String? statusIcon) => _$this._statusIcon = statusIcon;
+
+  String? _message;
+  String? get message => _$this._message;
+  set message(covariant String? message) => _$this._message = message;
+
+  int? _clearAt;
+  int? get clearAt => _$this._clearAt;
+  set clearAt(covariant int? clearAt) => _$this._clearAt = clearAt;
+
+  UserStatusSetCustomMessageRequestApplicationJsonBuilder() {
+    UserStatusSetCustomMessageRequestApplicationJson._defaults(this);
+  }
+
+  UserStatusSetCustomMessageRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _statusIcon = $v.statusIcon;
+      _message = $v.message;
+      _clearAt = $v.clearAt;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant UserStatusSetCustomMessageRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UserStatusSetCustomMessageRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(UserStatusSetCustomMessageRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UserStatusSetCustomMessageRequestApplicationJson build() => _build();
+
+  _$UserStatusSetCustomMessageRequestApplicationJson _build() {
+    UserStatusSetCustomMessageRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$UserStatusSetCustomMessageRequestApplicationJson._(
+            statusIcon: statusIcon, message: message, clearAt: clearAt);
     replace(_$result);
     return _$result;
   }

--- a/packages/nextcloud/lib/src/api/user_status.openapi.json
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.json
@@ -222,16 +222,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "status",
-                        "in": "query",
-                        "description": "Only online, away",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "status"
+                                ],
+                                "properties": {
+                                    "status": {
+                                        "type": "string",
+                                        "description": "Only online, away"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -415,27 +425,31 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "limit": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Maximum number of statuses to find"
+                                    },
+                                    "offset": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "Offset for finding statuses"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "description": "Maximum number of statuses to find",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "offset",
-                        "in": "query",
-                        "description": "Offset for finding statuses",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -686,16 +700,26 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "statusType",
-                        "in": "query",
-                        "description": "The new status type",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "statusType"
+                                ],
+                                "properties": {
+                                    "statusType": {
+                                        "type": "string",
+                                        "description": "The new status type"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -784,26 +808,32 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "messageId"
+                                ],
+                                "properties": {
+                                    "messageId": {
+                                        "type": "string",
+                                        "description": "ID of the predefined message"
+                                    },
+                                    "clearAt": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "When the message should be cleared"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "messageId",
-                        "in": "query",
-                        "description": "ID of the predefined message",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "clearAt",
-                        "in": "query",
-                        "description": "When the message should be cleared",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -892,35 +922,35 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "statusIcon": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Icon of the status"
+                                    },
+                                    "message": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Message of the status"
+                                    },
+                                    "clearAt": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "nullable": true,
+                                        "description": "When the message should be cleared"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "statusIcon",
-                        "in": "query",
-                        "description": "Icon of the status",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "message",
-                        "in": "query",
-                        "description": "Message of the status",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "clearAt",
-                        "in": "query",
-                        "description": "When the message should be cleared",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64",
-                            "nullable": true
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.dart
@@ -86,8 +86,8 @@ class $WeatherStatusClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $mode = _$jsonSerializers.serialize(mode, specifiedType: const FullType(int));
-    _parameters['mode'] = $mode;
+    final __mode = _$jsonSerializers.serialize(mode, specifiedType: const FullType(int));
+    _parameters['mode'] = __mode;
 
     final _path = _i4.UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/mode{?mode*}').expand(_parameters);
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
@@ -110,9 +110,9 @@ class $WeatherStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -196,9 +196,9 @@ class $WeatherStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -280,9 +280,9 @@ class $WeatherStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -351,14 +351,14 @@ class $WeatherStatusClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $address = _$jsonSerializers.serialize(address, specifiedType: const FullType(String));
-    _parameters['address'] = $address;
+    final __address = _$jsonSerializers.serialize(address, specifiedType: const FullType(String));
+    _parameters['address'] = __address;
 
-    final $lat = _$jsonSerializers.serialize(lat, specifiedType: const FullType(double));
-    _parameters['lat'] = $lat;
+    final __lat = _$jsonSerializers.serialize(lat, specifiedType: const FullType(double));
+    _parameters['lat'] = __lat;
 
-    final $lon = _$jsonSerializers.serialize(lon, specifiedType: const FullType(double));
-    _parameters['lon'] = $lon;
+    final __lon = _$jsonSerializers.serialize(lon, specifiedType: const FullType(double));
+    _parameters['lon'] = __lon;
 
     final _path =
         _i4.UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/location{?address*,lat*,lon*}').expand(_parameters);
@@ -382,9 +382,9 @@ class $WeatherStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -475,9 +475,9 @@ class $WeatherStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -559,9 +559,9 @@ class $WeatherStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -626,9 +626,9 @@ class $WeatherStatusClient {
     bool? oCSAPIRequest,
   }) {
     final _parameters = <String, Object?>{};
-    final $favorites =
+    final __favorites =
         _$jsonSerializers.serialize(favorites, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    _parameters['favorites%5B%5D'] = $favorites;
+    _parameters['favorites%5B%5D'] = __favorites;
 
     final _path =
         _i4.UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/favorites{?favorites%5B%5D*}').expand(_parameters);
@@ -652,9 +652,9 @@ class $WeatherStatusClient {
     }
 
 // coverage:ignore-end
-    var $oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
-    $oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert($oCSAPIRequest);
+    var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
+    __oCSAPIRequest ??= true;
+    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.dart
@@ -16,17 +16,18 @@
 /// It can be obtained at `https://spdx.org/licenses/AGPL-3.0-only.html`.
 library; // ignore_for_file: no_leading_underscores_for_library_prefixes
 
+import 'dart:convert';
+
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
-import 'package:built_value/standard_json_plugin.dart' as _i8;
-import 'package:collection/collection.dart' as _i5;
-import 'package:dynamite_runtime/built_value.dart' as _i7;
+import 'package:built_value/standard_json_plugin.dart' as _i7;
+import 'package:collection/collection.dart' as _i4;
+import 'package:dynamite_runtime/built_value.dart' as _i6;
 import 'package:dynamite_runtime/http_client.dart' as _i1;
-import 'package:dynamite_runtime/utils.dart' as _i6;
+import 'package:dynamite_runtime/utils.dart' as _i5;
 import 'package:http/http.dart' as _i3;
 import 'package:meta/meta.dart' as _i2;
-import 'package:uri/uri.dart' as _i4;
 
 part 'weather_status.openapi.g.dart';
 
@@ -71,7 +72,6 @@ class $WeatherStatusClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [mode] New mode.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -82,19 +82,15 @@ class $WeatherStatusClient {
   ///  * [$setMode_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setMode_Request({
-    required int mode,
+    required WeatherStatusSetModeRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __mode = _$jsonSerializers.serialize(mode, specifiedType: const FullType(int));
-    _parameters['mode'] = __mode;
-
-    final _path = _i4.UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/mode{?mode*}').expand(_parameters);
+    const _path = '/ocs/v2.php/apps/weather_status/api/v1/mode';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -112,8 +108,12 @@ class $WeatherStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize($body, specifiedType: const FullType(WeatherStatusSetModeRequestApplicationJson)),
+    );
     return _request;
   }
 
@@ -123,7 +123,6 @@ class $WeatherStatusClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [mode] New mode.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -133,12 +132,12 @@ class $WeatherStatusClient {
   ///  * [$setMode_Request] for the request send by this method.
   ///  * [$setMode_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<WeatherStatusSetModeResponseApplicationJson, void>> setMode({
-    required int mode,
+    required WeatherStatusSetModeRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setMode_Request(
-      mode: mode,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -180,7 +179,7 @@ class $WeatherStatusClient {
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -198,7 +197,7 @@ class $WeatherStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -264,7 +263,7 @@ class $WeatherStatusClient {
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -282,7 +281,7 @@ class $WeatherStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -332,9 +331,6 @@ class $WeatherStatusClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [address] Any approximative or exact address.
-  ///   * [lat] Latitude in decimal degree format.
-  ///   * [lon] Longitude in decimal degree format.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -345,28 +341,15 @@ class $WeatherStatusClient {
   ///  * [$setLocation_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setLocation_Request({
-    String? address,
-    double? lat,
-    double? lon,
     bool? oCSAPIRequest,
+    WeatherStatusSetLocationRequestApplicationJson? $body,
   }) {
-    final _parameters = <String, Object?>{};
-    final __address = _$jsonSerializers.serialize(address, specifiedType: const FullType(String));
-    _parameters['address'] = __address;
-
-    final __lat = _$jsonSerializers.serialize(lat, specifiedType: const FullType(double));
-    _parameters['lat'] = __lat;
-
-    final __lon = _$jsonSerializers.serialize(lon, specifiedType: const FullType(double));
-    _parameters['lon'] = __lon;
-
-    final _path =
-        _i4.UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/location{?address*,lat*,lon*}').expand(_parameters);
+    const _path = '/ocs/v2.php/apps/weather_status/api/v1/location';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -384,8 +367,22 @@ class $WeatherStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = $body != null
+        ? json.encode(
+            _$jsonSerializers.serialize(
+              $body,
+              specifiedType: const FullType(WeatherStatusSetLocationRequestApplicationJson),
+            ),
+          )
+        : json.encode(
+            _$jsonSerializers.serialize(
+              WeatherStatusSetLocationRequestApplicationJson(),
+              specifiedType: const FullType(WeatherStatusSetLocationRequestApplicationJson),
+            ),
+          );
     return _request;
   }
 
@@ -395,9 +392,6 @@ class $WeatherStatusClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [address] Any approximative or exact address.
-  ///   * [lat] Latitude in decimal degree format.
-  ///   * [lon] Longitude in decimal degree format.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -407,16 +401,12 @@ class $WeatherStatusClient {
   ///  * [$setLocation_Request] for the request send by this method.
   ///  * [$setLocation_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<WeatherStatusSetLocationResponseApplicationJson, void>> setLocation({
-    String? address,
-    double? lat,
-    double? lon,
     bool? oCSAPIRequest,
+    WeatherStatusSetLocationRequestApplicationJson? $body,
   }) async {
     final _request = $setLocation_Request(
-      address: address,
-      lat: lat,
-      lon: lon,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -459,7 +449,7 @@ class $WeatherStatusClient {
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -477,7 +467,7 @@ class $WeatherStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -543,7 +533,7 @@ class $WeatherStatusClient {
     final _request = _i3.Request('get', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -561,7 +551,7 @@ class $WeatherStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
     return _request;
   }
@@ -611,7 +601,6 @@ class $WeatherStatusClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [favorites] Favorite addresses.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -622,21 +611,15 @@ class $WeatherStatusClient {
   ///  * [$setFavorites_Serializer] for a converter to parse the `Response` from an executed this request.
   @_i2.experimental
   _i3.Request $setFavorites_Request({
-    required BuiltList<String> favorites,
+    required WeatherStatusSetFavoritesRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) {
-    final _parameters = <String, Object?>{};
-    final __favorites =
-        _$jsonSerializers.serialize(favorites, specifiedType: const FullType(BuiltList, [FullType(String)]));
-    _parameters['favorites%5B%5D'] = __favorites;
-
-    final _path =
-        _i4.UriTemplate('/ocs/v2.php/apps/weather_status/api/v1/favorites{?favorites%5B%5D*}').expand(_parameters);
+    const _path = '/ocs/v2.php/apps/weather_status/api/v1/favorites';
     final _uri = Uri.parse('${_rootClient.baseURL}$_path');
     final _request = _i3.Request('put', _uri);
     _request.headers['Accept'] = 'application/json';
 // coverage:ignore-start
-    final authentication = _i5.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
+    final authentication = _i4.IterableExtension(_rootClient.authentications)?.firstWhereOrNull(
       (auth) => switch (auth) {
         _i1.DynamiteHttpBearerAuthentication() || _i1.DynamiteHttpBasicAuthentication() => true,
         _ => false,
@@ -654,8 +637,15 @@ class $WeatherStatusClient {
 // coverage:ignore-end
     var __oCSAPIRequest = _$jsonSerializers.serialize(oCSAPIRequest, specifiedType: const FullType(bool));
     __oCSAPIRequest ??= true;
-    _request.headers['OCS-APIRequest'] = const _i6.HeaderEncoder().convert(__oCSAPIRequest);
+    _request.headers['OCS-APIRequest'] = const _i5.HeaderEncoder().convert(__oCSAPIRequest);
 
+    _request.headers['Content-Type'] = 'application/json';
+    _request.body = json.encode(
+      _$jsonSerializers.serialize(
+        $body,
+        specifiedType: const FullType(WeatherStatusSetFavoritesRequestApplicationJson),
+      ),
+    );
     return _request;
   }
 
@@ -665,7 +655,6 @@ class $WeatherStatusClient {
   /// Throws a `DynamiteApiException` if the API call does not return an expected status code.
   ///
   /// Parameters:
-  ///   * [favorites] Favorite addresses.
   ///   * [oCSAPIRequest] Required to be true for the API request to pass. Defaults to `true`.
   ///
   /// Status codes:
@@ -675,12 +664,12 @@ class $WeatherStatusClient {
   ///  * [$setFavorites_Request] for the request send by this method.
   ///  * [$setFavorites_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<WeatherStatusSetFavoritesResponseApplicationJson, void>> setFavorites({
-    required BuiltList<String> favorites,
+    required WeatherStatusSetFavoritesRequestApplicationJson $body,
     bool? oCSAPIRequest,
   }) async {
     final _request = $setFavorites_Request(
-      favorites: favorites,
       oCSAPIRequest: oCSAPIRequest,
+      $body: $body,
     );
     final _streamedResponse = await _rootClient.httpClient.send(_request);
     final _response = await _i3.Response.fromStream(_streamedResponse);
@@ -689,6 +678,70 @@ class $WeatherStatusClient {
     final _rawResponse =
         _i1.ResponseConverter<WeatherStatusSetFavoritesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $WeatherStatusSetModeRequestApplicationJsonInterface {
+  /// New mode.
+  int get mode;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusSetModeRequestApplicationJsonInterfaceBuilder].
+  $WeatherStatusSetModeRequestApplicationJsonInterface rebuild(
+    void Function($WeatherStatusSetModeRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusSetModeRequestApplicationJsonInterfaceBuilder].
+  $WeatherStatusSetModeRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusSetModeRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusSetModeRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class WeatherStatusSetModeRequestApplicationJson
+    implements
+        $WeatherStatusSetModeRequestApplicationJsonInterface,
+        Built<WeatherStatusSetModeRequestApplicationJson, WeatherStatusSetModeRequestApplicationJsonBuilder> {
+  /// Creates a new WeatherStatusSetModeRequestApplicationJson object using the builder pattern.
+  factory WeatherStatusSetModeRequestApplicationJson([
+    void Function(WeatherStatusSetModeRequestApplicationJsonBuilder)? b,
+  ]) = _$WeatherStatusSetModeRequestApplicationJson;
+
+  // coverage:ignore-start
+  const WeatherStatusSetModeRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory WeatherStatusSetModeRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for WeatherStatusSetModeRequestApplicationJson.
+  static Serializer<WeatherStatusSetModeRequestApplicationJson> get serializer =>
+      _$weatherStatusSetModeRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusSetModeRequestApplicationJsonBuilder b) {
+    $WeatherStatusSetModeRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusSetModeRequestApplicationJsonBuilder b) {
+    $WeatherStatusSetModeRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -1416,6 +1469,76 @@ abstract class WeatherStatusGetLocationResponseApplicationJson
   @BuiltValueHook(finalizeBuilder: true)
   static void _validate(WeatherStatusGetLocationResponseApplicationJsonBuilder b) {
     $WeatherStatusGetLocationResponseApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
+sealed class $WeatherStatusSetLocationRequestApplicationJsonInterface {
+  /// Any approximative or exact address.
+  String? get address;
+
+  /// Latitude in decimal degree format.
+  double? get lat;
+
+  /// Longitude in decimal degree format.
+  double? get lon;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusSetLocationRequestApplicationJsonInterfaceBuilder].
+  $WeatherStatusSetLocationRequestApplicationJsonInterface rebuild(
+    void Function($WeatherStatusSetLocationRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusSetLocationRequestApplicationJsonInterfaceBuilder].
+  $WeatherStatusSetLocationRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusSetLocationRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusSetLocationRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class WeatherStatusSetLocationRequestApplicationJson
+    implements
+        $WeatherStatusSetLocationRequestApplicationJsonInterface,
+        Built<WeatherStatusSetLocationRequestApplicationJson, WeatherStatusSetLocationRequestApplicationJsonBuilder> {
+  /// Creates a new WeatherStatusSetLocationRequestApplicationJson object using the builder pattern.
+  factory WeatherStatusSetLocationRequestApplicationJson([
+    void Function(WeatherStatusSetLocationRequestApplicationJsonBuilder)? b,
+  ]) = _$WeatherStatusSetLocationRequestApplicationJson;
+
+  // coverage:ignore-start
+  const WeatherStatusSetLocationRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory WeatherStatusSetLocationRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for WeatherStatusSetLocationRequestApplicationJson.
+  static Serializer<WeatherStatusSetLocationRequestApplicationJson> get serializer =>
+      _$weatherStatusSetLocationRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusSetLocationRequestApplicationJsonBuilder b) {
+    $WeatherStatusSetLocationRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusSetLocationRequestApplicationJsonBuilder b) {
+    $WeatherStatusSetLocationRequestApplicationJsonInterface._validate(b);
   }
 }
 
@@ -2662,6 +2785,70 @@ abstract class WeatherStatusGetFavoritesResponseApplicationJson
 }
 
 @BuiltValue(instantiable: false)
+sealed class $WeatherStatusSetFavoritesRequestApplicationJsonInterface {
+  /// Favorite addresses.
+  BuiltList<String> get favorites;
+
+  /// Rebuilds the instance.
+  ///
+  /// The result is the same as this instance but with [updates] applied.
+  /// [updates] is a function that takes a builder [$WeatherStatusSetFavoritesRequestApplicationJsonInterfaceBuilder].
+  $WeatherStatusSetFavoritesRequestApplicationJsonInterface rebuild(
+    void Function($WeatherStatusSetFavoritesRequestApplicationJsonInterfaceBuilder) updates,
+  );
+
+  /// Converts the instance to a builder [$WeatherStatusSetFavoritesRequestApplicationJsonInterfaceBuilder].
+  $WeatherStatusSetFavoritesRequestApplicationJsonInterfaceBuilder toBuilder();
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults($WeatherStatusSetFavoritesRequestApplicationJsonInterfaceBuilder b) {}
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate($WeatherStatusSetFavoritesRequestApplicationJsonInterfaceBuilder b) {}
+}
+
+abstract class WeatherStatusSetFavoritesRequestApplicationJson
+    implements
+        $WeatherStatusSetFavoritesRequestApplicationJsonInterface,
+        Built<WeatherStatusSetFavoritesRequestApplicationJson, WeatherStatusSetFavoritesRequestApplicationJsonBuilder> {
+  /// Creates a new WeatherStatusSetFavoritesRequestApplicationJson object using the builder pattern.
+  factory WeatherStatusSetFavoritesRequestApplicationJson([
+    void Function(WeatherStatusSetFavoritesRequestApplicationJsonBuilder)? b,
+  ]) = _$WeatherStatusSetFavoritesRequestApplicationJson;
+
+  // coverage:ignore-start
+  const WeatherStatusSetFavoritesRequestApplicationJson._();
+  // coverage:ignore-end
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use [toJson] to serialize it back into json.
+  // coverage:ignore-start
+  factory WeatherStatusSetFavoritesRequestApplicationJson.fromJson(Map<String, dynamic> json) =>
+      _$jsonSerializers.deserializeWith(serializer, json)!;
+  // coverage:ignore-end
+
+  /// Parses this object into a json like map.
+  ///
+  /// Use the fromJson factory to revive it again.
+  // coverage:ignore-start
+  Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+  // coverage:ignore-end
+
+  /// Serializer for WeatherStatusSetFavoritesRequestApplicationJson.
+  static Serializer<WeatherStatusSetFavoritesRequestApplicationJson> get serializer =>
+      _$weatherStatusSetFavoritesRequestApplicationJsonSerializer;
+
+  @BuiltValueHook(initializeBuilder: true)
+  static void _defaults(WeatherStatusSetFavoritesRequestApplicationJsonBuilder b) {
+    $WeatherStatusSetFavoritesRequestApplicationJsonInterface._defaults(b);
+  }
+
+  @BuiltValueHook(finalizeBuilder: true)
+  static void _validate(WeatherStatusSetFavoritesRequestApplicationJsonBuilder b) {
+    $WeatherStatusSetFavoritesRequestApplicationJsonInterface._validate(b);
+  }
+}
+
+@BuiltValue(instantiable: false)
 sealed class $WeatherStatusSetFavoritesResponseApplicationJson_OcsInterface {
   OCSMeta get meta;
   Success get data;
@@ -2931,13 +3118,13 @@ extension $20fe3de793aed6fbf929c9b82b472b1aExtension on _$20fe3de793aed6fbf929c9
   List<String> get _names => const ['builtListForecast', 'weatherStatusGetForecastResponseApplicationJsonOcsData1'];
 
   /// {@macro Dynamite.validateOneOf}
-  void validateOneOf() => _i6.validateOneOf(
+  void validateOneOf() => _i5.validateOneOf(
         _values,
         _names,
       );
 
   /// {@macro Dynamite.validateAnyOf}
-  void validateAnyOf() => _i6.validateAnyOf(
+  void validateAnyOf() => _i5.validateAnyOf(
         _values,
         _names,
       );
@@ -3019,6 +3206,11 @@ class _$20fe3de793aed6fbf929c9b82b472b1aSerializer implements PrimitiveSerialize
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
+        const FullType(WeatherStatusSetModeRequestApplicationJson),
+        WeatherStatusSetModeRequestApplicationJsonBuilder.new,
+      )
+      ..add(WeatherStatusSetModeRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(WeatherStatusSetModeResponseApplicationJson),
         WeatherStatusSetModeResponseApplicationJsonBuilder.new,
       )
@@ -3060,6 +3252,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(LocationWithMode.serializer)
       ..addBuilderFactory(const FullType(Mode), ModeBuilder.new)
       ..add(Mode.serializer)
+      ..addBuilderFactory(
+        const FullType(WeatherStatusSetLocationRequestApplicationJson),
+        WeatherStatusSetLocationRequestApplicationJsonBuilder.new,
+      )
+      ..add(WeatherStatusSetLocationRequestApplicationJson.serializer)
       ..addBuilderFactory(
         const FullType(WeatherStatusSetLocationResponseApplicationJson),
         WeatherStatusSetLocationResponseApplicationJsonBuilder.new,
@@ -3131,6 +3328,11 @@ final Serializers _$serializers = (Serializers().toBuilder()
       ..add(WeatherStatusGetFavoritesResponseApplicationJson_Ocs.serializer)
       ..addBuilderFactory(const FullType(BuiltList, [FullType(String)]), ListBuilder<String>.new)
       ..addBuilderFactory(
+        const FullType(WeatherStatusSetFavoritesRequestApplicationJson),
+        WeatherStatusSetFavoritesRequestApplicationJsonBuilder.new,
+      )
+      ..add(WeatherStatusSetFavoritesRequestApplicationJson.serializer)
+      ..addBuilderFactory(
         const FullType(WeatherStatusSetFavoritesResponseApplicationJson),
         WeatherStatusSetFavoritesResponseApplicationJsonBuilder.new,
       )
@@ -3153,9 +3355,9 @@ final Serializers _$serializers = (Serializers().toBuilder()
 @_i2.visibleForTesting
 final Serializers $jsonSerializers = _$jsonSerializers;
 final Serializers _$jsonSerializers = (_$serializers.toBuilder()
-      ..add(_i7.DynamiteDoubleSerializer())
-      ..addPlugin(_i8.StandardJsonPlugin(typesToLeaveAsList: const {_$20fe3de793aed6fbf929c9b82b472b1a}))
-      ..addPlugin(const _i7.HeaderPlugin())
-      ..addPlugin(const _i7.ContentStringPlugin()))
+      ..add(_i6.DynamiteDoubleSerializer())
+      ..addPlugin(_i7.StandardJsonPlugin(typesToLeaveAsList: const {_$20fe3de793aed6fbf929c9b82b472b1a}))
+      ..addPlugin(const _i6.HeaderPlugin())
+      ..addPlugin(const _i6.ContentStringPlugin()))
     .build();
 // coverage:ignore-end

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.g.dart
@@ -6,6 +6,8 @@ part of 'weather_status.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
+Serializer<WeatherStatusSetModeRequestApplicationJson> _$weatherStatusSetModeRequestApplicationJsonSerializer =
+    _$WeatherStatusSetModeRequestApplicationJsonSerializer();
 Serializer<OCSMeta> _$oCSMetaSerializer = _$OCSMetaSerializer();
 Serializer<Success> _$successSerializer = _$SuccessSerializer();
 Serializer<WeatherStatusSetModeResponseApplicationJson_Ocs> _$weatherStatusSetModeResponseApplicationJsonOcsSerializer =
@@ -28,6 +30,8 @@ Serializer<WeatherStatusGetLocationResponseApplicationJson_Ocs>
 Serializer<WeatherStatusGetLocationResponseApplicationJson>
     _$weatherStatusGetLocationResponseApplicationJsonSerializer =
     _$WeatherStatusGetLocationResponseApplicationJsonSerializer();
+Serializer<WeatherStatusSetLocationRequestApplicationJson> _$weatherStatusSetLocationRequestApplicationJsonSerializer =
+    _$WeatherStatusSetLocationRequestApplicationJsonSerializer();
 Serializer<WeatherStatusSetLocationResponseApplicationJson_Ocs>
     _$weatherStatusSetLocationResponseApplicationJsonOcsSerializer =
     _$WeatherStatusSetLocationResponseApplicationJson_OcsSerializer();
@@ -69,6 +73,9 @@ Serializer<WeatherStatusGetFavoritesResponseApplicationJson_Ocs>
 Serializer<WeatherStatusGetFavoritesResponseApplicationJson>
     _$weatherStatusGetFavoritesResponseApplicationJsonSerializer =
     _$WeatherStatusGetFavoritesResponseApplicationJsonSerializer();
+Serializer<WeatherStatusSetFavoritesRequestApplicationJson>
+    _$weatherStatusSetFavoritesRequestApplicationJsonSerializer =
+    _$WeatherStatusSetFavoritesRequestApplicationJsonSerializer();
 Serializer<WeatherStatusSetFavoritesResponseApplicationJson_Ocs>
     _$weatherStatusSetFavoritesResponseApplicationJsonOcsSerializer =
     _$WeatherStatusSetFavoritesResponseApplicationJson_OcsSerializer();
@@ -77,6 +84,48 @@ Serializer<WeatherStatusSetFavoritesResponseApplicationJson>
     _$WeatherStatusSetFavoritesResponseApplicationJsonSerializer();
 Serializer<Capabilities_WeatherStatus> _$capabilitiesWeatherStatusSerializer = _$Capabilities_WeatherStatusSerializer();
 Serializer<Capabilities> _$capabilitiesSerializer = _$CapabilitiesSerializer();
+
+class _$WeatherStatusSetModeRequestApplicationJsonSerializer
+    implements StructuredSerializer<WeatherStatusSetModeRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    WeatherStatusSetModeRequestApplicationJson,
+    _$WeatherStatusSetModeRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'WeatherStatusSetModeRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, WeatherStatusSetModeRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'mode',
+      serializers.serialize(object.mode, specifiedType: const FullType(int)),
+    ];
+
+    return result;
+  }
+
+  @override
+  WeatherStatusSetModeRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = WeatherStatusSetModeRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'mode':
+          result.mode = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
 
 class _$OCSMetaSerializer implements StructuredSerializer<OCSMeta> {
   @override
@@ -684,6 +733,69 @@ class _$WeatherStatusGetLocationResponseApplicationJsonSerializer
           result.ocs.replace(serializers.deserialize(value,
                   specifiedType: const FullType(WeatherStatusGetLocationResponseApplicationJson_Ocs))!
               as WeatherStatusGetLocationResponseApplicationJson_Ocs);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$WeatherStatusSetLocationRequestApplicationJsonSerializer
+    implements StructuredSerializer<WeatherStatusSetLocationRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    WeatherStatusSetLocationRequestApplicationJson,
+    _$WeatherStatusSetLocationRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'WeatherStatusSetLocationRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, WeatherStatusSetLocationRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.address;
+    if (value != null) {
+      result
+        ..add('address')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.lat;
+    if (value != null) {
+      result
+        ..add('lat')
+        ..add(serializers.serialize(value, specifiedType: const FullType(double)));
+    }
+    value = object.lon;
+    if (value != null) {
+      result
+        ..add('lon')
+        ..add(serializers.serialize(value, specifiedType: const FullType(double)));
+    }
+    return result;
+  }
+
+  @override
+  WeatherStatusSetLocationRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = WeatherStatusSetLocationRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'address':
+          result.address = serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'lat':
+          result.lat = serializers.deserialize(value, specifiedType: const FullType(double)) as double?;
+          break;
+        case 'lon':
+          result.lon = serializers.deserialize(value, specifiedType: const FullType(double)) as double?;
           break;
       }
     }
@@ -1592,6 +1704,49 @@ class _$WeatherStatusGetFavoritesResponseApplicationJsonSerializer
   }
 }
 
+class _$WeatherStatusSetFavoritesRequestApplicationJsonSerializer
+    implements StructuredSerializer<WeatherStatusSetFavoritesRequestApplicationJson> {
+  @override
+  final Iterable<Type> types = const [
+    WeatherStatusSetFavoritesRequestApplicationJson,
+    _$WeatherStatusSetFavoritesRequestApplicationJson
+  ];
+  @override
+  final String wireName = 'WeatherStatusSetFavoritesRequestApplicationJson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, WeatherStatusSetFavoritesRequestApplicationJson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'favorites',
+      serializers.serialize(object.favorites, specifiedType: const FullType(BuiltList, [FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  WeatherStatusSetFavoritesRequestApplicationJson deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = WeatherStatusSetFavoritesRequestApplicationJsonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'favorites':
+          result.favorites.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, [FullType(String)]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$WeatherStatusSetFavoritesResponseApplicationJson_OcsSerializer
     implements StructuredSerializer<WeatherStatusSetFavoritesResponseApplicationJson_Ocs> {
   @override
@@ -1759,6 +1914,101 @@ class _$CapabilitiesSerializer implements StructuredSerializer<Capabilities> {
     }
 
     return result.build();
+  }
+}
+
+abstract mixin class $WeatherStatusSetModeRequestApplicationJsonInterfaceBuilder {
+  void replace($WeatherStatusSetModeRequestApplicationJsonInterface other);
+  void update(void Function($WeatherStatusSetModeRequestApplicationJsonInterfaceBuilder) updates);
+  int? get mode;
+  set mode(int? mode);
+}
+
+class _$WeatherStatusSetModeRequestApplicationJson extends WeatherStatusSetModeRequestApplicationJson {
+  @override
+  final int mode;
+
+  factory _$WeatherStatusSetModeRequestApplicationJson(
+          [void Function(WeatherStatusSetModeRequestApplicationJsonBuilder)? updates]) =>
+      (WeatherStatusSetModeRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$WeatherStatusSetModeRequestApplicationJson._({required this.mode}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(mode, r'WeatherStatusSetModeRequestApplicationJson', 'mode');
+  }
+
+  @override
+  WeatherStatusSetModeRequestApplicationJson rebuild(
+          void Function(WeatherStatusSetModeRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  WeatherStatusSetModeRequestApplicationJsonBuilder toBuilder() =>
+      WeatherStatusSetModeRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is WeatherStatusSetModeRequestApplicationJson && mode == other.mode;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, mode.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'WeatherStatusSetModeRequestApplicationJson')..add('mode', mode)).toString();
+  }
+}
+
+class WeatherStatusSetModeRequestApplicationJsonBuilder
+    implements
+        Builder<WeatherStatusSetModeRequestApplicationJson, WeatherStatusSetModeRequestApplicationJsonBuilder>,
+        $WeatherStatusSetModeRequestApplicationJsonInterfaceBuilder {
+  _$WeatherStatusSetModeRequestApplicationJson? _$v;
+
+  int? _mode;
+  int? get mode => _$this._mode;
+  set mode(covariant int? mode) => _$this._mode = mode;
+
+  WeatherStatusSetModeRequestApplicationJsonBuilder() {
+    WeatherStatusSetModeRequestApplicationJson._defaults(this);
+  }
+
+  WeatherStatusSetModeRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _mode = $v.mode;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant WeatherStatusSetModeRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$WeatherStatusSetModeRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(WeatherStatusSetModeRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  WeatherStatusSetModeRequestApplicationJson build() => _build();
+
+  _$WeatherStatusSetModeRequestApplicationJson _build() {
+    WeatherStatusSetModeRequestApplicationJson._validate(this);
+    final _$result = _$v ??
+        _$WeatherStatusSetModeRequestApplicationJson._(
+            mode: BuiltValueNullFieldError.checkNotNull(mode, r'WeatherStatusSetModeRequestApplicationJson', 'mode'));
+    replace(_$result);
+    return _$result;
   }
 }
 
@@ -3156,6 +3406,126 @@ class WeatherStatusGetLocationResponseApplicationJsonBuilder
       }
       rethrow;
     }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $WeatherStatusSetLocationRequestApplicationJsonInterfaceBuilder {
+  void replace($WeatherStatusSetLocationRequestApplicationJsonInterface other);
+  void update(void Function($WeatherStatusSetLocationRequestApplicationJsonInterfaceBuilder) updates);
+  String? get address;
+  set address(String? address);
+
+  double? get lat;
+  set lat(double? lat);
+
+  double? get lon;
+  set lon(double? lon);
+}
+
+class _$WeatherStatusSetLocationRequestApplicationJson extends WeatherStatusSetLocationRequestApplicationJson {
+  @override
+  final String? address;
+  @override
+  final double? lat;
+  @override
+  final double? lon;
+
+  factory _$WeatherStatusSetLocationRequestApplicationJson(
+          [void Function(WeatherStatusSetLocationRequestApplicationJsonBuilder)? updates]) =>
+      (WeatherStatusSetLocationRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$WeatherStatusSetLocationRequestApplicationJson._({this.address, this.lat, this.lon}) : super._();
+
+  @override
+  WeatherStatusSetLocationRequestApplicationJson rebuild(
+          void Function(WeatherStatusSetLocationRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  WeatherStatusSetLocationRequestApplicationJsonBuilder toBuilder() =>
+      WeatherStatusSetLocationRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is WeatherStatusSetLocationRequestApplicationJson &&
+        address == other.address &&
+        lat == other.lat &&
+        lon == other.lon;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, address.hashCode);
+    _$hash = $jc(_$hash, lat.hashCode);
+    _$hash = $jc(_$hash, lon.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'WeatherStatusSetLocationRequestApplicationJson')
+          ..add('address', address)
+          ..add('lat', lat)
+          ..add('lon', lon))
+        .toString();
+  }
+}
+
+class WeatherStatusSetLocationRequestApplicationJsonBuilder
+    implements
+        Builder<WeatherStatusSetLocationRequestApplicationJson, WeatherStatusSetLocationRequestApplicationJsonBuilder>,
+        $WeatherStatusSetLocationRequestApplicationJsonInterfaceBuilder {
+  _$WeatherStatusSetLocationRequestApplicationJson? _$v;
+
+  String? _address;
+  String? get address => _$this._address;
+  set address(covariant String? address) => _$this._address = address;
+
+  double? _lat;
+  double? get lat => _$this._lat;
+  set lat(covariant double? lat) => _$this._lat = lat;
+
+  double? _lon;
+  double? get lon => _$this._lon;
+  set lon(covariant double? lon) => _$this._lon = lon;
+
+  WeatherStatusSetLocationRequestApplicationJsonBuilder() {
+    WeatherStatusSetLocationRequestApplicationJson._defaults(this);
+  }
+
+  WeatherStatusSetLocationRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _address = $v.address;
+      _lat = $v.lat;
+      _lon = $v.lon;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant WeatherStatusSetLocationRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$WeatherStatusSetLocationRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(WeatherStatusSetLocationRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  WeatherStatusSetLocationRequestApplicationJson build() => _build();
+
+  _$WeatherStatusSetLocationRequestApplicationJson _build() {
+    WeatherStatusSetLocationRequestApplicationJson._validate(this);
+    final _$result = _$v ?? _$WeatherStatusSetLocationRequestApplicationJson._(address: address, lat: lat, lon: lon);
     replace(_$result);
     return _$result;
   }
@@ -5423,6 +5793,115 @@ class WeatherStatusGetFavoritesResponseApplicationJsonBuilder
       } catch (e) {
         throw BuiltValueNestedFieldError(
             r'WeatherStatusGetFavoritesResponseApplicationJson', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+abstract mixin class $WeatherStatusSetFavoritesRequestApplicationJsonInterfaceBuilder {
+  void replace($WeatherStatusSetFavoritesRequestApplicationJsonInterface other);
+  void update(void Function($WeatherStatusSetFavoritesRequestApplicationJsonInterfaceBuilder) updates);
+  ListBuilder<String> get favorites;
+  set favorites(ListBuilder<String>? favorites);
+}
+
+class _$WeatherStatusSetFavoritesRequestApplicationJson extends WeatherStatusSetFavoritesRequestApplicationJson {
+  @override
+  final BuiltList<String> favorites;
+
+  factory _$WeatherStatusSetFavoritesRequestApplicationJson(
+          [void Function(WeatherStatusSetFavoritesRequestApplicationJsonBuilder)? updates]) =>
+      (WeatherStatusSetFavoritesRequestApplicationJsonBuilder()..update(updates))._build();
+
+  _$WeatherStatusSetFavoritesRequestApplicationJson._({required this.favorites}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(favorites, r'WeatherStatusSetFavoritesRequestApplicationJson', 'favorites');
+  }
+
+  @override
+  WeatherStatusSetFavoritesRequestApplicationJson rebuild(
+          void Function(WeatherStatusSetFavoritesRequestApplicationJsonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  WeatherStatusSetFavoritesRequestApplicationJsonBuilder toBuilder() =>
+      WeatherStatusSetFavoritesRequestApplicationJsonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is WeatherStatusSetFavoritesRequestApplicationJson && favorites == other.favorites;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, favorites.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'WeatherStatusSetFavoritesRequestApplicationJson')
+          ..add('favorites', favorites))
+        .toString();
+  }
+}
+
+class WeatherStatusSetFavoritesRequestApplicationJsonBuilder
+    implements
+        Builder<WeatherStatusSetFavoritesRequestApplicationJson,
+            WeatherStatusSetFavoritesRequestApplicationJsonBuilder>,
+        $WeatherStatusSetFavoritesRequestApplicationJsonInterfaceBuilder {
+  _$WeatherStatusSetFavoritesRequestApplicationJson? _$v;
+
+  ListBuilder<String>? _favorites;
+  ListBuilder<String> get favorites => _$this._favorites ??= ListBuilder<String>();
+  set favorites(covariant ListBuilder<String>? favorites) => _$this._favorites = favorites;
+
+  WeatherStatusSetFavoritesRequestApplicationJsonBuilder() {
+    WeatherStatusSetFavoritesRequestApplicationJson._defaults(this);
+  }
+
+  WeatherStatusSetFavoritesRequestApplicationJsonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _favorites = $v.favorites.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(covariant WeatherStatusSetFavoritesRequestApplicationJson other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$WeatherStatusSetFavoritesRequestApplicationJson;
+  }
+
+  @override
+  void update(void Function(WeatherStatusSetFavoritesRequestApplicationJsonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  WeatherStatusSetFavoritesRequestApplicationJson build() => _build();
+
+  _$WeatherStatusSetFavoritesRequestApplicationJson _build() {
+    WeatherStatusSetFavoritesRequestApplicationJson._validate(this);
+    _$WeatherStatusSetFavoritesRequestApplicationJson _$result;
+    try {
+      _$result = _$v ?? _$WeatherStatusSetFavoritesRequestApplicationJson._(favorites: favorites.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'favorites';
+        favorites.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'WeatherStatusSetFavoritesRequestApplicationJson', _$failedField, e.toString());
       }
       rethrow;
     }

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.json
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.json
@@ -286,17 +286,27 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "mode",
-                        "in": "query",
-                        "description": "New mode",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "mode"
+                                ],
+                                "properties": {
+                                    "mode": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "New mode"
+                                    }
+                                }
+                            }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -477,36 +487,36 @@
                         "basic_auth": []
                     }
                 ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "address": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "Any approximative or exact address"
+                                    },
+                                    "lat": {
+                                        "type": "number",
+                                        "format": "double",
+                                        "nullable": true,
+                                        "description": "Latitude in decimal degree format"
+                                    },
+                                    "lon": {
+                                        "type": "number",
+                                        "format": "double",
+                                        "nullable": true,
+                                        "description": "Longitude in decimal degree format"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "parameters": [
-                    {
-                        "name": "address",
-                        "in": "query",
-                        "description": "Any approximative or exact address",
-                        "schema": {
-                            "type": "string",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "lat",
-                        "in": "query",
-                        "description": "Latitude in decimal degree format",
-                        "schema": {
-                            "type": "number",
-                            "format": "double",
-                            "nullable": true
-                        }
-                    },
-                    {
-                        "name": "lon",
-                        "in": "query",
-                        "description": "Longitude in decimal degree format",
-                        "schema": {
-                            "type": "number",
-                            "format": "double",
-                            "nullable": true
-                        }
-                    },
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",
@@ -738,19 +748,29 @@
                         "basic_auth": []
                     }
                 ],
-                "parameters": [
-                    {
-                        "name": "favorites[]",
-                        "in": "query",
-                        "description": "Favorite addresses",
-                        "required": true,
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "favorites"
+                                ],
+                                "properties": {
+                                    "favorites": {
+                                        "type": "array",
+                                        "description": "Favorite addresses",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
                             }
                         }
-                    },
+                    }
+                },
+                "parameters": [
                     {
                         "name": "OCS-APIRequest",
                         "in": "header",

--- a/packages/nextcloud/lib/src/patches/spreed/1-enums.json
+++ b/packages/nextcloud/lib/src/patches/spreed/1-enums.json
@@ -94,14 +94,14 @@
   },
   {
     "op": "replace",
-    "path": "/paths/~1ocs~1v2.php~1apps~1spreed~1api~1{apiVersion}~1room~1{token}~1verify-dialout/post/parameters/1/schema/contentSchema/properties/actorType",
+    "path": "/paths/~1ocs~1v2.php~1apps~1spreed~1api~1{apiVersion}~1room~1{token}~1verify-dialout/post/requestBody/content/application~1json/schema/properties/options/properties/actorType",
     "value": {
       "$ref": "#/components/schemas/ActorType"
     }
   },
   {
     "op": "replace",
-    "path": "/paths/~1ocs~1v2.php~1apps~1spreed~1api~1{apiVersion}~1room~1{token}~1rejected-dialout/delete/parameters/1/schema/contentSchema/properties/actorType",
+    "path": "/paths/~1ocs~1v2.php~1apps~1spreed~1api~1{apiVersion}~1room~1{token}~1rejected-dialout/delete/requestBody/content/application~1json/schema/properties/options/properties/actorType",
     "value": {
       "$ref": "#/components/schemas/ActorType"
     }

--- a/packages/nextcloud/test/core_test.dart
+++ b/packages/nextcloud/test/core_test.dart
@@ -1,4 +1,3 @@
-import 'package:built_collection/built_collection.dart';
 import 'package:nextcloud/core.dart' as core;
 import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
@@ -101,10 +100,13 @@ void main() {
       group('Autocomplete', () {
         test('Get', () async {
           final response = await client.core.autoComplete.$get(
-            search: '',
-            itemType: 'call',
-            itemId: 'new',
-            shareTypes: BuiltList([core.ShareType.group.index]),
+            $body: core.AutoCompleteGetRequestApplicationJson(
+              (b) => b
+                ..search = ''
+                ..itemType = 'call'
+                ..itemId = 'new'
+                ..shareTypes.replace([core.ShareType.group.index]),
+            ),
           );
           expect(response.body.ocs.data, hasLength(1));
 
@@ -121,7 +123,11 @@ void main() {
 
       group('Preview', () {
         test('Get', () async {
-          final response = await client.core.preview.getPreview(file: 'Nextcloud.png');
+          final response = await client.core.preview.getPreview(
+            $body: core.PreviewGetPreviewRequestApplicationJson(
+              (b) => b..file = 'Nextcloud.png',
+            ),
+          );
           expect(response.statusCode, 200);
           expect(() => response.headers, isA<void>());
 
@@ -168,7 +174,9 @@ void main() {
         test('Search', () async {
           final response = await client.core.unifiedSearch.search(
             providerId: 'settings',
-            term: 'Personal info',
+            $body: core.UnifiedSearchSearchRequestApplicationJson(
+              (b) => b..term = 'Personal info',
+            ),
           );
 
           expect(response.statusCode, 200);
@@ -198,7 +206,11 @@ void main() {
           expect(response.body.poll.token, isNotEmpty);
 
           await expectLater(
-            () => client.core.clientFlowLoginV2.poll(token: response.body.poll.token),
+            () => client.core.clientFlowLoginV2.poll(
+              $body: core.ClientFlowLoginV2PollRequestApplicationJson(
+                (b) => b..token = response.body.poll.token,
+              ),
+            ),
             throwsA(predicate<DynamiteStatusCodeException>((e) => e.statusCode == 404)),
           );
         });

--- a/packages/nextcloud/test/fixtures/core/autocomplete/get.regexp
+++ b/packages/nextcloud/test/fixtures/core/autocomplete/get.regexp
@@ -1,4 +1,6 @@
-GET http://localhost/ocs/v2\.php/core/autocomplete/get\?search=&itemType=call&itemId=new&shareTypes%5B%5D=1&limit=10
+GET http://localhost/ocs/v2\.php/core/autocomplete/get
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"search":"","shareTypes":\[1\],"limit":10,"itemType":"call","itemId":"new"\}

--- a/packages/nextcloud/test/fixtures/core/client_login_flow_v2/init_and_poll.regexp
+++ b/packages/nextcloud/test/fixtures/core/client_login_flow_v2/init_and_poll.regexp
@@ -1,6 +1,8 @@
 POST http://localhost/index\.php/login/v2
 accept: application/json
 authorization: Bearer mock
-POST http://localhost/index\.php/login/v2/poll\?token=[a-zA-Z0-9]{128}
+POST http://localhost/index\.php/login/v2/poll
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
+\{"token":"[a-zA-Z0-9]{128}"\}

--- a/packages/nextcloud/test/fixtures/core/navigation/get_apps_navigation.regexp
+++ b/packages/nextcloud/test/fixtures/core/navigation/get_apps_navigation.regexp
@@ -1,4 +1,6 @@
-GET http://localhost/ocs/v2\.php/core/navigation/apps\?absolute=0
+GET http://localhost/ocs/v2\.php/core/navigation/apps
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"absolute":false\}

--- a/packages/nextcloud/test/fixtures/core/preview/get.regexp
+++ b/packages/nextcloud/test/fixtures/core/preview/get.regexp
@@ -1,3 +1,5 @@
-GET http://localhost/index\.php/core/preview\.png\?file=Nextcloud\.png&x=32&y=32&a=0&forceIcon=1&mode=fill&mimeFallback=0
+GET http://localhost/index\.php/core/preview\.png
 accept: \*/\*
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
+\{"file":"Nextcloud\.png","x":32,"y":32,"a":false,"forceIcon":true,"mode":"fill","mimeFallback":false\}

--- a/packages/nextcloud/test/fixtures/core/unified_search/get_providers.regexp
+++ b/packages/nextcloud/test/fixtures/core/unified_search/get_providers.regexp
@@ -1,4 +1,6 @@
-GET http://localhost/ocs/v2\.php/search/providers\?from=
+GET http://localhost/ocs/v2\.php/search/providers
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"from":""\}

--- a/packages/nextcloud/test/fixtures/core/unified_search/search.regexp
+++ b/packages/nextcloud/test/fixtures/core/unified_search/search.regexp
@@ -1,4 +1,6 @@
-GET http://localhost/ocs/v2\.php/search/providers/settings/search\?term=Personal%20info&from=
+GET http://localhost/ocs/v2\.php/search/providers/settings/search
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"term":"Personal info","from":""\}

--- a/packages/nextcloud/test/fixtures/dashboard/get_widget_items/v1.regexp
+++ b/packages/nextcloud/test/fixtures/dashboard/get_widget_items/v1.regexp
@@ -1,4 +1,6 @@
-GET http://localhost/ocs/v2\.php/apps/dashboard/api/v1/widget-items\?limit=7
+GET http://localhost/ocs/v2\.php/apps/dashboard/api/v1/widget-items
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"sinceIds":\{\},"limit":7,"widgets":\[\]\}

--- a/packages/nextcloud/test/fixtures/dashboard/get_widget_items/v2.regexp
+++ b/packages/nextcloud/test/fixtures/dashboard/get_widget_items/v2.regexp
@@ -1,4 +1,6 @@
-GET http://localhost/ocs/v2\.php/apps/dashboard/api/v2/widget-items\?limit=7
+GET http://localhost/ocs/v2\.php/apps/dashboard/api/v2/widget-items
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"sinceIds":\{\},"limit":7,"widgets":\[\]\}

--- a/packages/nextcloud/test/fixtures/notifications/api/send_admin_notification.regexp
+++ b/packages/nextcloud/test/fixtures/notifications/api/send_admin_notification.regexp
@@ -1,4 +1,6 @@
-POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/admin_notifications/admin\?shortMessage=123&longMessage=456
+POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/admin_notifications/admin
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"shortMessage":"123","longMessage":"456"\}

--- a/packages/nextcloud/test/fixtures/notifications/endpoint/delete_all_notifications.regexp
+++ b/packages/nextcloud/test/fixtures/notifications/endpoint/delete_all_notifications.regexp
@@ -2,14 +2,18 @@ DELETE http://localhost/ocs/v2\.php/apps/notifications/api/v2/notifications
 accept: application/json
 authorization: Bearer mock
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/admin_notifications/admin\?shortMessage=123&longMessage=456
+POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/admin_notifications/admin
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/admin_notifications/admin\?shortMessage=123&longMessage=456
+\{"shortMessage":"123","longMessage":"456"\}
+POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/admin_notifications/admin
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"shortMessage":"123","longMessage":"456"\}
 DELETE http://localhost/ocs/v2\.php/apps/notifications/api/v2/notifications
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/notifications/endpoint/delete_notification.regexp
+++ b/packages/nextcloud/test/fixtures/notifications/endpoint/delete_notification.regexp
@@ -2,10 +2,12 @@ DELETE http://localhost/ocs/v2\.php/apps/notifications/api/v2/notifications
 accept: application/json
 authorization: Bearer mock
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/admin_notifications/admin\?shortMessage=123&longMessage=456
+POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/admin_notifications/admin
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"shortMessage":"123","longMessage":"456"\}
 GET http://localhost/ocs/v2\.php/apps/notifications/api/v2/notifications
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/notifications/endpoint/get_notification.regexp
+++ b/packages/nextcloud/test/fixtures/notifications/endpoint/get_notification.regexp
@@ -2,15 +2,17 @@ DELETE http://localhost/ocs/v2\.php/apps/notifications/api/v2/notifications
 accept: application/json
 authorization: Bearer mock
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/admin_notifications/admin\?shortMessage=123&longMessage=456
+POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/admin_notifications/admin
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"shortMessage":"123","longMessage":"456"\}
 GET http://localhost/ocs/v2\.php/apps/notifications/api/v2/notifications
 accept: application/json
 authorization: Bearer mock
 ocs-apirequest: true
-GET http://localhost/ocs/v2\.php/apps/notifications/api/v2/notifications/[0-9]+
+GET http://localhost/ocs/v2\.php/apps/notifications/api/v2/notifications/4
 accept: application/json
 authorization: Bearer mock
 ocs-apirequest: true

--- a/packages/nextcloud/test/fixtures/notifications/endpoint/list_notifications.regexp
+++ b/packages/nextcloud/test/fixtures/notifications/endpoint/list_notifications.regexp
@@ -2,10 +2,12 @@ DELETE http://localhost/ocs/v2\.php/apps/notifications/api/v2/notifications
 accept: application/json
 authorization: Bearer mock
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/admin_notifications/admin\?shortMessage=123&longMessage=456
+POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/admin_notifications/admin
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"shortMessage":"123","longMessage":"456"\}
 GET http://localhost/ocs/v2\.php/apps/notifications/api/v2/notifications
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/notifications/push/register_and_remove_push_device.regexp
+++ b/packages/nextcloud/test/fixtures/notifications/push/register_and_remove_push_device.regexp
@@ -1,7 +1,9 @@
-POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/push\?pushTokenHash=[a-z0-9]{128}&devicePublicKey=-----BEGIN%20PUBLIC%20KEY-----[a-zA-Z0-9%]+-----END%20PUBLIC%20KEY-----&proxyServer=https%3A%2F%2Fexample\.com%2F
+POST http://localhost/ocs/v2\.php/apps/notifications/api/v2/push
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"pushTokenHash":"[a-z0-9]{128}","devicePublicKey":"-----BEGIN PUBLIC KEY-----.+-----END PUBLIC KEY-----","proxyServer":"https://example\.com/"\}
 DELETE http://localhost/ocs/v2\.php/apps/notifications/api/v2/push
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/provisioning_api/apps/get.regexp
+++ b/packages/nextcloud/test/fixtures/provisioning_api/apps/get.regexp
@@ -1,7 +1,9 @@
 GET http://localhost/ocs/v2\.php/cloud/apps
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{\}
 (GET http://localhost/ocs/v2\.php/cloud/apps/[a-z_]+
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/spreed/avatar/delete_avatar.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/avatar/delete_avatar.regexp
@@ -1,11 +1,15 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/room/[a-z0-9]{8}/avatar/emoji\?emoji=%F0%9F%98%80
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/room/[a-z0-9]{8}/avatar/emoji
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"emoji":"😀"\}
 DELETE http://localhost/ocs/v2\.php/apps/spreed/api/v1/room/[a-z0-9]{8}/avatar
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/spreed/avatar/get_avatar.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/avatar/get_avatar.regexp
@@ -1,12 +1,18 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/room/[a-z0-9]{8}/avatar/emoji\?emoji=%F0%9F%98%80
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/room/[a-z0-9]{8}/avatar/emoji
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/room/[a-z0-9]{8}/avatar\?darkTheme=0
+\{"emoji":"😀"\}
+GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/room/[a-z0-9]{8}/avatar
 accept: \*/\*
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"darkTheme":false\}

--- a/packages/nextcloud/test/fixtures/spreed/avatar/get_avatar_dark.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/avatar/get_avatar_dark.regexp
@@ -1,11 +1,15 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/room/[a-z0-9]{8}/avatar/emoji\?emoji=%F0%9F%98%80
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/room/[a-z0-9]{8}/avatar/emoji
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"emoji":"😀"\}
 GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/room/[a-z0-9]{8}/avatar/dark
 accept: \*/\*
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/spreed/avatar/set_emoji_avatar.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/avatar/set_emoji_avatar.regexp
@@ -1,8 +1,12 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/room/[a-z0-9]{8}/avatar/emoji\?emoji=%F0%9F%98%80
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/room/[a-z0-9]{8}/avatar/emoji
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"emoji":"😀"\}

--- a/packages/nextcloud/test/fixtures/spreed/call/start_and_end_call.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/call/start_and_end_call.regexp
@@ -1,23 +1,31 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}/participants/active\?password=&force=1
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}/participants/active
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/call/[a-z0-9]{8}\?silent=0&recordingConsent=0
+\{"password":"","force":true\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/call/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"silent":false,"recordingConsent":false\}
 GET http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
 ocs-apirequest: true
-DELETE http://localhost/ocs/v2\.php/apps/spreed/api/v4/call/[a-z0-9]{8}\?all=0
+DELETE http://localhost/ocs/v2\.php/apps/spreed/api/v4/call/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"all":false\}
 GET http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/spreed/chat/get_messages/directly.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/chat/get_messages/directly.regexp
@@ -1,16 +1,24 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?message=bla&actorDisplayName=&referenceId=&replyTo=0&silent=0
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?message=123&actorDisplayName=&referenceId=&replyTo=[0-9]+&silent=0
+\{"message":"bla","actorDisplayName":"","referenceId":"","replyTo":0,"silent":false\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?lookIntoFuture=0&limit=100&lastKnownMessageId=0&lastCommonReadId=0&timeout=30&setReadMarker=1&includeLastKnown=0&noStatusUpdate=0&markNotificationsAsRead=1
+\{"message":"123","actorDisplayName":"","referenceId":"","replyTo":[0-9]+,"silent":false\}
+GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"lookIntoFuture":0,"limit":100,"lastKnownMessageId":0,"lastCommonReadId":0,"timeout":30,"setReadMarker":1,"includeLastKnown":0,"noStatusUpdate":0,"markNotificationsAsRead":1\}

--- a/packages/nextcloud/test/fixtures/spreed/chat/get_messages/polling.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/chat/get_messages/polling.regexp
@@ -1,16 +1,24 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?message=bla&actorDisplayName=&referenceId=&replyTo=0&silent=0
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?lookIntoFuture=1&limit=100&lastKnownMessageId=[0-9]+&lastCommonReadId=0&timeout=3&setReadMarker=1&includeLastKnown=0&noStatusUpdate=0&markNotificationsAsRead=1
+\{"message":"bla","actorDisplayName":"","referenceId":"","replyTo":0,"silent":false\}
+GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?message=123&actorDisplayName=&referenceId=&replyTo=0&silent=0
+\{"lookIntoFuture":1,"limit":100,"lastKnownMessageId":[0-9]+,"lastCommonReadId":0,"timeout":3,"setReadMarker":1,"includeLastKnown":0,"noStatusUpdate":0,"markNotificationsAsRead":1\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"message":"123","actorDisplayName":"","referenceId":"","replyTo":0,"silent":false\}

--- a/packages/nextcloud/test/fixtures/spreed/chat/mention_suggestions.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/chat/mention_suggestions.regexp
@@ -1,12 +1,18 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}/participants\?newParticipant=user2&source=users
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}/participants
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}/mentions\?search=user&limit=20&includeStatus=0
+\{"newParticipant":"user2","source":"users"\}
+GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}/mentions
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"search":"user","limit":20,"includeStatus":false\}

--- a/packages/nextcloud/test/fixtures/spreed/chat/send_message.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/chat/send_message.regexp
@@ -1,8 +1,12 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?message=bla&actorDisplayName=&referenceId=&replyTo=0&silent=0
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"message":"bla","actorDisplayName":"","referenceId":"","replyTo":0,"silent":false\}

--- a/packages/nextcloud/test/fixtures/spreed/reaction/add_and_remove.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/reaction/add_and_remove.regexp
@@ -1,28 +1,42 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?message=bla&actorDisplayName=&referenceId=&replyTo=0&silent=0
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?lookIntoFuture=0&limit=100&lastKnownMessageId=0&lastCommonReadId=0&timeout=30&setReadMarker=1&includeLastKnown=0&noStatusUpdate=0&markNotificationsAsRead=1
+\{"message":"bla","actorDisplayName":"","referenceId":"","replyTo":0,"silent":false\}
+GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/reaction/[a-z0-9]{8}/[0-9]+\?reaction=%F0%9F%98%80
+\{"lookIntoFuture":0,"limit":100,"lastKnownMessageId":0,"lastCommonReadId":0,"timeout":30,"setReadMarker":1,"includeLastKnown":0,"noStatusUpdate":0,"markNotificationsAsRead":1\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/reaction/[a-z0-9]{8}/[0-9]+
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?lookIntoFuture=0&limit=100&lastKnownMessageId=0&lastCommonReadId=0&timeout=30&setReadMarker=1&includeLastKnown=0&noStatusUpdate=0&markNotificationsAsRead=1
+\{"reaction":"😀"\}
+GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-DELETE http://localhost/ocs/v2\.php/apps/spreed/api/v1/reaction/[a-z0-9]{8}/[0-9]+\?reaction=%F0%9F%98%80
+\{"lookIntoFuture":0,"limit":100,"lastKnownMessageId":0,"lastCommonReadId":0,"timeout":30,"setReadMarker":1,"includeLastKnown":0,"noStatusUpdate":0,"markNotificationsAsRead":1\}
+DELETE http://localhost/ocs/v2\.php/apps/spreed/api/v1/reaction/[a-z0-9]{8}/[0-9]+
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?lookIntoFuture=0&limit=100&lastKnownMessageId=0&lastCommonReadId=0&timeout=30&setReadMarker=1&includeLastKnown=0&noStatusUpdate=0&markNotificationsAsRead=1
+\{"reaction":"😀"\}
+GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"lookIntoFuture":0,"limit":100,"lastKnownMessageId":0,"lastCommonReadId":0,"timeout":30,"setReadMarker":1,"includeLastKnown":0,"noStatusUpdate":0,"markNotificationsAsRead":1\}

--- a/packages/nextcloud/test/fixtures/spreed/reaction/get.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/reaction/get.regexp
@@ -1,16 +1,24 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?message=bla&actorDisplayName=&referenceId=&replyTo=0&silent=0
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/reaction/[a-z0-9]{8}/[0-9]+\?reaction=%F0%9F%98%80
+\{"message":"bla","actorDisplayName":"","referenceId":"","replyTo":0,"silent":false\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v1/reaction/[a-z0-9]{8}/[0-9]+
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"reaction":"😀"\}
 GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/reaction/[a-z0-9]{8}/[0-9]+
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{\}

--- a/packages/nextcloud/test/fixtures/spreed/room/create_room/group.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/room/create_room/group.regexp
@@ -1,4 +1,6 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=2&invite=admin&roomName=&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"roomType":2,"invite":"admin","roomName":"","source":"","objectType":"","objectId":""\}

--- a/packages/nextcloud/test/fixtures/spreed/room/create_room/one-to-one.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/room/create_room/one-to-one.regexp
@@ -1,4 +1,6 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=1&invite=user2&roomName=&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"roomType":1,"invite":"user2","roomName":"","source":"","objectType":"","objectId":""\}

--- a/packages/nextcloud/test/fixtures/spreed/room/create_room/public.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/room/create_room/public.regexp
@@ -1,4 +1,6 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=abc&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"roomType":3,"invite":"","roomName":"abc","source":"","objectType":"","objectId":""\}

--- a/packages/nextcloud/test/fixtures/spreed/room/get_rooms.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/room/get_rooms.regexp
@@ -1,4 +1,6 @@
-GET http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?noStatusUpdate=0&includeStatus=0&modifiedSince=0
+GET http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"noStatusUpdate":0,"includeStatus":false,"modifiedSince":0\}

--- a/packages/nextcloud/test/fixtures/spreed/room/session.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/room/session.regexp
@@ -1,11 +1,15 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}/participants/active\?password=&force=1
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}/participants/active
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"password":"","force":true\}
 GET http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/spreed/signaling/get_settings.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/signaling/get_settings.regexp
@@ -1,8 +1,12 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-GET http://localhost/ocs/v2\.php/apps/spreed/api/v3/signaling/settings\?token=[a-z0-9]{8}
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+GET http://localhost/ocs/v2\.php/apps/spreed/api/v3/signaling/settings
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"token":"[a-z0-9]{8}"\}

--- a/packages/nextcloud/test/fixtures/spreed/signaling/send_and_receive_messages.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/signaling/send_and_receive_messages.regexp
@@ -1,27 +1,39 @@
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room\?roomType=3&invite=&roomName=Test&source=&objectType=&objectId=
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}/participants/active\?password=&force=1
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}/participants/active
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/call/[a-z0-9]{8}\?silent=0&recordingConsent=0
+\{"password":"","force":true\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/call/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}/participants/active\?password=&force=1
+\{"silent":false,"recordingConsent":false\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}/participants/active
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/call/[a-z0-9]{8}\?silent=0&recordingConsent=0
+\{"password":"","force":true\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/call/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-POST http://localhost/ocs/v2\.php/apps/spreed/api/v3/signaling/[a-z0-9]{8}\?messages=[a-zA-Z0-9%]+
+\{"silent":false,"recordingConsent":false\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v3/signaling/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"messages":"\[\{\\"ev\\":\\"message\\",\\"sessionId\\":\\".+\\"\}\\"\}\]"\}
 GET http://localhost/ocs/v2\.php/apps/spreed/api/v3/signaling/[a-z0-9]{8}
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/user_status/heartbeat/heartbeat.regexp
+++ b/packages/nextcloud/test/fixtures/user_status/heartbeat/heartbeat.regexp
@@ -1,12 +1,16 @@
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status\?statusType=online
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"statusType":"online"\}
 DELETE http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message
 accept: application/json
 authorization: Bearer mock
 ocs-apirequest: true
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/heartbeat\?status=online
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/heartbeat
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"status":"online"\}

--- a/packages/nextcloud/test/fixtures/user_status/statuses/find_all.regexp
+++ b/packages/nextcloud/test/fixtures/user_status/statuses/find_all.regexp
@@ -1,7 +1,9 @@
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status\?statusType=online
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"statusType":"online"\}
 DELETE http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message
 accept: application/json
 authorization: Bearer mock
@@ -9,4 +11,6 @@ ocs-apirequest: true
 GET http://localhost/ocs/v2\.php/apps/user_status/api/v1/statuses
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{\}

--- a/packages/nextcloud/test/fixtures/user_status/user_status/clear_message.regexp
+++ b/packages/nextcloud/test/fixtures/user_status/user_status/clear_message.regexp
@@ -1,15 +1,19 @@
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status\?statusType=online
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"statusType":"online"\}
 DELETE http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message
 accept: application/json
 authorization: Bearer mock
 ocs-apirequest: true
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message/custom\?statusIcon=%F0%9F%98%80&message=bla&clearAt=[0-9]+
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message/custom
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"statusIcon":"😀","message":"bla","clearAt":[0-9]+\}
 DELETE http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/user_status/user_status/find.regexp
+++ b/packages/nextcloud/test/fixtures/user_status/user_status/find.regexp
@@ -1,7 +1,9 @@
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status\?statusType=online
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"statusType":"online"\}
 DELETE http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/user_status/user_status/get.regexp
+++ b/packages/nextcloud/test/fixtures/user_status/user_status/get.regexp
@@ -1,7 +1,9 @@
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status\?statusType=online
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"statusType":"online"\}
 DELETE http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/user_status/user_status/set.regexp
+++ b/packages/nextcloud/test/fixtures/user_status/user_status/set.regexp
@@ -1,12 +1,16 @@
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status\?statusType=online
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"statusType":"online"\}
 DELETE http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message
 accept: application/json
 authorization: Bearer mock
 ocs-apirequest: true
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status\?statusType=online
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"statusType":"online"\}

--- a/packages/nextcloud/test/fixtures/user_status/user_status/set_custom_message.regexp
+++ b/packages/nextcloud/test/fixtures/user_status/user_status/set_custom_message.regexp
@@ -1,12 +1,16 @@
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status\?statusType=online
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"statusType":"online"\}
 DELETE http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message
 accept: application/json
 authorization: Bearer mock
 ocs-apirequest: true
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message/custom\?statusIcon=%F0%9F%98%80&message=bla&clearAt=[0-9]+
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message/custom
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"statusIcon":"😀","message":"bla","clearAt":[0-9]+\}

--- a/packages/nextcloud/test/fixtures/user_status/user_status/set_predefined_message.regexp
+++ b/packages/nextcloud/test/fixtures/user_status/user_status/set_predefined_message.regexp
@@ -1,12 +1,16 @@
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status\?statusType=online
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/status
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"statusType":"online"\}
 DELETE http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message
 accept: application/json
 authorization: Bearer mock
 ocs-apirequest: true
-PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message/predefined\?messageId=meeting&clearAt=[0-9]+
+PUT http://localhost/ocs/v2\.php/apps/user_status/api/v1/user_status/message/predefined
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"messageId":"meeting","clearAt":[0-9]+\}

--- a/packages/nextcloud/test/fixtures/weather_status/get_favorites.regexp
+++ b/packages/nextcloud/test/fixtures/weather_status/get_favorites.regexp
@@ -1,7 +1,9 @@
-PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/favorites\?favorites%5B%5D=a&favorites%5B%5D=b
+PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/favorites
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"favorites":\["a","b"\]\}
 GET http://localhost/ocs/v2\.php/apps/weather_status/api/v1/favorites
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/weather_status/get_forecast.regexp
+++ b/packages/nextcloud/test/fixtures/weather_status/get_forecast.regexp
@@ -1,7 +1,9 @@
-PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/location\?address=Berlin
+PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/location
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"address":"Berlin"\}
 GET http://localhost/ocs/v2\.php/apps/weather_status/api/v1/forecast
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/weather_status/get_location.regexp
+++ b/packages/nextcloud/test/fixtures/weather_status/get_location.regexp
@@ -1,7 +1,9 @@
-PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/location\?address=Berlin
+PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/location
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"address":"Berlin"\}
 GET http://localhost/ocs/v2\.php/apps/weather_status/api/v1/location
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/fixtures/weather_status/set_favorites.regexp
+++ b/packages/nextcloud/test/fixtures/weather_status/set_favorites.regexp
@@ -1,4 +1,6 @@
-PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/favorites\?favorites%5B%5D=a&favorites%5B%5D=b
+PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/favorites
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"favorites":\["a","b"\]\}

--- a/packages/nextcloud/test/fixtures/weather_status/set_location.regexp
+++ b/packages/nextcloud/test/fixtures/weather_status/set_location.regexp
@@ -1,8 +1,12 @@
-PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/location\?address=Hamburg
+PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/location
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/location\?lat=52\.5170365&lon=13\.3888599
+\{"address":"Hamburg"\}
+PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/location
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"lat":52\.5170365,"lon":13\.3888599\}

--- a/packages/nextcloud/test/fixtures/weather_status/set_mode.regexp
+++ b/packages/nextcloud/test/fixtures/weather_status/set_mode.regexp
@@ -1,4 +1,6 @@
-PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/mode\?mode=1
+PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/mode
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"mode":1\}

--- a/packages/nextcloud/test/fixtures/weather_status/use_personal_address.regexp
+++ b/packages/nextcloud/test/fixtures/weather_status/use_personal_address.regexp
@@ -1,15 +1,21 @@
-PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/location\?address=Hamburg
+PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/location
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-PUT http://localhost/ocs/v2\.php/core/apppassword/confirm\?password=user1
+\{"address":"Hamburg"\}
+PUT http://localhost/ocs/v2\.php/core/apppassword/confirm
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
-PUT http://localhost/ocs/v2\.php/cloud/users/user1\?key=address&value=Berlin
+\{"password":"user1"\}
+PUT http://localhost/ocs/v2\.php/cloud/users/user1
 accept: application/json
 authorization: Bearer mock
+content-type: application/json; charset=utf-8
 ocs-apirequest: true
+\{"key":"address","value":"Berlin"\}
 PUT http://localhost/ocs/v2\.php/apps/weather_status/api/v1/use-personal
 accept: application/json
 authorization: Bearer mock

--- a/packages/nextcloud/test/notes_test.dart
+++ b/packages/nextcloud/test/notes_test.dart
@@ -168,7 +168,7 @@ void main() {
         expect(response.body.noteMode, notes.Settings_NoteMode.rich);
 
         response = await client.notes.updateSettings(
-          settings: notes.Settings(
+          $body: notes.Settings(
             (b) => b
               ..notesPath = 'Test Notes'
               ..fileSuffix = '.txt'

--- a/packages/nextcloud/test/notifications_test.dart
+++ b/packages/nextcloud/test/notifications_test.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:crypton/crypton.dart';
 import 'package:nextcloud/nextcloud.dart';
-import 'package:nextcloud/notifications.dart';
+import 'package:nextcloud/notifications.dart' as notifications;
 import 'package:nextcloud/src/utils/date_time.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
@@ -28,8 +28,11 @@ void main() {
       Future<void> sendTestNotification() async {
         await client.notifications.api.generateNotification(
           userId: 'admin',
-          shortMessage: '123',
-          longMessage: '456',
+          $body: notifications.ApiGenerateNotificationRequestApplicationJson(
+            (b) => b
+              ..shortMessage = '123'
+              ..longMessage = '456',
+          ),
         );
       }
 
@@ -132,9 +135,12 @@ void main() {
           final keypair = generateKeypair();
 
           final subscription = (await client.notifications.push.registerDevice(
-            pushTokenHash: generatePushTokenHash(pushToken),
-            devicePublicKey: keypair.publicKey.toFormattedPEM(),
-            proxyServer: 'https://example.com/',
+            $body: notifications.PushRegisterDeviceRequestApplicationJson(
+              (b) => b
+                ..pushTokenHash = notifications.generatePushTokenHash(pushToken)
+                ..devicePublicKey = keypair.publicKey.toFormattedPEM()
+                ..proxyServer = 'https://example.com/',
+            ),
           ))
               .body
               .ocs

--- a/packages/nextcloud/test/spreed_test.dart
+++ b/packages/nextcloud/test/spreed_test.dart
@@ -26,8 +26,11 @@ void main() {
       });
 
       Future<spreed.Room> createTestRoom() async => (await client1.spreed.room.createRoom(
-            roomType: spreed.RoomType.public.value,
-            roomName: 'Test',
+            $body: spreed.RoomCreateRoomRequestApplicationJson(
+              (b) => b
+                ..roomType = spreed.RoomType.public.value
+                ..roomName = 'Test',
+            ),
           ))
               .body
               .ocs
@@ -106,8 +109,11 @@ void main() {
         group('Create room', () {
           test('One-to-One', () async {
             final response = await client1.spreed.room.createRoom(
-              roomType: spreed.RoomType.oneToOne.value,
-              invite: 'user2',
+              $body: spreed.RoomCreateRoomRequestApplicationJson(
+                (b) => b
+                  ..roomType = spreed.RoomType.oneToOne.value
+                  ..invite = 'user2',
+              ),
             );
             expect(response.body.ocs.data.id, isPositive);
             expect(response.body.ocs.data.token, isNotEmpty);
@@ -128,8 +134,11 @@ void main() {
 
           test('Group', () async {
             final response = await client1.spreed.room.createRoom(
-              roomType: spreed.RoomType.group.value,
-              invite: 'admin',
+              $body: spreed.RoomCreateRoomRequestApplicationJson(
+                (b) => b
+                  ..roomType = spreed.RoomType.group.value
+                  ..invite = 'admin',
+              ),
             );
             expect(response.body.ocs.data.id, isPositive);
             expect(response.body.ocs.data.token, isNotEmpty);
@@ -150,8 +159,11 @@ void main() {
 
           test('Public', () async {
             final response = await client1.spreed.room.createRoom(
-              roomType: spreed.RoomType.public.value,
-              roomName: 'abc',
+              $body: spreed.RoomCreateRoomRequestApplicationJson(
+                (b) => b
+                  ..roomType = spreed.RoomType.public.value
+                  ..roomName = 'abc',
+              ),
             );
             expect(response.body.ocs.data.id, isPositive);
             expect(response.body.ocs.data.token, isNotEmpty);
@@ -177,8 +189,10 @@ void main() {
           final room = await createTestRoom();
 
           final response = await client1.spreed.avatar.emojiAvatar(
-            emoji: '😀',
             token: room.token,
+            $body: spreed.AvatarEmojiAvatarRequestApplicationJson(
+              (b) => b..emoji = '😀',
+            ),
           );
           expect(response.statusCode, 200);
           expect(response.body.ocs.data.isCustomAvatar, true);
@@ -187,8 +201,10 @@ void main() {
         test('Get avatar', () async {
           final room = await createTestRoom();
           await client1.spreed.avatar.emojiAvatar(
-            emoji: '😀',
             token: room.token,
+            $body: spreed.AvatarEmojiAvatarRequestApplicationJson(
+              (b) => b..emoji = '😀',
+            ),
           );
 
           final response = await client1.spreed.avatar.getAvatar(
@@ -201,8 +217,10 @@ void main() {
         test('Get avatar dark', () async {
           final room = await createTestRoom();
           await client1.spreed.avatar.emojiAvatar(
-            emoji: '😀',
             token: room.token,
+            $body: spreed.AvatarEmojiAvatarRequestApplicationJson(
+              (b) => b..emoji = '😀',
+            ),
           );
 
           final response = await client1.spreed.avatar.getAvatarDark(
@@ -215,8 +233,10 @@ void main() {
         test('Delete avatar', () async {
           final room = await createTestRoom();
           await client1.spreed.avatar.emojiAvatar(
-            emoji: '😀',
             token: room.token,
+            $body: spreed.AvatarEmojiAvatarRequestApplicationJson(
+              (b) => b..emoji = '😀',
+            ),
           );
 
           final response = await client1.spreed.avatar.deleteAvatar(
@@ -234,7 +254,9 @@ void main() {
 
           final response = await client1.spreed.chat.sendMessage(
             token: room.token,
-            message: 'bla',
+            $body: spreed.ChatSendMessageRequestApplicationJson(
+              (b) => b..message = 'bla',
+            ),
           );
           expect(response.body.ocs.data!.id, isPositive);
           expect(response.body.ocs.data!.actorType, spreed.ActorType.users);
@@ -249,22 +271,31 @@ void main() {
           test('Directly', () async {
             final startTime = DateTime.timestamp();
             final room = await createTestRoom();
+
+            final message = (await client1.spreed.chat.sendMessage(
+              token: room.token,
+              $body: spreed.ChatSendMessageRequestApplicationJson(
+                (b) => b..message = 'bla',
+              ),
+            ))
+                .body
+                .ocs
+                .data!;
+
             await client1.spreed.chat.sendMessage(
               token: room.token,
-              message: '123',
-              replyTo: (await client1.spreed.chat.sendMessage(
-                token: room.token,
-                message: 'bla',
-              ))
-                  .body
-                  .ocs
-                  .data!
-                  .id,
+              $body: spreed.ChatSendMessageRequestApplicationJson(
+                (b) => b
+                  ..message = '123'
+                  ..replyTo = message.id,
+              ),
             );
 
             final response = await client1.spreed.chat.receiveMessages(
               token: room.token,
-              lookIntoFuture: spreed.ChatReceiveMessagesLookIntoFuture.$0,
+              $body: spreed.ChatReceiveMessagesRequestApplicationJson(
+                (b) => b..lookIntoFuture = spreed.ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.$0,
+              ),
             );
             expect(response.headers.xChatLastGiven, isNotEmpty);
             expect(response.headers.xChatLastCommonRead, isNotEmpty);
@@ -314,7 +345,9 @@ void main() {
             final room = await createTestRoom();
             final message = (await client1.spreed.chat.sendMessage(
               token: room.token,
-              message: 'bla',
+              $body: spreed.ChatSendMessageRequestApplicationJson(
+                (b) => b..message = 'bla',
+              ),
             ))
                 .body
                 .ocs
@@ -323,16 +356,21 @@ void main() {
               Future<void>.delayed(const Duration(seconds: 1)).then((_) async {
                 await client1.spreed.chat.sendMessage(
                   token: room.token,
-                  message: '123',
+                  $body: spreed.ChatSendMessageRequestApplicationJson(
+                    (b) => b..message = '123',
+                  ),
                 );
               }),
             );
 
             final response = await client1.spreed.chat.receiveMessages(
               token: room.token,
-              lookIntoFuture: spreed.ChatReceiveMessagesLookIntoFuture.$1,
-              timeout: 3,
-              lastKnownMessageId: message.id,
+              $body: spreed.ChatReceiveMessagesRequestApplicationJson(
+                (b) => b
+                  ..lookIntoFuture = spreed.ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.$1
+                  ..timeout = 3
+                  ..lastKnownMessageId = message.id,
+              ),
             );
             expect(response.body.ocs.data, hasLength(1));
             expect(response.body.ocs.data[0].id, isPositive);
@@ -349,13 +387,17 @@ void main() {
           final room = await createTestRoom();
 
           await client1.spreed.room.addParticipantToRoom(
-            newParticipant: 'user2',
             token: room.token,
+            $body: spreed.RoomAddParticipantToRoomRequestApplicationJson(
+              (b) => b..newParticipant = 'user2',
+            ),
           );
 
           final response = await client1.spreed.chat.mentions(
-            search: 'user',
             token: room.token,
+            $body: spreed.ChatMentionsRequestApplicationJson(
+              (b) => b..search = 'user',
+            ),
           );
           expect(response.body.ocs.data, hasLength(1));
           expect(response.body.ocs.data[0].id, 'user2');
@@ -389,7 +431,11 @@ void main() {
         test('Get settings', () async {
           final room = await createTestRoom();
 
-          final response = await client1.spreed.internalSignaling.signalingGetSettings(token: room.token);
+          final response = await client1.spreed.internalSignaling.signalingGetSettings(
+            $body: spreed.SignalingGetSettingsRequestApplicationJson(
+              (b) => b..token = room.token,
+            ),
+          );
           expect(response.body.ocs.data.signalingMode, 'internal');
           expect(response.body.ocs.data.userId, 'user1');
           expect(response.body.ocs.data.hideWarning, false);
@@ -443,15 +489,18 @@ void main() {
 
           await client1.spreed.internalSignaling.signalingSendMessages(
             token: room.token,
-            messages: json.encode([
-              {
-                'ev': 'message',
-                'sessionId': room1.sessionId,
-                'fn': json.encode({
-                  'to': room2.sessionId,
-                }),
-              },
-            ]),
+            $body: spreed.SignalingSendMessagesRequestApplicationJson(
+              (b) => b
+                ..messages = json.encode([
+                  {
+                    'ev': 'message',
+                    'sessionId': room1.sessionId,
+                    'fn': json.encode({
+                      'to': room2.sessionId,
+                    }),
+                  },
+                ]),
+            ),
           );
 
           await Future<void>.delayed(const Duration(seconds: 1));
@@ -474,14 +523,18 @@ void main() {
 
           final sendMessageResponse = await client1.spreed.chat.sendMessage(
             token: room.token,
-            message: 'bla',
+            $body: spreed.ChatSendMessageRequestApplicationJson(
+              (b) => b..message = 'bla',
+            ),
           );
           expect(sendMessageResponse.body.ocs.data!.reactions, isEmpty);
           expect(sendMessageResponse.body.ocs.data!.reactionsSelf, isNull);
 
           var receiveMessagesResponse = await client1.spreed.chat.receiveMessages(
             token: room.token,
-            lookIntoFuture: spreed.ChatReceiveMessagesLookIntoFuture.$0,
+            $body: spreed.ChatReceiveMessagesRequestApplicationJson(
+              (b) => b..lookIntoFuture = spreed.ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.$0,
+            ),
           );
           var message = receiveMessagesResponse.body.ocs.data[0];
           expect(message.message, 'bla');
@@ -489,16 +542,20 @@ void main() {
           expect(message.reactionsSelf, isNull);
 
           final addResponse = await client1.spreed.reaction.react(
-            reaction: '😀',
             token: room.token,
             messageId: message.id,
+            $body: spreed.ReactionReactRequestApplicationJson(
+              (b) => b..reaction = '😀',
+            ),
           );
           expect(addResponse.body.ocs.data, hasLength(1));
           expect(addResponse.body.ocs.data['😀'], isNotNull);
 
           receiveMessagesResponse = await client1.spreed.chat.receiveMessages(
             token: room.token,
-            lookIntoFuture: spreed.ChatReceiveMessagesLookIntoFuture.$0,
+            $body: spreed.ChatReceiveMessagesRequestApplicationJson(
+              (b) => b..lookIntoFuture = spreed.ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.$0,
+            ),
           );
           message = receiveMessagesResponse.body.ocs.data[1];
           expect(message.message, 'bla');
@@ -508,15 +565,19 @@ void main() {
           expect(message.reactionsSelf, contains('😀'));
 
           final removeResponse = await client1.spreed.reaction.delete(
-            reaction: '😀',
             token: room.token,
             messageId: message.id,
+            $body: spreed.ReactionDeleteRequestApplicationJson(
+              (b) => b..reaction = '😀',
+            ),
           );
           expect(removeResponse.body.ocs.data, isEmpty);
 
           receiveMessagesResponse = await client1.spreed.chat.receiveMessages(
             token: room.token,
-            lookIntoFuture: spreed.ChatReceiveMessagesLookIntoFuture.$0,
+            $body: spreed.ChatReceiveMessagesRequestApplicationJson(
+              (b) => b..lookIntoFuture = spreed.ChatReceiveMessagesRequestApplicationJson_LookIntoFuture.$0,
+            ),
           );
           message = receiveMessagesResponse.body.ocs.data[2];
           expect(message.message, 'bla');
@@ -529,13 +590,17 @@ void main() {
 
           final sendMessageResponse = await client1.spreed.chat.sendMessage(
             token: room.token,
-            message: 'bla',
+            $body: spreed.ChatSendMessageRequestApplicationJson(
+              (b) => b..message = 'bla',
+            ),
           );
 
           final addResponse = await client1.spreed.reaction.react(
-            reaction: '😀',
             token: room.token,
             messageId: sendMessageResponse.body.ocs.data!.id,
+            $body: spreed.ReactionReactRequestApplicationJson(
+              (b) => b..reaction = '😀',
+            ),
           );
           expect(addResponse.body.ocs.data, hasLength(1));
           expect(addResponse.body.ocs.data['😀'], isNotNull);

--- a/packages/nextcloud/test/user_status_test.dart
+++ b/packages/nextcloud/test/user_status_test.dart
@@ -20,7 +20,11 @@ void main() {
       });
 
       Future<void> resetStatus() async {
-        await client.userStatus.userStatus.setStatus(statusType: user_status.$Type.online.value);
+        await client.userStatus.userStatus.setStatus(
+          $body: user_status.UserStatusSetStatusRequestApplicationJson(
+            (b) => b..statusType = user_status.$Type.online.value,
+          ),
+        );
         await client.userStatus.userStatus.clearMessage();
       }
 
@@ -64,7 +68,11 @@ void main() {
         test('Set', () async {
           await resetStatus();
 
-          final response = await client.userStatus.userStatus.setStatus(statusType: user_status.$Type.online.value);
+          final response = await client.userStatus.userStatus.setStatus(
+            $body: user_status.UserStatusSetStatusRequestApplicationJson(
+              (b) => b..statusType = user_status.$Type.online.value,
+            ),
+          );
           expect(response.statusCode, 200);
           expect(() => response.headers, isA<void>());
 
@@ -114,8 +122,11 @@ void main() {
 
           final clearAt = DateTime.timestamp().secondsSinceEpoch + 60;
           final response = await client.userStatus.userStatus.setPredefinedMessage(
-            messageId: 'meeting',
-            clearAt: clearAt,
+            $body: user_status.UserStatusSetPredefinedMessageRequestApplicationJson(
+              (b) => b
+                ..messageId = 'meeting'
+                ..clearAt = clearAt,
+            ),
           );
           expect(response.statusCode, 200);
           expect(() => response.headers, isA<void>());
@@ -135,9 +146,12 @@ void main() {
 
           final clearAt = DateTime.timestamp().secondsSinceEpoch + 60;
           final response = await client.userStatus.userStatus.setCustomMessage(
-            statusIcon: '😀',
-            message: 'bla',
-            clearAt: clearAt,
+            $body: user_status.UserStatusSetCustomMessageRequestApplicationJson(
+              (b) => b
+                ..statusIcon = '😀'
+                ..message = 'bla'
+                ..clearAt = clearAt,
+            ),
           );
           expect(response.statusCode, 200);
           expect(() => response.headers, isA<void>());
@@ -157,9 +171,12 @@ void main() {
 
           final clearAt = DateTime.timestamp().secondsSinceEpoch + 60;
           await client.userStatus.userStatus.setCustomMessage(
-            statusIcon: '😀',
-            message: 'bla',
-            clearAt: clearAt,
+            $body: user_status.UserStatusSetCustomMessageRequestApplicationJson(
+              (b) => b
+                ..statusIcon = '😀'
+                ..message = 'bla'
+                ..clearAt = clearAt,
+            ),
           );
           await client.userStatus.userStatus.clearMessage();
 
@@ -198,7 +215,11 @@ void main() {
         test('Heartbeat', () async {
           await resetStatus();
 
-          final response = await client.userStatus.heartbeat.heartbeat(status: user_status.$Type.online.value);
+          final response = await client.userStatus.heartbeat.heartbeat(
+            $body: user_status.HeartbeatHeartbeatRequestApplicationJson(
+              (b) => b..status = user_status.$Type.online.value,
+            ),
+          );
           expect(response.statusCode, 200);
           expect(() => response.headers, isA<void>());
 

--- a/packages/nextcloud/test/weather_status_test.dart
+++ b/packages/nextcloud/test/weather_status_test.dart
@@ -1,8 +1,7 @@
-import 'package:built_collection/built_collection.dart';
-import 'package:nextcloud/core.dart';
+import 'package:nextcloud/core.dart' as core;
 import 'package:nextcloud/nextcloud.dart';
-import 'package:nextcloud/provisioning_api.dart';
-import 'package:nextcloud/weather_status.dart';
+import 'package:nextcloud/provisioning_api.dart' as provisioning_api;
+import 'package:nextcloud/weather_status.dart' as weather_status;
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
 import 'package:version/version.dart';
@@ -24,7 +23,9 @@ void main() {
 
       test('Set mode', () async {
         final response = await client.weatherStatus.weatherStatus.setMode(
-          mode: 1,
+          $body: weather_status.WeatherStatusSetModeRequestApplicationJson(
+            (b) => b..mode = 1,
+          ),
         );
         expect(response.statusCode, 200);
         expect(response.body.ocs.data.success, true);
@@ -32,7 +33,9 @@ void main() {
 
       test('Get location', () async {
         await client.weatherStatus.weatherStatus.setLocation(
-          address: 'Berlin',
+          $body: weather_status.WeatherStatusSetLocationRequestApplicationJson(
+            (b) => b..address = 'Berlin',
+          ),
         );
 
         final response = await client.weatherStatus.weatherStatus.getLocation();
@@ -45,7 +48,9 @@ void main() {
 
       test('Set location', () async {
         var response = await client.weatherStatus.weatherStatus.setLocation(
-          address: 'Hamburg',
+          $body: weather_status.WeatherStatusSetLocationRequestApplicationJson(
+            (b) => b..address = 'Hamburg',
+          ),
         );
         expect(response.statusCode, 200);
         expect(response.body.ocs.data.success, true);
@@ -54,8 +59,11 @@ void main() {
         expect(response.body.ocs.data.lon, '10.000654');
 
         response = await client.weatherStatus.weatherStatus.setLocation(
-          lat: 52.5170365,
-          lon: 13.3888599,
+          $body: weather_status.WeatherStatusSetLocationRequestApplicationJson(
+            (b) => b
+              ..lat = 52.5170365
+              ..lon = 13.3888599,
+          ),
         );
         expect(response.statusCode, 200);
         expect(response.body.ocs.data.success, true);
@@ -68,17 +76,24 @@ void main() {
         'Use personal address',
         () async {
           await client.weatherStatus.weatherStatus.setLocation(
-            address: 'Hamburg',
+            $body: weather_status.WeatherStatusSetLocationRequestApplicationJson(
+              (b) => b..address = 'Hamburg',
+            ),
           );
 
           await client.core.appPassword.confirmUserPassword(
-            password: 'user1',
+            $body: core.AppPasswordConfirmUserPasswordRequestApplicationJson(
+              (b) => b..password = 'user1',
+            ),
           );
 
           await client.provisioningApi.users.editUser(
-            key: 'address',
-            value: 'Berlin',
             userId: 'user1',
+            $body: provisioning_api.UsersEditUserRequestApplicationJson(
+              (b) => b
+                ..key = 'address'
+                ..value = 'Berlin',
+            ),
           );
 
           final response = await client.weatherStatus.weatherStatus.usePersonalAddress();
@@ -93,7 +108,9 @@ void main() {
 
       test('Get forecast', () async {
         await client.weatherStatus.weatherStatus.setLocation(
-          address: 'Berlin',
+          $body: weather_status.WeatherStatusSetLocationRequestApplicationJson(
+            (b) => b..address = 'Berlin',
+          ),
         );
 
         final response = await client.weatherStatus.weatherStatus.getForecast();
@@ -103,7 +120,11 @@ void main() {
       });
 
       test('Get favorites', () async {
-        await client.weatherStatus.weatherStatus.setFavorites(favorites: BuiltList(['a', 'b']));
+        await client.weatherStatus.weatherStatus.setFavorites(
+          $body: weather_status.WeatherStatusSetFavoritesRequestApplicationJson(
+            (b) => b..favorites.replace(['a', 'b']),
+          ),
+        );
 
         final response = await client.weatherStatus.weatherStatus.getFavorites();
         expect(response.statusCode, 200);
@@ -111,7 +132,11 @@ void main() {
       });
 
       test('Set favorites', () async {
-        final response = await client.weatherStatus.weatherStatus.setFavorites(favorites: BuiltList(['a', 'b']));
+        final response = await client.weatherStatus.weatherStatus.setFavorites(
+          $body: weather_status.WeatherStatusSetFavoritesRequestApplicationJson(
+            (b) => b..favorites.replace(['a', 'b']),
+          ),
+        );
         expect(response.statusCode, 200);
         expect(response.body.ocs.data.success, true);
       });


### PR DESCRIPTION
Depends on https://github.com/nextcloud/openapi-extractor/pull/105

I can't even begin to list all the problems this solves :sweat_smile:
There were quite some bugs in the way we serialized and encoded request bodies and how we handle default values in those cases. I wasn't really able to separate the fixes, so I hope this is ok.

We can also already merge the dynamite fixes and stash the nextcloud changes until the openapi-extractor PR is merged (which could be very soon already as there is only one minor blocker with the ocs_api_viewer).