### PR TITLE
fix(neon_talk): Shrink reactions width to avoid unnecessary reactions loading on hover

### DIFF
--- a/packages/neon/neon_talk/lib/src/widgets/reactions.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/reactions.dart
@@ -100,6 +100,7 @@ class TalkReactions extends StatelessWidget {
           );
 
           return Row(
+            mainAxisSize: MainAxisSize.min,
             children: children
                 .intersperse(
                   const SizedBox(


### PR DESCRIPTION
The reactions widget always filled the full width of the message. If you put the cursor into the window and then scrolled up the reactions for all messages were loaded because the hover was triggered.