### PR TITLE
fix(neon_framework): Reject non-200/201 status codes in BinaryResponseConverter

### DIFF
--- a/packages/neon_framework/lib/src/utils/request_manager.dart
+++ b/packages/neon_framework/lib/src/utils/request_manager.dart
@@ -323,5 +323,11 @@ class BinaryResponseConverter with Converter<http.Response, Uint8List> {
   const BinaryResponseConverter();
 
   @override
-  Uint8List convert(http.Response input) => input.bodyBytes;
+  Uint8List convert(http.Response input) {
+    if (input.statusCode != 200 && input.statusCode != 201) {
+      throw DynamiteStatusCodeException(input);
+    }
+
+    return input.bodyBytes;
+  }
 }


### PR DESCRIPTION
Otherwise data of other status codes like 404 will be passed on but then fails to parse/decode.