### PR TITLE
fix: Dispose all state and cancel all stream subscriptions

### DIFF
--- a/packages/neon/neon_files/lib/src/pages/main.dart
+++ b/packages/neon/neon_files/lib/src/pages/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:neon_files/l10n/localizations.dart';
 import 'package:neon_files/src/blocs/files.dart';
@@ -18,15 +20,23 @@ class FilesMainPage extends StatefulWidget {
 
 class _FilesMainPageState extends State<FilesMainPage> {
   late FilesBloc bloc;
+  late final StreamSubscription<Object> errorsSubscription;
 
   @override
   void initState() {
     super.initState();
     bloc = NeonProvider.of<FilesBloc>(context);
 
-    bloc.errors.listen((error) {
+    errorsSubscription = bloc.errors.listen((error) {
       NeonError.showSnackbar(context, error);
     });
+  }
+
+  @override
+  void dispose() {
+    unawaited(errorsSubscription.cancel());
+
+    super.dispose();
   }
 
   @override

--- a/packages/neon/neon_files/lib/src/widgets/browser_view.dart
+++ b/packages/neon/neon_files/lib/src/widgets/browser_view.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:built_collection/built_collection.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
@@ -29,13 +31,22 @@ class FilesBrowserView extends StatefulWidget {
 }
 
 class _FilesBrowserViewState extends State<FilesBrowserView> {
+  late final StreamSubscription<Object> errorsSubscription;
+
   @override
   void initState() {
-    widget.bloc.errors.listen((error) {
+    errorsSubscription = widget.bloc.errors.listen((error) {
       NeonError.showSnackbar(context, error);
     });
 
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    unawaited(errorsSubscription.cancel());
+
+    super.dispose();
   }
 
   @override

--- a/packages/neon/neon_news/lib/src/pages/article.dart
+++ b/packages/neon/neon_news/lib/src/pages/article.dart
@@ -38,12 +38,13 @@ class _NewsArticlePageState extends State<NewsArticlePage> {
   WebViewController? _webviewController;
   Timer? _markAsReadTimer;
   bool loading = false;
+  late final StreamSubscription<Object> errorsSubscription;
 
   @override
   void initState() {
     super.initState();
 
-    widget.bloc.errors.listen((error) {
+    errorsSubscription = widget.bloc.errors.listen((error) {
       NeonError.showSnackbar(context, error);
     });
 
@@ -81,6 +82,7 @@ class _NewsArticlePageState extends State<NewsArticlePage> {
   @override
   void dispose() {
     _cancelMarkAsReadTimer();
+    unawaited(errorsSubscription.cancel());
 
     super.dispose();
   }

--- a/packages/neon/neon_news/lib/src/pages/main.dart
+++ b/packages/neon/neon_news/lib/src/pages/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:neon_framework/theme.dart';
 import 'package:neon_framework/utils.dart';
@@ -22,15 +24,23 @@ class NewsMainPage extends StatefulWidget {
 class _NewsMainPageState extends State<NewsMainPage> {
   late NewsBloc bloc;
   late int _index = bloc.options.defaultCategoryOption.value.index;
+  late final StreamSubscription<Object> errorsSubscription;
 
   @override
   void initState() {
     super.initState();
     bloc = NeonProvider.of<NewsBloc>(context);
 
-    bloc.errors.listen((error) {
+    errorsSubscription = bloc.errors.listen((error) {
       NeonError.showSnackbar(context, error);
     });
+  }
+
+  @override
+  void dispose() {
+    unawaited(errorsSubscription.cancel());
+
+    super.dispose();
   }
 
   @override

--- a/packages/neon/neon_news/lib/src/widgets/articles_view.dart
+++ b/packages/neon/neon_news/lib/src/widgets/articles_view.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:html/dom.dart' as html_dom;
 import 'package:html/parser.dart' as html_parser;
@@ -39,13 +41,22 @@ class NewsArticlesView extends StatefulWidget {
 }
 
 class _NewsArticlesViewState extends State<NewsArticlesView> {
+  late final StreamSubscription<Object> errorsSubscription;
+
   @override
   void initState() {
     super.initState();
 
-    widget.bloc.errors.listen((error) {
+    errorsSubscription = widget.bloc.errors.listen((error) {
       NeonError.showSnackbar(context, error);
     });
+  }
+
+  @override
+  void dispose() {
+    unawaited(errorsSubscription.cancel());
+
+    super.dispose();
   }
 
   @override

--- a/packages/neon/neon_notes/lib/src/pages/main.dart
+++ b/packages/neon/neon_notes/lib/src/pages/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:neon_framework/theme.dart';
 import 'package:neon_framework/utils.dart';
@@ -20,6 +22,7 @@ class NotesMainPage extends StatefulWidget {
 class _NotesMainPageState extends State<NotesMainPage> {
   late NotesBloc bloc;
   late int _index = bloc.options.defaultCategoryOption.value.index;
+  late final StreamSubscription<Object> errorsSubscription;
 
   @override
   void initState() {
@@ -27,9 +30,16 @@ class _NotesMainPageState extends State<NotesMainPage> {
 
     bloc = NeonProvider.of<NotesBloc>(context);
 
-    bloc.errors.listen((error) {
+    errorsSubscription = bloc.errors.listen((error) {
       handleNotesException(context, error);
     });
+  }
+
+  @override
+  void dispose() {
+    unawaited(errorsSubscription.cancel());
+
+    super.dispose();
   }
 
   @override

--- a/packages/neon/neon_notes/lib/src/pages/note.dart
+++ b/packages/neon/neon_notes/lib/src/pages/note.dart
@@ -36,6 +36,7 @@ class _NotesNotePageState extends State<NotesNotePage> {
   bool _showEditor = false;
   final _contentStreamController = StreamController<String>();
   final _titleStreamController = StreamController<String>();
+  late final StreamSubscription<Object> errorsSubscription;
 
   void _focusEditor() {
     _contentFocusNode.requestFocus();
@@ -46,7 +47,7 @@ class _NotesNotePageState extends State<NotesNotePage> {
   void initState() {
     super.initState();
 
-    widget.bloc.errors.listen((error) {
+    errorsSubscription = widget.bloc.errors.listen((error) {
       handleNotesException(context, error);
     });
 
@@ -79,6 +80,7 @@ class _NotesNotePageState extends State<NotesNotePage> {
     _titleFocusNode.dispose();
     unawaited(_contentStreamController.close());
     unawaited(_titleStreamController.close());
+    unawaited(errorsSubscription.cancel());
     super.dispose();
   }
 

--- a/packages/neon/neon_notifications/lib/src/pages/main.dart
+++ b/packages/neon/neon_notifications/lib/src/pages/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
 import 'package:neon_framework/blocs.dart';
@@ -19,6 +21,7 @@ class NotificationsMainPage extends StatefulWidget {
 
 class _NotificationsMainPageState extends State<NotificationsMainPage> {
   late NotificationsBloc bloc;
+  late final StreamSubscription<Object> errorsSubscription;
 
   @override
   void initState() {
@@ -26,9 +29,16 @@ class _NotificationsMainPageState extends State<NotificationsMainPage> {
 
     bloc = NeonProvider.of<NotificationsBlocInterface>(context) as NotificationsBloc;
 
-    bloc.errors.listen((error) {
+    errorsSubscription = bloc.errors.listen((error) {
       NeonError.showSnackbar(context, error);
     });
+  }
+
+  @override
+  void dispose() {
+    unawaited(errorsSubscription.cancel());
+
+    super.dispose();
   }
 
   @override

--- a/packages/neon/neon_talk/lib/src/pages/main.dart
+++ b/packages/neon/neon_talk/lib/src/pages/main.dart
@@ -28,7 +28,7 @@ class TalkMainPage extends StatefulWidget {
 class _TalkMainPageState extends State<TalkMainPage> {
   late Account account;
   late TalkBloc bloc;
-  late StreamSubscription<Object> errorsSubscription;
+  late final StreamSubscription<Object> errorsSubscription;
 
   @override
   void initState() {

--- a/packages/neon_framework/lib/src/blocs/apps.dart
+++ b/packages/neon_framework/lib/src/blocs/apps.dart
@@ -68,7 +68,7 @@ class _AppsBloc extends InteractiveBloc implements AppsBloc {
       unawaited(updateApps());
     });
 
-    capabilitiesSubject.listen((result) {
+    capabilitiesSubscription = capabilitiesSubject.listen((result) {
       unawaited(updateApps());
     });
 
@@ -214,6 +214,8 @@ class _AppsBloc extends InteractiveBloc implements AppsBloc {
   }
 
   final BehaviorSubject<Result<core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data>> capabilitiesSubject;
+  late final StreamSubscription<Result<core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data>>
+      capabilitiesSubscription;
   final Account account;
   final AccountOptions accountOptions;
   final BuiltSet<AppImplementation> allAppImplementations;
@@ -221,6 +223,7 @@ class _AppsBloc extends InteractiveBloc implements AppsBloc {
 
   @override
   void dispose() {
+    unawaited(capabilitiesSubscription.cancel());
     unawaited(apps.close());
     unawaited(appImplementations.close());
     unawaited(activeApp.close());

--- a/packages/neon_framework/lib/src/blocs/next_push.dart
+++ b/packages/neon_framework/lib/src/blocs/next_push.dart
@@ -33,7 +33,7 @@ class _NextPushBloc extends Bloc implements NextPushBloc {
     if (disabled) {
       return;
     }
-    Rx.merge([
+    changesSubscription = Rx.merge([
       globalOptions.pushNotificationsEnabled.stream,
       globalOptions.pushNotificationsDistributor.stream,
       accountsSubject,
@@ -88,9 +88,11 @@ class _NextPushBloc extends Bloc implements NextPushBloc {
   final BehaviorSubject<BuiltList<Account>> accountsSubject;
   final GlobalOptions globalOptions;
   final supported = <Account, bool>{};
+  late final StreamSubscription<Object?> changesSubscription;
 
   @override
   void dispose() {
+    unawaited(changesSubscription.cancel());
     unawaited(onNextPushSupported.close());
   }
 

--- a/packages/neon_framework/lib/src/blocs/unified_search.dart
+++ b/packages/neon_framework/lib/src/blocs/unified_search.dart
@@ -41,7 +41,7 @@ class _UnifiedSearchBloc extends InteractiveBloc implements UnifiedSearchBloc {
     required this.activeAppSubject,
     required this.account,
   }) {
-    activeAppSubject.listen((_) {
+    activeAppSubscription = activeAppSubject.listen((_) {
       term = '';
       extendedSearchEnabled = false;
       results.add(BuiltMap());
@@ -52,6 +52,7 @@ class _UnifiedSearchBloc extends InteractiveBloc implements UnifiedSearchBloc {
   final log = Logger('UnifiedSearchBloc');
 
   final BehaviorSubject<AppImplementation> activeAppSubject;
+  late final StreamSubscription<AppImplementation> activeAppSubscription;
   final Account account;
   String term = '';
   bool extendedSearchEnabled = false;
@@ -67,6 +68,7 @@ class _UnifiedSearchBloc extends InteractiveBloc implements UnifiedSearchBloc {
 
   @override
   void dispose() {
+    unawaited(activeAppSubscription.cancel());
     unawaited(isExtendedSearch.close());
     unawaited(providers.close());
     unawaited(results.close());

--- a/packages/neon_framework/lib/src/pages/home.dart
+++ b/packages/neon_framework/lib/src/pages/home.dart
@@ -32,9 +32,9 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   late global_options.GlobalOptions _globalOptions;
   late AppsBloc _appsBloc;
-  late StreamSubscription<BuiltMap<String, VersionCheck>> _versionCheckSubscription;
-  late StreamSubscription<Object> maintenanceModeErrorsSubscription;
-  late StreamSubscription<void> maintenanceModeSubscription;
+  late final StreamSubscription<BuiltMap<String, VersionCheck>> _versionCheckSubscription;
+  late final StreamSubscription<Object> maintenanceModeErrorsSubscription;
+  late final StreamSubscription<void> maintenanceModeSubscription;
 
   @override
   void initState() {

--- a/packages/neon_framework/lib/src/pages/settings.dart
+++ b/packages/neon_framework/lib/src/pages/settings.dart
@@ -72,7 +72,7 @@ enum SettingsCategories {
 ///
 /// Settings are specified as `Option`s.
 @internal
-class SettingsPage extends StatefulWidget {
+class SettingsPage extends StatelessWidget {
   /// Creates a new settings page.
   const SettingsPage({
     this.initialCategory,
@@ -82,11 +82,6 @@ class SettingsPage extends StatefulWidget {
   /// The optional initial category to show.
   final SettingsCategories? initialCategory;
 
-  @override
-  State<SettingsPage> createState() => _SettingsPageState();
-}
-
-class _SettingsPageState extends State<SettingsPage> {
   @override
   Widget build(BuildContext context) {
     final globalOptions = NeonProvider.of<GlobalOptions>(context);
@@ -128,7 +123,7 @@ class _SettingsPageState extends State<SettingsPage> {
       ],
     );
     final body = SettingsList(
-      initialCategoryKey: widget.initialCategory?.name,
+      initialCategoryKey: initialCategory?.name,
       categories: [
         SettingsCategory(
           hasLeading: true,
@@ -173,7 +168,7 @@ class _SettingsPageState extends State<SettingsPage> {
             ),
           ],
         ),
-        if (NeonPlatform.instance.canUsePushNotifications) buildNotificationsCategory(),
+        if (NeonPlatform.instance.canUsePushNotifications) buildNotificationsCategory(context),
         if (NeonPlatform.instance.canUseWindowManager)
           SettingsCategory(
             title: Text(NeonLocalizations.of(context).optionsCategoryStartup),
@@ -187,7 +182,7 @@ class _SettingsPageState extends State<SettingsPage> {
               ),
             ],
           ),
-        ...buildAccountCategory(),
+        ...buildAccountCategory(context),
         SettingsCategory(
           hasLeading: true,
           title: Text(NeonLocalizations.of(context).optionsCategoryOther),
@@ -325,7 +320,7 @@ class _SettingsPageState extends State<SettingsPage> {
     );
   }
 
-  Widget buildNotificationsCategory() {
+  Widget buildNotificationsCategory(BuildContext context) {
     final globalOptions = NeonProvider.of<GlobalOptions>(context);
 
     return ValueListenableBuilder(
@@ -354,7 +349,7 @@ class _SettingsPageState extends State<SettingsPage> {
     );
   }
 
-  Iterable<Widget> buildAccountCategory() sync* {
+  Iterable<Widget> buildAccountCategory(BuildContext context) sync* {
     final globalOptions = NeonProvider.of<GlobalOptions>(context);
     final accountsBloc = NeonProvider.of<AccountsBloc>(context);
     final accounts = accountsBloc.accounts.value;

--- a/packages/neon_framework/lib/src/settings/widgets/option_settings_tile.dart
+++ b/packages/neon_framework/lib/src/settings/widgets/option_settings_tile.dart
@@ -123,11 +123,10 @@ class SelectSettingsTileDialog<T> extends StatefulWidget {
 
 class _SelectSettingsTileDialogState<T> extends State<SelectSettingsTileDialog<T>> {
   late T value;
-  late SelectOption<T> option = widget.option;
 
   @override
   void initState() {
-    value = option.value;
+    value = widget.option.value;
 
     super.initState();
   }
@@ -140,10 +139,10 @@ class _SelectSettingsTileDialogState<T> extends State<SelectSettingsTileDialog<T
     final content = SingleChildScrollView(
       child: Column(
         children: [
-          ...option.values.keys.map(
+          ...widget.option.values.keys.map(
             (k) => RadioListTile(
               title: Text(
-                option.values[k]!(context),
+                widget.option.values[k]!(context),
                 overflow: TextOverflow.ellipsis,
               ),
               value: k,
@@ -176,7 +175,7 @@ class _SelectSettingsTileDialogState<T> extends State<SelectSettingsTileDialog<T
 
     return AlertDialog(
       title: Text(
-        option.label(context),
+        widget.option.label(context),
       ),
       content: content,
       actions: widget.immediateSelection ? null : actions,

--- a/packages/neon_framework/lib/src/widgets/dialog.dart
+++ b/packages/neon_framework/lib/src/widgets/dialog.dart
@@ -562,6 +562,8 @@ class NeonAccountDeletionDialog extends StatefulWidget {
 class _NeonAccountDeletionDialogState extends State<NeonAccountDeletionDialog> {
   core.DropAccountCapabilities_DropAccount? dropAccountCapabilities;
   AccountDeletion value = AccountDeletion.local;
+  late final StreamSubscription<Result<core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data>>
+      capabilitiesSubscription;
 
   void update(AccountDeletion value) {
     setState(() {
@@ -573,7 +575,7 @@ class _NeonAccountDeletionDialogState extends State<NeonAccountDeletionDialog> {
   void initState() {
     super.initState();
 
-    widget.capabilitiesBloc.capabilities.listen((result) {
+    capabilitiesSubscription = widget.capabilitiesBloc.capabilities.listen((result) {
       setState(() {
         dropAccountCapabilities = result.data?.capabilities.dropAccountCapabilities?.dropAccount;
         if (!(dropAccountCapabilities?.enabled ?? false)) {
@@ -581,6 +583,13 @@ class _NeonAccountDeletionDialogState extends State<NeonAccountDeletionDialog> {
         }
       });
     });
+  }
+
+  @override
+  void dispose() {
+    unawaited(capabilitiesSubscription.cancel());
+
+    super.dispose();
   }
 
   @override

--- a/packages/neon_framework/lib/src/widgets/drawer.dart
+++ b/packages/neon_framework/lib/src/widgets/drawer.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:built_collection/built_collection.dart';
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/blocs.dart';
@@ -28,6 +31,7 @@ class _NeonDrawerState extends State<NeonDrawer> {
   late AppsBloc _appsBloc;
   List<AppImplementation>? _apps;
   int? _activeApp;
+  late final StreamSubscription<Result<BuiltSet<AppImplementation>>> appImplementationsSubscription;
 
   @override
   void initState() {
@@ -35,12 +39,19 @@ class _NeonDrawerState extends State<NeonDrawer> {
 
     _appsBloc = NeonProvider.of<AppsBloc>(context);
 
-    _appsBloc.appImplementations.listen((result) {
+    appImplementationsSubscription = _appsBloc.appImplementations.listen((result) {
       setState(() {
         _apps = result.data?.toList();
         _activeApp = _apps?.indexWhere((app) => app.id == _appsBloc.activeApp.valueOrNull?.id);
       });
     });
+  }
+
+  @override
+  void dispose() {
+    unawaited(appImplementationsSubscription.cancel());
+
+    super.dispose();
   }
 
   void onAppChange(int index) {


### PR DESCRIPTION
This should be all of them. I chose not to add subscriptions inside blocs where we also manage the stream controller. The controller and subscription would be disposed at the same time anyway and thus we can just close the controller and call it a day.