### PR TITLE
fix(neon_talk): Fix animated GIFs not being animated inside chat messages

### DIFF
--- a/packages/neon/neon_talk/test/rich_object_test.dart
+++ b/packages/neon/neon_talk/test/rich_object_test.dart
@@ -31,6 +31,7 @@ void main() {
   setUp(() {
     account = MockAccount();
     when(() => account.username).thenReturn('username');
+    when(() => account.serverURL).thenReturn(Uri.parse('http://example.com'));
     when(() => account.client).thenReturn(
       NextcloudClient(
         Uri(),
@@ -418,6 +419,37 @@ void main() {
         findsOne,
       );
       expect(find.byTooltip('name'), findsOne);
+    });
+
+    testWidgets('Full image for animated GIF', (tester) async {
+      await tester.pumpWidgetWithAccessibility(
+        TestApp(
+          providers: [
+            Provider<Account>.value(value: account),
+          ],
+          child: TalkRichObjectFile(
+            parameter: spreed.RichObjectParameter(
+              (b) => b
+                ..type = ''
+                ..id = '0'
+                ..name = 'name'
+                ..previewAvailable = spreed.RichObjectParameter_PreviewAvailable.yes
+                ..path = 'path'
+                ..mimetype = 'image/gif',
+            ),
+            textStyle: null,
+          ),
+        ),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is NeonUriImage &&
+              widget.uri.toString() == 'http://example.com/remote.php/dav/files/username/path',
+        ),
+        findsOne,
+      );
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/2166

Previews for animated GIFs are not animated, so we have to request the full file.
I'm pretty sure this is an upstream bug, I already asked if this behavior is intended.
The web frontend is not affected because it always requests the full file instead of the preview (which is pretty inefficient because the images are usually displayed in a lot smaller resolution than the original file).