### PR TITLE
refactor(dynamite_runtime)!: Make ResponseConverter sync

### DIFF
--- a/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
+++ b/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
@@ -126,10 +126,11 @@ class $Client extends _i1.DynamiteClient {
       tags: tags,
       limit: limit,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findPets_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<BuiltList<Pet>, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<BuiltList<Pet>, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -181,10 +182,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $addPet_Request(
       newPet: newPet,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addPet_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Pet, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Pet, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -244,10 +246,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $findPetById_Request(
       id: id,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findPetById_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Pet, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Pet, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -306,10 +309,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $deletePet_Request(
       id: id,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deletePet_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/dynamite/dynamite/lib/src/builder/client.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/client.dart
@@ -425,7 +425,8 @@ ${allocate(returnType)}(
           ..body = Code.scope(
             (allocate) => '''
 final _request = \$${name}_Request($rawParameters);
-final _response = await $client.httpClient.send(_request);
+final _streamedResponse = await $client.httpClient.send(_request);
+final _response = await ${allocate(refer('Response', 'package:http/http.dart'))}.fromStream(_streamedResponse);
 
 final _serializer = \$${name}_Serializer();
 final _rawResponse = await ${allocate(responseConverterType)}(_serializer).convert(_response);

--- a/packages/dynamite/dynamite_end_to_end_test/lib/authentication.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/authentication.openapi.dart
@@ -72,10 +72,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$noAuthentication_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<JsonObject, void>> noAuthentication() async {
     final _request = $noAuthentication_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $noAuthentication_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -134,10 +135,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$basicAuthentication_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<JsonObject, void>> basicAuthentication() async {
     final _request = $basicAuthentication_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $basicAuthentication_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -196,10 +198,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$bearerAuthentication_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<JsonObject, void>> bearerAuthentication() async {
     final _request = $bearerAuthentication_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $bearerAuthentication_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -258,10 +261,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$multipleAuthentications_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<JsonObject, void>> multipleAuthentications() async {
     final _request = $multipleAuthentications_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $multipleAuthentications_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/dynamite/dynamite_end_to_end_test/lib/deprecation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/deprecation.openapi.dart
@@ -102,10 +102,11 @@ class $Client extends _i1.DynamiteClient {
       tags: tags,
       limit: limit,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findValues_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
@@ -131,10 +131,11 @@ class $Client extends _i1.DynamiteClient {
       tags: tags,
       limit: limit,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findValues_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -203,10 +204,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$multipleNewLines_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Object1, void>> multipleNewLines() async {
     final _request = $multipleNewLines_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $multipleNewLines_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -251,10 +253,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$nonRootClientSetMode_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Object1, void>> nonRootClientSetMode() async {
     final _request = $nonRootClientSetMode_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $nonRootClientSetMode_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -331,10 +334,11 @@ class $NonRootClientClient {
   ///  * [$multipleNewLines_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Object1, void>> multipleNewLines() async {
     final _request = $multipleNewLines_Request();
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $multipleNewLines_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -379,10 +383,11 @@ class $NonRootClientClient {
   ///  * [$setMode_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Object1, void>> setMode() async {
     final _request = $setMode_Request();
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setMode_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
@@ -73,10 +73,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$$get_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<void, GetHeaders>> $get() async {
     final _request = $$get_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, GetHeaders>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, GetHeaders>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -118,11 +119,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$withContentOperationId_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<void, WithContentOperationIdHeaders>> withContentOperationId() async {
     final _request = $withContentOperationId_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $withContentOperationId_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<void, WithContentOperationIdHeaders>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, WithContentOperationIdHeaders>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -164,10 +165,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$getWithContent_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Uint8List, GetWithContentHeaders>> getWithContent() async {
     final _request = $getWithContent_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getWithContent_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, GetWithContentHeaders>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, GetWithContentHeaders>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
@@ -217,10 +217,11 @@ class $Client extends _i1.DynamiteClient {
       anyOf: anyOf,
       enumPattern: enumPattern,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -418,10 +419,11 @@ class $Client extends _i1.DynamiteClient {
       anyOf: anyOf,
       enumPattern: enumPattern,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getDefaults_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -626,10 +628,11 @@ class $Client extends _i1.DynamiteClient {
       anyOf: anyOf,
       enumPattern: enumPattern,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getHeaders_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -677,10 +680,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $getPathParameter_Request(
       pathParameter: pathParameter,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPathParameter_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -764,10 +768,11 @@ class $Client extends _i1.DynamiteClient {
       parameters: parameters,
       headers: headers,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getNamingCollisions_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.dart
@@ -76,10 +76,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $$get_Request(
       uint8List: uint8List,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -125,10 +126,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $post_Request(
       string: string,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $post_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/dynamite/dynamite_end_to_end_test/lib/responses.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/responses.openapi.dart
@@ -68,10 +68,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$$get_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<String, void>> $get() async {
     final _request = $$get_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<String, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<String, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -115,10 +116,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$put_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<String, void>> put() async {
     final _request = $put_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $put_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<String, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<String, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -163,10 +165,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$post_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<String, void>> post() async {
     final _request = $post_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $post_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<String, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<String, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -210,10 +213,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$patch_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<String, void>> patch() async {
     final _request = $patch_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $patch_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<String, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<String, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/dynamite/dynamite_end_to_end_test/lib/tags.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/tags.openapi.dart
@@ -78,10 +78,11 @@ class $FirstClient {
   ///  * [$$get_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<void, void>> $get() async {
     final _request = $$get_Request();
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -128,10 +129,11 @@ class $SecondClient {
   ///  * [$$get_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<void, void>> $get() async {
     final _request = $$get_Request();
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/neon_framework/lib/src/utils/request_manager.dart
+++ b/packages/neon_framework/lib/src/utils/request_manager.dart
@@ -87,7 +87,8 @@ class RequestManager {
         cacheKey: cacheKey,
         subject: subject,
         request: () async {
-          final response = await account.client.send(getRequest());
+          final streamedResponse = await account.client.send(getRequest());
+          final response = await http.Response.fromStream(streamedResponse);
           return ResponseConverter<B, H>(serializer).convert(response);
         },
         unwrap: (rawResponse) => unwrap(rawResponse),
@@ -114,7 +115,8 @@ class RequestManager {
         cacheKey: cacheKey,
         subject: subject,
         request: () async {
-          final response = await account.client.webdav.csrfClient.send(getRequest());
+          final streamedResponse = await account.client.webdav.csrfClient.send(getRequest());
+          final response = await http.Response.fromStream(streamedResponse);
           return const WebDavResponseConverter().convert(response);
         },
         unwrap: unwrap,
@@ -148,8 +150,8 @@ class RequestManager {
       cacheKey: cacheKey,
       subject: subject,
       request: () async {
-        final response = await account.client.send(getRequest());
-
+        final streamedResponse = await account.client.send(getRequest());
+        final response = await http.Response.fromStream(streamedResponse);
         return ResponseConverter<Uint8List, Map<String, String>>(serializer).convert(response);
       },
       unwrap: (rawResponse) {

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -135,10 +135,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$getStatus_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Status, void>> getStatus() async {
     final _request = $getStatus_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getStatus_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Status, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Status, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -229,12 +230,12 @@ class $AppPasswordClient {
     final _request = $getAppPassword_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAppPassword_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<AppPasswordGetAppPasswordResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<AppPasswordGetAppPasswordResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -314,12 +315,12 @@ class $AppPasswordClient {
     final _request = $deleteAppPassword_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteAppPassword_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<AppPasswordDeleteAppPasswordResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<AppPasswordDeleteAppPasswordResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -399,12 +400,12 @@ class $AppPasswordClient {
     final _request = $rotateAppPassword_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $rotateAppPassword_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<AppPasswordRotateAppPasswordResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<AppPasswordRotateAppPasswordResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -495,12 +496,12 @@ class $AppPasswordClient {
       password: password,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $confirmUserPassword_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<AppPasswordConfirmUserPasswordResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<AppPasswordConfirmUserPasswordResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -640,11 +641,12 @@ class $AutoCompleteClient {
       limit: limit,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<AutoCompleteGetResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<AutoCompleteGetResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -740,11 +742,12 @@ class $AvatarClient {
       userId: userId,
       size: size,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAvatarDark_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<Uint8List, AvatarAvatarGetAvatarDarkHeaders>(_serializer).convert(_response);
+        _i1.ResponseConverter<Uint8List, AvatarAvatarGetAvatarDarkHeaders>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -831,11 +834,11 @@ class $AvatarClient {
       userId: userId,
       size: size,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAvatar_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<Uint8List, AvatarAvatarGetAvatarHeaders>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, AvatarAvatarGetAvatarHeaders>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -917,10 +920,11 @@ class $ClientFlowLoginV2Client {
     final _request = $poll_Request(
       token: token,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $poll_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<LoginFlowV2Credentials, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<LoginFlowV2Credentials, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -981,10 +985,11 @@ class $ClientFlowLoginV2Client {
   ///  * [$init_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<LoginFlowV2, void>> init() async {
     final _request = $init_Request();
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $init_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<LoginFlowV2, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<LoginFlowV2, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -1084,11 +1089,12 @@ class $CollaborationResourcesClient {
       collectionId: collectionId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listCollection_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CollaborationResourcesListCollectionResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<CollaborationResourcesListCollectionResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -1191,11 +1197,12 @@ class $CollaborationResourcesClient {
       collectionId: collectionId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $renameCollection_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CollaborationResourcesRenameCollectionResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<CollaborationResourcesRenameCollectionResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -1307,11 +1314,12 @@ class $CollaborationResourcesClient {
       collectionId: collectionId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addResource_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CollaborationResourcesAddResourceResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<CollaborationResourcesAddResourceResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -1423,11 +1431,12 @@ class $CollaborationResourcesClient {
       collectionId: collectionId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeResource_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CollaborationResourcesRemoveResourceResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<CollaborationResourcesRemoveResourceResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -1520,11 +1529,12 @@ class $CollaborationResourcesClient {
       filter: filter,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $searchCollections_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CollaborationResourcesSearchCollectionsResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<CollaborationResourcesSearchCollectionsResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -1626,11 +1636,12 @@ class $CollaborationResourcesClient {
       resourceId: resourceId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getCollectionsByResource_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson, void>(
+        _i1.ResponseConverter<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson, void>(
       _serializer,
     ).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -1745,11 +1756,12 @@ class $CollaborationResourcesClient {
       baseResourceId: baseResourceId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createCollectionOnResource_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson, void>(
+        _i1.ResponseConverter<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson, void>(
       _serializer,
     ).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -1858,10 +1870,11 @@ class $GuestAvatarClient {
       size: size,
       darkTheme: darkTheme,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAvatar_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1950,10 +1963,11 @@ class $GuestAvatarClient {
       guestName: guestName,
       size: size,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAvatarDark_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -2050,11 +2064,12 @@ class $HoverCardClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUser_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<HoverCardGetUserResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<HoverCardGetUserResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -2141,11 +2156,12 @@ class $LoginClient {
     final _request = $confirmPassword_Request(
       password: password,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $confirmPassword_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<LoginConfirmPasswordResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<LoginConfirmPasswordResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -2245,12 +2261,12 @@ class $NavigationClient {
       absolute: absolute,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAppsNavigation_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<NavigationGetAppsNavigationResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<NavigationGetAppsNavigationResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2343,11 +2359,12 @@ class $NavigationClient {
       absolute: absolute,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getSettingsNavigation_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<NavigationGetSettingsNavigationResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<NavigationGetSettingsNavigationResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -2420,12 +2437,12 @@ class $OcmClient {
   ///  * [$discovery_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<OcmDiscoveryResponseApplicationJson, OcmOcmDiscoveryHeaders>> discovery() async {
     final _request = $discovery_Request();
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $discovery_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<OcmDiscoveryResponseApplicationJson, OcmOcmDiscoveryHeaders>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<OcmDiscoveryResponseApplicationJson, OcmOcmDiscoveryHeaders>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -2508,11 +2525,12 @@ class $OcsClient {
     final _request = $getCapabilities_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getCapabilities_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<OcsGetCapabilitiesResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<OcsGetCapabilitiesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -2663,10 +2681,11 @@ class $PreviewClient {
       mode: mode,
       mimeFallback: mimeFallback,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPreview_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2811,10 +2830,11 @@ class $PreviewClient {
       mode: mode,
       mimeFallback: mimeFallback,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPreviewByFileId_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -2936,11 +2956,12 @@ class $ProfileApiClient {
       targetUserId: targetUserId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setVisibility_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<ProfileApiSetVisibilityResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<ProfileApiSetVisibilityResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -3022,10 +3043,11 @@ class $ReferenceClient {
     final _request = $preview_Request(
       referenceId: referenceId,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $preview_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -3139,11 +3161,12 @@ class $ReferenceApiClient {
       limit: limit,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $extract_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ReferenceApiExtractResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ReferenceApiExtractResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3232,11 +3255,12 @@ class $ReferenceApiClient {
       reference: reference,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $resolveOne_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<ReferenceApiResolveOneResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<ReferenceApiResolveOneResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3335,11 +3359,12 @@ class $ReferenceApiClient {
       limit: limit,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $resolve_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ReferenceApiResolveResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ReferenceApiResolveResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3417,12 +3442,12 @@ class $ReferenceApiClient {
     final _request = $getProvidersInfo_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getProvidersInfo_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<ReferenceApiGetProvidersInfoResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<ReferenceApiGetProvidersInfoResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3519,12 +3544,12 @@ class $ReferenceApiClient {
       timestamp: timestamp,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $touchProvider_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ReferenceApiTouchProviderResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<ReferenceApiTouchProviderResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -3620,11 +3645,12 @@ class $TeamsApiClient {
       teamId: teamId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $resolveOne_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TeamsApiResolveOneResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<TeamsApiResolveOneResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3721,11 +3747,12 @@ class $TeamsApiClient {
       resourceId: resourceId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listTeams_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TeamsApiListTeamsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<TeamsApiListTeamsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -3808,12 +3835,12 @@ class $TextProcessingApiClient {
     final _request = $taskTypes_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $taskTypes_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TextProcessingApiTaskTypesResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<TextProcessingApiTaskTypesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3932,12 +3959,12 @@ class $TextProcessingApiClient {
       identifier: identifier,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $schedule_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TextProcessingApiScheduleResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<TextProcessingApiScheduleResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -4028,11 +4055,12 @@ class $TextProcessingApiClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getTask_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<TextProcessingApiGetTaskResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<TextProcessingApiGetTaskResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -4125,12 +4153,12 @@ class $TextProcessingApiClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteTask_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TextProcessingApiDeleteTaskResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<TextProcessingApiDeleteTaskResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -4229,11 +4257,12 @@ class $TextProcessingApiClient {
       identifier: identifier,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listTasksByApp_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TextProcessingApiListTasksByAppResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<TextProcessingApiListTasksByAppResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -4317,12 +4346,12 @@ class $TextToImageApiClient {
     final _request = $isAvailable_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $isAvailable_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TextToImageApiIsAvailableResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<TextToImageApiIsAvailableResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -4440,11 +4469,12 @@ class $TextToImageApiClient {
       numberOfImages: numberOfImages,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $schedule_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<TextToImageApiScheduleResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<TextToImageApiScheduleResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -4535,11 +4565,12 @@ class $TextToImageApiClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getTask_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TextToImageApiGetTaskResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<TextToImageApiGetTaskResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -4632,11 +4663,12 @@ class $TextToImageApiClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteTask_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<TextToImageApiDeleteTaskResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<TextToImageApiDeleteTaskResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -4734,10 +4766,11 @@ class $TextToImageApiClient {
       index: index,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getImage_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -4836,12 +4869,12 @@ class $TextToImageApiClient {
       identifier: identifier,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listTasksByApp_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<TextToImageApiListTasksByAppResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<TextToImageApiListTasksByAppResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -4924,11 +4957,12 @@ class $TranslationApiClient {
     final _request = $languages_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $languages_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<TranslationApiLanguagesResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<TranslationApiLanguagesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -5038,11 +5072,12 @@ class $TranslationApiClient {
       fromLanguage: fromLanguage,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $translate_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<TranslationApiTranslateResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<TranslationApiTranslateResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -5139,12 +5174,12 @@ class $UnifiedSearchClient {
       from: from,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getProviders_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UnifiedSearchGetProvidersResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<UnifiedSearchGetProvidersResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -5283,11 +5318,12 @@ class $UnifiedSearchClient {
       from: from,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $search_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UnifiedSearchSearchResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UnifiedSearchSearchResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -5371,11 +5407,12 @@ class $WhatsNewClient {
     final _request = $$get_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<WhatsNewGetResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<WhatsNewGetResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -5465,11 +5502,12 @@ class $WhatsNewClient {
       version: version,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $dismiss_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<WhatsNewDismissResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<WhatsNewDismissResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -5551,11 +5589,12 @@ class $WipeClient {
     final _request = $checkWipe_Request(
       token: token,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $checkWipe_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<WipeCheckWipeResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<WipeCheckWipeResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -5630,10 +5669,11 @@ class $WipeClient {
     final _request = $wipeDone_Request(
       token: token,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $wipeDone_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.dart
@@ -130,11 +130,12 @@ class $DashboardApiClient {
     final _request = $getWidgets_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getWidgets_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<DashboardApiGetWidgetsResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<DashboardApiGetWidgetsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -253,12 +254,12 @@ class $DashboardApiClient {
       widgets: widgets,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getWidgetItems_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<DashboardApiGetWidgetItemsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<DashboardApiGetWidgetItemsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -377,12 +378,12 @@ class $DashboardApiClient {
       widgets: widgets,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getWidgetItemsV2_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<DashboardApiGetWidgetItemsV2ResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<DashboardApiGetWidgetItemsV2ResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/dav.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.dart
@@ -155,11 +155,12 @@ class $DirectClient {
       expirationTime: expirationTime,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUrl_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<DirectGetUrlResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<DirectGetUrlResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -258,11 +259,12 @@ class $OutOfOfficeClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getCurrentOutOfOfficeData_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -354,12 +356,12 @@ class $OutOfOfficeClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getOutOfOffice_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<OutOfOfficeGetOutOfOfficeResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<OutOfOfficeGetOutOfOfficeResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -486,12 +488,12 @@ class $OutOfOfficeClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setOutOfOffice_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<OutOfOfficeSetOutOfOfficeResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<OutOfOfficeSetOutOfOfficeResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -582,12 +584,12 @@ class $OutOfOfficeClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $clearOutOfOffice_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<OutOfOfficeClearOutOfOfficeResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<OutOfOfficeClearOutOfOfficeResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/files.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.dart
@@ -166,10 +166,11 @@ class $ApiClient {
       y: y,
       file: file,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getThumbnail_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -251,11 +252,12 @@ class $DirectEditingClient {
     final _request = $info_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $info_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<DirectEditingInfoResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<DirectEditingInfoResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -355,11 +357,12 @@ class $DirectEditingClient {
       creatorId: creatorId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $templates_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<DirectEditingTemplatesResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<DirectEditingTemplatesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -468,11 +471,12 @@ class $DirectEditingClient {
       fileId: fileId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $open_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<DirectEditingOpenResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<DirectEditingOpenResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -591,11 +595,12 @@ class $DirectEditingClient {
       templateId: templateId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $create_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<DirectEditingCreateResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<DirectEditingCreateResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -693,11 +698,12 @@ class $OpenLocalEditorClient {
       path: path,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $create_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<OpenLocalEditorCreateResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<OpenLocalEditorCreateResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -796,11 +802,12 @@ class $OpenLocalEditorClient {
       token: token,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $validate_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<OpenLocalEditorValidateResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<OpenLocalEditorValidateResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -882,11 +889,12 @@ class $TemplateClient {
     final _request = $list_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $list_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TemplateListResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<TemplateListResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -996,11 +1004,12 @@ class $TemplateClient {
       templateType: templateType,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $create_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TemplateCreateResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<TemplateCreateResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1104,11 +1113,12 @@ class $TemplateClient {
       copySystemTemplates: copySystemTemplates,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $path_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TemplatePathResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<TemplatePathResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -1217,12 +1227,12 @@ class $TransferOwnershipClient {
       path: path,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $transfer_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TransferOwnershipTransferResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<TransferOwnershipTransferResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1315,11 +1325,12 @@ class $TransferOwnershipClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $accept_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<TransferOwnershipAcceptResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<TransferOwnershipAcceptResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1412,11 +1423,12 @@ class $TransferOwnershipClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $reject_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<TransferOwnershipRejectResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<TransferOwnershipRejectResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/files_external.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_external.openapi.dart
@@ -129,11 +129,12 @@ class $ApiClient {
     final _request = $getUserMounts_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUserMounts_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ApiGetUserMountsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ApiGetUserMountsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
@@ -154,11 +154,11 @@ class $ApiClient {
       fileId: fileId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<ApiGetResponseApplicationJson, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<ApiGetResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -276,11 +276,11 @@ class $ApiClient {
       fileId: fileId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$set_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<ApiSetResponseApplicationJson, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<ApiSetResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -385,11 +385,11 @@ class $ApiClient {
       fileId: fileId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $remove_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<ApiRemoveResponseApplicationJson, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<ApiRemoveResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -140,11 +140,12 @@ class $DeletedShareapiClient {
     final _request = $index_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $index_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<DeletedShareapiIndexResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<DeletedShareapiIndexResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -235,11 +236,12 @@ class $DeletedShareapiClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $undelete_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<DeletedShareapiUndeleteResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<DeletedShareapiUndeleteResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -325,10 +327,11 @@ class $PublicPreviewClient {
     final _request = $directLink_Request(
       token: token,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $directLink_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -448,10 +451,11 @@ class $PublicPreviewClient {
       y: y,
       a: a,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPreview_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -534,11 +538,12 @@ class $RemoteClient {
     final _request = $getShares_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getShares_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RemoteGetSharesResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RemoteGetSharesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -616,11 +621,12 @@ class $RemoteClient {
     final _request = $getOpenShares_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getOpenShares_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RemoteGetOpenSharesResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RemoteGetOpenSharesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -712,11 +718,12 @@ class $RemoteClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $acceptShare_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RemoteAcceptShareResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RemoteAcceptShareResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -808,11 +815,12 @@ class $RemoteClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $declineShare_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RemoteDeclineShareResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RemoteDeclineShareResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -902,11 +910,12 @@ class $RemoteClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getShare_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RemoteGetShareResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RemoteGetShareResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -998,11 +1007,12 @@ class $RemoteClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $unshare_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RemoteUnshareResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RemoteUnshareResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -1116,10 +1126,11 @@ class $ShareInfoClient {
       dir: dir,
       depth: depth,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $info_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<ShareInfo, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<ShareInfo, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -1256,11 +1267,12 @@ class $ShareapiClient {
       includeTags: includeTags,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getShares_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ShareapiGetSharesResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ShareapiGetSharesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1443,11 +1455,12 @@ class $ShareapiClient {
       attributes: attributes,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createShare_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ShareapiCreateShareResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ShareapiCreateShareResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1540,12 +1553,12 @@ class $ShareapiClient {
       path: path,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getInheritedShares_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ShareapiGetInheritedSharesResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<ShareapiGetInheritedSharesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1623,11 +1636,12 @@ class $ShareapiClient {
     final _request = $pendingShares_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $pendingShares_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ShareapiPendingSharesResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ShareapiPendingSharesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1729,11 +1743,12 @@ class $ShareapiClient {
       includeTags: includeTags,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getShare_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ShareapiGetShareResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ShareapiGetShareResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1902,11 +1917,12 @@ class $ShareapiClient {
       attributes: attributes,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $updateShare_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ShareapiUpdateShareResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ShareapiUpdateShareResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1999,11 +2015,12 @@ class $ShareapiClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteShare_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ShareapiDeleteShareResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ShareapiDeleteShareResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2096,11 +2113,12 @@ class $ShareapiClient {
       id: id,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $acceptShare_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ShareapiAcceptShareResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ShareapiAcceptShareResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -2244,11 +2262,12 @@ class $ShareesapiClient {
       lookup: lookup,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $search_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ShareesapiSearchResponseApplicationJson, ShareesapiShareesapiSearchHeaders>(
+        _i1.ResponseConverter<ShareesapiSearchResponseApplicationJson, ShareesapiShareesapiSearchHeaders>(
       _serializer,
     ).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -2349,12 +2368,12 @@ class $ShareesapiClient {
       shareType: shareType,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findRecommended_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ShareesapiFindRecommendedResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<ShareesapiFindRecommendedResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
@@ -163,10 +163,11 @@ class $PreviewClient {
       y: y,
       a: a,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPreview_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.dart
@@ -162,10 +162,11 @@ class $PreviewClient {
       y: y,
       version: version,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPreview_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/news.openapi.dart
+++ b/packages/nextcloud/lib/src/api/news.openapi.dart
@@ -102,10 +102,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$getSupportedApiVersions_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<SupportedAPIVersions, void>> getSupportedApiVersions() async {
     final _request = $getSupportedApiVersions_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getSupportedApiVersions_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<SupportedAPIVersions, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<SupportedAPIVersions, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -164,10 +165,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$listFolders_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ListFolders, void>> listFolders() async {
     final _request = $listFolders_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listFolders_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<ListFolders, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<ListFolders, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -238,10 +240,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $createFolder_Request(
       name: name,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createFolder_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<ListFolders, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<ListFolders, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -321,10 +324,11 @@ class $Client extends _i1.DynamiteClient {
       folderId: folderId,
       name: name,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $renameFolder_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -388,10 +392,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $deleteFolder_Request(
       folderId: folderId,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteFolder_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -472,10 +477,11 @@ class $Client extends _i1.DynamiteClient {
       folderId: folderId,
       newestItemId: newestItemId,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $markFolderAsRead_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -534,10 +540,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$listFeeds_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<ListFeeds, void>> listFeeds() async {
     final _request = $listFeeds_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listFeeds_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<ListFeeds, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<ListFeeds, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -620,10 +627,11 @@ class $Client extends _i1.DynamiteClient {
       url: url,
       folderId: folderId,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addFeed_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<ListFeeds, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<ListFeeds, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -687,10 +695,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $deleteFeed_Request(
       feedId: feedId,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteFeed_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -770,10 +779,11 @@ class $Client extends _i1.DynamiteClient {
       feedId: feedId,
       folderId: folderId,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $moveFeed_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -854,10 +864,11 @@ class $Client extends _i1.DynamiteClient {
       feedId: feedId,
       feedTitle: feedTitle,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $renameFeed_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -938,10 +949,11 @@ class $Client extends _i1.DynamiteClient {
       feedId: feedId,
       newestItemId: newestItemId,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $markFeedAsRead_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1064,10 +1076,11 @@ class $Client extends _i1.DynamiteClient {
       offset: offset,
       oldestFirst: oldestFirst,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listArticles_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<ListArticles, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<ListArticles, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1162,10 +1175,11 @@ class $Client extends _i1.DynamiteClient {
       id: id,
       lastModified: lastModified,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listUpdatedArticles_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<ListArticles, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<ListArticles, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1229,10 +1243,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $markArticleAsRead_Request(
       itemId: itemId,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $markArticleAsRead_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1296,10 +1311,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $markArticleAsUnread_Request(
       itemId: itemId,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $markArticleAsUnread_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1363,10 +1379,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $starArticle_Request(
       itemId: itemId,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $starArticle_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1430,10 +1447,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $unstarArticle_Request(
       itemId: itemId,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $unstarArticle_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/notes.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notes.openapi.dart
@@ -168,10 +168,11 @@ class $Client extends _i1.DynamiteClient {
       chunkCursor: chunkCursor,
       ifNoneMatch: ifNoneMatch,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getNotes_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<BuiltList<Note>, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<BuiltList<Note>, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -284,10 +285,11 @@ class $Client extends _i1.DynamiteClient {
       modified: modified,
       favorite: favorite,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createNote_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Note, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Note, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -379,10 +381,11 @@ class $Client extends _i1.DynamiteClient {
       exclude: exclude,
       ifNoneMatch: ifNoneMatch,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getNote_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Note, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Note, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -507,10 +510,11 @@ class $Client extends _i1.DynamiteClient {
       favorite: favorite,
       ifMatch: ifMatch,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $updateNote_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Note, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Note, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -575,10 +579,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $deleteNote_Request(
       id: id,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteNote_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<String, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<String, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -637,10 +642,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$getSettings_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Settings, void>> getSettings() async {
     final _request = $getSettings_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getSettings_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Settings, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Settings, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -703,10 +709,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $updateSettings_Request(
       settings: settings,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $updateSettings_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Settings, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Settings, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/notifications.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.dart
@@ -186,11 +186,12 @@ class $ApiClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $generateNotification_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<ApiGenerateNotificationResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<ApiGenerateNotificationResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -293,10 +294,11 @@ class $EndpointClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listNotifications_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<EndpointListNotificationsResponseApplicationJson,
+    final _rawResponse = _i1.ResponseConverter<EndpointListNotificationsResponseApplicationJson,
             EndpointEndpointListNotificationsHeaders>(_serializer)
         .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -393,12 +395,12 @@ class $EndpointClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteAllNotifications_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<EndpointDeleteAllNotificationsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<EndpointDeleteAllNotificationsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -500,11 +502,12 @@ class $EndpointClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getNotification_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<EndpointGetNotificationResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<EndpointGetNotificationResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -608,12 +611,12 @@ class $EndpointClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteNotification_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<EndpointDeleteNotificationResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<EndpointDeleteNotificationResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -715,12 +718,12 @@ class $EndpointClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $confirmIdsForUser_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<EndpointConfirmIdsForUserResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<EndpointConfirmIdsForUserResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -850,11 +853,12 @@ class $PushClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $registerDevice_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<PushRegisterDeviceResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<PushRegisterDeviceResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -951,11 +955,12 @@ class $PushClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeDevice_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<PushRemoveDeviceResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<PushRemoveDeviceResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -1079,11 +1084,12 @@ class $SettingsClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $personal_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<SettingsPersonalResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<SettingsPersonalResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1202,11 +1208,12 @@ class $SettingsClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $admin_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<SettingsAdminResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<SettingsAdminResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -140,11 +140,12 @@ class $AppConfigClient {
     final _request = $getApps_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getApps_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<AppConfigGetAppsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<AppConfigGetAppsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -238,11 +239,12 @@ class $AppConfigClient {
       app: app,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getKeys_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<AppConfigGetKeysResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<AppConfigGetKeysResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -354,11 +356,12 @@ class $AppConfigClient {
       key: key,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setValue_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<AppConfigSetValueResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<AppConfigSetValueResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -457,11 +460,12 @@ class $AppsClient {
       filter: filter,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getApps_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<AppsGetAppsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<AppsGetAppsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -554,11 +558,12 @@ class $AppsClient {
       app: app,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAppInfo_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<AppsGetAppInfoResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<AppsGetAppInfoResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -652,11 +657,11 @@ class $AppsClient {
       app: app,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $enable_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<AppsEnableResponseApplicationJson, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<AppsEnableResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -750,11 +755,12 @@ class $AppsClient {
       app: app,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $disable_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<AppsDisableResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<AppsDisableResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -859,12 +865,12 @@ class $GroupsClient {
       groupId: groupId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getSubAdminsOfGroup_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<GroupsGetSubAdminsOfGroupResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<GroupsGetSubAdminsOfGroupResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -971,11 +977,12 @@ class $GroupsClient {
       offset: offset,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getGroups_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<GroupsGetGroupsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<GroupsGetGroupsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1071,11 +1078,12 @@ class $GroupsClient {
       groupId: groupId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getGroup_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<GroupsGetGroupResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<GroupsGetGroupResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1182,11 +1190,12 @@ class $GroupsClient {
       offset: offset,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getGroupsDetails_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<GroupsGetGroupsDetailsResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<GroupsGetGroupsDetailsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1284,11 +1293,12 @@ class $GroupsClient {
       groupId: groupId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getGroupUsers_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<GroupsGetGroupUsersResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<GroupsGetGroupUsersResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1409,12 +1419,12 @@ class $GroupsClient {
       offset: offset,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getGroupUsersDetails_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<GroupsGetGroupUsersDetailsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<GroupsGetGroupUsersDetailsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -1530,11 +1540,12 @@ class $PreferencesClient {
       configKey: configKey,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setPreference_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<PreferencesSetPreferenceResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<PreferencesSetPreferenceResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1634,12 +1645,12 @@ class $PreferencesClient {
       configKey: configKey,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deletePreference_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<PreferencesDeletePreferenceResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<PreferencesDeletePreferenceResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1744,11 +1755,12 @@ class $PreferencesClient {
       appId: appId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setMultiplePreferences_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<PreferencesSetMultiplePreferencesResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<PreferencesSetMultiplePreferencesResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -1851,11 +1863,12 @@ class $PreferencesClient {
       appId: appId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteMultiplePreference_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<PreferencesDeleteMultiplePreferenceResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<PreferencesDeleteMultiplePreferenceResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -1956,12 +1969,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUserSubAdminGroups_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersGetUserSubAdminGroupsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<UsersGetUserSubAdminGroupsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2064,11 +2077,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addSubAdmin_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersAddSubAdminResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersAddSubAdminResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2171,11 +2185,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeSubAdmin_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersRemoveSubAdminResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersRemoveSubAdminResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2281,11 +2296,12 @@ class $UsersClient {
       offset: offset,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUsers_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersGetUsersResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersGetUsersResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2452,11 +2468,12 @@ class $UsersClient {
       manager: manager,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addUser_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersAddUserResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersAddUserResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2563,11 +2580,12 @@ class $UsersClient {
       offset: offset,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUsersDetails_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersGetUsersDetailsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersGetUsersDetailsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2665,12 +2683,12 @@ class $UsersClient {
       offset: offset,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getDisabledUsersDetails_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<UsersGetDisabledUsersDetailsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<UsersGetDisabledUsersDetailsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2777,12 +2795,12 @@ class $UsersClient {
       search: search,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $searchByPhoneNumbers_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersSearchByPhoneNumbersResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<UsersSearchByPhoneNumbersResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2870,11 +2888,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUser_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersGetUserResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersGetUserResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2982,11 +3001,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $editUser_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersEditUserResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersEditUserResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3079,11 +3099,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteUser_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersDeleteUserResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersDeleteUserResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3161,11 +3182,12 @@ class $UsersClient {
     final _request = $getCurrentUser_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getCurrentUser_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersGetCurrentUserResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersGetCurrentUserResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3243,11 +3265,12 @@ class $UsersClient {
     final _request = $getEditableFields_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getEditableFields_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<UsersGetEditableFieldsResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<UsersGetEditableFieldsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3336,12 +3359,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getEditableFieldsForUser_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<UsersGetEditableFieldsForUserResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<UsersGetEditableFieldsForUserResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3464,11 +3487,12 @@ class $UsersClient {
       collectionName: collectionName,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $editUserMultiValue_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<UsersEditUserMultiValueResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<UsersEditUserMultiValueResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3561,11 +3585,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $wipeUserDevices_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersWipeUserDevicesResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersWipeUserDevicesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3658,11 +3683,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $enableUser_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersEnableUserResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersEnableUserResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3755,11 +3781,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $disableUser_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersDisableUserResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersDisableUserResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3848,11 +3875,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUsersGroups_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersGetUsersGroupsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersGetUsersGroupsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3954,11 +3982,12 @@ class $UsersClient {
       groupid: groupid,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addToGroup_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersAddToGroupResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersAddToGroupResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -4059,11 +4088,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeFromGroup_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersRemoveFromGroupResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UsersRemoveFromGroupResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -4156,12 +4186,12 @@ class $UsersClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $resendWelcomeMessage_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UsersResendWelcomeMessageResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<UsersResendWelcomeMessageResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/settings.openapi.dart
+++ b/packages/nextcloud/lib/src/api/settings.openapi.dart
@@ -176,12 +176,12 @@ class $DeclarativeSettingsClient {
       value: value,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setValue_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<DeclarativeSettingsSetValueResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<DeclarativeSettingsSetValueResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -261,12 +261,12 @@ class $DeclarativeSettingsClient {
     final _request = $getForms_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getForms_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<DeclarativeSettingsGetFormsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<DeclarativeSettingsGetFormsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -341,11 +341,12 @@ class $LogSettingsClient {
   ///  * [$download_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Uint8List, LogSettingsLogSettingsDownloadHeaders>> download() async {
     final _request = $download_Request();
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $download_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<Uint8List, LogSettingsLogSettingsDownloadHeaders>(_serializer).convert(_response);
+        _i1.ResponseConverter<Uint8List, LogSettingsLogSettingsDownloadHeaders>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -201,10 +201,11 @@ class $AvatarClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAvatar_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -308,11 +309,12 @@ class $AvatarClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $uploadAvatar_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<AvatarUploadAvatarResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<AvatarUploadAvatarResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -414,11 +416,12 @@ class $AvatarClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteAvatar_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<AvatarDeleteAvatarResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<AvatarDeleteAvatarResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -539,11 +542,12 @@ class $AvatarClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $emojiAvatar_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<AvatarEmojiAvatarResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<AvatarEmojiAvatarResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -645,10 +649,11 @@ class $AvatarClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAvatarDark_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -771,10 +776,11 @@ class $AvatarClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUserProxyAvatarWithoutRoom_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -885,10 +891,11 @@ class $AvatarClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUserProxyAvatarDarkWithoutRoom_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1017,10 +1024,11 @@ class $AvatarClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUserProxyAvatar_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1139,10 +1147,11 @@ class $AvatarClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUserProxyAvatarDark_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -1251,11 +1260,12 @@ class $BotClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listBots_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<BotListBotsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<BotListBotsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1369,11 +1379,12 @@ class $BotClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $enableBot_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<BotEnableBotResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<BotEnableBotResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1485,11 +1496,12 @@ class $BotClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $disableBot_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<BotDisableBotResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<BotDisableBotResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1637,11 +1649,12 @@ class $BotClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $sendMessage_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<BotSendMessageResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<BotSendMessageResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1767,11 +1780,11 @@ class $BotClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $react_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<BotReactResponseApplicationJson, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<BotReactResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1897,11 +1910,12 @@ class $BotClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteReaction_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<BotDeleteReactionResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<BotDeleteReactionResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -2050,11 +2064,12 @@ class $BreakoutRoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $configureBreakoutRooms_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -2162,11 +2177,12 @@ class $BreakoutRoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeBreakoutRooms_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -2287,11 +2303,12 @@ class $BreakoutRoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $broadcastChatMessage_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<BreakoutRoomBroadcastChatMessageResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<BreakoutRoomBroadcastChatMessageResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -2408,12 +2425,12 @@ class $BreakoutRoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $applyAttendeeMap_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<BreakoutRoomApplyAttendeeMapResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<BreakoutRoomApplyAttendeeMapResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2520,12 +2537,12 @@ class $BreakoutRoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $requestAssistance_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<BreakoutRoomRequestAssistanceResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<BreakoutRoomRequestAssistanceResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2635,11 +2652,12 @@ class $BreakoutRoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $resetRequestForAssistance_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<BreakoutRoomResetRequestForAssistanceResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<BreakoutRoomResetRequestForAssistanceResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -2749,12 +2767,12 @@ class $BreakoutRoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $startBreakoutRooms_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<BreakoutRoomStartBreakoutRoomsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<BreakoutRoomStartBreakoutRoomsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2861,12 +2879,12 @@ class $BreakoutRoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $stopBreakoutRooms_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<BreakoutRoomStopBreakoutRoomsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<BreakoutRoomStopBreakoutRoomsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -2983,12 +3001,12 @@ class $BreakoutRoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $switchBreakoutRoom_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -3097,11 +3115,12 @@ class $CallClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPeersForCall_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CallGetPeersForCallResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<CallGetPeersForCallResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3221,11 +3240,12 @@ class $CallClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $updateCallFlags_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CallUpdateCallFlagsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<CallUpdateCallFlagsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3378,11 +3398,12 @@ class $CallClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $joinCall_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CallJoinCallResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<CallJoinCallResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3493,11 +3514,12 @@ class $CallClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $leaveCall_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CallLeaveCallResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<CallLeaveCallResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3612,11 +3634,12 @@ class $CallClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $ringAttendee_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CallRingAttendeeResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<CallRingAttendeeResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -3732,11 +3755,12 @@ class $CallClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $sipDialOut_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CallSipDialOutResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<CallSipDialOutResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -3963,11 +3987,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $receiveMessages_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatReceiveMessagesResponseApplicationJson, ChatChatReceiveMessagesHeaders>(
+        _i1.ResponseConverter<ChatReceiveMessagesResponseApplicationJson, ChatChatReceiveMessagesHeaders>(
       _serializer,
     ).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -4133,11 +4158,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $sendMessage_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatSendMessageResponseApplicationJson, ChatChatSendMessageHeaders>(_serializer)
+        _i1.ResponseConverter<ChatSendMessageResponseApplicationJson, ChatChatSendMessageHeaders>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -4246,11 +4272,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $clearHistory_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatClearHistoryResponseApplicationJson, ChatChatClearHistoryHeaders>(_serializer)
+        _i1.ResponseConverter<ChatClearHistoryResponseApplicationJson, ChatChatClearHistoryHeaders>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -4386,11 +4413,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $editMessage_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatEditMessageResponseApplicationJson, ChatChatEditMessageHeaders>(_serializer)
+        _i1.ResponseConverter<ChatEditMessageResponseApplicationJson, ChatChatEditMessageHeaders>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -4517,11 +4545,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteMessage_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatDeleteMessageResponseApplicationJson, ChatChatDeleteMessageHeaders>(_serializer)
+        _i1.ResponseConverter<ChatDeleteMessageResponseApplicationJson, ChatChatDeleteMessageHeaders>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -4656,11 +4685,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getMessageContext_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatGetMessageContextResponseApplicationJson, ChatChatGetMessageContextHeaders>(
+        _i1.ResponseConverter<ChatGetMessageContextResponseApplicationJson, ChatChatGetMessageContextHeaders>(
       _serializer,
     ).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -4781,11 +4811,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getReminder_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatGetReminderResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ChatGetReminderResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -4918,11 +4949,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setReminder_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatSetReminderResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ChatSetReminderResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -5042,11 +5074,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteReminder_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatDeleteReminderResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ChatDeleteReminderResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -5162,11 +5195,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setReadMarker_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatSetReadMarkerResponseApplicationJson, ChatChatSetReadMarkerHeaders>(_serializer)
+        _i1.ResponseConverter<ChatSetReadMarkerResponseApplicationJson, ChatChatSetReadMarkerHeaders>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -5268,11 +5302,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $markUnread_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatMarkUnreadResponseApplicationJson, ChatChatMarkUnreadHeaders>(_serializer)
+        _i1.ResponseConverter<ChatMarkUnreadResponseApplicationJson, ChatChatMarkUnreadHeaders>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -5402,11 +5437,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $mentions_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatMentionsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ChatMentionsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -5548,12 +5584,14 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getObjectsSharedInRoom_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<ChatGetObjectsSharedInRoomResponseApplicationJson,
-            ChatChatGetObjectsSharedInRoomHeaders>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<ChatGetObjectsSharedInRoomResponseApplicationJson, ChatChatGetObjectsSharedInRoomHeaders>(
+      _serializer,
+    ).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -5711,11 +5749,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $shareObjectToChat_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatShareObjectToChatResponseApplicationJson, ChatChatShareObjectToChatHeaders>(
+        _i1.ResponseConverter<ChatShareObjectToChatResponseApplicationJson, ChatChatShareObjectToChatHeaders>(
       _serializer,
     ).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -5838,11 +5877,12 @@ class $ChatClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getObjectsSharedInRoomOverview_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -5953,11 +5993,12 @@ class $ExternalSignalingClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $signalingGetSettings_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<SignalingGetSettingsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<SignalingGetSettingsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -6079,11 +6120,12 @@ class $FederationClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $acceptShare_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<FederationAcceptShareResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<FederationAcceptShareResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -6196,11 +6238,12 @@ class $FederationClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $rejectShare_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<FederationRejectShareResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<FederationRejectShareResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -6295,11 +6338,12 @@ class $FederationClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getShares_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<FederationGetSharesResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<FederationGetSharesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -6424,11 +6468,12 @@ class $FilesIntegrationClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getRoomByFileId_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<FilesIntegrationGetRoomByFileIdResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<FilesIntegrationGetRoomByFileIdResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -6548,11 +6593,12 @@ class $FilesIntegrationClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getRoomByShareToken_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<FilesIntegrationGetRoomByShareTokenResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<FilesIntegrationGetRoomByShareTokenResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -6659,12 +6705,12 @@ class $FilesIntegrationClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $publicShareAuthCreateRoom_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<PublicShareAuthCreateRoomResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<PublicShareAuthCreateRoomResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -6786,11 +6832,12 @@ class $GuestClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setDisplayName_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<GuestSetDisplayNameResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<GuestSetDisplayNameResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -6940,11 +6987,12 @@ class $HostedSignalingServerClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $requestTrial_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<HostedSignalingServerRequestTrialResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<HostedSignalingServerRequestTrialResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -7045,10 +7093,11 @@ class $HostedSignalingServerClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteAccount_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<void, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -7158,11 +7207,12 @@ class $InternalSignalingClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $signalingGetSettings_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<SignalingGetSettingsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<SignalingGetSettingsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -7270,11 +7320,12 @@ class $InternalSignalingClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $signalingPullMessages_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<SignalingPullMessagesResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<SignalingPullMessagesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -7387,11 +7438,12 @@ class $InternalSignalingClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $signalingSendMessages_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<SignalingSendMessagesResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<SignalingSendMessagesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -7502,12 +7554,12 @@ class $MatterbridgeClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getBridgeOfRoom_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<MatterbridgeGetBridgeOfRoomResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<MatterbridgeGetBridgeOfRoomResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -7638,12 +7690,12 @@ class $MatterbridgeClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $editBridgeOfRoom_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<MatterbridgeEditBridgeOfRoomResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<MatterbridgeEditBridgeOfRoomResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -7751,12 +7803,12 @@ class $MatterbridgeClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteBridgeOfRoom_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -7863,11 +7915,12 @@ class $MatterbridgeClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getBridgeProcessState_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<MatterbridgeGetBridgeProcessStateResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<MatterbridgeGetBridgeProcessStateResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -7968,11 +8021,12 @@ class $MatterbridgeClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $matterbridgeSettingsStopAllBridges_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<MatterbridgeSettingsStopAllBridgesResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<MatterbridgeSettingsStopAllBridgesResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -8073,11 +8127,11 @@ class $MatterbridgeClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $matterbridgeSettingsGetMatterbridgeVersion_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson, void>(
+    final _rawResponse = _i1.ResponseConverter<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson, void>(
       _serializer,
     ).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -8224,11 +8278,12 @@ class $PollClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createPoll_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<PollCreatePollResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<PollCreatePollResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -8343,11 +8398,12 @@ class $PollClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $showPoll_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<PollShowPollResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<PollShowPollResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -8474,11 +8530,12 @@ class $PollClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $votePoll_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<PollVotePollResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<PollVotePollResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -8599,11 +8656,12 @@ class $PollClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $closePoll_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<PollClosePollResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<PollClosePollResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -8736,11 +8794,12 @@ class $ReactionClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getReactions_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ReactionGetReactionsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ReactionGetReactionsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -8868,11 +8927,12 @@ class $ReactionClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $react_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ReactionReactResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ReactionReactResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -8998,11 +9058,12 @@ class $ReactionClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $delete_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ReactionDeleteResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ReactionDeleteResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -9122,11 +9183,12 @@ class $RecordingClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $start_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RecordingStartResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RecordingStartResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -9230,11 +9292,12 @@ class $RecordingClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $stop_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RecordingStopResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RecordingStopResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -9355,12 +9418,12 @@ class $RecordingClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $notificationDismiss_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<RecordingNotificationDismissResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<RecordingNotificationDismissResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -9494,11 +9557,12 @@ class $RecordingClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $shareToChat_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RecordingShareToChatResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RecordingShareToChatResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -9592,11 +9656,12 @@ class $RecordingClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $backend_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RecordingBackendResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RecordingBackendResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -9709,11 +9774,12 @@ class $RecordingClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $store_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RecordingStoreResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RecordingStoreResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -9846,11 +9912,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getRooms_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomGetRoomsResponseApplicationJson, RoomRoomGetRoomsHeaders>(_serializer)
+        _i1.ResponseConverter<RoomGetRoomsResponseApplicationJson, RoomRoomGetRoomsHeaders>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -10004,11 +10071,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createRoom_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomCreateRoomResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomCreateRoomResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -10109,11 +10177,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getListedRooms_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomGetListedRoomsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomGetListedRoomsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -10210,10 +10279,11 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getNoteToSelfConversation_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<RoomGetNoteToSelfConversationResponseApplicationJson,
+    final _rawResponse = _i1.ResponseConverter<RoomGetNoteToSelfConversationResponseApplicationJson,
             RoomRoomGetNoteToSelfConversationHeaders>(_serializer)
         .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -10321,11 +10391,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getSingleRoom_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomGetSingleRoomResponseApplicationJson, RoomRoomGetSingleRoomHeaders>(_serializer)
+        _i1.ResponseConverter<RoomGetSingleRoomResponseApplicationJson, RoomRoomGetSingleRoomHeaders>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -10437,11 +10508,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getBreakoutRooms_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomGetBreakoutRoomsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomGetBreakoutRoomsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -10546,11 +10618,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $makePublic_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomMakePublicResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomMakePublicResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -10655,11 +10728,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $makePrivate_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomMakePrivateResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomMakePrivateResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -10772,11 +10846,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setDescription_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomSetDescriptionResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomSetDescriptionResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -10890,11 +10965,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setReadOnly_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomSetReadOnlyResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomSetReadOnlyResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -11008,11 +11084,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setListable_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomSetListableResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomSetListableResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -11126,11 +11203,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setPassword_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomSetPasswordResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomSetPasswordResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -11263,11 +11341,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setPermissions_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomSetPermissionsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomSetPermissionsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -11383,11 +11462,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getParticipants_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomGetParticipantsResponseApplicationJson, RoomRoomGetParticipantsHeaders>(
+        _i1.ResponseConverter<RoomGetParticipantsResponseApplicationJson, RoomRoomGetParticipantsHeaders>(
       _serializer,
     ).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -11518,11 +11598,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addParticipantToRoom_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<RoomAddParticipantToRoomResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<RoomAddParticipantToRoomResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -11647,10 +11728,11 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getBreakoutRoomParticipants_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
+    final _rawResponse = _i1.ResponseConverter<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
             RoomRoomGetBreakoutRoomParticipantsHeaders>(_serializer)
         .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -11761,11 +11843,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeSelfFromRoom_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<RoomRemoveSelfFromRoomResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<RoomRemoveSelfFromRoomResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -11887,12 +11970,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeAttendeeFromRoom_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomRemoveAttendeeFromRoomResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<RoomRemoveAttendeeFromRoomResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -12038,12 +12121,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setAttendeePermissions_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomSetAttendeePermissionsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<RoomSetAttendeePermissionsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -12174,12 +12257,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setAllAttendeesPermissions_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<RoomSetAllAttendeesPermissionsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<RoomSetAllAttendeesPermissionsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -12306,11 +12389,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $joinRoom_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomJoinRoomResponseApplicationJson, RoomRoomJoinRoomHeaders>(_serializer)
+        _i1.ResponseConverter<RoomJoinRoomResponseApplicationJson, RoomRoomJoinRoomHeaders>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -12412,11 +12496,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $leaveRoom_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomLeaveRoomResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomLeaveRoomResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -12537,11 +12622,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $resendInvitations_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomResendInvitationsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomResendInvitationsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -12656,11 +12742,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setSessionState_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomSetSessionStateResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomSetSessionStateResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -12782,11 +12869,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $promoteModerator_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomPromoteModeratorResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomPromoteModeratorResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -12908,11 +12996,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $demoteModerator_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomDemoteModeratorResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomDemoteModeratorResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -13016,11 +13105,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addToFavorites_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomAddToFavoritesResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomAddToFavoritesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -13124,11 +13214,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeFromFavorites_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<RoomRemoveFromFavoritesResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<RoomRemoveFromFavoritesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -13243,11 +13334,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setNotificationLevel_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<RoomSetNotificationLevelResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<RoomSetNotificationLevelResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -13362,11 +13454,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setNotificationCalls_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<RoomSetNotificationCallsResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<RoomSetNotificationCallsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -13492,11 +13585,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setLobby_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomSetLobbyResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomSetLobbyResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -13617,11 +13711,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setsipEnabled_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomSetsipEnabledResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomSetsipEnabledResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -13739,11 +13834,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setRecordingConsent_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<RoomSetRecordingConsentResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<RoomSetRecordingConsentResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -13861,11 +13957,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setMessageExpiration_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<RoomSetMessageExpirationResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<RoomSetMessageExpirationResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -13973,11 +14070,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getCapabilities_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomGetCapabilitiesResponseApplicationJson, RoomRoomGetCapabilitiesHeaders>(
+        _i1.ResponseConverter<RoomGetCapabilitiesResponseApplicationJson, RoomRoomGetCapabilitiesHeaders>(
       _serializer,
     ).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -14085,11 +14183,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $joinFederatedRoom_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomJoinFederatedRoomResponseApplicationJson, RoomRoomJoinFederatedRoomHeaders>(
+        _i1.ResponseConverter<RoomJoinFederatedRoomResponseApplicationJson, RoomRoomJoinFederatedRoomHeaders>(
       _serializer,
     ).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
@@ -14213,12 +14312,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $verifyDialInPinDeprecated_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<RoomVerifyDialInPinDeprecatedResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<RoomVerifyDialInPinDeprecatedResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -14335,11 +14434,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $verifyDialInPin_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomVerifyDialInPinResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<RoomVerifyDialInPinResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -14470,11 +14570,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $verifyDialOutNumber_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<RoomVerifyDialOutNumberResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<RoomVerifyDialOutNumberResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -14581,11 +14682,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createGuestByDialIn_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<RoomCreateGuestByDialInResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<RoomCreateGuestByDialInResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -14716,12 +14818,12 @@ class $RoomClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $rejectedDialOutRequest_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RoomRejectedDialOutRequestResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<RoomRejectedDialOutRequestResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -14838,11 +14940,12 @@ class $SettingsClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setUserSetting_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<SettingsSetUserSettingResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<SettingsSetUserSettingResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -14937,11 +15040,12 @@ class $SettingsClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $botAdminListBots_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<BotAdminListBotsResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<BotAdminListBotsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -15050,11 +15154,12 @@ class $SettingsClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $certificateGetCertificateExpiration_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CertificateGetCertificateExpirationResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<CertificateGetCertificateExpirationResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -15168,12 +15273,12 @@ class $SettingsClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $recordingGetWelcomeMessage_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<RecordingGetWelcomeMessageResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<RecordingGetWelcomeMessageResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -15298,11 +15403,12 @@ class $SettingsClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setsipSettings_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<SettingsSetsipSettingsResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<SettingsSetsipSettingsResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -15417,12 +15523,12 @@ class $SettingsClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $signalingGetWelcomeMessage_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<SignalingGetWelcomeMessageResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<SignalingGetWelcomeMessageResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -15521,11 +15627,12 @@ class $SignalingClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $backend_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<SignalingBackendResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<SignalingBackendResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -15612,11 +15719,12 @@ class $UserAvatarClient {
     final _request = $tempAvatarPostAvatar_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $tempAvatarPostAvatar_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<TempAvatarPostAvatarResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<TempAvatarPostAvatarResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -15696,11 +15804,12 @@ class $UserAvatarClient {
     final _request = $tempAvatarDeleteAvatar_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $tempAvatarDeleteAvatar_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<TempAvatarDeleteAvatarResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<TempAvatarDeleteAvatarResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/theming.openapi.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.dart
@@ -138,10 +138,11 @@ class $IconClient {
     final _request = $getFavicon_Request(
       app: app,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getFavicon_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -219,10 +220,11 @@ class $IconClient {
     final _request = $getTouchIcon_Request(
       app: app,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getTouchIcon_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -316,10 +318,11 @@ class $IconClient {
       app: app,
       image: image,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getThemedIcon_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -429,10 +432,11 @@ class $ThemingClient {
       plain: plain,
       withCustomCss: withCustomCss,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getThemeStylesheet_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<String, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<String, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -522,10 +526,11 @@ class $ThemingClient {
       key: key,
       useSvg: useSvg,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getImage_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -602,11 +607,12 @@ class $ThemingClient {
     final _request = $getManifest_Request(
       app: app,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getManifest_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ThemingGetManifestResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ThemingGetManifestResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -678,10 +684,11 @@ class $UserThemeClient {
   ///  * [$getBackground_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<Uint8List, void>> getBackground() async {
     final _request = $getBackground_Request();
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getBackground_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -774,11 +781,12 @@ class $UserThemeClient {
       themeId: themeId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $enableTheme_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UserThemeEnableThemeResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UserThemeEnableThemeResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -871,11 +879,12 @@ class $UserThemeClient {
       themeId: themeId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $disableTheme_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UserThemeDisableThemeResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UserThemeDisableThemeResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
@@ -155,11 +155,12 @@ class $ApiClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAppList_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ApiGetAppListResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ApiGetAppListResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -273,11 +274,12 @@ class $ApiClient {
       apiVersion: apiVersion,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAppChangelogEntry_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<ApiGetAppChangelogEntryResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<ApiGetAppChangelogEntryResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/uppush.openapi.dart
+++ b/packages/nextcloud/lib/src/api/uppush.openapi.dart
@@ -104,11 +104,11 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$check_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<CheckResponseApplicationJson, void>> check() async {
     final _request = $check_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $check_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<CheckResponseApplicationJson, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<CheckResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -188,11 +188,12 @@ class $Client extends _i1.DynamiteClient {
     final _request = $setKeepalive_Request(
       keepalive: keepalive,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setKeepalive_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<SetKeepaliveResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<SetKeepaliveResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -270,11 +271,12 @@ class $Client extends _i1.DynamiteClient {
     final _request = $createDevice_Request(
       deviceName: deviceName,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createDevice_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<CreateDeviceResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<CreateDeviceResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -347,11 +349,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $syncDevice_Request(
       deviceId: deviceId,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $syncDevice_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<SyncDeviceResponseApplicationJson, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<SyncDeviceResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -423,11 +425,12 @@ class $Client extends _i1.DynamiteClient {
     final _request = $deleteDevice_Request(
       deviceId: deviceId,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteDevice_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<DeleteDeviceResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<DeleteDeviceResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -514,11 +517,11 @@ class $Client extends _i1.DynamiteClient {
       deviceId: deviceId,
       appName: appName,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createApp_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<CreateAppResponseApplicationJson, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<CreateAppResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -587,11 +590,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $deleteApp_Request(
       token: token,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteApp_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<DeleteAppResponseApplicationJson, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<DeleteAppResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -663,11 +666,12 @@ class $Client extends _i1.DynamiteClient {
     final _request = $unifiedpushDiscovery_Request(
       token: token,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $unifiedpushDiscovery_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UnifiedpushDiscoveryResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UnifiedpushDiscoveryResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -736,10 +740,11 @@ class $Client extends _i1.DynamiteClient {
     final _request = $push_Request(
       token: token,
     );
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $push_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<PushResponseApplicationJson, void>(_serializer).convert(_response);
+    final _rawResponse = _i1.ResponseConverter<PushResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -803,11 +808,12 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$gatewayMatrixDiscovery_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<GatewayMatrixDiscoveryResponseApplicationJson, void>> gatewayMatrixDiscovery() async {
     final _request = $gatewayMatrixDiscovery_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $gatewayMatrixDiscovery_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<GatewayMatrixDiscoveryResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<GatewayMatrixDiscoveryResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -871,11 +877,12 @@ class $Client extends _i1.DynamiteClient {
   ///  * [$gatewayMatrix_Serializer] for a converter to parse the `Response` from an executed request.
   Future<_i1.DynamiteResponse<GatewayMatrixResponseApplicationJson, void>> gatewayMatrix() async {
     final _request = $gatewayMatrix_Request();
-    final _response = await httpClient.send(_request);
+    final _streamedResponse = await httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $gatewayMatrix_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<GatewayMatrixResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<GatewayMatrixResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/user_ldap.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_ldap.openapi.dart
@@ -132,11 +132,12 @@ class $ConfigapiClient {
     final _request = $create_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $create_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ConfigapiCreateResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ConfigapiCreateResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -243,11 +244,12 @@ class $ConfigapiClient {
       showPassword: showPassword,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$show_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ConfigapiShowResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ConfigapiShowResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -357,11 +359,12 @@ class $ConfigapiClient {
       configID: configID,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $modify_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ConfigapiModifyResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ConfigapiModifyResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -455,11 +458,12 @@ class $ConfigapiClient {
       configID: configID,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $delete_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<ConfigapiDeleteResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<ConfigapiDeleteResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -153,11 +153,12 @@ class $HeartbeatClient {
       status: status,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $heartbeat_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<HeartbeatHeartbeatResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<HeartbeatHeartbeatResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -242,11 +243,12 @@ class $PredefinedStatusClient {
     final _request = $findAll_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findAll_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<PredefinedStatusFindAllResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<PredefinedStatusFindAllResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -349,11 +351,12 @@ class $StatusesClient {
       offset: offset,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findAll_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<StatusesFindAllResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<StatusesFindAllResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -443,11 +446,12 @@ class $StatusesClient {
       userId: userId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $find_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<StatusesFindResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<StatusesFindResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
@@ -534,11 +538,12 @@ class $UserStatusClient {
     final _request = $getStatus_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getStatus_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UserStatusGetStatusResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UserStatusGetStatusResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -630,11 +635,12 @@ class $UserStatusClient {
       statusType: statusType,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setStatus_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UserStatusSetStatusResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<UserStatusSetStatusResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -735,12 +741,12 @@ class $UserStatusClient {
       clearAt: clearAt,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setPredefinedMessage_Serializer();
-    final _rawResponse =
-        await _i1.ResponseConverter<UserStatusSetPredefinedMessageResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+    final _rawResponse = _i1.ResponseConverter<UserStatusSetPredefinedMessageResponseApplicationJson, void>(_serializer)
+        .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -849,12 +855,12 @@ class $UserStatusClient {
       clearAt: clearAt,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setCustomMessage_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<UserStatusSetCustomMessageResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<UserStatusSetCustomMessageResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -932,11 +938,12 @@ class $UserStatusClient {
     final _request = $clearMessage_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $clearMessage_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<UserStatusClearMessageResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<UserStatusClearMessageResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -1026,11 +1033,12 @@ class $UserStatusClient {
       messageId: messageId,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $revertStatus_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<UserStatusRevertStatusResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<UserStatusRevertStatusResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.dart
@@ -140,11 +140,12 @@ class $WeatherStatusClient {
       mode: mode,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setMode_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<WeatherStatusSetModeResponseApplicationJson, void>(_serializer).convert(_response);
+        _i1.ResponseConverter<WeatherStatusSetModeResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -222,11 +223,12 @@ class $WeatherStatusClient {
     final _request = $usePersonalAddress_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $usePersonalAddress_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<WeatherStatusUsePersonalAddressResponseApplicationJson, void>(_serializer)
+        _i1.ResponseConverter<WeatherStatusUsePersonalAddressResponseApplicationJson, void>(_serializer)
             .convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
@@ -305,11 +307,12 @@ class $WeatherStatusClient {
     final _request = $getLocation_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getLocation_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<WeatherStatusGetLocationResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<WeatherStatusGetLocationResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -415,11 +418,12 @@ class $WeatherStatusClient {
       lon: lon,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setLocation_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<WeatherStatusSetLocationResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<WeatherStatusSetLocationResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -499,11 +503,12 @@ class $WeatherStatusClient {
     final _request = $getForecast_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getForecast_Serializer();
-    final _rawResponse = await _i1.ResponseConverter<WeatherStatusGetForecastResponseApplicationJson, void>(_serializer)
-        .convert(_response);
+    final _rawResponse =
+        _i1.ResponseConverter<WeatherStatusGetForecastResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -581,12 +586,12 @@ class $WeatherStatusClient {
     final _request = $getFavorites_Request(
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getFavorites_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<WeatherStatusGetFavoritesResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<WeatherStatusGetFavoritesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
@@ -677,12 +682,12 @@ class $WeatherStatusClient {
       favorites: favorites,
       oCSAPIRequest: oCSAPIRequest,
     );
-    final _response = await _rootClient.httpClient.send(_request);
+    final _streamedResponse = await _rootClient.httpClient.send(_request);
+    final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setFavorites_Serializer();
     final _rawResponse =
-        await _i1.ResponseConverter<WeatherStatusSetFavoritesResponseApplicationJson, void>(_serializer)
-            .convert(_response);
+        _i1.ResponseConverter<WeatherStatusSetFavoritesResponseApplicationJson, void>(_serializer).convert(_response);
     return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }

--- a/packages/nextcloud/lib/src/webdav/client.dart
+++ b/packages/nextcloud/lib/src/webdav/client.dart
@@ -381,7 +381,8 @@ class WebDavClient {
       depth: depth,
     );
 
-    final response = await csrfClient.send(request);
+    final streamedResponse = await csrfClient.send(request);
+    final response = await http.Response.fromStream(streamedResponse);
     return const WebDavResponseConverter().convert(response);
   }
 
@@ -422,7 +423,8 @@ class WebDavClient {
       prop: prop,
     );
 
-    final response = await csrfClient.send(request);
+    final streamedResponse = await csrfClient.send(request);
+    final response = await http.Response.fromStream(streamedResponse);
     return const WebDavResponseConverter().convert(response);
   }
 
@@ -465,8 +467,9 @@ class WebDavClient {
       remove: remove,
     );
 
-    final response = await csrfClient.send(request);
-    final data = await const WebDavResponseConverter().convert(response);
+    final streamedResponse = await csrfClient.send(request);
+    final response = await http.Response.fromStream(streamedResponse);
+    final data = const WebDavResponseConverter().convert(response);
     for (final a in data.responses) {
       for (final b in a.propstats) {
         if (!b.status.contains('200')) {

--- a/packages/nextcloud/lib/src/webdav/utils.dart
+++ b/packages/nextcloud/lib/src/webdav/utils.dart
@@ -38,18 +38,16 @@ Uri constructUri(Uri baseURL, [PathUri? path]) {
 /// Converter to transform a [http.StreamedResponse] into a [DynamiteResponse].
 ///
 /// Throws a [DynamiteApiException] on errors.
-final class WebDavResponseConverter with Converter<http.StreamedResponse, Future<WebDavMultistatus>> {
+final class WebDavResponseConverter with Converter<http.Response, WebDavMultistatus> {
   /// Creates a new response converter
   const WebDavResponseConverter();
 
   @override
-  Future<WebDavMultistatus> convert(http.StreamedResponse input) async {
-    final response = await http.Response.fromStream(input);
-
+  WebDavMultistatus convert(http.Response input) {
     final xml = XmlEventDecoder()
         .fuse(const XmlNormalizeEvents())
         .fuse(const XmlNodeDecoder())
-        .convert(response.body)
+        .convert(input.body)
         .firstWhere((element) => element is XmlElement) as XmlElement;
 
     return WebDavMultistatus.fromXmlElement(xml);

--- a/tool/generate-nextcloud.sh
+++ b/tool/generate-nextcloud.sh
@@ -10,4 +10,6 @@ cd "$(dirname "$0")/.."
   fvm dart run generate_exports.dart
   fvm dart fix --apply lib/src/api/
   melos run format
+  fvm dart fix --apply lib/src/api/
+  melos run format
 )


### PR DESCRIPTION
Simplifies the usage of the converter when fusing multiple together. Otherwise the next converter needs to accept `Future<DynamiteResponse>` as an input.
Also moves reading the body from the response outside of the converter which clarifies the responsibilities and makes stacktraces more readable.