### PR TITLE
Correctly refresh everything after updating Account credentials

### DIFF
--- a/packages/neon_framework/lib/src/blocs/accounts.dart
+++ b/packages/neon_framework/lib/src/blocs/accounts.dart
@@ -236,19 +236,19 @@ class _AccountsBloc extends Bloc implements AccountsBloc {
 
   @override
   void updateAccount(Account account) {
-    var as = accounts.value;
+    final as = accounts.value;
     final index = as.indexWhere((a) => a.id == account.id);
 
-    as = as.rebuild((b) {
-      if (index == -1) {
-        // TODO: Figure out how we can remove the old account without potentially race conditioning
-        b.add(account);
-      } else {
-        b[index] = account;
-      }
-    });
+    accounts.add(
+      as.rebuild((b) {
+        if (index == -1) {
+          b.add(account);
+        } else {
+          b[index] = account;
+        }
+      }),
+    );
 
-    accounts.add(as);
     setActiveAccount(account);
   }
 

--- a/packages/neon_framework/lib/src/blocs/accounts.dart
+++ b/packages/neon_framework/lib/src/blocs/accounts.dart
@@ -149,6 +149,8 @@ class _AccountsBloc extends Bloc implements AccountsBloc {
       userDetailsBlocs.pruneAgainst(accounts);
       userStatusBlocs.pruneAgainst(accounts);
       unifiedSearchBlocs.pruneAgainst(accounts);
+      weatherStatusBlocs.pruneAgainst(accounts);
+      maintenanceModeBlocs.pruneAgainst(accounts);
       for (final app in allAppImplementations) {
         app.blocsCache.pruneAgainst(accounts);
       }

--- a/packages/neon_framework/lib/src/models/account.dart
+++ b/packages/neon_framework/lib/src/models/account.dart
@@ -79,7 +79,12 @@ class Account implements Credentials, Findable {
       other.userAgent == userAgent;
 
   @override
-  int get hashCode => serverURL.hashCode + username.hashCode;
+  int get hashCode => Object.hashAll([
+        serverURL,
+        username,
+        password,
+        userAgent,
+      ]);
 
   /// An authenticated API client.
   @JsonKey(includeFromJson: false, includeToJson: false)

--- a/packages/neon_framework/lib/src/models/account_cache.dart
+++ b/packages/neon_framework/lib/src/models/account_cache.dart
@@ -1,13 +1,12 @@
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/src/models/disposable.dart';
-import 'package:neon_framework/src/utils/findable.dart';
 
 /// Cache for [Account] specific [Disposable] objects.
 class AccountCache<T extends Disposable> implements Disposable {
   /// Creates a new account cache.
   AccountCache();
 
-  final Map<String, T> _cache = {};
+  final Map<Account, T> _cache = {};
 
   /// Disposes all entries and clears the cache.
   @override
@@ -22,9 +21,9 @@ class AccountCache<T extends Disposable> implements Disposable {
   /// Every cache entry with an account no longer in [accounts] is removed and
   /// disposed. This method is in O(N²).
   void pruneAgainst(Iterable<Account> accounts) {
-    _cache.removeWhere((key, value) {
-      if (accounts.tryFind(key) == null) {
-        value.dispose();
+    _cache.removeWhere((account, disposable) {
+      if (!accounts.contains(account)) {
+        disposable.dispose();
         return true;
       }
 
@@ -36,16 +35,16 @@ class AccountCache<T extends Disposable> implements Disposable {
   ///
   /// If present the value associated with `account` is disposed.
   void remove(Account? account) {
-    final removed = _cache.remove(account?.id);
+    final removed = _cache.remove(account);
     removed?.dispose();
   }
 
   /// The value for the given [account], or `null` if [account] is not in the cache.
-  T? operator [](Account account) => _cache[account.id];
+  T? operator [](Account account) => _cache[account];
 
   /// Associates the [account] with the given [value].
   ///
   /// If the account was already in the cache, its associated value is changed.
   /// Otherwise the account/value pair is added to the cache.
-  void operator []=(Account account, T value) => _cache[account.id] = value;
+  void operator []=(Account account, T value) => _cache[account] = value;
 }

--- a/packages/neon_framework/lib/src/pages/login_check_account.dart
+++ b/packages/neon_framework/lib/src/pages/login_check_account.dart
@@ -88,7 +88,7 @@ class _LoginCheckAccountPageState extends State<LoginCheckAccountPage> {
                                   ..updateAccount(state.requireData)
                                   ..setActiveAccount(state.requireData);
 
-                                const HomeRoute().go(context);
+                                const HomeRoute().pushReplacement(context);
                               }
                             : () {
                                 if (state.hasError && NeonError.getDetails(state.error).isUnauthorized) {

--- a/packages/neon_framework/test/account_cache_test.dart
+++ b/packages/neon_framework/test/account_cache_test.dart
@@ -9,9 +9,6 @@ void main() {
   final account0 = MockAccount();
   final account1 = MockAccount();
 
-  when(() => account0.id).thenReturn('key0');
-  when(() => account1.id).thenReturn('key1');
-
   group('AccountCache', () {
     test('map functionality', () {
       final cache = AccountCache<MockDisposable>();


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/741

There were two problems:
1. AccountCache only compared by ID, so pruneAgainst never removed "old" Blocs since the ID was still the same after updating an Account.
2. The HomePage and everything below it still had references to the "old" Blocs, so a force refresh is necessary.