### PR TITLE
fix(nextcloud_test): Skip CSRF token requests in fixtures

### DIFF
--- a/packages/nextcloud/test/fixtures/webdav/list_directory.regexp
+++ b/packages/nextcloud/test/fixtures/webdav/list_directory.regexp
@@ -1,4 +1,3 @@
-GET http://localhost/index\.php
 PROPFIND http://localhost/remote\.php/webdav
 authorization: Bearer mock
 content-type: application/xml

--- a/packages/nextcloud_test/lib/src/proxy_http_client.dart
+++ b/packages/nextcloud_test/lib/src/proxy_http_client.dart
@@ -15,8 +15,10 @@ BaseClient getProxyHttpClient({
   final realClient = Client();
   return MockClient.streaming((baseRequest, bytesStream) async {
     final bodyBytes = await bytesStream.toBytes();
-    final fixture = _formatHttpRequest(baseRequest, bodyBytes);
-    onRequest(fixture);
+    if (baseRequest.url.path != '/index.php') {
+      final fixture = _formatHttpRequest(baseRequest, bodyBytes);
+      onRequest(fixture);
+    }
 
     final request = Request(baseRequest.method, baseRequest.url)
       ..persistentConnection = baseRequest.persistentConnection


### PR DESCRIPTION
Needed for https://github.com/nextcloud/neon/issues/1901