### PR TITLE
Fix semanticsLabel for Nextcloud client logo

### DIFF
--- a/packages/neon_framework/lib/src/models/app_implementation.dart
+++ b/packages/neon_framework/lib/src/models/app_implementation.dart
@@ -171,7 +171,7 @@ abstract class AppImplementation<T extends Bloc, R extends AppImplementationOpti
               'assets/app.svg.vec',
               packageName: 'neon_$id',
             ),
-            semanticsLabel: NeonLocalizations.of(context).nextcloudLogo,
+            semanticsLabel: "Nextcloud Client Logo",
           );
         },
       );


### PR DESCRIPTION
# Issue -> https://github.com/nextcloud/neon/issues/2273
## Fix Incorrect Semantics Label for Nextcloud Logo

**Issue:** The `semanticsLabel` for the Nextcloud logo was incorrectly transcribed as "Nextcloud logo". This needed to be updated for better accessibility and accuracy.

**Changes Made:**

- Updated the `semanticsLabel` in the `app_implementation.dart` file to provide a more accurate description.
