### PR TITLE
fix(neon_talk): Rescale rich object file preview if width is too big

### DIFF
--- a/packages/neon/neon_talk/lib/src/widgets/rich_object/file_preview.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/rich_object/file_preview.dart
@@ -18,46 +18,54 @@ class TalkRichObjectFilePreview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final maxHeight = MediaQuery.sizeOf(context).height / 2;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maxSize = Size(constraints.maxWidth, MediaQuery.sizeOf(context).height / 2);
 
-    Size? logicalSize;
-    var deviceSize = const Size(-1, -1);
+        Size? logicalSize;
+        var deviceSize = const Size(-1, -1);
 
-    if (parameter.width != null && parameter.height != null) {
-      final devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
+        if (parameter.width != null && parameter.height != null) {
+          final devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
 
-      deviceSize = Size(_parseDimension(parameter.width!).toDouble(), _parseDimension(parameter.height!).toDouble());
+          deviceSize = Size(
+            _parseDimension(parameter.width!).toDouble(),
+            _parseDimension(parameter.height!).toDouble(),
+          );
 
-      // Convert to logical pixels
-      logicalSize = deviceSize / devicePixelRatio;
+          // Convert to logical pixels
+          logicalSize = deviceSize / devicePixelRatio;
 
-      // Constrain size to max height but keep aspect ratio
-      if (logicalSize.height > maxHeight) {
-        logicalSize = logicalSize * (maxHeight / logicalSize.height);
-      }
+          // Constrain size to max size but keep aspect ratio
+          if (logicalSize.width > maxSize.width) {
+            logicalSize = logicalSize * (maxSize.width / logicalSize.width);
+          }
+          if (logicalSize.height > maxSize.height) {
+            logicalSize = logicalSize * (maxSize.height / logicalSize.height);
+          }
 
-      // Convert back to device pixels
-      deviceSize = logicalSize * devicePixelRatio;
-    }
+          // Convert back to device pixels
+          deviceSize = logicalSize * devicePixelRatio;
+        }
 
-    return ConstrainedBox(
-      constraints: logicalSize != null
-          ? BoxConstraints.tight(logicalSize)
-          : BoxConstraints.loose(Size(double.infinity, maxHeight)),
-      child: Tooltip(
-        message: parameter.name,
-        child: NeonApiImage(
-          account: NeonProvider.of<Account>(context),
-          cacheKey: 'preview-${parameter.path!}-${deviceSize.width.toInt()}-${deviceSize.height.toInt()}',
-          etag: parameter.etag,
-          expires: null,
-          getRequest: (client) => client.core.preview.$getPreviewByFileId_Request(
-            fileId: int.parse(parameter.id),
-            x: deviceSize.width.toInt(),
-            y: deviceSize.height.toInt(),
+        return ConstrainedBox(
+          constraints: logicalSize != null ? BoxConstraints.tight(logicalSize) : BoxConstraints.loose(maxSize),
+          child: Tooltip(
+            message: parameter.name,
+            child: NeonApiImage(
+              account: NeonProvider.of<Account>(context),
+              cacheKey: 'preview-${parameter.path!}-${deviceSize.width.toInt()}-${deviceSize.height.toInt()}',
+              etag: parameter.etag,
+              expires: null,
+              getRequest: (client) => client.core.preview.$getPreviewByFileId_Request(
+                fileId: int.parse(parameter.id),
+                x: deviceSize.width.toInt(),
+                y: deviceSize.height.toInt(),
+              ),
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 

--- a/packages/neon/neon_talk/test/rich_object_test.dart
+++ b/packages/neon/neon_talk/test/rich_object_test.dart
@@ -302,6 +302,10 @@ void main() {
   });
 
   group('File preview', () {
+    const pixelRatio = 3;
+    const maxWidth = 800;
+    const maxHeight = 600 ~/ 2;
+
     testWidgets('Without dimensions', (tester) async {
       await tester.pumpWidgetWithAccessibility(
         TestApp(
@@ -322,7 +326,7 @@ void main() {
         ),
       );
 
-      final expectedConstraints = BoxConstraints.loose(const Size(double.infinity, 300));
+      final expectedConstraints = BoxConstraints.loose(Size(maxWidth.toDouble(), maxHeight.toDouble()));
       expect(
         find.byWidgetPredicate((widget) => widget is ConstrainedBox && widget.constraints == expectedConstraints),
         findsOne,
@@ -336,7 +340,8 @@ void main() {
     });
 
     testWidgets('With dimensions', (tester) async {
-      // Default device pixel ratio for tests is 3, so we don't need to set it manually to ensure the calculations are right.
+      const width = 900;
+      const height = 300;
 
       await tester.pumpWidgetWithAccessibility(
         TestApp(
@@ -351,20 +356,20 @@ void main() {
                 ..name = 'name'
                 ..previewAvailable = spreed.RichObjectParameter_PreviewAvailable.yes
                 ..path = 'path'
-                ..width = ($int: 900, string: null)
-                ..height = ($int: 300, string: null),
+                ..width = ($int: width, string: null)
+                ..height = ($int: height, string: null),
             ),
             textStyle: null,
           ),
         ),
       );
 
-      final expectedConstraints = BoxConstraints.tight(const Size(300, 100));
+      final expectedConstraints = BoxConstraints.tight(const Size(width / pixelRatio, height / pixelRatio));
       expect(
         find.byWidgetPredicate((widget) => widget is ConstrainedBox && widget.constraints == expectedConstraints),
         findsOne,
       );
-      const expectedCacheKey = 'preview-path-900-300';
+      const expectedCacheKey = 'preview-path-$width-$height';
       expect(
         find.byWidgetPredicate((widget) => widget is NeonApiImage && widget.cacheKey == expectedCacheKey),
         findsOne,
@@ -373,7 +378,8 @@ void main() {
     });
 
     testWidgets('With dimensions too big', (tester) async {
-      // Default device pixel ratio for tests is 3, so we don't need to set it manually to ensure the calculations are right.
+      const widthFactor = 2; // Make it too big
+      const heightFactor = 4; // Make this even bigger
 
       await tester.pumpWidgetWithAccessibility(
         TestApp(
@@ -388,20 +394,25 @@ void main() {
                 ..name = 'name'
                 ..previewAvailable = spreed.RichObjectParameter_PreviewAvailable.yes
                 ..path = 'path'
-                ..width = ($int: 6000, string: null)
-                ..height = ($int: 2000, string: null),
+                ..width = ($int: (maxWidth * widthFactor) * pixelRatio, string: null)
+                ..height = ($int: (maxHeight * heightFactor) * pixelRatio, string: null),
             ),
             textStyle: null,
           ),
         ),
       );
 
-      final expectedConstraints = BoxConstraints.tight(const Size(900, 300));
+      final size = Size(
+        widthFactor * maxWidth / heightFactor,
+        maxHeight.toDouble(),
+      );
+      final expectedConstraints = BoxConstraints.tight(size);
       expect(
         find.byWidgetPredicate((widget) => widget is ConstrainedBox && widget.constraints == expectedConstraints),
         findsOne,
       );
-      const expectedCacheKey = 'preview-path-2700-900';
+      final expectedCacheKey =
+          'preview-path-${(size.width * pixelRatio).toInt()}-${(size.height * pixelRatio).toInt()}';
       expect(
         find.byWidgetPredicate((widget) => widget is NeonApiImage && widget.cacheKey == expectedCacheKey),
         findsOne,


### PR DESCRIPTION
In case the image width was still too big after rescaling the image by the height it needs to be rescaled again by the width to ensure the constraints are always correct.

Also reworked the tests to do the calculations on the fly as I couldn't even understand myself what I wrote there just a few days ago...

Best reviewed with https://github.com/nextcloud/neon/pull/2136/files?w=1