### PR TITLE
fix(neon_framework): Use the local timezone

### DIFF
--- a/packages/neon_framework/lib/neon.dart
+++ b/packages/neon_framework/lib/neon.dart
@@ -15,11 +15,13 @@ import 'package:neon_framework/src/platform/platform.dart';
 import 'package:neon_framework/src/theme/neon.dart';
 import 'package:neon_framework/src/utils/global_options.dart';
 import 'package:neon_framework/src/utils/provider.dart';
+import 'package:neon_framework/src/utils/timezone.dart';
 import 'package:neon_framework/src/utils/user_agent.dart';
 import 'package:neon_framework/storage.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
-import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/data/latest.dart' as tzdata;
+import 'package:timezone/timezone.dart' as tz;
 
 /// Runs Neon with the given [appImplementations].
 ///
@@ -38,7 +40,12 @@ Future<void> runNeon({
   FlutterNativeSplash.preserve(widgetsBinding: binding);
 
   await NeonPlatform.instance.init();
-  tz.initializeTimeZones();
+  tzdata.initializeTimeZones();
+
+  final location = guessDeviceLocation();
+  if (location != null) {
+    tz.setLocalLocation(location);
+  }
 
   await NeonStorage().init();
 

--- a/packages/neon_framework/lib/src/utils/timezone.dart
+++ b/packages/neon_framework/lib/src/utils/timezone.dart
@@ -1,0 +1,17 @@
+import 'package:collection/collection.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+/// Guesses the location of the device used for the timezone.
+///
+/// It will most likely report a different location than the location that is configured on the device,
+/// because it just estimates the location by returning the first location which matches the timezone name or abbreviation.
+/// This is still accurate, as many locations share the same timezone.
+tz.Location? guessDeviceLocation() {
+  final timezoneName = DateTime.now().timeZoneName;
+
+  final match = tz.timeZoneDatabase.locations.entries.firstWhereOrNull(
+    (entry) => entry.key == timezoneName || entry.value.currentTimeZone.abbreviation == timezoneName,
+  );
+
+  return match?.value;
+}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/2147

I'm not 100% sure this is the correct way to fix it, but the available flutter plugins for getting the device timezone all don't work anymore.

The only problem I can imagine is that a location without DST is picked, but then while the app is running the actual location changes it's timezone due to DST and the user would get wrong times displayed. I'm not sure if that can actually happen, but I think it is still better to have this super tiny chance of wrong time display over everything being displayed in UTC as it is right now.