### PR TITLE
fix(neon_framework): Fix QR-Code login resulting in infinite login loop

### DIFF
--- a/packages/neon_framework/lib/src/pages/login_qr_code.dart
+++ b/packages/neon_framework/lib/src/pages/login_qr_code.dart
@@ -48,11 +48,11 @@ class _LoginQRcodePageState extends State<LoginQRcodePage> {
                 throw const InvalidQRcodeException();
               }
 
-              await LoginCheckServerStatusWithCredentialsRoute(
+              LoginCheckServerStatusWithCredentialsRoute(
                 serverUrl: match.serverURL,
                 loginName: match.username,
                 password: match.password,
-              ).push<LoginCheckServerStatusRoute>(context);
+              ).pushReplacement(context);
             } on InvalidQRcodeException catch (error, stackTrace) {
               if (_lastErrorURL != url) {
                 _log.warning(


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/2260

Due to only using push the scan page was kept open and the qr code was continuously scanned. This lead to the page being pushed again and again. Replacing the page solves this as the scan widget is then disposed.