### PR TITLE
test(nextcloud): Remove expect skip

### DIFF
--- a/packages/nextcloud/test/spreed_test.dart
+++ b/packages/nextcloud/test/spreed_test.dart
@@ -403,7 +403,7 @@ void main() {
           expect(response.body.ocs.data[0].id, 'user2');
           expect(response.body.ocs.data[0].label, 'User Two');
           expect(response.body.ocs.data[0].source, 'users');
-          expect(response.body.ocs.data[0].mentionId, 'user2', skip: preset.version < Version(19, 0, 0));
+          expect(response.body.ocs.data[0].mentionId, preset.version < Version(19, 0, 0) ? null : 'user2');
           expect(response.body.ocs.data[0].status, null);
           expect(response.body.ocs.data[0].statusClearAt, null);
           expect(response.body.ocs.data[0].statusIcon, null);


### PR DESCRIPTION
A skip in an expect will make the test retry which of course doesn't change anything. Also it should ensure the value, even if it is null, instead of ignoring it.