### PR TITLE
refactor(neon_talk): Parse timestamps to local timezone

### DIFF
--- a/packages/neon/neon_talk/lib/src/pages/main.dart
+++ b/packages/neon/neon_talk/lib/src/pages/main.dart
@@ -112,7 +112,7 @@ class _TalkMainPageState extends State<TalkMainPage> {
         );
       }
 
-      final timestamp = lastChatMessage.parsedTimestamp.toLocal();
+      final timestamp = lastChatMessage.parsedTimestamp;
 
       final time = Tooltip(
         message: DateFormat.yMd().add_jm().format(timestamp),

--- a/packages/neon/neon_talk/lib/src/utils/helpers.dart
+++ b/packages/neon/neon_talk/lib/src/utils/helpers.dart
@@ -23,27 +23,27 @@ extension ChatMessageHidden on spreed.$ChatMessageInterface {
 /// Helper extension for [spreed.$BaseMessageInterface]
 extension $BaseMessageInterfaceHelpers on spreed.$BaseMessageInterface {
   /// Parsed equivalent of [expirationTimestamp].
-  tz.TZDateTime get parsedExpirationTimestamp => DateTimeUtils.fromSecondsSinceEpoch(tz.UTC, expirationTimestamp);
+  tz.TZDateTime get parsedExpirationTimestamp => DateTimeUtils.fromSecondsSinceEpoch(tz.local, expirationTimestamp);
 }
 
 /// Helper extension for [spreed.$ChatMessageInterface]
 extension $ChatMessageInterfaceHelpers on spreed.$ChatMessageInterface {
   /// Parsed equivalent of [timestamp].
-  tz.TZDateTime get parsedTimestamp => DateTimeUtils.fromSecondsSinceEpoch(tz.UTC, timestamp);
+  tz.TZDateTime get parsedTimestamp => DateTimeUtils.fromSecondsSinceEpoch(tz.local, timestamp);
 
   /// Parsed equivalent of [lastEditTimestamp].
   tz.TZDateTime? get parsedLastEditTimestamp =>
-      lastEditTimestamp != null ? DateTimeUtils.fromSecondsSinceEpoch(tz.UTC, lastEditTimestamp!) : null;
+      lastEditTimestamp != null ? DateTimeUtils.fromSecondsSinceEpoch(tz.local, lastEditTimestamp!) : null;
 }
 
 /// Helper extension for [spreed.$ChatReminderInterface]
 extension $ChatReminderInterfaceHelpers on spreed.$ChatReminderInterface {
   /// Parsed equivalent of [timestamp].
-  tz.TZDateTime get parsedTimestamp => DateTimeUtils.fromSecondsSinceEpoch(tz.UTC, timestamp);
+  tz.TZDateTime get parsedTimestamp => DateTimeUtils.fromSecondsSinceEpoch(tz.local, timestamp);
 }
 
 /// Helper extension for [spreed.$ReactionInterface]
 extension $ReactionInterfaceHelpers on spreed.$ReactionInterface {
   /// Parsed equivalent of [timestamp].
-  tz.TZDateTime get parsedTimestamp => DateTimeUtils.fromSecondsSinceEpoch(tz.UTC, timestamp);
+  tz.TZDateTime get parsedTimestamp => DateTimeUtils.fromSecondsSinceEpoch(tz.local, timestamp);
 }

--- a/packages/neon/neon_talk/lib/src/widgets/message.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/message.dart
@@ -450,10 +450,10 @@ class _TalkCommentMessageState extends State<TalkCommentMessage> {
         final textTheme = Theme.of(context).textTheme;
         final labelColor = Theme.of(context).colorScheme.inverseSurface.withOpacity(0.7);
 
-        final date = widget.chatMessage.parsedTimestamp.toLocal();
+        final date = widget.chatMessage.parsedTimestamp;
         tz.TZDateTime? previousDate;
         if (widget.previousChatMessage != null) {
-          previousDate = widget.previousChatMessage!.parsedTimestamp.toLocal();
+          previousDate = widget.previousChatMessage!.parsedTimestamp;
         }
 
         final separateMessages = widget.chatMessage.actorId != widget.previousChatMessage?.actorId ||
@@ -479,9 +479,9 @@ class _TalkCommentMessageState extends State<TalkCommentMessage> {
             );
 
             time = Tooltip(
-              message: _dateTimeFormat.format(date.toLocal()),
+              message: _dateTimeFormat.format(date),
               child: Text(
-                _timeFormat.format(date.toLocal()),
+                _timeFormat.format(date),
                 style: textTheme.labelSmall,
               ),
             );


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/neon/pull/2287.
I originally parse the timestamps as UTC because they were in the nextcloud package where the local timezone might not be desired, but in neon_talk we always want the local timezone.