### PR TITLE
chore(dynamite): Fix deprecation warning

### DIFF
--- a/packages/dynamite/dynamite/lib/src/builder/client.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/client.dart
@@ -365,7 +365,7 @@ ${allocate(returnType)}(
 
             final acceptHeader = responses.keys
                 .map((response) => response.content?.keys)
-                .whereNotNull()
+                .nonNulls
                 .expand((element) => element)
                 .toSet()
                 .join(',');


### PR DESCRIPTION
Fixes CI failure https://github.com/nextcloud/neon/actions/runs/9523085914/job/26253858939?pr=2173

The warning was added in collection 1.19.0.