### PR TITLE
refactor(neon_news, neon_notes, neon_notifications): replace long press actions with swipe-to-dismiss 

### DIFF
--- a/packages/neon/neon_news/lib/src/widgets/articles_view.dart
+++ b/packages/neon/neon_news/lib/src/widgets/articles_view.dart
@@ -142,145 +142,152 @@ class _NewsArticlesViewState extends State<NewsArticlesView> {
     news.Article article,
     news.Feed feed,
   ) =>
-      ListTile(
-        title: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Flexible(
-              child: Text(
-                article.title,
-                style: article.unread
-                    ? null
-                    : Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).disabledColor),
-              ),
-            ),
-            if (article.mediaThumbnail != null)
-              NeonUriImage(
-                uri: Uri.parse(article.mediaThumbnail!),
-                size: const Size(100, 50),
-                fit: BoxFit.cover,
-                account: NeonProvider.of<Account>(context),
-              ),
-          ],
-        ),
-        subtitle: Row(
-          children: [
-            Container(
-              margin: const EdgeInsets.only(
-                top: 8,
-                bottom: 8,
-                right: 8,
-              ),
-              child: NewsFeedIcon(
-                feed: feed,
-                size: smallIconSize,
-                borderRadius: const BorderRadius.all(Radius.circular(2)),
-              ),
-            ),
-            RelativeTime(
-              date: DateTimeUtils.fromSecondsSinceEpoch(
-                tz.UTC,
-                article.pubDate,
-              ),
-              style: const TextStyle(
-                fontWeight: FontWeight.w300,
-                fontSize: 12,
-              ),
-            ),
-            const SizedBox(
-              width: 5,
-            ),
-            Flexible(
-              child: Text(
-                feed.title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ],
-        ),
-        trailing: IconButton(
-          onPressed: () {
-            if (article.starred) {
-              widget.bloc.unstarArticle(article);
-            } else {
-              widget.bloc.starArticle(article);
-            }
-          },
-          tooltip:
-              article.starred ? NewsLocalizations.of(context).articleUnstar : NewsLocalizations.of(context).articleStar,
-          icon: Icon(
-            article.starred ? AdaptiveIcons.star : AdaptiveIcons.star_outline,
-            color: Theme.of(context).colorScheme.primary,
-          ),
-        ),
-        onLongPress: () {
+      Dismissible(
+        key: Key(article.id.toString()),
+        direction: DismissDirection.startToEnd,
+        behavior: HitTestBehavior.translucent,
+        background: Container(color: Colors.red),
+        onDismissed: (_) {
           if (article.unread) {
             widget.bloc.markArticleAsRead(article);
           } else {
             widget.bloc.markArticleAsUnread(article);
           }
         },
-        onTap: () async {
-          final viewType = options.articleViewTypeOption.value;
-          String? bodyData;
-          try {
-            bodyData = _fixArticleBody(article.body);
-          } on Exception catch (error, stackTrace) {
-            _log.warning(
-              'Could not parse the body of ${article.title}',
-              error,
-              stackTrace,
-            );
-          }
-
-          final account = NeonProvider.of<Account>(context);
-
-          if ((viewType == ArticleViewType.direct || article.url == null) && bodyData != null) {
-            await Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (context) => NewsArticlePage(
-                  bloc: NewsArticleBloc(
-                    articlesBloc: widget.bloc,
-                    account: account,
-                    article: article,
-                  ),
-                  articlesBloc: widget.bloc,
-                  useWebView: false,
-                  bodyData: bodyData,
-                  url: article.url,
+        child: ListTile(
+          title: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Flexible(
+                child: Text(
+                  article.title,
+                  style: article.unread
+                      ? null
+                      : Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).disabledColor),
                 ),
               ),
-            );
-          } else if (viewType == ArticleViewType.internalBrowser &&
-              article.url != null &&
-              NeonPlatform.instance.canUseWebView) {
-            await Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (context) => NewsArticlePage(
-                  bloc: NewsArticleBloc(
-                    articlesBloc: widget.bloc,
-                    account: account,
-                    article: article,
-                  ),
-                  articlesBloc: widget.bloc,
-                  useWebView: true,
-                  url: article.url,
+              if (article.mediaThumbnail != null)
+                NeonUriImage(
+                  uri: Uri.parse(article.mediaThumbnail!),
+                  size: const Size(100, 50),
+                  fit: BoxFit.cover,
+                  account: NeonProvider.of<Account>(context),
+                ),
+            ],
+          ),
+          subtitle: Row(
+            children: [
+              Container(
+                margin: const EdgeInsets.only(
+                  top: 8,
+                  bottom: 8,
+                  right: 8,
+                ),
+                child: NewsFeedIcon(
+                  feed: feed,
+                  size: smallIconSize,
+                  borderRadius: const BorderRadius.all(Radius.circular(2)),
                 ),
               ),
-            );
-          } else {
-            if (article.unread) {
-              widget.bloc.markArticleAsRead(article);
-            }
-            if (article.url != null) {
-              await launchUrlString(
-                article.url!,
-                mode: LaunchMode.externalApplication,
+              RelativeTime(
+                date: DateTimeUtils.fromSecondsSinceEpoch(
+                  tz.UTC,
+                  article.pubDate,
+                ),
+                style: const TextStyle(
+                  fontWeight: FontWeight.w300,
+                  fontSize: 12,
+                ),
+              ),
+              const SizedBox(
+                width: 5,
+              ),
+              Flexible(
+                child: Text(
+                  feed.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+          trailing: IconButton(
+            onPressed: () {
+              if (article.starred) {
+                widget.bloc.unstarArticle(article);
+              } else {
+                widget.bloc.starArticle(article);
+              }
+            },
+            tooltip: article.starred
+                ? NewsLocalizations.of(context).articleUnstar
+                : NewsLocalizations.of(context).articleStar,
+            icon: Icon(
+              article.starred ? AdaptiveIcons.star : AdaptiveIcons.star_outline,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+          onTap: () async {
+            final viewType = options.articleViewTypeOption.value;
+            String? bodyData;
+            try {
+              bodyData = _fixArticleBody(article.body);
+            } on Exception catch (error, stackTrace) {
+              _log.warning(
+                'Could not parse the body of ${article.title}',
+                error,
+                stackTrace,
               );
             }
-          }
-        },
+
+            final account = NeonProvider.of<Account>(context);
+
+            if ((viewType == ArticleViewType.direct || article.url == null) && bodyData != null) {
+              await Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (context) => NewsArticlePage(
+                    bloc: NewsArticleBloc(
+                      articlesBloc: widget.bloc,
+                      account: account,
+                      article: article,
+                    ),
+                    articlesBloc: widget.bloc,
+                    useWebView: false,
+                    bodyData: bodyData,
+                    url: article.url,
+                  ),
+                ),
+              );
+            } else if (viewType == ArticleViewType.internalBrowser &&
+                article.url != null &&
+                NeonPlatform.instance.canUseWebView) {
+              await Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (context) => NewsArticlePage(
+                    bloc: NewsArticleBloc(
+                      articlesBloc: widget.bloc,
+                      account: account,
+                      article: article,
+                    ),
+                    articlesBloc: widget.bloc,
+                    useWebView: true,
+                    url: article.url,
+                  ),
+                ),
+              );
+            } else {
+              if (article.unread) {
+                widget.bloc.markArticleAsRead(article);
+              }
+              if (article.url != null) {
+                await launchUrlString(
+                  article.url!,
+                  mode: LaunchMode.externalApplication,
+                );
+              }
+            }
+          },
+        ),
       );
 
   String _fixArticleBody(String b) => _fixArticleBodyElement(html_parser.parse(b).documentElement!).outerHtml;

--- a/packages/neon/neon_news/lib/src/widgets/feeds_view.dart
+++ b/packages/neon/neon_news/lib/src/widgets/feeds_view.dart
@@ -59,121 +59,127 @@ class NewsFeedsView extends StatelessWidget {
     news.Feed feed,
     BuiltList<news.Folder> folders,
   ) =>
-      ListTile(
-        title: Text(
-          feed.title,
-          style: feed.unreadCount! == 0
-              ? Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).disabledColor)
-              : null,
-        ),
-        subtitle: feed.unreadCount! > 0
-            ? Text(NewsLocalizations.of(context).articlesUnread(feed.unreadCount!))
-            : const SizedBox(),
-        leading: NewsFeedIcon(feed: feed),
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (feed.updateErrorCount > 0)
-              IconButton(
-                onPressed: () async => showAdaptiveDialog<void>(
-                  context: context,
-                  builder: (context) => NewsFeedUpdateErrorDialog(
-                    feed: feed,
-                  ),
-                ),
-                tooltip: NewsLocalizations.of(context).feedShowErrorMessage,
-                iconSize: 30,
-                icon: Text(
-                  feed.updateErrorCount.toString(),
-                  style: TextStyle(
-                    color: Theme.of(context).colorScheme.error,
-                  ),
-                ),
-              ),
-            PopupMenuButton(
-              itemBuilder: (context) => [
-                PopupMenuItem(
-                  value: NewsFeedAction.showURL,
-                  child: Text(NewsLocalizations.of(context).feedShowURL),
-                ),
-                PopupMenuItem(
-                  value: NewsFeedAction.delete,
-                  child: Text(NewsLocalizations.of(context).actionDelete),
-                ),
-                PopupMenuItem(
-                  value: NewsFeedAction.rename,
-                  child: Text(NewsLocalizations.of(context).actionRename),
-                ),
-                if (folders.isNotEmpty)
-                  PopupMenuItem(
-                    value: NewsFeedAction.move,
-                    child: Text(NewsLocalizations.of(context).actionMove),
-                  ),
-              ],
-              onSelected: (action) async {
-                switch (action) {
-                  case NewsFeedAction.showURL:
-                    await showAdaptiveDialog<void>(
-                      context: context,
-                      builder: (context) => NewsFeedShowURLDialog(
-                        feed: feed,
-                      ),
-                    );
-                  case NewsFeedAction.delete:
-                    if (!context.mounted) {
-                      return;
-                    }
-                    final result = await showDeleteFeedDialog(context, feed);
-
-                    if (result) {
-                      bloc.removeFeed(feed.id);
-                    }
-                  case NewsFeedAction.rename:
-                    if (!context.mounted) {
-                      return;
-                    }
-                    final result = await showRenameDialog(
-                      context: context,
-                      title: NewsLocalizations.of(context).feedRename,
-                      initialValue: feed.title,
-                    );
-                    if (result != null) {
-                      bloc.renameFeed(feed.id, result);
-                    }
-                  case NewsFeedAction.move:
-                    if (!context.mounted) {
-                      return;
-                    }
-                    final result = await showAdaptiveDialog<({int? value})>(
-                      context: context,
-                      builder: (context) => NewsMoveFeedDialog(
-                        folders: folders,
-                        feed: feed,
-                      ),
-                    );
-                    if (result != null && result.value != feed.folderId) {
-                      bloc.moveFeed(feed.id, result.value);
-                    }
-                }
-              },
-            ),
-          ],
-        ),
-        onLongPress: () {
+      Dismissible(
+        key: Key(feed.id.toString()),
+        direction: DismissDirection.startToEnd,
+        behavior: HitTestBehavior.translucent,
+        background: Container(color: Colors.red),
+        onDismissed: (_) {
           if (feed.unreadCount! > 0) {
             bloc.markFeedAsRead(feed.id);
           }
         },
-        onTap: () async {
-          await Navigator.of(context).push(
-            MaterialPageRoute<void>(
-              builder: (context) => NewsFeedPage(
-                bloc: bloc,
-                feed: feed,
+        child: ListTile(
+          title: Text(
+            feed.title,
+            style: feed.unreadCount! == 0
+                ? Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).disabledColor)
+                : null,
+          ),
+          subtitle: feed.unreadCount! > 0
+              ? Text(NewsLocalizations.of(context).articlesUnread(feed.unreadCount!))
+              : const SizedBox(),
+          leading: NewsFeedIcon(feed: feed),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (feed.updateErrorCount > 0)
+                IconButton(
+                  onPressed: () async => showAdaptiveDialog<void>(
+                    context: context,
+                    builder: (context) => NewsFeedUpdateErrorDialog(
+                      feed: feed,
+                    ),
+                  ),
+                  tooltip: NewsLocalizations.of(context).feedShowErrorMessage,
+                  iconSize: 30,
+                  icon: Text(
+                    feed.updateErrorCount.toString(),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+                ),
+              PopupMenuButton(
+                itemBuilder: (context) => [
+                  PopupMenuItem(
+                    value: NewsFeedAction.showURL,
+                    child: Text(NewsLocalizations.of(context).feedShowURL),
+                  ),
+                  PopupMenuItem(
+                    value: NewsFeedAction.delete,
+                    child: Text(NewsLocalizations.of(context).actionDelete),
+                  ),
+                  PopupMenuItem(
+                    value: NewsFeedAction.rename,
+                    child: Text(NewsLocalizations.of(context).actionRename),
+                  ),
+                  if (folders.isNotEmpty)
+                    PopupMenuItem(
+                      value: NewsFeedAction.move,
+                      child: Text(NewsLocalizations.of(context).actionMove),
+                    ),
+                ],
+                onSelected: (action) async {
+                  switch (action) {
+                    case NewsFeedAction.showURL:
+                      await showAdaptiveDialog<void>(
+                        context: context,
+                        builder: (context) => NewsFeedShowURLDialog(
+                          feed: feed,
+                        ),
+                      );
+                    case NewsFeedAction.delete:
+                      if (!context.mounted) {
+                        return;
+                      }
+                      final result = await showDeleteFeedDialog(context, feed);
+
+                      if (result) {
+                        bloc.removeFeed(feed.id);
+                      }
+                    case NewsFeedAction.rename:
+                      if (!context.mounted) {
+                        return;
+                      }
+                      final result = await showRenameDialog(
+                        context: context,
+                        title: NewsLocalizations.of(context).feedRename,
+                        initialValue: feed.title,
+                      );
+                      if (result != null) {
+                        bloc.renameFeed(feed.id, result);
+                      }
+                    case NewsFeedAction.move:
+                      if (!context.mounted) {
+                        return;
+                      }
+                      final result = await showAdaptiveDialog<({int? value})>(
+                        context: context,
+                        builder: (context) => NewsMoveFeedDialog(
+                          folders: folders,
+                          feed: feed,
+                        ),
+                      );
+                      if (result != null && result.value != feed.folderId) {
+                        bloc.moveFeed(feed.id, result.value);
+                      }
+                  }
+                },
               ),
-            ),
-          );
-        },
+            ],
+          ),
+          onTap: () async {
+            await Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (context) => NewsFeedPage(
+                  bloc: bloc,
+                  feed: feed,
+                ),
+              ),
+            );
+          },
+        ),
       );
 }
 

--- a/packages/neon/neon_news/lib/src/widgets/folders_view.dart
+++ b/packages/neon/neon_news/lib/src/widgets/folders_view.dart
@@ -64,84 +64,89 @@ class NewsFoldersView extends StatelessWidget {
     FolderFeedsWrapper folderFeedsWrapper,
   ) {
     final (folder: folder, feedCount: feedCount, unreadCount: unreadCount) = folderFeedsWrapper;
-    return ListTile(
-      title: Text(
-        folder?.name ?? NewsLocalizations.of(context).folderRoot,
-        style: unreadCount == 0
-            ? Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).disabledColor)
-            : null,
-      ),
-      subtitle: unreadCount > 0 ? Text(NewsLocalizations.of(context).articlesUnread(unreadCount)) : const SizedBox(),
-      leading: SizedBox.square(
-        dimension: largeIconSize,
-        child: Stack(
-          children: [
-            Icon(
-              AdaptiveIcons.folder,
-              size: largeIconSize,
-              color: Theme.of(context).colorScheme.primary,
-            ),
-            Center(
-              child: Text(
-                feedCount.toString(),
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.onPrimary,
-                ),
-              ),
-            ),
-          ],
+
+    return Dismissible(
+      key: Key(folder?.id.toString() ?? 'root'),
+      direction: DismissDirection.startToEnd,
+      behavior: HitTestBehavior.translucent,
+      background: Container(color: Colors.red),
+      onDismissed: (_) {
+        if (folder != null && unreadCount > 0) {
+          bloc.markFolderAsRead(folder.id);
+        }
+      },
+      child: ListTile(
+        title: Text(
+          folder?.name ?? NewsLocalizations.of(context).folderRoot,
+          style: unreadCount == 0
+              ? Theme.of(context).textTheme.titleMedium!.copyWith(color: Theme.of(context).disabledColor)
+              : null,
         ),
-      ),
-      trailing: folder != null
-          ? PopupMenuButton(
-              itemBuilder: (context) => [
-                PopupMenuItem(
-                  value: NewsFolderAction.delete,
-                  child: Text(NewsLocalizations.of(context).actionDelete),
-                ),
-                PopupMenuItem(
-                  value: NewsFolderAction.rename,
-                  child: Text(NewsLocalizations.of(context).actionRename),
-                ),
-              ],
-              onSelected: (action) async {
-                switch (action) {
-                  case NewsFolderAction.delete:
-                    final result = await showFolderDeleteDialog(context: context, folderName: folder.name);
-                    if (result) {
-                      bloc.deleteFolder(folder.id);
-                    }
-                  case NewsFolderAction.rename:
-                    if (!context.mounted) {
-                      return;
-                    }
-                    final result = await showFolderRenameDialog(context: context, folderName: folder.name);
-                    if (result != null) {
-                      bloc.renameFolder(folder.id, result);
-                    }
-                }
-              },
-            )
-          : null,
-      onLongPress: folder != null
-          ? () {
-              if (unreadCount > 0) {
-                bloc.markFolderAsRead(folder.id);
-              }
-            }
-          : null,
-      onTap: folder != null
-          ? () async {
-              await Navigator.of(context).push(
-                MaterialPageRoute<void>(
-                  builder: (context) => NewsFolderPage(
-                    bloc: bloc,
-                    folder: folder,
+        subtitle: unreadCount > 0 ? Text(NewsLocalizations.of(context).articlesUnread(unreadCount)) : const SizedBox(),
+        leading: SizedBox.square(
+          dimension: largeIconSize,
+          child: Stack(
+            children: [
+              Icon(
+                AdaptiveIcons.folder,
+                size: largeIconSize,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+              Center(
+                child: Text(
+                  feedCount.toString(),
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onPrimary,
                   ),
                 ),
-              );
-            }
-          : null,
+              ),
+            ],
+          ),
+        ),
+        trailing: folder != null
+            ? PopupMenuButton(
+                itemBuilder: (context) => [
+                  PopupMenuItem(
+                    value: NewsFolderAction.delete,
+                    child: Text(NewsLocalizations.of(context).actionDelete),
+                  ),
+                  PopupMenuItem(
+                    value: NewsFolderAction.rename,
+                    child: Text(NewsLocalizations.of(context).actionRename),
+                  ),
+                ],
+                onSelected: (action) async {
+                  switch (action) {
+                    case NewsFolderAction.delete:
+                      final result = await showFolderDeleteDialog(context: context, folderName: folder.name);
+                      if (result) {
+                        bloc.deleteFolder(folder.id);
+                      }
+                    case NewsFolderAction.rename:
+                      if (!context.mounted) {
+                        return;
+                      }
+                      final result = await showFolderRenameDialog(context: context, folderName: folder.name);
+                      if (result != null) {
+                        bloc.renameFolder(folder.id, result);
+                      }
+                  }
+                },
+              )
+            : null,
+        onTap: folder != null
+            ? () async {
+                await Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (context) => NewsFolderPage(
+                      bloc: bloc,
+                      folder: folder,
+                    ),
+                  ),
+                );
+              }
+            : null,
+      ),
     );
   }
 }

--- a/packages/neon/neon_notes/lib/src/widgets/notes_view.dart
+++ b/packages/neon/neon_notes/lib/src/widgets/notes_view.dart
@@ -58,68 +58,73 @@ class NotesView extends StatelessWidget {
     BuildContext context,
     notes.Note note,
   ) =>
-      ListTile(
-        title: Text(note.title),
-        subtitle: Row(
-          children: [
-            RelativeTime(
-              date: DateTimeUtils.fromSecondsSinceEpoch(
-                tz.UTC,
-                note.modified,
-              ),
-            ),
-            if (note.category.isNotEmpty) ...[
-              const SizedBox(
-                width: 8,
-              ),
-              Icon(
-                AdaptiveIcons.tag,
-                size: smallIconSize,
-                color: NotesCategoryColor.compute(note.category),
-              ),
-              const SizedBox(
-                width: 2,
-              ),
-              Text(note.category),
-            ],
-          ],
+      Dismissible(
+        key: Key(note.id.toString()),
+        direction: DismissDirection.startToEnd,
+        behavior: HitTestBehavior.translucent,
+        background: Container(color: Colors.red),
+        confirmDismiss: (direction) async => showConfirmationDialog(
+          context: context,
+          title: NotesLocalizations.of(context).noteDeleteConfirm(note.title),
         ),
-        trailing: IconButton(
-          onPressed: () {
-            bloc.updateNote(
-              note.id,
-              note.etag,
-              favorite: !note.favorite,
+        onDismissed: (_) async {
+          bloc.deleteNote(note.id);
+        },
+        child: ListTile(
+          title: Text(note.title),
+          subtitle: Row(
+            children: [
+              RelativeTime(
+                date: DateTimeUtils.fromSecondsSinceEpoch(
+                  tz.UTC,
+                  note.modified,
+                ),
+              ),
+              if (note.category.isNotEmpty) ...[
+                const SizedBox(
+                  width: 8,
+                ),
+                Icon(
+                  AdaptiveIcons.tag,
+                  size: smallIconSize,
+                  color: NotesCategoryColor.compute(note.category),
+                ),
+                const SizedBox(
+                  width: 2,
+                ),
+                Text(note.category),
+              ],
+            ],
+          ),
+          trailing: IconButton(
+            onPressed: () {
+              bloc.updateNote(
+                note.id,
+                note.etag,
+                favorite: !note.favorite,
+              );
+            },
+            tooltip:
+                note.favorite ? NotesLocalizations.of(context).noteUnstar : NotesLocalizations.of(context).noteStar,
+            icon: Icon(
+              note.favorite ? AdaptiveIcons.star : AdaptiveIcons.star_outline,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+          onTap: () async {
+            await Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (context) => NotesNotePage(
+                  bloc: NotesNoteBloc(
+                    notesBloc: bloc,
+                    account: NeonProvider.of<Account>(context),
+                    note: note,
+                  ),
+                  notesBloc: bloc,
+                ),
+              ),
             );
           },
-          tooltip: note.favorite ? NotesLocalizations.of(context).noteUnstar : NotesLocalizations.of(context).noteStar,
-          icon: Icon(
-            note.favorite ? AdaptiveIcons.star : AdaptiveIcons.star_outline,
-            color: Theme.of(context).colorScheme.primary,
-          ),
         ),
-        onTap: () async {
-          await Navigator.of(context).push(
-            MaterialPageRoute<void>(
-              builder: (context) => NotesNotePage(
-                bloc: NotesNoteBloc(
-                  notesBloc: bloc,
-                  account: NeonProvider.of<Account>(context),
-                  note: note,
-                ),
-                notesBloc: bloc,
-              ),
-            ),
-          );
-        },
-        onLongPress: () async {
-          final result = await showConfirmationDialog(
-            context: context,
-            title: NotesLocalizations.of(context).noteDeleteConfirm(note.title),
-          );
-          if (result) {
-            bloc.deleteNote(note.id);
-          }
-        },
       );
 }

--- a/packages/neon/neon_notifications/lib/src/widgets/notification.dart
+++ b/packages/neon/neon_notifications/lib/src/widgets/notification.dart
@@ -22,45 +22,53 @@ class NotificationsNotification extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      title: Text(notification.subject),
-      subtitle: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (notification.message.isNotEmpty)
-            Text(
-              notification.message,
-              overflow: TextOverflow.ellipsis,
-            ),
-          RelativeTime(
-            date: tz.TZDateTime.parse(tz.UTC, notification.datetime),
-          ),
-          if (notification.actions.isNotEmpty)
-            Row(
-              children: notification.actions
-                  .map(
-                    (action) => NotificationsAction(
-                      action: action,
-                    ),
-                  )
-                  .toList(),
-            ),
-        ]
-            .intersperse(
-              const SizedBox(
-                height: 5,
+    return Dismissible(
+      key: Key(notification.notificationId.toString()),
+      direction: DismissDirection.startToEnd,
+      behavior: HitTestBehavior.translucent,
+      background: Container(color: Colors.red),
+      onDismissed: (_) {
+        onDelete();
+      },
+      child: ListTile(
+        title: Text(notification.subject),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (notification.message.isNotEmpty)
+              Text(
+                notification.message,
+                overflow: TextOverflow.ellipsis,
               ),
-            )
-            .toList(),
+            RelativeTime(
+              date: tz.TZDateTime.parse(tz.UTC, notification.datetime),
+            ),
+            if (notification.actions.isNotEmpty)
+              Row(
+                children: notification.actions
+                    .map(
+                      (action) => NotificationsAction(
+                        action: action,
+                      ),
+                    )
+                    .toList(),
+              ),
+          ]
+              .intersperse(
+                const SizedBox(
+                  height: 5,
+                ),
+              )
+              .toList(),
+        ),
+        leading: NeonUriImage(
+          account: NeonProvider.of<Account>(context),
+          uri: Uri.parse(notification.icon!),
+          size: const Size.square(largeIconSize),
+          svgColorFilter: ColorFilter.mode(Theme.of(context).colorScheme.primary, BlendMode.srcIn),
+        ),
+        onTap: notification.link.isNotEmpty ? () => context.go(notification.link) : null,
       ),
-      leading: NeonUriImage(
-        account: NeonProvider.of<Account>(context),
-        uri: Uri.parse(notification.icon!),
-        size: const Size.square(largeIconSize),
-        svgColorFilter: ColorFilter.mode(Theme.of(context).colorScheme.primary, BlendMode.srcIn),
-      ),
-      onTap: notification.link.isNotEmpty ? () => context.go(notification.link) : null,
-      onLongPress: onDelete,
     );
   }
 }

--- a/packages/neon/neon_notifications/test/main_page_test.dart
+++ b/packages/neon/neon_notifications/test/main_page_test.dart
@@ -131,7 +131,8 @@ void main() {
     await tester.tap(find.byType(FloatingActionButton));
     verify(() => bloc.deleteAllNotifications()).called(1);
 
-    await tester.longPress(find.byType(NotificationsNotification).first);
+    await tester.drag(find.byType(NotificationsNotification).first, const Offset(500, 0));
+    await tester.pumpAndSettle();
     verify(() => bloc.deleteNotification(0)).called(1);
   });
 }

--- a/packages/neon/neon_notifications/test/notification_test.dart
+++ b/packages/neon/neon_notifications/test/notification_test.dart
@@ -35,6 +35,7 @@ void main() {
     when(() => secondaryAction.primary).thenReturn(false);
 
     notification = MockNotification();
+    when(() => notification.notificationId).thenReturn(0);
     when(() => notification.app).thenReturn('app');
     when(() => notification.subject).thenReturn('subject');
     when(() => notification.message).thenReturn('message');
@@ -75,11 +76,11 @@ void main() {
     expect(find.byType(NotificationsAction), findsExactly(2));
     await expectLater(find.byType(TestApp), matchesGoldenFile('goldens/notification.png'));
 
-    await tester.longPress(find.byType(NotificationsNotification));
-    verify(callback.call).called(1);
-
     await tester.tap(find.byType(NotificationsNotification));
-
     verify(() => router.go('/link')).called(1);
+
+    await tester.drag(find.byType(NotificationsNotification), const Offset(500, 0));
+    await tester.pumpAndSettle();
+    verify(callback.call).called(1);
   });
 }


### PR DESCRIPTION
#2158 
## Implemented swipe-to-dismiss feature in : 
1. Neon News 
   - Articles (swipe to mark read/unread)
   - Folders
   - Feeds

2. Neon Notifications 
3. Neon notes