### PR TITLE
refactor(neon_framework): Compute RequestManager cache keys automatically

### DIFF
--- a/packages/neon/neon_dashboard/lib/src/blocs/dashboard.dart
+++ b/packages/neon/neon_dashboard/lib/src/blocs/dashboard.dart
@@ -69,7 +69,6 @@ class _DashboardBloc extends InteractiveBloc implements DashboardBloc {
     if (!widgets.hasValue || !widgets.value.hasSuccessfulData) {
       await RequestManager.instance.wrap(
         account: account,
-        cacheKey: 'dashboard-widgets',
         subject: widgets,
         getRequest: account.client.dashboard.dashboardApi.$getWidgets_Request,
         converter: ResponseConverter(account.client.dashboard.dashboardApi.$getWidgets_Serializer()),
@@ -100,7 +99,6 @@ class _DashboardBloc extends InteractiveBloc implements DashboardBloc {
       if (v1WidgetIDs.isNotEmpty)
         RequestManager.instance.wrap(
           account: account,
-          cacheKey: 'dashboard-widgets-v1',
           subject: itemsV1,
           getRequest: () => account.client.dashboard.dashboardApi.$getWidgetItems_Request(
             $body: dashboard.DashboardApiGetWidgetItemsRequestApplicationJson(
@@ -115,7 +113,6 @@ class _DashboardBloc extends InteractiveBloc implements DashboardBloc {
       if (v2WidgetIDs.isNotEmpty)
         RequestManager.instance.wrap(
           account: account,
-          cacheKey: 'dashboard-widgets-v2',
           subject: itemsV2,
           getRequest: () => account.client.dashboard.dashboardApi.$getWidgetItemsV2_Request(
             $body: dashboard.DashboardApiGetWidgetItemsV2RequestApplicationJson(

--- a/packages/neon/neon_files/lib/src/blocs/browser.dart
+++ b/packages/neon/neon_files/lib/src/blocs/browser.dart
@@ -93,7 +93,6 @@ class _FilesBrowserBloc extends InteractiveBloc implements FilesBrowserBloc {
   Future<void> refresh() async {
     await RequestManager.instance.wrap(
       account: account,
-      cacheKey: 'files-${uri.value.path}',
       subject: files,
       getRequest: () => account.client.webdav.propfind_Request(
         uri.value,

--- a/packages/neon/neon_files/lib/src/widgets/file_preview.dart
+++ b/packages/neon/neon_files/lib/src/widgets/file_preview.dart
@@ -86,12 +86,10 @@ class FilePreviewImage extends NeonApiImage {
   }) {
     final width = size.width.toInt();
     final height = size.height.toInt();
-    final cacheKey = 'preview-${file.uri.path}-$width-$height';
 
     return FilePreviewImage._(
       file: file,
       size: size,
-      cacheKey: cacheKey,
       width: width,
       height: height,
       account: account,
@@ -101,7 +99,6 @@ class FilePreviewImage extends NeonApiImage {
   FilePreviewImage._({
     required FileDetails file,
     required Size super.size,
-    required super.cacheKey,
     required int width,
     required int height,
     required super.account,

--- a/packages/neon/neon_news/lib/src/blocs/articles.dart
+++ b/packages/neon/neon_news/lib/src/blocs/articles.dart
@@ -143,7 +143,6 @@ class _NewsArticlesBloc extends InteractiveBloc implements NewsArticlesBloc {
 
     await RequestManager.instance.wrap(
       account: account,
-      cacheKey: 'news-articles-${type.index}-$id-$getRead',
       subject: articles,
       getRequest: () => account.client.news.$listArticles_Request(
         type: type.index,

--- a/packages/neon/neon_news/lib/src/blocs/news.dart
+++ b/packages/neon/neon_news/lib/src/blocs/news.dart
@@ -112,7 +112,6 @@ class _NewsBloc extends InteractiveBloc implements NewsBloc, NewsMainArticlesBlo
     await Future.wait([
       RequestManager.instance.wrap(
         account: account,
-        cacheKey: 'news-folders',
         subject: folders,
         getRequest: account.client.news.$listFolders_Request,
         converter: ResponseConverter(account.client.news.$listFolders_Serializer()),
@@ -120,7 +119,6 @@ class _NewsBloc extends InteractiveBloc implements NewsBloc, NewsMainArticlesBlo
       ),
       RequestManager.instance.wrap(
         account: account,
-        cacheKey: 'news-feeds',
         subject: feeds,
         getRequest: account.client.news.$listFeeds_Request,
         converter: ResponseConverter(account.client.news.$listFeeds_Serializer()),

--- a/packages/neon/neon_notes/lib/src/blocs/notes.dart
+++ b/packages/neon/neon_notes/lib/src/blocs/notes.dart
@@ -65,7 +65,6 @@ class _NotesBloc extends InteractiveBloc implements NotesBloc {
   Future<void> refresh() async {
     await RequestManager.instance.wrap(
       account: account,
-      cacheKey: 'notes-notes',
       subject: notes,
       getRequest: account.client.notes.$getNotes_Request,
       converter: ResponseConverter(account.client.notes.$getNotes_Serializer()),

--- a/packages/neon/neon_notifications/lib/src/blocs/notifications.dart
+++ b/packages/neon/neon_notifications/lib/src/blocs/notifications.dart
@@ -64,7 +64,6 @@ class _NotificationsBloc extends InteractiveBloc implements NotificationsBlocInt
   Future<void> refresh() async {
     await RequestManager.instance.wrap(
       account: account,
-      cacheKey: 'notifications-notifications',
       subject: notifications,
       getRequest: account.client.notifications.endpoint.$listNotifications_Request,
       converter: ResponseConverter(account.client.notifications.endpoint.$listNotifications_Serializer()),

--- a/packages/neon/neon_talk/lib/src/blocs/room.dart
+++ b/packages/neon/neon_talk/lib/src/blocs/room.dart
@@ -197,7 +197,6 @@ class _TalkRoomBloc extends InteractiveBloc implements TalkRoomBloc {
     await Future.wait([
       RequestManager.instance.wrap(
         account: account,
-        cacheKey: 'spreed-room-$token',
         subject: room,
         getRequest: () => account.client.spreed.room.$joinRoom_Request(
           token: token,
@@ -207,7 +206,6 @@ class _TalkRoomBloc extends InteractiveBloc implements TalkRoomBloc {
       ),
       RequestManager.instance.wrap(
         account: account,
-        cacheKey: 'spreed-room-$token-messages',
         subject: messages,
         getRequest: () => account.client.spreed.chat.$receiveMessages_Request(
           token: token,

--- a/packages/neon/neon_talk/lib/src/blocs/talk.dart
+++ b/packages/neon/neon_talk/lib/src/blocs/talk.dart
@@ -77,7 +77,6 @@ class _TalkBloc extends InteractiveBloc implements TalkBloc {
   Future<void> refresh() async {
     await RequestManager.instance.wrap(
       account: account,
-      cacheKey: 'talk-rooms',
       subject: rooms,
       getRequest: account.client.spreed.room.$getRooms_Request,
       converter: ResponseConverter(account.client.spreed.room.$getRooms_Serializer()),

--- a/packages/neon/neon_talk/lib/src/widgets/rich_object/file_preview.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/rich_object/file_preview.dart
@@ -59,7 +59,6 @@ class TalkRichObjectFilePreview extends StatelessWidget {
         } else {
           image = NeonApiImage(
             account: account,
-            cacheKey: 'preview-${parameter.path!}-${deviceSize.width.toInt()}-${deviceSize.height.toInt()}',
             etag: parameter.etag,
             expires: null,
             getRequest: (client) => client.core.preview.$getPreviewByFileId_Request(

--- a/packages/neon/neon_talk/lib/src/widgets/room_avatar.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/room_avatar.dart
@@ -32,7 +32,6 @@ class TalkRoomAvatar extends StatelessWidget {
               Brightness.dark => client.spreed.avatar.$getAvatarDark_Request(token: room.token),
               Brightness.light => client.spreed.avatar.$getAvatar_Request(token: room.token),
             },
-            cacheKey: 'talk-room-${room.token}-avatar-$brightness',
             etag: room.avatarVersion,
             expires: null,
             account: NeonProvider.of<Account>(context),

--- a/packages/neon/neon_talk/test/rich_object_test.dart
+++ b/packages/neon/neon_talk/test/rich_object_test.dart
@@ -332,11 +332,6 @@ void main() {
         find.byWidgetPredicate((widget) => widget is ConstrainedBox && widget.constraints == expectedConstraints),
         findsOne,
       );
-      const expectedCacheKey = 'preview-path--1--1';
-      expect(
-        find.byWidgetPredicate((widget) => widget is NeonApiImage && widget.cacheKey == expectedCacheKey),
-        findsOne,
-      );
       expect(find.byTooltip('name'), findsOne);
     });
 
@@ -368,11 +363,6 @@ void main() {
       final expectedConstraints = BoxConstraints.tight(const Size(width / pixelRatio, height / pixelRatio));
       expect(
         find.byWidgetPredicate((widget) => widget is ConstrainedBox && widget.constraints == expectedConstraints),
-        findsOne,
-      );
-      const expectedCacheKey = 'preview-path-$width-$height';
-      expect(
-        find.byWidgetPredicate((widget) => widget is NeonApiImage && widget.cacheKey == expectedCacheKey),
         findsOne,
       );
       expect(find.byTooltip('name'), findsOne);
@@ -410,12 +400,6 @@ void main() {
       final expectedConstraints = BoxConstraints.tight(size);
       expect(
         find.byWidgetPredicate((widget) => widget is ConstrainedBox && widget.constraints == expectedConstraints),
-        findsOne,
-      );
-      final expectedCacheKey =
-          'preview-path-${(size.width * pixelRatio).toInt()}-${(size.height * pixelRatio).toInt()}';
-      expect(
-        find.byWidgetPredicate((widget) => widget is NeonApiImage && widget.cacheKey == expectedCacheKey),
         findsOne,
       );
       expect(find.byTooltip('name'), findsOne);

--- a/packages/neon_framework/lib/src/blocs/apps.dart
+++ b/packages/neon_framework/lib/src/blocs/apps.dart
@@ -250,7 +250,6 @@ class _AppsBloc extends InteractiveBloc implements AppsBloc {
   Future<void> refresh() async {
     await RequestManager.instance.wrap(
       account: account,
-      cacheKey: 'apps-apps',
       subject: apps,
       getRequest: account.client.core.navigation.$getAppsNavigation_Request,
       converter: ResponseConverter(account.client.core.navigation.$getAppsNavigation_Serializer()),

--- a/packages/neon_framework/lib/src/blocs/capabilities.dart
+++ b/packages/neon_framework/lib/src/blocs/capabilities.dart
@@ -48,7 +48,6 @@ class _CapabilitiesBloc extends InteractiveBloc implements CapabilitiesBloc {
   Future<void> refresh() async {
     await RequestManager.instance.wrap(
       account: account,
-      cacheKey: 'capabilities',
       subject: capabilities,
       getRequest: account.client.core.ocs.$getCapabilities_Request,
       converter: ResponseConverter(account.client.core.ocs.$getCapabilities_Serializer()),

--- a/packages/neon_framework/lib/src/blocs/unified_search.dart
+++ b/packages/neon_framework/lib/src/blocs/unified_search.dart
@@ -81,7 +81,6 @@ class _UnifiedSearchBloc extends InteractiveBloc implements UnifiedSearchBloc {
     if (!providers.value.hasSuccessfulData) {
       await RequestManager.instance.wrap(
         account: account,
-        cacheKey: 'unified-search-providers',
         subject: providers,
         getRequest: account.client.core.unifiedSearch.$getProviders_Request,
         converter: ResponseConverter(account.client.core.unifiedSearch.$getProviders_Serializer()),

--- a/packages/neon_framework/lib/src/blocs/user_details.dart
+++ b/packages/neon_framework/lib/src/blocs/user_details.dart
@@ -48,7 +48,6 @@ class _UserDetailsBloc extends InteractiveBloc implements UserDetailsBloc {
   Future<void> refresh() async {
     await RequestManager.instance.wrap(
       account: account,
-      cacheKey: 'user-details',
       subject: userDetails,
       getRequest: account.client.provisioningApi.users.$getCurrentUser_Request,
       converter: ResponseConverter(account.client.provisioningApi.users.$getCurrentUser_Serializer()),

--- a/packages/neon_framework/lib/src/blocs/user_status.dart
+++ b/packages/neon_framework/lib/src/blocs/user_status.dart
@@ -103,7 +103,6 @@ class _UserStatusBloc extends InteractiveBloc implements UserStatusBloc {
     await Future.wait([
       RequestManager.instance.wrap(
         account: account,
-        cacheKey: 'user_status-predefined-statuses',
         subject: predefinedStatuses,
         getRequest: account.client.userStatus.predefinedStatus.$findAll_Request,
         converter: ResponseConverter(account.client.userStatus.predefinedStatus.$findAll_Serializer()),

--- a/packages/neon_framework/lib/src/blocs/weather_status.dart
+++ b/packages/neon_framework/lib/src/blocs/weather_status.dart
@@ -87,7 +87,6 @@ class _WeatherStatusBloc extends InteractiveBloc implements WeatherStatusBloc {
 
     await RequestManager.instance.wrap(
       account: account,
-      cacheKey: 'weather_status-location',
       subject: location,
       getRequest: account.client.weatherStatus.weatherStatus.$getLocation_Request,
       converter: ResponseConverter(account.client.weatherStatus.weatherStatus.$getLocation_Serializer()),
@@ -115,7 +114,6 @@ class _WeatherStatusBloc extends InteractiveBloc implements WeatherStatusBloc {
 
     await RequestManager.instance.wrap(
       account: account,
-      cacheKey: 'weather_status-forecast',
       subject: forecasts,
       getRequest: account.client.weatherStatus.weatherStatus.$getForecast_Request,
       converter: ResponseConverter(account.client.weatherStatus.weatherStatus.$getForecast_Serializer()),

--- a/packages/neon_framework/lib/src/storage/request_cache.dart
+++ b/packages/neon_framework/lib/src/storage/request_cache.dart
@@ -15,16 +15,16 @@ final _log = Logger('RequestCache');
 
 /// A storage used to cache HTTP requests.
 abstract interface class RequestCache {
-  /// Gets the cached status code, body and headers for the given [key].
-  Future<http.Response?> get(Account account, String key);
+  /// Gets the cached status code, body and headers for the [request].
+  Future<http.Response?> get(Account account, http.Request request);
 
-  /// Sets the cached [response] at the given [key].
+  /// Sets the cached [response] for the [request].
   ///
   /// If a request is already present it will be updated with the new one.
-  Future<void> set(Account account, String key, http.Response response);
+  Future<void> set(Account account, http.Request request, http.Response response);
 
-  /// Updates the cache [headers] for a given [key] without modifying anything else.
-  Future<void> updateHeaders(Account account, String key, Map<String, String> headers);
+  /// Updates the cache [headers] for the [request] without modifying anything else.
+  Future<void> updateHeaders(Account account, http.Request request, Map<String, String> headers);
 }
 
 /// Default implementation of the [RequestCache].
@@ -60,14 +60,14 @@ final class DefaultRequestCache implements RequestCache {
     final cacheDir = await getApplicationCacheDirectory();
     database = await openDatabase(
       p.join(cacheDir.path, 'cache.db'),
-      version: 6,
+      version: 7,
       onCreate: onCreate,
       onUpgrade: (db, oldVersion, newVersion) async {
         // We can safely drop the table as it only contains cached data.
         // Non breaking migrations should not drop the cache. The next
         // breaking change should remove all non breaking migrations before it.
         await db.transaction((txn) async {
-          if (oldVersion <= 5) {
+          if (oldVersion <= 6) {
             await txn.execute('DROP TABLE cache');
             await onCreate(txn);
           }
@@ -80,12 +80,15 @@ final class DefaultRequestCache implements RequestCache {
   static Future<void> onCreate(DatabaseExecutor db, [int? version]) async {
     await db.execute('''
 CREATE TABLE "cache" (
-	"account"    TEXT NOT NULL,
-	"key"        TEXT NOT NULL,
-	"statusCode" INTEGER NOT NULL,
-	"body"       BLOB NOT NULL,
-	"headers"    TEXT NOT NULL,
-	PRIMARY KEY("key", "account")
+	"account"              TEXT NOT NULL,
+	"request_method"       TEXT NOT NULL,
+	"request_url"          TEXT NOT NULL,
+	"request_headers"      TEXT NOT NULL,
+	"request_body"         BLOB NOT NULL,
+	"response_status_code" INTEGER NOT NULL,
+	"response_headers"     TEXT NOT NULL,
+	"response_body"        BLOB NOT NULL,
+	PRIMARY KEY("account", "request_method", "request_url", "request_headers", "request_body")
 );
 ''');
   }
@@ -102,20 +105,32 @@ CREATE TABLE "cache" (
   }
 
   @override
-  Future<http.Response?> get(Account account, String key) async {
+  Future<http.Response?> get(Account account, http.Request request) async {
     List<Map<String, Object?>>? result;
     try {
       result = await _requireDatabase.rawQuery(
         '''
-SELECT statusCode, body, headers
+SELECT response_status_code,
+       response_headers,
+       response_body
 FROM cache
-WHERE account = ? AND key = ?
+WHERE account = ?
+  AND request_method = ?
+  AND request_url = ?
+  AND request_headers = ?
+  AND request_body = ?
 ''',
-        [account.id, key],
+        [
+          account.id,
+          request.method.toUpperCase(),
+          request.url.toString(),
+          json.encode(sanitizeRequestHeaders(request.headers)),
+          request.bodyBytes,
+        ],
       );
     } on DatabaseException catch (error, stackTrace) {
       _log.severe(
-        'Error while getting `$key` from cache.',
+        'Error while getting `$request` from cache.',
         error,
         stackTrace,
       );
@@ -127,15 +142,16 @@ WHERE account = ? AND key = ?
     }
 
     return http.Response.bytes(
-      row['body']! as Uint8List,
-      row['statusCode']! as int,
-      headers: (json.decode(row['headers']! as String) as Map<String, dynamic>).cast<String, String>(),
+      row['response_body']! as Uint8List,
+      row['response_status_code']! as int,
+      headers: (json.decode(row['response_headers']! as String) as Map<String, dynamic>).cast<String, String>(),
     );
   }
 
   @override
-  Future<void> set(Account account, String key, http.Response response) async {
-    final encodedHeaders = json.encode(response.headers);
+  Future<void> set(Account account, http.Request request, http.Response response) async {
+    final encodedRequestHeaders = json.encode(sanitizeRequestHeaders(request.headers));
+    final encodedResponseHeaders = json.encode(response.headers);
 
     try {
       // UPSERT is only available since SQLite 3.24.0 (June 4, 2018).
@@ -145,32 +161,53 @@ WHERE account = ? AND key = ?
           'cache',
           {
             'account': account.id,
-            'key': key,
-            'statusCode': response.statusCode,
-            'body': response.bodyBytes,
-            'headers': encodedHeaders,
+            'request_method': request.method.toUpperCase(),
+            'request_url': request.url.toString(),
+            'request_headers': encodedRequestHeaders,
+            'request_body': request.bodyBytes,
+            'response_status_code': response.statusCode,
+            'response_headers': encodedResponseHeaders,
+            'response_body': response.bodyBytes,
           },
-          where: 'account = ? AND key = ?',
-          whereArgs: [account.id, key],
+          where: 'account = ? AND request_method = ? AND request_url = ? AND request_headers = ? AND request_body = ?',
+          whereArgs: [
+            account.id,
+            request.method.toUpperCase(),
+            request.url.toString(),
+            encodedRequestHeaders,
+            request.bodyBytes,
+          ],
         )
         ..rawInsert(
           '''
-INSERT INTO cache (account, key, statusCode, body, headers)
-SELECT ?, ?, ?, ?, ?
+INSERT INTO cache (
+  account,
+  request_method,
+  request_url,
+  request_headers,
+  request_body,
+  response_status_code,
+  response_headers,
+  response_body
+)
+SELECT ?, ?, ?, ?, ?, ?, ?, ?
 WHERE (SELECT changes() = 0)
 ''',
           [
             account.id,
-            key,
+            request.method.toUpperCase(),
+            request.url.toString(),
+            encodedRequestHeaders,
+            request.bodyBytes,
             response.statusCode,
+            encodedResponseHeaders,
             response.bodyBytes,
-            encodedHeaders,
           ],
         );
       await batch.commit(noResult: true);
     } on DatabaseException catch (error, stackTrace) {
       _log.severe(
-        'Error while setting `$key` in the cache.',
+        'Error while setting `$request` in the cache.',
         error,
         stackTrace,
       );
@@ -178,23 +215,37 @@ WHERE (SELECT changes() = 0)
   }
 
   @override
-  Future<void> updateHeaders(Account account, String key, Map<String, String> headers) async {
+  Future<void> updateHeaders(Account account, http.Request request, Map<String, String> headers) async {
     try {
       await _requireDatabase.update(
         'cache',
         {
           'account': account.id,
-          'headers': json.encode(headers),
+          'response_headers': json.encode(headers),
         },
-        where: 'account = ? AND key = ?',
-        whereArgs: [account.id, key],
+        where: 'account = ? AND request_method = ? AND request_url = ? AND request_headers = ? AND request_body = ?',
+        whereArgs: [
+          account.id,
+          request.method.toUpperCase(),
+          request.url.toString(),
+          json.encode(sanitizeRequestHeaders(request.headers)),
+          request.bodyBytes,
+        ],
       );
     } on DatabaseException catch (error, stackTrace) {
       _log.severe(
-        'Error while updating headers at `$key`.',
+        'Error while updating headers at `$request`.',
         error,
         stackTrace,
       );
     }
+  }
+
+  /// Ensures header names are case-insensitive and removes headers that would potentially prevent caching.
+  Map<String, String> sanitizeRequestHeaders(Map<String, String> headers) {
+    return headers.map((key, value) => MapEntry(key.toLowerCase(), value))
+      ..remove('authorization')
+      ..remove('cookie')
+      ..remove('user-agent');
   }
 }

--- a/packages/neon_framework/lib/src/utils/push_utils.dart
+++ b/packages/neon_framework/lib/src/utils/push_utils.dart
@@ -191,7 +191,6 @@ class PushUtils {
     final headers = account.getAuthorizationHeaders(uri);
     await RequestManager.instance.wrap(
       account: account,
-      cacheKey: uri.toString(),
       getCacheHeaders: () async {
         final response = await account.client.head(
           uri,

--- a/packages/neon_framework/lib/src/widgets/image.dart
+++ b/packages/neon_framework/lib/src/widgets/image.dart
@@ -162,7 +162,6 @@ class NeonApiImage extends StatefulWidget {
   /// Creates a new Neon API image fetching the image with the currently active account.
   const NeonApiImage({
     required this.getRequest,
-    required this.cacheKey,
     required this.etag,
     required this.expires,
     required this.account,
@@ -183,9 +182,6 @@ class NeonApiImage extends StatefulWidget {
   /// Every time it is called a new [http.Request] has to be created.
   /// Re-using the same will not work when retrying failed requests.
   final http.Request Function(NextcloudClient) getRequest;
-
-  /// The unique key used for caching the image.
-  final String cacheKey;
 
   /// The ETag used for invalidating the cache.
   final String? etag;
@@ -235,7 +231,6 @@ class _NeonApiImageState extends State<NeonApiImage> {
   Future<void> load() async {
     await RequestManager.instance.wrap(
       account: widget.account,
-      cacheKey: widget.cacheKey,
       getCacheHeaders: () async {
         return {
           if (widget.etag != null) 'etag': widget.etag!,
@@ -354,7 +349,6 @@ class _NeonUriImageState extends State<NeonUriImage> {
 
     await RequestManager.instance.wrap(
       account: widget.account,
-      cacheKey: completedUri.toString(),
       getCacheHeaders: () async {
         final response = await widget.account.client.head(
           completedUri,

--- a/packages/neon_framework/lib/src/widgets/user_avatar.dart
+++ b/packages/neon_framework/lib/src/widgets/user_avatar.dart
@@ -69,7 +69,6 @@ class _UserAvatarState extends State<NeonUserAvatar> {
           child: ClipOval(
             child: NeonApiImage(
               account: widget.account,
-              cacheKey: 'avatar-$username-$brightness-$pixelSize',
               etag: null,
               expires: null,
               getRequest: (client) => switch (brightness) {

--- a/packages/neon_framework/test/image_test.dart
+++ b/packages/neon_framework/test/image_test.dart
@@ -84,7 +84,6 @@ void main() {
     when(
       () => mockRequestManager.wrap<Uint8List, Uint8List>(
         account: mockAccount,
-        cacheKey: 'key',
         getCacheHeaders: any(named: 'getCacheHeaders'),
         getRequest: any(named: 'getRequest'),
         converter: any(named: 'converter'),
@@ -100,7 +99,6 @@ void main() {
       TestApp(
         child: NeonApiImage(
           getRequest: (_) => mockRequest,
-          cacheKey: 'key',
           etag: null,
           expires: null,
           account: mockAccount,
@@ -111,7 +109,6 @@ void main() {
     verify(
       () => mockRequestManager.wrap<Uint8List, Uint8List>(
         account: mockAccount,
-        cacheKey: 'key',
         getCacheHeaders: any(named: 'getCacheHeaders'),
         getRequest: any(named: 'getRequest'),
         converter: any(named: 'converter'),
@@ -132,7 +129,6 @@ void main() {
     when(
       () => mockRequestManager.wrap<Uint8List, Uint8List>(
         account: mockAccount,
-        cacheKey: 'https://example.com',
         getCacheHeaders: any(named: 'getCacheHeaders'),
         getRequest: any(named: 'getRequest'),
         converter: any(named: 'converter'),
@@ -155,7 +151,6 @@ void main() {
     verify(
       () => mockRequestManager.wrap<Uint8List, Uint8List>(
         account: mockAccount,
-        cacheKey: 'https://example.com',
         getCacheHeaders: any(named: 'getCacheHeaders'),
         getRequest: any(named: 'getRequest'),
         converter: any(named: 'converter'),

--- a/packages/neon_framework/test/request_manager_test.dart
+++ b/packages/neon_framework/test/request_manager_test.dart
@@ -89,7 +89,6 @@ void main() {
 
           await RequestManager.instance.wrap<String, Uint8List>(
             account: account,
-            cacheKey: 'key',
             subject: subject,
             getRequest: () => http.Request('GET', Uri()),
             converter: const BinaryResponseConverter(),
@@ -131,7 +130,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri()),
           converter: const BinaryResponseConverter(),
@@ -154,7 +152,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri()),
           converter: const BinaryResponseConverter(),
@@ -186,7 +183,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri(host: 'delay')),
           converter: const BinaryResponseConverter(),
@@ -225,7 +221,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri(host: 'delay')),
           converter: const BinaryResponseConverter(),
@@ -250,7 +245,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri(host: 'error')),
           converter: const BinaryResponseConverter(),
@@ -273,7 +267,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri(host: 'error')),
           converter: const BinaryResponseConverter(),
@@ -335,7 +328,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri()),
           converter: const BinaryResponseConverter(),
@@ -343,11 +335,11 @@ void main() {
         );
 
         await subject.close();
-        verify(() => cache.get(account, 'key')).called(1);
+        verify(() => cache.get(account, any())).called(1);
         verify(
           () => cache.set(
             account,
-            'key',
+            any(),
             any(
               that: isA<http.Response>()
                   .having((response) => response.statusCode, 'statusCode', 200)
@@ -371,7 +363,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri()),
           converter: const BinaryResponseConverter(),
@@ -379,11 +370,11 @@ void main() {
         );
 
         await subject.close();
-        verify(() => cache.get(account, 'key')).called(1);
+        verify(() => cache.get(account, any())).called(1);
         verify(
           () => cache.set(
             account,
-            'key',
+            any(),
             any(
               that: isA<http.Response>()
                   .having((response) => response.statusCode, 'statusCode', 200)
@@ -424,7 +415,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri(host: 'delay')),
           converter: const BinaryResponseConverter(),
@@ -433,7 +423,7 @@ void main() {
         );
 
         await subject.close();
-        verify(() => cache.get(account, 'key')).called(1);
+        verify(() => cache.get(account, any())).called(1);
         verifyNever(() => cache.set(any(), any(), any()));
 
         subject = BehaviorSubject<Result<String>>.seeded(Result.success('Seed value'));
@@ -465,7 +455,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri(host: 'delay')),
           converter: const BinaryResponseConverter(),
@@ -474,7 +463,7 @@ void main() {
         );
 
         await subject.close();
-        verify(() => cache.get(account, 'key')).called(1);
+        verify(() => cache.get(account, any())).called(1);
         verifyNever(() => cache.set(any(), any(), any()));
       });
 
@@ -493,7 +482,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri(host: 'error')),
           converter: const BinaryResponseConverter(),
@@ -501,7 +489,7 @@ void main() {
         );
 
         await subject.close();
-        verify(() => cache.get(account, 'key')).called(1);
+        verify(() => cache.get(account, any())).called(1);
         verifyNever(() => cache.set(any(), any(), any()));
 
         subject = BehaviorSubject<Result<String>>.seeded(Result.success('Seed value'));
@@ -518,7 +506,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri(host: 'error')),
           converter: const BinaryResponseConverter(),
@@ -526,7 +513,7 @@ void main() {
         );
 
         await subject.close();
-        verify(() => cache.get(account, 'key')).called(1);
+        verify(() => cache.get(account, any())).called(1);
         verifyNever(() => cache.set(any(), any(), any()));
       });
 
@@ -556,7 +543,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri()),
           converter: const BinaryResponseConverter(),
@@ -564,7 +550,7 @@ void main() {
         );
 
         await subject.close();
-        verify(() => cache.get(account, 'key')).called(1);
+        verify(() => cache.get(account, any())).called(1);
         verifyNever(() => cache.set(any(), any(), any()));
 
         when(() => cache.get(any(), any())).thenAnswer(
@@ -593,7 +579,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri()),
           converter: const BinaryResponseConverter(),
@@ -601,7 +586,7 @@ void main() {
         );
 
         await subject.close();
-        verify(() => cache.get(account, 'key')).called(1);
+        verify(() => cache.get(account, any())).called(1);
         verify(() => cache.set(any(), any(), any())).called(1);
       });
 
@@ -646,7 +631,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri()),
           converter: const BinaryResponseConverter(),
@@ -655,9 +639,9 @@ void main() {
         );
 
         await subject.close();
-        verify(() => cache.get(account, 'key')).called(1);
+        verify(() => cache.get(account, any())).called(1);
         verify(callback.call).called(1);
-        verify(() => cache.updateHeaders(account, 'key', {'etag': 'a', 'expires': newExpires})).called(1);
+        verify(() => cache.updateHeaders(account, any(), {'etag': 'a', 'expires': newExpires})).called(1);
         verifyNever(() => cache.set(any(), any(), any()));
 
         when(() => cache.get(any(), any())).thenAnswer(
@@ -692,7 +676,6 @@ void main() {
 
         await RequestManager.instance.wrap<String, Uint8List>(
           account: account,
-          cacheKey: 'key',
           subject: subject,
           getRequest: () => http.Request('GET', Uri()),
           converter: const BinaryResponseConverter(),
@@ -701,12 +684,12 @@ void main() {
         );
 
         await subject.close();
-        verify(() => cache.get(account, 'key')).called(1);
+        verify(() => cache.get(account, any())).called(1);
         verify(callback.call).called(1);
         verify(
           () => cache.set(
             account,
-            'key',
+            any(),
             any(
               that: isA<http.Response>()
                   .having((response) => response.statusCode, 'statusCode', 200)
@@ -752,7 +735,6 @@ void main() {
 
           await RequestManager.instance.wrap<String, Uint8List>(
             account: account,
-            cacheKey: 'key',
             subject: subject,
             getRequest: () => http.Request('GET', Uri()),
             converter: const BinaryResponseConverter(),
@@ -760,11 +742,11 @@ void main() {
           );
 
           await subject.close();
-          verify(() => cache.get(account, 'key')).called(1);
+          verify(() => cache.get(account, any())).called(1);
           verify(
             () => cache.set(
               account,
-              'key',
+              any(),
               any(
                 that: isA<http.Response>()
                     .having((response) => response.statusCode, 'statusCode', 200)


### PR DESCRIPTION
https://github.com/nextcloud/neon/issues/2155

I'm not sure myself if hashing the request is the best way, as it makes it a lot harder to understand the data that is stored in the cache. OTOH storing all those request parameters in the cache is tedious and we rarely or even never need to inspect the cached data, so it feels a bit pointless.