### PR TITLE
fix(tool): Skip pushing docker images when PR is from a fork

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -49,6 +49,9 @@ jobs:
           packages_glob="${packages_glob:1}"
           if [ -n "$packages_glob" ]; then
             if [[ "$packages_glob" == *"nextcloud"* ]]; then
+              if [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
+                export PUSH_IMAGES="1"
+              fi
               ./tool/build-dev-container.sh
             fi
             MELOS_PACKAGES="$packages_glob" melos test

--- a/tool/common.sh
+++ b/tool/common.sh
@@ -15,7 +15,7 @@ function cache_build_args() {
       "--cache-to" "type=inline,mode=max"
       "--cache-from" "type=registry,ref=$tag"
     )
-    if [ -v GITHUB_REPOSITORY ]; then
+    if [ -v PUSH_IMAGES ]; then
       build_args+=("--cache-to" "type=registry,ref=$tag,mode=max")
     fi
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/2128
Forks now skip pushing the images which was always failing: https://github.com/nextcloud/neon/actions/runs/9378866792/job/25822785309?pr=2130
And running on this repo still pushes the images to the cache: https://github.com/nextcloud/neon/actions/runs/9378920660/job/25822950408?pr=2131