### PR TITLE
refactor(neon_framework): Only use Converter in RequestManager and store raw responses in RequestCache

### DIFF
--- a/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
+++ b/packages/dynamite/dynamite/example/lib/petstore.openapi.dart
@@ -130,8 +130,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findPets_Serializer();
-    final _rawResponse = _i1.ResponseConverter<BuiltList<Pet>, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BuiltList<Pet>, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$addPet_Request].
@@ -186,8 +185,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addPet_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Pet, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Pet, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$findPetById_Request].
@@ -250,8 +248,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findPetById_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Pet, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Pet, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deletePet_Request].
@@ -313,8 +310,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deletePet_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/dynamite/dynamite/lib/src/builder/client.dart
+++ b/packages/dynamite/dynamite/lib/src/builder/client.dart
@@ -439,8 +439,7 @@ final _streamedResponse = await $client.httpClient.send(_request);
 final _response = await ${allocate(refer('Response', 'package:http/http.dart'))}.fromStream(_streamedResponse);
 
 final _serializer = \$${name}_Serializer();
-final _rawResponse = await ${allocate(responseConverterType)}(_serializer).convert(_response);
-return ${allocate(responseType)}.fromRawResponse(_rawResponse);
+return ${allocate(responseConverterType)}(_serializer).convert(_response);
 ''',
           );
       });

--- a/packages/dynamite/dynamite_end_to_end_test/lib/authentication.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/authentication.openapi.dart
@@ -76,8 +76,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $noAuthentication_Serializer();
-    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$basicAuthentication_Request].
@@ -139,8 +138,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $basicAuthentication_Serializer();
-    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$bearerAuthentication_Request].
@@ -202,8 +200,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $bearerAuthentication_Serializer();
-    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$multipleAuthentications_Request].
@@ -265,8 +262,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $multipleAuthentications_Serializer();
-    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/deprecation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/deprecation.openapi.dart
@@ -106,8 +106,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findValues_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/documentation.openapi.dart
@@ -135,8 +135,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findValues_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$multipleNewLines_Request].
@@ -208,8 +207,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $multipleNewLines_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$nonRootClientSetMode_Request].
@@ -257,8 +255,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $nonRootClientSetMode_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
   }
 }
 
@@ -338,8 +335,7 @@ class $NonRootClientClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $multipleNewLines_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setMode_Request].
@@ -387,8 +383,7 @@ class $NonRootClientClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setMode_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Object1, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/headers.openapi.dart
@@ -77,8 +77,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, GetHeaders>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, GetHeaders>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$withContentOperationId_Request].
@@ -123,8 +122,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $withContentOperationId_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, WithContentOperationIdHeaders>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, WithContentOperationIdHeaders>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getWithContent_Request].
@@ -169,8 +167,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getWithContent_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, GetWithContentHeaders>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, GetWithContentHeaders>(_serializer).convert(_response);
   }
 }
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/parameters.openapi.dart
@@ -222,8 +222,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getDefaults_Request].
@@ -424,8 +423,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getDefaults_Serializer();
-    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getHeaders_Request].
@@ -635,8 +633,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getHeaders_Serializer();
-    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getPathParameter_Request].
@@ -687,8 +684,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPathParameter_Serializer();
-    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getNamingCollisions_Request].
@@ -775,8 +771,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getNamingCollisions_Serializer();
-    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/request_body.openapi.dart
@@ -99,8 +99,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $post_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getObject_Request].
@@ -155,8 +154,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getObject_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$putObject_Request].
@@ -211,8 +209,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $putObject_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$postObject_Request].
@@ -260,8 +257,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $postObject_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteObject_Request].
@@ -312,8 +308,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteObject_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getBinary_Request].
@@ -360,8 +355,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getBinary_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$putBinary_Request].
@@ -408,8 +402,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $putBinary_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$postBinary_Request].
@@ -456,8 +449,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $postBinary_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/responses.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/responses.openapi.dart
@@ -72,8 +72,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse = _i1.ResponseConverter<String, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<String, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$put_Request].
@@ -120,8 +119,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $put_Serializer();
-    final _rawResponse = _i1.ResponseConverter<String, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<String, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$post_Request].
@@ -169,8 +167,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $post_Serializer();
-    final _rawResponse = _i1.ResponseConverter<String, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<String, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$patch_Request].
@@ -217,8 +214,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $patch_Serializer();
-    final _rawResponse = _i1.ResponseConverter<String, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<String, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/dynamite/dynamite_end_to_end_test/lib/tags.openapi.dart
+++ b/packages/dynamite/dynamite_end_to_end_test/lib/tags.openapi.dart
@@ -82,8 +82,7 @@ class $FirstClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 }
 
@@ -133,8 +132,7 @@ class $SecondClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/dynamite/dynamite_runtime/lib/src/client/client.dart
+++ b/packages/dynamite/dynamite_runtime/lib/src/client/client.dart
@@ -8,7 +8,6 @@ import 'package:http/http.dart' as http;
 ///
 /// See:
 ///   * [DynamiteResponse] as the response returned by an operation.
-///   * [DynamiteRawResponse] as the raw response that can be serialized.
 ///   * [DynamiteApiException] as the exception that can be thrown in operations
 ///   * [DynamiteAuthentication] for providing authentication methods.
 abstract class DynamiteClient {

--- a/packages/dynamite/dynamite_runtime/lib/src/client/response.dart
+++ b/packages/dynamite/dynamite_runtime/lib/src/client/response.dart
@@ -16,14 +16,6 @@ class DynamiteResponse<B, H> {
     this.headers,
   );
 
-  /// Converts the [rawResponse] to a generic dynamite response to free the
-  /// resources taken by the raw parameters.
-  factory DynamiteResponse.fromRawResponse(DynamiteRawResponse<B, H> rawResponse) => DynamiteResponse(
-        rawResponse.statusCode,
-        rawResponse.body,
-        rawResponse.headers,
-      );
-
   /// The status code of the response.
   final int statusCode;
 
@@ -35,37 +27,6 @@ class DynamiteResponse<B, H> {
 
   @override
   String toString() => 'DynamiteResponse(data: $body, headers: $headers, statusCode: $statusCode)';
-}
-
-/// Raw response that can be efficiently serialized into a json Map.
-class DynamiteRawResponse<B, H> extends DynamiteResponse<B, H> {
-  /// Creates a new raw dynamite response.
-  const DynamiteRawResponse({
-    required int statusCode,
-    required B body,
-    required H headers,
-    this.rawHeaders,
-    this.rawBody,
-  }) : super(statusCode, body, headers);
-
-  /// Caches the raw headers for later serialization in [toJson].
-  final Map<String, Object?>? rawHeaders;
-
-  /// Caches the raw response body for later serialization in [toJson].
-  final Object? rawBody;
-
-  /// Serializes this response into json.
-  ///
-  /// To revive it again use `DynamiteRawResponse.fromJson` with the same
-  /// serializer and `FullType`s as this.
-  Map<String, Object?> toJson() => {
-        'statusCode': statusCode,
-        'body': rawBody,
-        'headers': rawHeaders,
-      };
-
-  @override
-  String toString() => 'DynamiteRawResponse(data: $body, headers: $headers, statusCode: $statusCode)';
 }
 
 /// The serializer to convert the raw headers and body from a [http.BaseResponse].
@@ -102,7 +63,7 @@ final class DynamiteSerializer<B, H> {
 /// Converter to transform a [http.Response] into a [DynamiteResponse].
 ///
 /// Throws a [DynamiteApiException] on errors.
-final class ResponseConverter<B, H> with Converter<http.Response, DynamiteRawResponse<B, H>> {
+final class ResponseConverter<B, H> with Converter<http.Response, DynamiteResponse<B, H>> {
   /// Creates a new response converter
   const ResponseConverter(this.serializer);
 
@@ -110,7 +71,7 @@ final class ResponseConverter<B, H> with Converter<http.Response, DynamiteRawRes
   final DynamiteSerializer<B, H> serializer;
 
   @override
-  DynamiteRawResponse<B, H> convert(http.Response input) {
+  DynamiteResponse<B, H> convert(http.Response input) {
     final rawHeaders = input.headers;
     final statusCode = input.statusCode;
     final validStatuses = serializer.validStatuses;
@@ -127,51 +88,8 @@ final class ResponseConverter<B, H> with Converter<http.Response, DynamiteRawRes
     };
     final body = _deserialize<B>(rawBody, serializer.serializers, serializer.bodyType);
 
-    return DynamiteRawResponse<B, H>(
-      statusCode: statusCode,
-      rawHeaders: rawHeaders,
-      headers: headers as H,
-      rawBody: rawBody,
-      body: body as B,
-    );
-  }
-}
-
-/// Encoder to efficiently convert a raw response to json.
-final class RawResponseEncoder with Converter<DynamiteRawResponse<dynamic, dynamic>, Object?> {
-  /// Creates a new raw response encoder.
-  const RawResponseEncoder();
-
-  @override
-  Map<String, Object?> convert(DynamiteRawResponse<dynamic, dynamic> input) => {
-        'statusCode': input.statusCode,
-        'body': input.rawBody,
-        'headers': input.rawHeaders,
-      };
-}
-
-/// Encoder to revive the json from a raw response.
-final class RawResponseDecoder<B, H> with Converter<Object?, DynamiteResponse<B, H>> {
-  /// Creates a new raw response decoder.
-  const RawResponseDecoder(this.serializer);
-
-  /// The serializer to convert the raw header and body into [B] and [H].
-  final DynamiteSerializer<B, H> serializer;
-
-  @override
-  DynamiteResponse<B, H> convert(Object? input) {
-    if (input is! Map<String, Object?>) {
-      throw ArgumentError('Expected Map<String, Object?>, got ${input.runtimeType} instead');
-    }
-
-    final rawHeaders = input['headers'];
-    final headers = _deserialize<H>(rawHeaders, serializer.serializers, serializer.headersType);
-
-    final rawBody = input['body'];
-    final body = _deserialize<B>(rawBody, serializer.serializers, serializer.bodyType);
-
     return DynamiteResponse<B, H>(
-      input['statusCode']! as int,
+      statusCode,
       body as B,
       headers as H,
     );

--- a/packages/neon_framework/lib/src/widgets/image.dart
+++ b/packages/neon_framework/lib/src/widgets/image.dart
@@ -14,6 +14,7 @@ import 'package:neon_framework/src/utils/request_manager.dart';
 import 'package:neon_framework/src/widgets/error.dart';
 import 'package:neon_framework/src/widgets/linear_progress_indicator.dart';
 import 'package:nextcloud/nextcloud.dart';
+import 'package:nextcloud/utils.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:timezone/timezone.dart' as tz;
 
@@ -235,10 +236,12 @@ class _NeonApiImageState extends State<NeonApiImage> {
     await RequestManager.instance.wrapBinary(
       account: widget.account,
       cacheKey: widget.cacheKey,
-      getCacheParameters: () async => CacheParameters(
-        etag: widget.etag,
-        expires: widget.expires,
-      ),
+      getCacheHeaders: () async {
+        return {
+          if (widget.etag != null) 'etag': widget.etag!,
+          if (widget.expires != null) 'expires': formatHttpDate(widget.expires!),
+        };
+      },
       getRequest: () => widget.getRequest(widget.account.client),
       unwrap: (data) {
         try {

--- a/packages/neon_framework/test/image_test.dart
+++ b/packages/neon_framework/test/image_test.dart
@@ -79,7 +79,7 @@ void main() {
       () => mockRequestManager.wrapBinary(
         account: any(named: 'account'),
         cacheKey: any(named: 'cacheKey'),
-        getCacheParameters: any(named: 'getCacheParameters'),
+        getCacheHeaders: any(named: 'getCacheHeaders'),
         getRequest: any(named: 'getRequest'),
         unwrap: any(named: 'unwrap'),
         subject: any(named: 'subject'),
@@ -110,7 +110,7 @@ void main() {
       () => mockRequestManager.wrapBinary(
         account: mockAccount,
         cacheKey: 'key',
-        getCacheParameters: any(named: 'getCacheParameters'),
+        getCacheHeaders: any(named: 'getCacheHeaders'),
         getRequest: any(named: 'getRequest'),
         unwrap: any(named: 'unwrap', that: isNotNull),
         subject: any(named: 'subject'),

--- a/packages/nextcloud/lib/nextcloud.dart
+++ b/packages/nextcloud/lib/nextcloud.dart
@@ -1,6 +1,5 @@
 export 'package:dynamite_runtime/http_client.dart'
-    show DynamiteApiException, DynamiteRawResponse, DynamiteResponse, DynamiteStatusCodeException;
-
+    show DynamiteApiException, DynamiteResponse, DynamiteStatusCodeException;
 export 'package:dynamite_runtime/models.dart';
 
 export 'ids.dart';

--- a/packages/nextcloud/lib/src/api/core.openapi.dart
+++ b/packages/nextcloud/lib/src/api/core.openapi.dart
@@ -140,8 +140,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getStatus_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Status, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Status, void>(_serializer).convert(_response);
   }
 }
 
@@ -235,9 +234,8 @@ class $AppPasswordClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAppPassword_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<AppPasswordGetAppPasswordResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<AppPasswordGetAppPasswordResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteAppPassword_Request].
@@ -320,9 +318,8 @@ class $AppPasswordClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteAppPassword_Serializer();
-    final _rawResponse = _i1.ResponseConverter<AppPasswordDeleteAppPasswordResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<AppPasswordDeleteAppPasswordResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$rotateAppPassword_Request].
@@ -405,9 +402,8 @@ class $AppPasswordClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $rotateAppPassword_Serializer();
-    final _rawResponse = _i1.ResponseConverter<AppPasswordRotateAppPasswordResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<AppPasswordRotateAppPasswordResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$confirmUserPassword_Request].
@@ -502,9 +498,8 @@ class $AppPasswordClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $confirmUserPassword_Serializer();
-    final _rawResponse = _i1.ResponseConverter<AppPasswordConfirmUserPasswordResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<AppPasswordConfirmUserPasswordResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
 
@@ -600,9 +595,7 @@ class $AutoCompleteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<AutoCompleteGetResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<AutoCompleteGetResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -701,9 +694,7 @@ class $AvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAvatarDark_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<Uint8List, AvatarAvatarGetAvatarDarkHeaders>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, AvatarAvatarGetAvatarDarkHeaders>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getAvatar_Request].
@@ -793,8 +784,7 @@ class $AvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAvatar_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, AvatarAvatarGetAvatarHeaders>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, AvatarAvatarGetAvatarHeaders>(_serializer).convert(_response);
   }
 }
 
@@ -875,8 +865,7 @@ class $ClientFlowLoginV2Client {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $poll_Serializer();
-    final _rawResponse = _i1.ResponseConverter<LoginFlowV2Credentials, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<LoginFlowV2Credentials, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$init_Request].
@@ -940,8 +929,7 @@ class $ClientFlowLoginV2Client {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $init_Serializer();
-    final _rawResponse = _i1.ResponseConverter<LoginFlowV2, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<LoginFlowV2, void>(_serializer).convert(_response);
   }
 }
 
@@ -1044,10 +1032,8 @@ class $CollaborationResourcesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listCollection_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CollaborationResourcesListCollectionResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CollaborationResourcesListCollectionResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$renameCollection_Request].
@@ -1153,10 +1139,8 @@ class $CollaborationResourcesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $renameCollection_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CollaborationResourcesRenameCollectionResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CollaborationResourcesRenameCollectionResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$addResource_Request].
@@ -1262,10 +1246,8 @@ class $CollaborationResourcesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addResource_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CollaborationResourcesAddResourceResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CollaborationResourcesAddResourceResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$removeResource_Request].
@@ -1371,10 +1353,8 @@ class $CollaborationResourcesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeResource_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CollaborationResourcesRemoveResourceResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CollaborationResourcesRemoveResourceResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$searchCollections_Request].
@@ -1469,10 +1449,8 @@ class $CollaborationResourcesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $searchCollections_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CollaborationResourcesSearchCollectionsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CollaborationResourcesSearchCollectionsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getCollectionsByResource_Request].
@@ -1576,11 +1554,9 @@ class $CollaborationResourcesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getCollectionsByResource_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson, void>(
+    return _i1.ResponseConverter<CollaborationResourcesGetCollectionsByResourceResponseApplicationJson, void>(
       _serializer,
     ).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$createCollectionOnResource_Request].
@@ -1698,11 +1674,9 @@ class $CollaborationResourcesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createCollectionOnResource_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson, void>(
+    return _i1.ResponseConverter<CollaborationResourcesCreateCollectionOnResourceResponseApplicationJson, void>(
       _serializer,
     ).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
 
@@ -1819,8 +1793,7 @@ class $GuestAvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAvatar_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getAvatarDark_Request].
@@ -1912,8 +1885,7 @@ class $GuestAvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAvatarDark_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 }
 
@@ -2013,9 +1985,7 @@ class $HoverCardClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUser_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<HoverCardGetUserResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<HoverCardGetUserResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -2099,9 +2069,7 @@ class $LoginClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $confirmPassword_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<LoginConfirmPasswordResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<LoginConfirmPasswordResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -2210,9 +2178,8 @@ class $NavigationClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAppsNavigation_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<NavigationGetAppsNavigationResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<NavigationGetAppsNavigationResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getSettingsNavigation_Request].
@@ -2314,10 +2281,8 @@ class $NavigationClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getSettingsNavigation_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<NavigationGetSettingsNavigationResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<NavigationGetSettingsNavigationResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 
@@ -2392,9 +2357,8 @@ class $OcmClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $discovery_Serializer();
-    final _rawResponse = _i1.ResponseConverter<OcmDiscoveryResponseApplicationJson, OcmOcmDiscoveryHeaders>(_serializer)
+    return _i1.ResponseConverter<OcmDiscoveryResponseApplicationJson, OcmOcmDiscoveryHeaders>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
 
@@ -2480,9 +2444,7 @@ class $OcsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getCapabilities_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<OcsGetCapabilitiesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<OcsGetCapabilitiesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -2576,8 +2538,7 @@ class $PreviewClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPreview_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getPreviewByFileId_Request].
@@ -2669,8 +2630,7 @@ class $PreviewClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPreviewByFileId_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 }
 
@@ -2789,9 +2749,7 @@ class $ProfileApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setVisibility_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ProfileApiSetVisibilityResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ProfileApiSetVisibilityResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -2876,8 +2834,7 @@ class $ReferenceClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $preview_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 }
 
@@ -2974,9 +2931,7 @@ class $ReferenceApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $extract_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ReferenceApiExtractResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ReferenceApiExtractResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$resolveOne_Request].
@@ -3069,9 +3024,7 @@ class $ReferenceApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $resolveOne_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ReferenceApiResolveOneResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ReferenceApiResolveOneResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$resolve_Request].
@@ -3161,9 +3114,7 @@ class $ReferenceApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $resolve_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ReferenceApiResolveResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ReferenceApiResolveResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getProvidersInfo_Request].
@@ -3244,9 +3195,8 @@ class $ReferenceApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getProvidersInfo_Serializer();
-    final _rawResponse = _i1.ResponseConverter<ReferenceApiGetProvidersInfoResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<ReferenceApiGetProvidersInfoResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$touchProvider_Request].
@@ -3355,9 +3305,8 @@ class $ReferenceApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $touchProvider_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ReferenceApiTouchProviderResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ReferenceApiTouchProviderResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 
@@ -3456,9 +3405,7 @@ class $TeamsApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $resolveOne_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TeamsApiResolveOneResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TeamsApiResolveOneResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$listTeams_Request].
@@ -3558,9 +3505,7 @@ class $TeamsApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listTeams_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TeamsApiListTeamsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TeamsApiListTeamsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -3646,9 +3591,8 @@ class $TextProcessingApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $taskTypes_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TextProcessingApiTaskTypesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TextProcessingApiTaskTypesResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$schedule_Request].
@@ -3745,9 +3689,8 @@ class $TextProcessingApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $schedule_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TextProcessingApiScheduleResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TextProcessingApiScheduleResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getTask_Request].
@@ -3841,9 +3784,7 @@ class $TextProcessingApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getTask_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TextProcessingApiGetTaskResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TextProcessingApiGetTaskResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteTask_Request].
@@ -3939,9 +3880,8 @@ class $TextProcessingApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteTask_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TextProcessingApiDeleteTaskResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TextProcessingApiDeleteTaskResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$listTasksByApp_Request].
@@ -4052,10 +3992,8 @@ class $TextProcessingApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listTasksByApp_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TextProcessingApiListTasksByAppResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TextProcessingApiListTasksByAppResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 
@@ -4141,9 +4079,8 @@ class $TextToImageApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $isAvailable_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TextToImageApiIsAvailableResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TextToImageApiIsAvailableResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$schedule_Request].
@@ -4238,9 +4175,7 @@ class $TextToImageApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $schedule_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TextToImageApiScheduleResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TextToImageApiScheduleResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getTask_Request].
@@ -4334,9 +4269,7 @@ class $TextToImageApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getTask_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TextToImageApiGetTaskResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TextToImageApiGetTaskResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteTask_Request].
@@ -4432,9 +4365,7 @@ class $TextToImageApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteTask_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TextToImageApiDeleteTaskResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TextToImageApiDeleteTaskResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getImage_Request].
@@ -4535,8 +4466,7 @@ class $TextToImageApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getImage_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$listTasksByApp_Request].
@@ -4647,9 +4577,8 @@ class $TextToImageApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listTasksByApp_Serializer();
-    final _rawResponse = _i1.ResponseConverter<TextToImageApiListTasksByAppResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<TextToImageApiListTasksByAppResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
 
@@ -4735,9 +4664,7 @@ class $TranslationApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $languages_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TranslationApiLanguagesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TranslationApiLanguagesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$translate_Request].
@@ -4834,9 +4761,7 @@ class $TranslationApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $translate_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TranslationApiTranslateResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TranslationApiTranslateResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -4943,9 +4868,8 @@ class $UnifiedSearchClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getProviders_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UnifiedSearchGetProvidersResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UnifiedSearchGetProvidersResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$search_Request].
@@ -5060,9 +4984,7 @@ class $UnifiedSearchClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $search_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UnifiedSearchSearchResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UnifiedSearchSearchResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -5149,9 +5071,7 @@ class $WhatsNewClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<WhatsNewGetResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<WhatsNewGetResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$dismiss_Request].
@@ -5242,9 +5162,7 @@ class $WhatsNewClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $dismiss_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<WhatsNewDismissResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<WhatsNewDismissResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -5324,9 +5242,7 @@ class $WipeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $checkWipe_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<WipeCheckWipeResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<WipeCheckWipeResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$wipeDone_Request].
@@ -5397,8 +5313,7 @@ class $WipeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $wipeDone_Serializer();
-    final _rawResponse = _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<JsonObject, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/dashboard.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dashboard.openapi.dart
@@ -134,9 +134,7 @@ class $DashboardApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getWidgets_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<DashboardApiGetWidgetsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DashboardApiGetWidgetsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getWidgetItems_Request].
@@ -236,9 +234,8 @@ class $DashboardApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getWidgetItems_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<DashboardApiGetWidgetItemsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DashboardApiGetWidgetItemsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getWidgetItemsV2_Request].
@@ -338,9 +335,8 @@ class $DashboardApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getWidgetItemsV2_Serializer();
-    final _rawResponse = _i1.ResponseConverter<DashboardApiGetWidgetItemsV2ResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<DashboardApiGetWidgetItemsV2ResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/dav.openapi.dart
+++ b/packages/nextcloud/lib/src/api/dav.openapi.dart
@@ -150,9 +150,7 @@ class $DirectClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUrl_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<DirectGetUrlResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DirectGetUrlResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -254,10 +252,8 @@ class $OutOfOfficeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getCurrentOutOfOfficeData_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<OutOfOfficeGetCurrentOutOfOfficeDataResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getOutOfOffice_Request].
@@ -351,9 +347,8 @@ class $OutOfOfficeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getOutOfOffice_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<OutOfOfficeGetOutOfOfficeResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<OutOfOfficeGetOutOfOfficeResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setOutOfOffice_Request].
@@ -459,9 +454,8 @@ class $OutOfOfficeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setOutOfOffice_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<OutOfOfficeSetOutOfOfficeResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<OutOfOfficeSetOutOfOfficeResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$clearOutOfOffice_Request].
@@ -555,9 +549,8 @@ class $OutOfOfficeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $clearOutOfOffice_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<OutOfOfficeClearOutOfOfficeResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<OutOfOfficeClearOutOfOfficeResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/files.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files.openapi.dart
@@ -171,8 +171,7 @@ class $ApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getThumbnail_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 }
 
@@ -257,9 +256,7 @@ class $DirectEditingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $info_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<DirectEditingInfoResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DirectEditingInfoResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$templates_Request].
@@ -362,9 +359,7 @@ class $DirectEditingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $templates_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<DirectEditingTemplatesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DirectEditingTemplatesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$open_Request].
@@ -457,9 +452,7 @@ class $DirectEditingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $open_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<DirectEditingOpenResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DirectEditingOpenResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$create_Request].
@@ -553,9 +546,7 @@ class $DirectEditingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $create_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<DirectEditingCreateResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DirectEditingCreateResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -654,9 +645,7 @@ class $OpenLocalEditorClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $create_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<OpenLocalEditorCreateResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<OpenLocalEditorCreateResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$validate_Request].
@@ -760,9 +749,7 @@ class $OpenLocalEditorClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $validate_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<OpenLocalEditorValidateResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<OpenLocalEditorValidateResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -847,9 +834,7 @@ class $TemplateClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $list_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TemplateListResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TemplateListResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$create_Request].
@@ -940,9 +925,7 @@ class $TemplateClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $create_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TemplateCreateResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TemplateCreateResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$path_Request].
@@ -1040,9 +1023,7 @@ class $TemplateClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $path_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TemplatePathResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TemplatePathResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -1146,9 +1127,8 @@ class $TransferOwnershipClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $transfer_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TransferOwnershipTransferResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TransferOwnershipTransferResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$accept_Request].
@@ -1244,9 +1224,7 @@ class $TransferOwnershipClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $accept_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TransferOwnershipAcceptResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TransferOwnershipAcceptResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$reject_Request].
@@ -1342,9 +1320,7 @@ class $TransferOwnershipClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $reject_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TransferOwnershipRejectResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TransferOwnershipRejectResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/files_external.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_external.openapi.dart
@@ -133,9 +133,7 @@ class $ApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUserMounts_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ApiGetUserMountsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ApiGetUserMountsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_reminders.openapi.dart
@@ -160,8 +160,7 @@ class $ApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$get_Serializer();
-    final _rawResponse = _i1.ResponseConverter<ApiGetResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ApiGetResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$$set_Request].
@@ -279,8 +278,7 @@ class $ApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$set_Serializer();
-    final _rawResponse = _i1.ResponseConverter<ApiSetResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ApiSetResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$remove_Request].
@@ -388,8 +386,7 @@ class $ApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $remove_Serializer();
-    final _rawResponse = _i1.ResponseConverter<ApiRemoveResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ApiRemoveResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_sharing.openapi.dart
@@ -145,9 +145,7 @@ class $DeletedShareapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $index_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<DeletedShareapiIndexResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DeletedShareapiIndexResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$undelete_Request].
@@ -241,9 +239,7 @@ class $DeletedShareapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $undelete_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<DeletedShareapiUndeleteResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DeletedShareapiUndeleteResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -332,8 +328,7 @@ class $PublicPreviewClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $directLink_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getPreview_Request].
@@ -436,8 +431,7 @@ class $PublicPreviewClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPreview_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 }
 
@@ -523,9 +517,7 @@ class $RemoteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getShares_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RemoteGetSharesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RemoteGetSharesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getOpenShares_Request].
@@ -606,9 +598,7 @@ class $RemoteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getOpenShares_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RemoteGetOpenSharesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RemoteGetOpenSharesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$acceptShare_Request].
@@ -703,9 +693,7 @@ class $RemoteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $acceptShare_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RemoteAcceptShareResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RemoteAcceptShareResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$declineShare_Request].
@@ -800,9 +788,7 @@ class $RemoteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $declineShare_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RemoteDeclineShareResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RemoteDeclineShareResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getShare_Request].
@@ -895,9 +881,7 @@ class $RemoteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getShare_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RemoteGetShareResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RemoteGetShareResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$unshare_Request].
@@ -992,9 +976,7 @@ class $RemoteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $unshare_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RemoteUnshareResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RemoteUnshareResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -1074,8 +1056,7 @@ class $ShareInfoClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $info_Serializer();
-    final _rawResponse = _i1.ResponseConverter<ShareInfo, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ShareInfo, void>(_serializer).convert(_response);
   }
 }
 
@@ -1181,9 +1162,7 @@ class $ShareapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getShares_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ShareapiGetSharesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ShareapiGetSharesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$createShare_Request].
@@ -1289,9 +1268,7 @@ class $ShareapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createShare_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ShareapiCreateShareResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ShareapiCreateShareResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getInheritedShares_Request].
@@ -1388,9 +1365,8 @@ class $ShareapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getInheritedShares_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ShareapiGetInheritedSharesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ShareapiGetInheritedSharesResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$pendingShares_Request].
@@ -1471,9 +1447,7 @@ class $ShareapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $pendingShares_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ShareapiPendingSharesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ShareapiPendingSharesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getShare_Request].
@@ -1581,9 +1555,7 @@ class $ShareapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getShare_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ShareapiGetShareResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ShareapiGetShareResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$updateShare_Request].
@@ -1698,9 +1670,7 @@ class $ShareapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $updateShare_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ShareapiUpdateShareResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ShareapiUpdateShareResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteShare_Request].
@@ -1796,9 +1766,7 @@ class $ShareapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteShare_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ShareapiDeleteShareResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ShareapiDeleteShareResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$acceptShare_Request].
@@ -1894,9 +1862,7 @@ class $ShareapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $acceptShare_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ShareapiAcceptShareResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ShareapiAcceptShareResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -2002,11 +1968,9 @@ class $ShareesapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $search_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ShareesapiSearchResponseApplicationJson, ShareesapiShareesapiSearchHeaders>(
+    return _i1.ResponseConverter<ShareesapiSearchResponseApplicationJson, ShareesapiShareesapiSearchHeaders>(
       _serializer,
     ).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$findRecommended_Request].
@@ -2099,9 +2063,8 @@ class $ShareesapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findRecommended_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ShareesapiFindRecommendedResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ShareesapiFindRecommendedResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_trashbin.openapi.dart
@@ -135,8 +135,7 @@ class $PreviewClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPreview_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/files_versions.openapi.dart
+++ b/packages/nextcloud/lib/src/api/files_versions.openapi.dart
@@ -135,8 +135,7 @@ class $PreviewClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPreview_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/news.openapi.dart
+++ b/packages/nextcloud/lib/src/api/news.openapi.dart
@@ -106,8 +106,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getSupportedApiVersions_Serializer();
-    final _rawResponse = _i1.ResponseConverter<SupportedAPIVersions, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SupportedAPIVersions, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$listFolders_Request].
@@ -169,8 +168,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listFolders_Serializer();
-    final _rawResponse = _i1.ResponseConverter<ListFolders, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ListFolders, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$createFolder_Request].
@@ -244,8 +242,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createFolder_Serializer();
-    final _rawResponse = _i1.ResponseConverter<ListFolders, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ListFolders, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$renameFolder_Request].
@@ -328,8 +325,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $renameFolder_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteFolder_Request].
@@ -396,8 +392,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteFolder_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$markFolderAsRead_Request].
@@ -481,8 +476,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $markFolderAsRead_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$listFeeds_Request].
@@ -544,8 +538,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listFeeds_Serializer();
-    final _rawResponse = _i1.ResponseConverter<ListFeeds, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ListFeeds, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$addFeed_Request].
@@ -631,8 +624,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addFeed_Serializer();
-    final _rawResponse = _i1.ResponseConverter<ListFeeds, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ListFeeds, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteFeed_Request].
@@ -699,8 +691,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteFeed_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$moveFeed_Request].
@@ -783,8 +774,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $moveFeed_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$renameFeed_Request].
@@ -868,8 +858,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $renameFeed_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$markFeedAsRead_Request].
@@ -953,8 +942,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $markFeedAsRead_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$listArticles_Request].
@@ -1080,8 +1068,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listArticles_Serializer();
-    final _rawResponse = _i1.ResponseConverter<ListArticles, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ListArticles, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$listUpdatedArticles_Request].
@@ -1179,8 +1166,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listUpdatedArticles_Serializer();
-    final _rawResponse = _i1.ResponseConverter<ListArticles, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ListArticles, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$markArticleAsRead_Request].
@@ -1247,8 +1233,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $markArticleAsRead_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$markArticleAsUnread_Request].
@@ -1315,8 +1300,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $markArticleAsUnread_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$starArticle_Request].
@@ -1383,8 +1367,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $starArticle_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$unstarArticle_Request].
@@ -1451,8 +1434,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $unstarArticle_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/notes.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notes.openapi.dart
@@ -172,8 +172,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getNotes_Serializer();
-    final _rawResponse = _i1.ResponseConverter<BuiltList<Note>, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BuiltList<Note>, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$createNote_Request].
@@ -289,8 +288,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createNote_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Note, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Note, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getNote_Request].
@@ -385,8 +383,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getNote_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Note, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Note, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$updateNote_Request].
@@ -514,8 +511,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $updateNote_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Note, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Note, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteNote_Request].
@@ -583,8 +579,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteNote_Serializer();
-    final _rawResponse = _i1.ResponseConverter<String, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<String, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getSettings_Request].
@@ -646,8 +641,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getSettings_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Settings, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Settings, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$updateSettings_Request].
@@ -713,8 +707,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $updateSettings_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Settings, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Settings, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/notifications.openapi.dart
+++ b/packages/nextcloud/lib/src/api/notifications.openapi.dart
@@ -184,9 +184,7 @@ class $ApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $generateNotification_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ApiGenerateNotificationResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ApiGenerateNotificationResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -292,10 +290,9 @@ class $EndpointClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listNotifications_Serializer();
-    final _rawResponse = _i1.ResponseConverter<EndpointListNotificationsResponseApplicationJson,
+    return _i1.ResponseConverter<EndpointListNotificationsResponseApplicationJson,
             EndpointEndpointListNotificationsHeaders>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$deleteAllNotifications_Request].
@@ -393,9 +390,8 @@ class $EndpointClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteAllNotifications_Serializer();
-    final _rawResponse = _i1.ResponseConverter<EndpointDeleteAllNotificationsResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<EndpointDeleteAllNotificationsResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$getNotification_Request].
@@ -500,9 +496,7 @@ class $EndpointClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getNotification_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<EndpointGetNotificationResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<EndpointGetNotificationResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteNotification_Request].
@@ -609,9 +603,8 @@ class $EndpointClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteNotification_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<EndpointDeleteNotificationResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<EndpointDeleteNotificationResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$confirmIdsForUser_Request].
@@ -718,9 +711,8 @@ class $EndpointClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $confirmIdsForUser_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<EndpointConfirmIdsForUserResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<EndpointConfirmIdsForUserResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 
@@ -834,9 +826,7 @@ class $PushClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $registerDevice_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<PushRegisterDeviceResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PushRegisterDeviceResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$removeDevice_Request].
@@ -936,9 +926,7 @@ class $PushClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeDevice_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<PushRemoveDeviceResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PushRemoveDeviceResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -1046,9 +1034,7 @@ class $SettingsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $personal_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<SettingsPersonalResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SettingsPersonalResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$admin_Request].
@@ -1150,9 +1136,7 @@ class $SettingsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $admin_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<SettingsAdminResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SettingsAdminResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api.openapi.dart
@@ -145,9 +145,7 @@ class $AppConfigClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getApps_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<AppConfigGetAppsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<AppConfigGetAppsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getKeys_Request].
@@ -244,9 +242,7 @@ class $AppConfigClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getKeys_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<AppConfigGetKeysResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<AppConfigGetKeysResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setValue_Request].
@@ -360,9 +356,7 @@ class $AppConfigClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setValue_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<AppConfigSetValueResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<AppConfigSetValueResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -469,9 +463,7 @@ class $AppsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getApps_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<AppsGetAppsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<AppsGetAppsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getAppInfo_Request].
@@ -567,9 +559,7 @@ class $AppsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAppInfo_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<AppsGetAppInfoResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<AppsGetAppInfoResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$enable_Request].
@@ -666,8 +656,7 @@ class $AppsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $enable_Serializer();
-    final _rawResponse = _i1.ResponseConverter<AppsEnableResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<AppsEnableResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$disable_Request].
@@ -764,9 +753,7 @@ class $AppsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $disable_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<AppsDisableResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<AppsDisableResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -874,9 +861,8 @@ class $GroupsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getSubAdminsOfGroup_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<GroupsGetSubAdminsOfGroupResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<GroupsGetSubAdminsOfGroupResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getGroups_Request].
@@ -973,9 +959,7 @@ class $GroupsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getGroups_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<GroupsGetGroupsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<GroupsGetGroupsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getGroup_Request].
@@ -1074,9 +1058,7 @@ class $GroupsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getGroup_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<GroupsGetGroupResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<GroupsGetGroupResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getGroupsDetails_Request].
@@ -1176,9 +1158,7 @@ class $GroupsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getGroupsDetails_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<GroupsGetGroupsDetailsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<GroupsGetGroupsDetailsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getGroupUsers_Request].
@@ -1279,9 +1259,7 @@ class $GroupsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getGroupUsers_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<GroupsGetGroupUsersResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<GroupsGetGroupUsersResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getGroupUsersDetails_Request].
@@ -1395,9 +1373,8 @@ class $GroupsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getGroupUsersDetails_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<GroupsGetGroupUsersDetailsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<GroupsGetGroupUsersDetailsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 
@@ -1517,9 +1494,7 @@ class $PreferencesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setPreference_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<PreferencesSetPreferenceResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PreferencesSetPreferenceResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deletePreference_Request].
@@ -1622,9 +1597,8 @@ class $PreferencesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deletePreference_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<PreferencesDeletePreferenceResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PreferencesDeletePreferenceResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setMultiplePreferences_Request].
@@ -1728,10 +1702,8 @@ class $PreferencesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setMultiplePreferences_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<PreferencesSetMultiplePreferencesResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PreferencesSetMultiplePreferencesResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteMultiplePreference_Request].
@@ -1836,10 +1808,8 @@ class $PreferencesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteMultiplePreference_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<PreferencesDeleteMultiplePreferenceResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PreferencesDeleteMultiplePreferenceResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 
@@ -1942,9 +1912,8 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUserSubAdminGroups_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersGetUserSubAdminGroupsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersGetUserSubAdminGroupsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$addSubAdmin_Request].
@@ -2049,9 +2018,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addSubAdmin_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersAddSubAdminResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersAddSubAdminResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$removeSubAdmin_Request].
@@ -2156,9 +2123,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeSubAdmin_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersRemoveSubAdminResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersRemoveSubAdminResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getUsers_Request].
@@ -2254,9 +2219,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUsers_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersGetUsersResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersGetUsersResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$addUser_Request].
@@ -2350,9 +2313,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addUser_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersAddUserResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersAddUserResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getUsersDetails_Request].
@@ -2452,9 +2413,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUsersDetails_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersGetUsersDetailsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersGetUsersDetailsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getDisabledUsersDetails_Request].
@@ -2554,9 +2513,8 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getDisabledUsersDetails_Serializer();
-    final _rawResponse = _i1.ResponseConverter<UsersGetDisabledUsersDetailsResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<UsersGetDisabledUsersDetailsResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$searchByPhoneNumbers_Request].
@@ -2651,9 +2609,8 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $searchByPhoneNumbers_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersSearchByPhoneNumbersResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersSearchByPhoneNumbersResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getUser_Request].
@@ -2744,9 +2701,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUser_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersGetUserResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersGetUserResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$editUser_Request].
@@ -2847,9 +2802,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $editUser_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersEditUserResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersEditUserResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteUser_Request].
@@ -2945,9 +2898,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteUser_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersDeleteUserResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersDeleteUserResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getCurrentUser_Request].
@@ -3028,9 +2979,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getCurrentUser_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersGetCurrentUserResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersGetCurrentUserResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getEditableFields_Request].
@@ -3111,9 +3060,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getEditableFields_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersGetEditableFieldsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersGetEditableFieldsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getEditableFieldsForUser_Request].
@@ -3205,9 +3152,8 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getEditableFieldsForUser_Serializer();
-    final _rawResponse = _i1.ResponseConverter<UsersGetEditableFieldsForUserResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<UsersGetEditableFieldsForUserResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$editUserMultiValue_Request].
@@ -3326,9 +3272,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $editUserMultiValue_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersEditUserMultiValueResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersEditUserMultiValueResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$wipeUserDevices_Request].
@@ -3424,9 +3368,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $wipeUserDevices_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersWipeUserDevicesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersWipeUserDevicesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$enableUser_Request].
@@ -3522,9 +3464,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $enableUser_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersEnableUserResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersEnableUserResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$disableUser_Request].
@@ -3620,9 +3560,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $disableUser_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersDisableUserResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersDisableUserResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getUsersGroups_Request].
@@ -3714,9 +3652,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUsersGroups_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersGetUsersGroupsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersGetUsersGroupsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$addToGroup_Request].
@@ -3826,9 +3762,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addToGroup_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersAddToGroupResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersAddToGroupResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$removeFromGroup_Request].
@@ -3931,9 +3865,7 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeFromGroup_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersRemoveFromGroupResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersRemoveFromGroupResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$resendWelcomeMessage_Request].
@@ -4029,9 +3961,8 @@ class $UsersClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $resendWelcomeMessage_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UsersResendWelcomeMessageResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UsersResendWelcomeMessageResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/settings.openapi.dart
+++ b/packages/nextcloud/lib/src/api/settings.openapi.dart
@@ -154,9 +154,8 @@ class $DeclarativeSettingsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setValue_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<DeclarativeSettingsSetValueResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DeclarativeSettingsSetValueResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getForms_Request].
@@ -239,9 +238,8 @@ class $DeclarativeSettingsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getForms_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<DeclarativeSettingsGetFormsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DeclarativeSettingsGetFormsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 
@@ -319,9 +317,7 @@ class $LogSettingsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $download_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<Uint8List, LogSettingsLogSettingsDownloadHeaders>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, LogSettingsLogSettingsDownloadHeaders>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/spreed.openapi.dart
+++ b/packages/nextcloud/lib/src/api/spreed.openapi.dart
@@ -211,8 +211,7 @@ class $AvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAvatar_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$uploadAvatar_Request].
@@ -319,9 +318,7 @@ class $AvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $uploadAvatar_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<AvatarUploadAvatarResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<AvatarUploadAvatarResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteAvatar_Request].
@@ -426,9 +423,7 @@ class $AvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteAvatar_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<AvatarDeleteAvatarResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<AvatarDeleteAvatarResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$emojiAvatar_Request].
@@ -543,9 +538,7 @@ class $AvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $emojiAvatar_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<AvatarEmojiAvatarResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<AvatarEmojiAvatarResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getAvatarDark_Request].
@@ -650,8 +643,7 @@ class $AvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAvatarDark_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getUserProxyAvatarWithoutRoom_Request].
@@ -766,8 +758,7 @@ class $AvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUserProxyAvatarWithoutRoom_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getUserProxyAvatarDarkWithoutRoom_Request].
@@ -882,8 +873,7 @@ class $AvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUserProxyAvatarDarkWithoutRoom_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getUserProxyAvatar_Request].
@@ -1006,8 +996,7 @@ class $AvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUserProxyAvatar_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getUserProxyAvatarDark_Request].
@@ -1130,8 +1119,7 @@ class $AvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getUserProxyAvatarDark_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 }
 
@@ -1243,9 +1231,7 @@ class $BotClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $listBots_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<BotListBotsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BotListBotsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$enableBot_Request].
@@ -1362,9 +1348,7 @@ class $BotClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $enableBot_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<BotEnableBotResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BotEnableBotResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$disableBot_Request].
@@ -1479,9 +1463,7 @@ class $BotClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $disableBot_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<BotDisableBotResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BotDisableBotResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$sendMessage_Request].
@@ -1602,9 +1584,7 @@ class $BotClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $sendMessage_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<BotSendMessageResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BotSendMessageResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$react_Request].
@@ -1730,8 +1710,7 @@ class $BotClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $react_Serializer();
-    final _rawResponse = _i1.ResponseConverter<BotReactResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BotReactResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteReaction_Request].
@@ -1858,9 +1837,7 @@ class $BotClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteReaction_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<BotDeleteReactionResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BotDeleteReactionResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -1989,10 +1966,8 @@ class $BreakoutRoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $configureBreakoutRooms_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BreakoutRoomConfigureBreakoutRoomsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$removeBreakoutRooms_Request].
@@ -2102,10 +2077,8 @@ class $BreakoutRoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeBreakoutRooms_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BreakoutRoomRemoveBreakoutRoomsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$broadcastChatMessage_Request].
@@ -2229,10 +2202,8 @@ class $BreakoutRoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $broadcastChatMessage_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<BreakoutRoomBroadcastChatMessageResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BreakoutRoomBroadcastChatMessageResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$applyAttendeeMap_Request].
@@ -2352,9 +2323,8 @@ class $BreakoutRoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $applyAttendeeMap_Serializer();
-    final _rawResponse = _i1.ResponseConverter<BreakoutRoomApplyAttendeeMapResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<BreakoutRoomApplyAttendeeMapResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$requestAssistance_Request].
@@ -2464,9 +2434,8 @@ class $BreakoutRoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $requestAssistance_Serializer();
-    final _rawResponse = _i1.ResponseConverter<BreakoutRoomRequestAssistanceResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<BreakoutRoomRequestAssistanceResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$resetRequestForAssistance_Request].
@@ -2579,10 +2548,8 @@ class $BreakoutRoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $resetRequestForAssistance_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<BreakoutRoomResetRequestForAssistanceResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BreakoutRoomResetRequestForAssistanceResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$startBreakoutRooms_Request].
@@ -2694,9 +2661,8 @@ class $BreakoutRoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $startBreakoutRooms_Serializer();
-    final _rawResponse = _i1.ResponseConverter<BreakoutRoomStartBreakoutRoomsResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<BreakoutRoomStartBreakoutRoomsResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$stopBreakoutRooms_Request].
@@ -2806,9 +2772,8 @@ class $BreakoutRoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $stopBreakoutRooms_Serializer();
-    final _rawResponse = _i1.ResponseConverter<BreakoutRoomStopBreakoutRoomsResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<BreakoutRoomStopBreakoutRoomsResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$switchBreakoutRoom_Request].
@@ -2930,9 +2895,8 @@ class $BreakoutRoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $switchBreakoutRoom_Serializer();
-    final _rawResponse = _i1.ResponseConverter<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<BreakoutRoomSwitchBreakoutRoomResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 }
 
@@ -3044,9 +3008,7 @@ class $CallClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getPeersForCall_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CallGetPeersForCallResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CallGetPeersForCallResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$updateCallFlags_Request].
@@ -3162,9 +3124,7 @@ class $CallClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $updateCallFlags_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CallUpdateCallFlagsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CallUpdateCallFlagsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$joinCall_Request].
@@ -3285,9 +3245,7 @@ class $CallClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $joinCall_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CallJoinCallResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CallJoinCallResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$leaveCall_Request].
@@ -3406,9 +3364,7 @@ class $CallClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $leaveCall_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CallLeaveCallResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CallLeaveCallResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$ringAttendee_Request].
@@ -3526,9 +3482,7 @@ class $CallClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $ringAttendee_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CallRingAttendeeResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CallRingAttendeeResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$sipDialOut_Request].
@@ -3647,9 +3601,7 @@ class $CallClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $sipDialOut_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CallSipDialOutResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CallSipDialOutResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -3779,11 +3731,9 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $receiveMessages_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatReceiveMessagesResponseApplicationJson, ChatChatReceiveMessagesHeaders>(
+    return _i1.ResponseConverter<ChatReceiveMessagesResponseApplicationJson, ChatChatReceiveMessagesHeaders>(
       _serializer,
     ).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$sendMessage_Request].
@@ -3907,10 +3857,8 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $sendMessage_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatSendMessageResponseApplicationJson, ChatChatSendMessageHeaders>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ChatSendMessageResponseApplicationJson, ChatChatSendMessageHeaders>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$clearHistory_Request].
@@ -4021,10 +3969,8 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $clearHistory_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatClearHistoryResponseApplicationJson, ChatChatClearHistoryHeaders>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ChatClearHistoryResponseApplicationJson, ChatChatClearHistoryHeaders>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$editMessage_Request].
@@ -4162,10 +4108,8 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $editMessage_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatEditMessageResponseApplicationJson, ChatChatEditMessageHeaders>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ChatEditMessageResponseApplicationJson, ChatChatEditMessageHeaders>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteMessage_Request].
@@ -4294,10 +4238,8 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteMessage_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatDeleteMessageResponseApplicationJson, ChatChatDeleteMessageHeaders>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ChatDeleteMessageResponseApplicationJson, ChatChatDeleteMessageHeaders>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getMessageContext_Request].
@@ -4436,11 +4378,9 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getMessageContext_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatGetMessageContextResponseApplicationJson, ChatChatGetMessageContextHeaders>(
+    return _i1.ResponseConverter<ChatGetMessageContextResponseApplicationJson, ChatChatGetMessageContextHeaders>(
       _serializer,
     ).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$getReminder_Request].
@@ -4563,9 +4503,7 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getReminder_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatGetReminderResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ChatGetReminderResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setReminder_Request].
@@ -4695,9 +4633,7 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setReminder_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatSetReminderResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ChatSetReminderResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteReminder_Request].
@@ -4820,9 +4756,7 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteReminder_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatDeleteReminderResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ChatDeleteReminderResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setReadMarker_Request].
@@ -4941,10 +4875,8 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setReadMarker_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatSetReadMarkerResponseApplicationJson, ChatChatSetReadMarkerHeaders>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ChatSetReadMarkerResponseApplicationJson, ChatChatSetReadMarkerHeaders>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$markUnread_Request].
@@ -5048,10 +4980,8 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $markUnread_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatMarkUnreadResponseApplicationJson, ChatChatMarkUnreadHeaders>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ChatMarkUnreadResponseApplicationJson, ChatChatMarkUnreadHeaders>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$mentions_Request].
@@ -5160,9 +5090,7 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $mentions_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatMentionsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ChatMentionsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getObjectsSharedInRoom_Request].
@@ -5278,11 +5206,9 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getObjectsSharedInRoom_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatGetObjectsSharedInRoomResponseApplicationJson, ChatChatGetObjectsSharedInRoomHeaders>(
-      _serializer,
-    ).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ChatGetObjectsSharedInRoomResponseApplicationJson,
+            ChatChatGetObjectsSharedInRoomHeaders>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$shareObjectToChat_Request].
@@ -5405,11 +5331,9 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $shareObjectToChat_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatShareObjectToChatResponseApplicationJson, ChatChatShareObjectToChatHeaders>(
+    return _i1.ResponseConverter<ChatShareObjectToChatResponseApplicationJson, ChatChatShareObjectToChatHeaders>(
       _serializer,
     ).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$getObjectsSharedInRoomOverview_Request].
@@ -5535,10 +5459,8 @@ class $ChatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getObjectsSharedInRoomOverview_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ChatGetObjectsSharedInRoomOverviewResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 
@@ -5658,9 +5580,7 @@ class $ExternalSignalingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $signalingGetSettings_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<SignalingGetSettingsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SignalingGetSettingsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -5785,9 +5705,7 @@ class $FederationClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $acceptShare_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<FederationAcceptShareResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<FederationAcceptShareResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$rejectShare_Request].
@@ -5903,9 +5821,7 @@ class $FederationClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $rejectShare_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<FederationRejectShareResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<FederationRejectShareResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getShares_Request].
@@ -6003,9 +5919,7 @@ class $FederationClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getShares_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<FederationGetSharesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<FederationGetSharesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -6133,10 +6047,8 @@ class $FilesIntegrationClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getRoomByFileId_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<FilesIntegrationGetRoomByFileIdResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<FilesIntegrationGetRoomByFileIdResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getRoomByShareToken_Request].
@@ -6258,10 +6170,8 @@ class $FilesIntegrationClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getRoomByShareToken_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<FilesIntegrationGetRoomByShareTokenResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<FilesIntegrationGetRoomByShareTokenResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$publicShareAuthCreateRoom_Request].
@@ -6371,9 +6281,8 @@ class $FilesIntegrationClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $publicShareAuthCreateRoom_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<PublicShareAuthCreateRoomResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PublicShareAuthCreateRoomResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 
@@ -6496,9 +6405,7 @@ class $GuestClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setDisplayName_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<GuestSetDisplayNameResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<GuestSetDisplayNameResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -6620,10 +6527,8 @@ class $HostedSignalingServerClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $requestTrial_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<HostedSignalingServerRequestTrialResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<HostedSignalingServerRequestTrialResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteAccount_Request].
@@ -6726,8 +6631,7 @@ class $HostedSignalingServerClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteAccount_Serializer();
-    final _rawResponse = _i1.ResponseConverter<void, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<void, void>(_serializer).convert(_response);
   }
 }
 
@@ -6847,9 +6751,7 @@ class $InternalSignalingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $signalingGetSettings_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<SignalingGetSettingsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SignalingGetSettingsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$signalingPullMessages_Request].
@@ -6960,9 +6862,7 @@ class $InternalSignalingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $signalingPullMessages_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<SignalingPullMessagesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SignalingPullMessagesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$signalingSendMessages_Request].
@@ -7076,9 +6976,7 @@ class $InternalSignalingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $signalingSendMessages_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<SignalingSendMessagesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SignalingSendMessagesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -7192,9 +7090,8 @@ class $MatterbridgeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getBridgeOfRoom_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<MatterbridgeGetBridgeOfRoomResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<MatterbridgeGetBridgeOfRoomResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$editBridgeOfRoom_Request].
@@ -7313,9 +7210,8 @@ class $MatterbridgeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $editBridgeOfRoom_Serializer();
-    final _rawResponse = _i1.ResponseConverter<MatterbridgeEditBridgeOfRoomResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<MatterbridgeEditBridgeOfRoomResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$deleteBridgeOfRoom_Request].
@@ -7426,9 +7322,8 @@ class $MatterbridgeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteBridgeOfRoom_Serializer();
-    final _rawResponse = _i1.ResponseConverter<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<MatterbridgeDeleteBridgeOfRoomResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$getBridgeProcessState_Request].
@@ -7538,10 +7433,8 @@ class $MatterbridgeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getBridgeProcessState_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<MatterbridgeGetBridgeProcessStateResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<MatterbridgeGetBridgeProcessStateResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$matterbridgeSettingsStopAllBridges_Request].
@@ -7644,10 +7537,8 @@ class $MatterbridgeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $matterbridgeSettingsStopAllBridges_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<MatterbridgeSettingsStopAllBridgesResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<MatterbridgeSettingsStopAllBridgesResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$matterbridgeSettingsGetMatterbridgeVersion_Request].
@@ -7750,10 +7641,8 @@ class $MatterbridgeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $matterbridgeSettingsGetMatterbridgeVersion_Serializer();
-    final _rawResponse = _i1.ResponseConverter<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson, void>(
-      _serializer,
-    ).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<MatterbridgeSettingsGetMatterbridgeVersionResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 
@@ -7873,9 +7762,7 @@ class $PollClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createPoll_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<PollCreatePollResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PollCreatePollResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$showPoll_Request].
@@ -7993,9 +7880,7 @@ class $PollClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $showPoll_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<PollShowPollResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PollShowPollResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$votePoll_Request].
@@ -8129,9 +8014,7 @@ class $PollClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $votePoll_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<PollVotePollResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PollVotePollResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$closePoll_Request].
@@ -8255,9 +8138,7 @@ class $PollClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $closePoll_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<PollClosePollResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PollClosePollResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -8402,9 +8283,7 @@ class $ReactionClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getReactions_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ReactionGetReactionsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ReactionGetReactionsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$react_Request].
@@ -8533,9 +8412,7 @@ class $ReactionClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $react_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ReactionReactResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ReactionReactResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$delete_Request].
@@ -8663,9 +8540,7 @@ class $ReactionClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $delete_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ReactionDeleteResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ReactionDeleteResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -8786,9 +8661,7 @@ class $RecordingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $start_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RecordingStartResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RecordingStartResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$stop_Request].
@@ -8895,9 +8768,7 @@ class $RecordingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $stop_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RecordingStopResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RecordingStopResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$notificationDismiss_Request].
@@ -9017,9 +8888,8 @@ class $RecordingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $notificationDismiss_Serializer();
-    final _rawResponse = _i1.ResponseConverter<RecordingNotificationDismissResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<RecordingNotificationDismissResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$shareToChat_Request].
@@ -9136,9 +9006,7 @@ class $RecordingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $shareToChat_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RecordingShareToChatResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RecordingShareToChatResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$backend_Request].
@@ -9235,9 +9103,7 @@ class $RecordingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $backend_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RecordingBackendResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RecordingBackendResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$store_Request].
@@ -9352,9 +9218,7 @@ class $RecordingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $store_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RecordingStoreResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RecordingStoreResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -9468,10 +9332,8 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getRooms_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomGetRoomsResponseApplicationJson, RoomRoomGetRoomsHeaders>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomGetRoomsResponseApplicationJson, RoomRoomGetRoomsHeaders>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$createRoom_Request].
@@ -9579,9 +9441,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createRoom_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomCreateRoomResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomCreateRoomResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getListedRooms_Request].
@@ -9689,9 +9549,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getListedRooms_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomGetListedRoomsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomGetListedRoomsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getNoteToSelfConversation_Request].
@@ -9791,10 +9649,9 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getNoteToSelfConversation_Serializer();
-    final _rawResponse = _i1.ResponseConverter<RoomGetNoteToSelfConversationResponseApplicationJson,
+    return _i1.ResponseConverter<RoomGetNoteToSelfConversationResponseApplicationJson,
             RoomRoomGetNoteToSelfConversationHeaders>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$getSingleRoom_Request].
@@ -9903,10 +9760,8 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getSingleRoom_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomGetSingleRoomResponseApplicationJson, RoomRoomGetSingleRoomHeaders>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomGetSingleRoomResponseApplicationJson, RoomRoomGetSingleRoomHeaders>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getBreakoutRooms_Request].
@@ -10020,9 +9875,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getBreakoutRooms_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomGetBreakoutRoomsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomGetBreakoutRoomsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$makePublic_Request].
@@ -10130,9 +9983,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $makePublic_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomMakePublicResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomMakePublicResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$makePrivate_Request].
@@ -10241,9 +10092,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $makePrivate_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomMakePrivateResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomMakePrivateResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setDescription_Request].
@@ -10358,9 +10207,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setDescription_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetDescriptionResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetDescriptionResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setReadOnly_Request].
@@ -10477,9 +10324,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setReadOnly_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetReadOnlyResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetReadOnlyResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setListable_Request].
@@ -10595,9 +10440,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setListable_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetListableResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetListableResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setPassword_Request].
@@ -10713,9 +10556,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setPassword_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetPasswordResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetPasswordResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setPermissions_Request].
@@ -10843,9 +10684,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setPermissions_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetPermissionsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetPermissionsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getParticipants_Request].
@@ -10971,11 +10810,9 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getParticipants_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomGetParticipantsResponseApplicationJson, RoomRoomGetParticipantsHeaders>(
+    return _i1.ResponseConverter<RoomGetParticipantsResponseApplicationJson, RoomRoomGetParticipantsHeaders>(
       _serializer,
     ).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$addParticipantToRoom_Request].
@@ -11099,9 +10936,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addParticipantToRoom_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomAddParticipantToRoomResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomAddParticipantToRoomResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getBreakoutRoomParticipants_Request].
@@ -11233,10 +11068,9 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getBreakoutRoomParticipants_Serializer();
-    final _rawResponse = _i1.ResponseConverter<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
+    return _i1.ResponseConverter<RoomGetBreakoutRoomParticipantsResponseApplicationJson,
             RoomRoomGetBreakoutRoomParticipantsHeaders>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$removeSelfFromRoom_Request].
@@ -11348,9 +11182,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeSelfFromRoom_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomRemoveSelfFromRoomResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomRemoveSelfFromRoomResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$removeAttendeeFromRoom_Request].
@@ -11472,9 +11304,8 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeAttendeeFromRoom_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomRemoveAttendeeFromRoomResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomRemoveAttendeeFromRoomResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setAttendeePermissions_Request].
@@ -11596,9 +11427,8 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setAttendeePermissions_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetAttendeePermissionsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetAttendeePermissionsResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setAllAttendeesPermissions_Request].
@@ -11718,9 +11548,8 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setAllAttendeesPermissions_Serializer();
-    final _rawResponse = _i1.ResponseConverter<RoomSetAllAttendeesPermissionsResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<RoomSetAllAttendeesPermissionsResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$joinRoom_Request].
@@ -11845,10 +11674,8 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $joinRoom_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomJoinRoomResponseApplicationJson, RoomRoomJoinRoomHeaders>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomJoinRoomResponseApplicationJson, RoomRoomJoinRoomHeaders>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$leaveRoom_Request].
@@ -11952,9 +11779,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $leaveRoom_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomLeaveRoomResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomLeaveRoomResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$resendInvitations_Request].
@@ -12082,9 +11907,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $resendInvitations_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomResendInvitationsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomResendInvitationsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setSessionState_Request].
@@ -12201,9 +12024,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setSessionState_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetSessionStateResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetSessionStateResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$promoteModerator_Request].
@@ -12322,9 +12143,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $promoteModerator_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomPromoteModeratorResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomPromoteModeratorResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$demoteModerator_Request].
@@ -12443,9 +12262,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $demoteModerator_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomDemoteModeratorResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomDemoteModeratorResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$addToFavorites_Request].
@@ -12552,9 +12369,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $addToFavorites_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomAddToFavoritesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomAddToFavoritesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$removeFromFavorites_Request].
@@ -12661,9 +12476,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $removeFromFavorites_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomRemoveFromFavoritesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomRemoveFromFavoritesResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setNotificationLevel_Request].
@@ -12782,9 +12595,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setNotificationLevel_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetNotificationLevelResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetNotificationLevelResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setNotificationCalls_Request].
@@ -12904,9 +12715,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setNotificationCalls_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetNotificationCallsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetNotificationCallsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setLobby_Request].
@@ -13020,9 +12829,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setLobby_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetLobbyResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetLobbyResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setsipEnabled_Request].
@@ -13145,9 +12952,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setsipEnabled_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetsipEnabledResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetsipEnabledResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setRecordingConsent_Request].
@@ -13269,9 +13074,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setRecordingConsent_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetRecordingConsentResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetRecordingConsentResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setMessageExpiration_Request].
@@ -13389,9 +13192,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setMessageExpiration_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomSetMessageExpirationResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomSetMessageExpirationResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getCapabilities_Request].
@@ -13502,11 +13303,9 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getCapabilities_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomGetCapabilitiesResponseApplicationJson, RoomRoomGetCapabilitiesHeaders>(
+    return _i1.ResponseConverter<RoomGetCapabilitiesResponseApplicationJson, RoomRoomGetCapabilitiesHeaders>(
       _serializer,
     ).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$joinFederatedRoom_Request].
@@ -13615,11 +13414,9 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $joinFederatedRoom_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomJoinFederatedRoomResponseApplicationJson, RoomRoomJoinFederatedRoomHeaders>(
+    return _i1.ResponseConverter<RoomJoinFederatedRoomResponseApplicationJson, RoomRoomJoinFederatedRoomHeaders>(
       _serializer,
     ).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$verifyDialInPinDeprecated_Request].
@@ -13744,9 +13541,8 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $verifyDialInPinDeprecated_Serializer();
-    final _rawResponse = _i1.ResponseConverter<RoomVerifyDialInPinDeprecatedResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<RoomVerifyDialInPinDeprecatedResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$verifyDialInPin_Request].
@@ -13865,9 +13661,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $verifyDialInPin_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomVerifyDialInPinResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomVerifyDialInPinResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$verifyDialOutNumber_Request].
@@ -13991,9 +13785,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $verifyDialOutNumber_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomVerifyDialOutNumberResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomVerifyDialOutNumberResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$createGuestByDialIn_Request].
@@ -14103,9 +13895,7 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createGuestByDialIn_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomCreateGuestByDialInResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomCreateGuestByDialInResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$rejectedDialOutRequest_Request].
@@ -14229,9 +14019,8 @@ class $RoomClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $rejectedDialOutRequest_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RoomRejectedDialOutRequestResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RoomRejectedDialOutRequestResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 
@@ -14344,9 +14133,7 @@ class $SettingsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setUserSetting_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<SettingsSetUserSettingResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SettingsSetUserSettingResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$botAdminListBots_Request].
@@ -14444,9 +14231,7 @@ class $SettingsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $botAdminListBots_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<BotAdminListBotsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<BotAdminListBotsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$certificateGetCertificateExpiration_Request].
@@ -14560,10 +14345,8 @@ class $SettingsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $certificateGetCertificateExpiration_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CertificateGetCertificateExpirationResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CertificateGetCertificateExpirationResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$recordingGetWelcomeMessage_Request].
@@ -14679,9 +14462,8 @@ class $SettingsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $recordingGetWelcomeMessage_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<RecordingGetWelcomeMessageResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<RecordingGetWelcomeMessageResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setsipSettings_Request].
@@ -14796,9 +14578,7 @@ class $SettingsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setsipSettings_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<SettingsSetsipSettingsResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SettingsSetsipSettingsResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$signalingGetWelcomeMessage_Request].
@@ -14916,9 +14696,8 @@ class $SettingsClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $signalingGetWelcomeMessage_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<SignalingGetWelcomeMessageResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SignalingGetWelcomeMessageResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 
@@ -15020,9 +14799,7 @@ class $SignalingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $backend_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<SignalingBackendResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SignalingBackendResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -15112,9 +14889,7 @@ class $UserAvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $tempAvatarPostAvatar_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TempAvatarPostAvatarResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TempAvatarPostAvatarResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$tempAvatarDeleteAvatar_Request].
@@ -15197,9 +14972,7 @@ class $UserAvatarClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $tempAvatarDeleteAvatar_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<TempAvatarDeleteAvatarResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<TempAvatarDeleteAvatarResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/theming.openapi.dart
+++ b/packages/nextcloud/lib/src/api/theming.openapi.dart
@@ -143,8 +143,7 @@ class $IconClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getFavicon_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getTouchIcon_Request].
@@ -225,8 +224,7 @@ class $IconClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getTouchIcon_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getThemedIcon_Request].
@@ -323,8 +321,7 @@ class $IconClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getThemedIcon_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 }
 
@@ -432,8 +429,7 @@ class $ThemingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getThemeStylesheet_Serializer();
-    final _rawResponse = _i1.ResponseConverter<String, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<String, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getImage_Request].
@@ -531,8 +527,7 @@ class $ThemingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getImage_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getManifest_Request].
@@ -612,9 +607,7 @@ class $ThemingClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getManifest_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ThemingGetManifestResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ThemingGetManifestResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -689,8 +682,7 @@ class $UserThemeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getBackground_Serializer();
-    final _rawResponse = _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<Uint8List, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$enableTheme_Request].
@@ -786,9 +778,7 @@ class $UserThemeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $enableTheme_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UserThemeEnableThemeResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UserThemeEnableThemeResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$disableTheme_Request].
@@ -884,9 +874,7 @@ class $UserThemeClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $disableTheme_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UserThemeDisableThemeResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UserThemeDisableThemeResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
+++ b/packages/nextcloud/lib/src/api/updatenotification.openapi.dart
@@ -161,9 +161,7 @@ class $ApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAppList_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ApiGetAppListResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ApiGetAppListResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getAppChangelogEntry_Request].
@@ -289,9 +287,7 @@ class $ApiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getAppChangelogEntry_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ApiGetAppChangelogEntryResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ApiGetAppChangelogEntryResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/uppush.openapi.dart
+++ b/packages/nextcloud/lib/src/api/uppush.openapi.dart
@@ -108,8 +108,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $check_Serializer();
-    final _rawResponse = _i1.ResponseConverter<CheckResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CheckResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setKeepalive_Request].
@@ -192,9 +191,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setKeepalive_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<SetKeepaliveResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SetKeepaliveResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$createDevice_Request].
@@ -275,9 +272,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createDevice_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<CreateDeviceResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CreateDeviceResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$syncDevice_Request].
@@ -353,8 +348,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $syncDevice_Serializer();
-    final _rawResponse = _i1.ResponseConverter<SyncDeviceResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<SyncDeviceResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteDevice_Request].
@@ -429,9 +423,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteDevice_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<DeleteDeviceResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DeleteDeviceResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$createApp_Request].
@@ -521,8 +513,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $createApp_Serializer();
-    final _rawResponse = _i1.ResponseConverter<CreateAppResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<CreateAppResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$deleteApp_Request].
@@ -594,8 +585,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $deleteApp_Serializer();
-    final _rawResponse = _i1.ResponseConverter<DeleteAppResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<DeleteAppResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$unifiedpushDiscovery_Request].
@@ -670,9 +660,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $unifiedpushDiscovery_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UnifiedpushDiscoveryResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UnifiedpushDiscoveryResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$push_Request].
@@ -744,8 +732,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $push_Serializer();
-    final _rawResponse = _i1.ResponseConverter<PushResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PushResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$gatewayMatrixDiscovery_Request].
@@ -812,9 +799,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $gatewayMatrixDiscovery_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<GatewayMatrixDiscoveryResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<GatewayMatrixDiscoveryResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$gatewayMatrix_Request].
@@ -881,9 +866,7 @@ class $Client extends _i1.DynamiteClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $gatewayMatrix_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<GatewayMatrixResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<GatewayMatrixResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/user_ldap.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_ldap.openapi.dart
@@ -137,9 +137,7 @@ class $ConfigapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $create_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ConfigapiCreateResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ConfigapiCreateResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$$show_Request].
@@ -252,9 +250,7 @@ class $ConfigapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $$show_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ConfigapiShowResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ConfigapiShowResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$modify_Request].
@@ -360,9 +356,7 @@ class $ConfigapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $modify_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ConfigapiModifyResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ConfigapiModifyResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$delete_Request].
@@ -459,9 +453,7 @@ class $ConfigapiClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $delete_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<ConfigapiDeleteResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<ConfigapiDeleteResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/user_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/user_status.openapi.dart
@@ -157,9 +157,7 @@ class $HeartbeatClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $heartbeat_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<HeartbeatHeartbeatResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<HeartbeatHeartbeatResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -247,9 +245,7 @@ class $PredefinedStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findAll_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<PredefinedStatusFindAllResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<PredefinedStatusFindAllResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -352,9 +348,7 @@ class $StatusesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $findAll_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<StatusesFindAllResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<StatusesFindAllResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$find_Request].
@@ -447,9 +441,7 @@ class $StatusesClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $find_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<StatusesFindResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<StatusesFindResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 
@@ -539,9 +531,7 @@ class $UserStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getStatus_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UserStatusGetStatusResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UserStatusGetStatusResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setStatus_Request].
@@ -633,9 +623,7 @@ class $UserStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setStatus_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UserStatusSetStatusResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UserStatusSetStatusResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setPredefinedMessage_Request].
@@ -730,9 +718,8 @@ class $UserStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setPredefinedMessage_Serializer();
-    final _rawResponse = _i1.ResponseConverter<UserStatusSetPredefinedMessageResponseApplicationJson, void>(_serializer)
+    return _i1.ResponseConverter<UserStatusSetPredefinedMessageResponseApplicationJson, void>(_serializer)
         .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
   }
 
   /// Builds a serializer to parse the response of [$setCustomMessage_Request].
@@ -834,9 +821,8 @@ class $UserStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setCustomMessage_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UserStatusSetCustomMessageResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UserStatusSetCustomMessageResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$clearMessage_Request].
@@ -917,9 +903,7 @@ class $UserStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $clearMessage_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UserStatusClearMessageResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UserStatusClearMessageResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$revertStatus_Request].
@@ -1012,9 +996,7 @@ class $UserStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $revertStatus_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<UserStatusRevertStatusResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<UserStatusRevertStatusResponseApplicationJson, void>(_serializer).convert(_response);
   }
 }
 

--- a/packages/nextcloud/lib/src/api/weather_status.openapi.dart
+++ b/packages/nextcloud/lib/src/api/weather_status.openapi.dart
@@ -143,9 +143,7 @@ class $WeatherStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setMode_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<WeatherStatusSetModeResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<WeatherStatusSetModeResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$usePersonalAddress_Request].
@@ -226,10 +224,8 @@ class $WeatherStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $usePersonalAddress_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<WeatherStatusUsePersonalAddressResponseApplicationJson, void>(_serializer)
-            .convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<WeatherStatusUsePersonalAddressResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getLocation_Request].
@@ -310,9 +306,7 @@ class $WeatherStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getLocation_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<WeatherStatusGetLocationResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<WeatherStatusGetLocationResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setLocation_Request].
@@ -412,9 +406,7 @@ class $WeatherStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setLocation_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<WeatherStatusSetLocationResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<WeatherStatusSetLocationResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getForecast_Request].
@@ -497,9 +489,7 @@ class $WeatherStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getForecast_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<WeatherStatusGetForecastResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<WeatherStatusGetForecastResponseApplicationJson, void>(_serializer).convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$getFavorites_Request].
@@ -580,9 +570,8 @@ class $WeatherStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $getFavorites_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<WeatherStatusGetFavoritesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<WeatherStatusGetFavoritesResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 
   /// Builds a serializer to parse the response of [$setFavorites_Request].
@@ -675,9 +664,8 @@ class $WeatherStatusClient {
     final _response = await _i3.Response.fromStream(_streamedResponse);
 
     final _serializer = $setFavorites_Serializer();
-    final _rawResponse =
-        _i1.ResponseConverter<WeatherStatusSetFavoritesResponseApplicationJson, void>(_serializer).convert(_response);
-    return _i1.DynamiteResponse.fromRawResponse(_rawResponse);
+    return _i1.ResponseConverter<WeatherStatusSetFavoritesResponseApplicationJson, void>(_serializer)
+        .convert(_response);
   }
 }
 

--- a/tool/generate-nextcloud.sh
+++ b/tool/generate-nextcloud.sh
@@ -10,6 +10,4 @@ cd "$(dirname "$0")/.."
   fvm dart run generate_exports.dart
   fvm dart fix --apply lib/src/api/
   melos run format
-  fvm dart fix --apply lib/src/api/
-  melos run format
 )


### PR DESCRIPTION
Towards https://github.com/nextcloud/neon/issues/2155

Unfortunately there was no way to split the changes to RequestCache and to RequestManager into separate commits because they rely on each other.
This should also give us some performance boost for reading and writing cache.
Next steps would be to eliminate the separate methods in RequestManager and only pass in the converter.