### PR TITLE
feat(neon_http_client): add csrf interceptor 

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -41,7 +41,11 @@ scripts:
   test: >
     melos run test:dart &&
     melos run test:flutter
-  test:dart: melos exec --no-flutter --concurrency=1 --fail-fast --dir-exists=test -- flutter test --concurrency=$(nproc --all) --coverage
+  test:dart: >
+    melos exec --no-flutter --concurrency=1 --fail-fast --dir-exists=test -- "
+      dart test --concurrency=$(nproc --all) --coverage=coverage &&
+      dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o ./coverage/lcov.info -i ./coverage
+    "
   test:flutter: melos exec --flutter --concurrency=1 --fail-fast --dir-exists=test -- flutter test --concurrency=$(nproc --all) --coverage
   generate:neon:build_runner: melos exec --scope="neon*" --file-exists="build.yaml" -- dart run build_runner build --delete-conflicting-outputs && melos run format
   generate:neon:l10n: melos exec --flutter --dir-exists="lib/l10n" flutter gen-l10n && melos run format

--- a/packages/neon_framework/lib/src/blocs/login_check_account.dart
+++ b/packages/neon_framework/lib/src/blocs/login_check_account.dart
@@ -46,6 +46,7 @@ class _LoginCheckAccountBloc extends InteractiveBloc implements LoginCheckAccoun
     password: password,
     httpClient: NeonHttpClient(
       userAgent: neonUserAgent,
+      baseURL: serverURL,
     ),
   );
 

--- a/packages/neon_framework/lib/src/blocs/login_check_server_status.dart
+++ b/packages/neon_framework/lib/src/blocs/login_check_server_status.dart
@@ -37,6 +37,7 @@ class _LoginCheckServerStatusBloc extends InteractiveBloc implements LoginCheckS
     serverURL,
     httpClient: NeonHttpClient(
       userAgent: neonUserAgent,
+      baseURL: serverURL,
     ),
   );
 

--- a/packages/neon_framework/lib/src/blocs/login_flow.dart
+++ b/packages/neon_framework/lib/src/blocs/login_flow.dart
@@ -42,6 +42,7 @@ class _LoginFlowBloc extends InteractiveBloc implements LoginFlowBloc {
     serverURL,
     httpClient: NeonHttpClient(
       userAgent: neonUserAgent,
+      baseURL: serverURL,
     ),
   );
   final resultController = StreamController<core.LoginFlowV2Credentials>();

--- a/packages/neon_framework/lib/src/models/account.dart
+++ b/packages/neon_framework/lib/src/models/account.dart
@@ -79,6 +79,7 @@ abstract class Account implements Credentials, Findable, Built<Account, AccountB
       userAgent: userAgent,
       client: this.httpClient,
       timeLimit: kDefaultTimeout,
+      baseURL: serverURL,
     );
 
     return NextcloudClient(

--- a/packages/neon_framework/lib/src/utils/request_manager.dart
+++ b/packages/neon_framework/lib/src/utils/request_manager.dart
@@ -12,7 +12,6 @@ import 'package:neon_framework/src/models/account.dart';
 import 'package:neon_framework/storage.dart';
 import 'package:neon_http_client/neon_http_client.dart';
 import 'package:nextcloud/utils.dart';
-import 'package:nextcloud/webdav.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:timezone/timezone.dart' as tz;
 
@@ -162,13 +161,7 @@ class RequestManager {
       subject.add(subject.value.asLoading());
     }
 
-    var client = httpClient;
-    // Assume the request is for WebDAV if the Content-Type is application/xml,
-    if (request.headers['content-type']?.split(';').first == 'application/xml') {
-      client ??= account.client.webdav.csrfClient;
-    } else {
-      client ??= account.client;
-    }
+    final client = httpClient ?? account.client;
 
     for (var i = 0; i < kMaxTries; i++) {
       try {

--- a/packages/neon_http_client/dart_test.yaml
+++ b/packages/neon_http_client/dart_test.yaml
@@ -1,0 +1,10 @@
+platforms:
+  - vm
+  - chrome
+
+define_platforms:
+  chromium:
+    name: Chromium
+    extends: chrome
+    settings:
+      executable: chromium

--- a/packages/neon_http_client/lib/src/interceptors/csrf_interceptor.dart
+++ b/packages/neon_http_client/lib/src/interceptors/csrf_interceptor.dart
@@ -1,0 +1,99 @@
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+import 'package:neon_http_client/src/interceptors/http_interceptor.dart';
+import 'package:nextcloud/nextcloud.dart';
+import 'package:nextcloud/webdav.dart';
+import 'package:universal_io/io.dart';
+
+/// A HttpInterceptor that works around a Nextcloud CSRF bug when cookies are sent.
+///
+/// A fix is proposed in: https://github.com/nextcloud/server/pull/43699
+///
+///
+/// Because cookies are always sent when run on web this interceptor will acquire
+/// a token from the server and attach it to the request headers.
+/// If the response is has a `401` status code the token is cleared so a future
+/// request will acquire a new one.
+///
+/// On non web platforms the interceptor will simply remove the `cookies` header
+/// for requests to the webdav endpoint.
+@internal
+final class CSRFInterceptor implements HttpInterceptor {
+  /// Creates a new csrf interceptor.
+  CSRFInterceptor({
+    required http.Client client,
+    required Uri baseURL,
+  })  : _client = client,
+        _baseURL = baseURL;
+
+  final http.Client _client;
+
+  final Uri _baseURL;
+
+  /// The request token sent by the [CSRFInterceptor].
+  @visibleForTesting
+  String? token;
+
+  static final _log = Logger('CSRFInterceptor');
+
+  // ignore: do_not_use_environment
+  static const bool _kIsWeb = bool.fromEnvironment('dart.library.js_util');
+
+  @override
+  bool shouldInterceptRequest(http.BaseRequest request) {
+    if (request.url.host != _baseURL.host || !request.url.path.startsWith('${_baseURL.path}$webdavBase')) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
+  Future<http.BaseRequest> interceptRequest({required http.BaseRequest request}) async {
+    assert(
+      shouldInterceptRequest(request),
+      'Request should not be intercepted.',
+    );
+
+    if (!_kIsWeb) {
+      return request..headers.remove(HttpHeaders.cookieHeader);
+    }
+
+    if (token == null) {
+      _log.fine('Acquiring new CSRF token for WebDAV');
+
+      final response = await _client.get(Uri.parse('$_baseURL/index.php'));
+      if (response.statusCode >= 300) {
+        throw DynamiteStatusCodeException(response);
+      }
+
+      token = RegExp('data-requesttoken="([^"]*)"').firstMatch(response.body)!.group(1);
+    }
+
+    request.headers.addAll({
+      'OCS-APIRequest': 'true',
+      'requesttoken': token!,
+    });
+
+    return request;
+  }
+
+  @override
+  bool shouldInterceptResponse(http.StreamedResponse response) {
+    return _kIsWeb && response.statusCode == 401;
+  }
+
+  @override
+  http.StreamedResponse interceptResponse({required http.StreamedResponse response, required Uri url}) {
+    assert(
+      shouldInterceptResponse(response),
+      'Response should not be intercepted.',
+    );
+
+    // Clear the token just in case it expired and lead to the failure.
+    _log.fine('Clearing CSRF token for WebDAV');
+    token = null;
+    return response;
+  }
+}

--- a/packages/neon_http_client/lib/src/interceptors/interceptors.dart
+++ b/packages/neon_http_client/lib/src/interceptors/interceptors.dart
@@ -1,3 +1,4 @@
 export 'base_header_interceptor.dart';
 export 'cookie_interceptor.dart';
+export 'csrf_interceptor.dart';
 export 'http_interceptor.dart';

--- a/packages/neon_http_client/pubspec.yaml
+++ b/packages/neon_http_client/pubspec.yaml
@@ -13,7 +13,9 @@ dependencies:
       url: https://github.com/nextcloud/neon
       path: packages/cookie_store
   http: ^1.0.0
+  logging: ^1.0.0
   meta: ^1.0.0
+  nextcloud: ^6.1.0
   universal_io: ^2.0.0
 
 dev_dependencies:

--- a/packages/neon_http_client/pubspec_overrides.yaml
+++ b/packages/neon_http_client/pubspec_overrides.yaml
@@ -1,6 +1,10 @@
-# melos_managed_dependency_overrides: cookie_store,neon_lints
+# melos_managed_dependency_overrides: cookie_store,dynamite_runtime,neon_lints,nextcloud
 dependency_overrides:
   cookie_store:
     path: ../cookie_store
+  dynamite_runtime:
+    path: ../dynamite/dynamite_runtime
   neon_lints:
     path: ../neon_lints
+  nextcloud:
+    path: ../nextcloud

--- a/packages/neon_http_client/test/client_conformance_test.dart
+++ b/packages/neon_http_client/test/client_conformance_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Skip()
 library;
 
 import 'package:http_client_conformance_tests/http_client_conformance_tests.dart';
@@ -7,7 +8,7 @@ import 'package:test/test.dart';
 
 void main() {
   testAll(
-    NeonHttpClient.new,
+    () => NeonHttpClient(baseURL: Uri()),
     canReceiveSetCookieHeaders: true,
     canSendCookieHeaders: true,
   );

--- a/packages/neon_http_client/test/interceptors/csrf_interceptor_test.dart
+++ b/packages/neon_http_client/test/interceptors/csrf_interceptor_test.dart
@@ -1,0 +1,252 @@
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:neon_http_client/src/interceptors/csrf_interceptor.dart';
+import 'package:nextcloud/nextcloud.dart';
+import 'package:test/test.dart';
+
+class _FakeClient extends Fake implements Client {}
+
+void main() {
+  group('CSRFInterceptor', () {
+    test('does intercept requests to the webdav endpoint', () {
+      final interceptor = CSRFInterceptor(
+        client: _FakeClient(),
+        baseURL: Uri.https('example.com', '/nextcloud'),
+      );
+
+      final request = Request('GET', Uri.https('example.com', '/nextcloud/remote.php/webdav'));
+
+      expect(interceptor.shouldInterceptRequest(request), isTrue);
+    });
+
+    test('does not intercept requests to non webdav endpoints', () async {
+      final interceptor = CSRFInterceptor(
+        client: _FakeClient(),
+        baseURL: Uri.https('example.com', '/nextcloud'),
+      );
+
+      var request = Request('GET', Uri.https('example.com', '/remote.php/webdav'));
+      expect(interceptor.shouldInterceptRequest(request), isFalse);
+      expect(
+        () => interceptor.interceptRequest(request: request),
+        throwsA(isA<AssertionError>()),
+      );
+
+      request = Request('GET', Uri.https('other-example.com', '/nextcloud/remote.php/webdav'));
+      expect(interceptor.shouldInterceptRequest(request), isFalse);
+      expect(
+        () => interceptor.interceptRequest(request: request),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('does intercept requests to non webdav endpoints', () {
+      final interceptor = CSRFInterceptor(
+        client: _FakeClient(),
+        baseURL: Uri.https('example.com', '/nextcloud'),
+      );
+
+      var request = Request('GET', Uri.https('example.com', '/remote.php/webdav'));
+      expect(interceptor.shouldInterceptRequest(request), isFalse);
+
+      request = Request('GET', Uri.https('other-example.com', '/nextcloud/remote.php/webdav'));
+      expect(interceptor.shouldInterceptRequest(request), isFalse);
+    });
+
+    test(
+      'removes cookie header on dart vm',
+      () async {
+        final interceptor = CSRFInterceptor(
+          client: _FakeClient(),
+          baseURL: Uri.https('example.com', '/nextcloud'),
+        );
+
+        final request = Request('GET', Uri.https('example.com', '/nextcloud/remote.php/webdav'))
+          ..headers['cookie'] = 'key=value';
+
+        expect(
+          interceptor.interceptRequest(request: request),
+          completion(
+            isA<Request>().having(
+              (r) => r.headers,
+              'headers',
+              isNot(contains('cookie')),
+            ),
+          ),
+        );
+
+        expect(interceptor.token, isNull);
+      },
+      onPlatform: const {
+        'browser': [Skip()],
+      },
+    );
+
+    test(
+      'requests and attaches a new token on web ',
+      () async {
+        final mockedClient = MockClient((request) async {
+          return Response('data-requesttoken="token"', 200);
+        });
+
+        final interceptor = CSRFInterceptor(
+          client: mockedClient,
+          baseURL: Uri.https('example.com', '/nextcloud'),
+        );
+
+        final request = Request('GET', Uri.https('example.com', '/nextcloud/remote.php/webdav'));
+
+        await interceptor.interceptRequest(request: request);
+
+        expect(
+          request.headers,
+          equals({
+            'OCS-APIRequest': 'true',
+            'requesttoken': 'token',
+          }),
+        );
+        expect(interceptor.token, equals('token'));
+      },
+      onPlatform: const {
+        'dart-vm': [Skip()],
+      },
+    );
+
+    test(
+      'attaches cached token on web',
+      () async {
+        final interceptor = CSRFInterceptor(
+          client: _FakeClient(),
+          baseURL: Uri.https('example.com', '/nextcloud'),
+        )..token = 'token';
+
+        final request = Request('GET', Uri.https('example.com', '/nextcloud/remote.php/webdav'));
+
+        await interceptor.interceptRequest(request: request);
+
+        expect(
+          request.headers,
+          equals({
+            'OCS-APIRequest': 'true',
+            'requesttoken': 'token',
+          }),
+        );
+        expect(interceptor.token, equals('token'));
+      },
+      onPlatform: const {
+        'dart-vm': [Skip()],
+      },
+    );
+
+    test(
+      'throws DynamiteStatusCodeException when token request status code >=300',
+      () async {
+        final mockedClient = MockClient((request) async {
+          return Response('', 404);
+        });
+
+        final interceptor = CSRFInterceptor(
+          client: mockedClient,
+          baseURL: Uri.https('example.com', '/nextcloud'),
+        );
+
+        final request = Request('GET', Uri.https('example.com', '/nextcloud/remote.php/webdav'));
+
+        expect(
+          interceptor.interceptRequest(request: request),
+          throwsA(isA<DynamiteStatusCodeException>()),
+        );
+      },
+      onPlatform: const {
+        'dart-vm': [Skip()],
+      },
+    );
+
+    test(
+      'does intercept response on web with 401 response',
+      () async {
+        final interceptor = CSRFInterceptor(
+          client: _FakeClient(),
+          baseURL: Uri.https('example.com', '/nextcloud'),
+        );
+
+        final response = StreamedResponse(const Stream.empty(), 401);
+        expect(interceptor.shouldInterceptResponse(response), isTrue);
+      },
+      onPlatform: const {
+        'dart-vm': [Skip()],
+      },
+    );
+
+    test(
+      'does not intercept response on web with non 401 response',
+      () {
+        final interceptor = CSRFInterceptor(
+          client: _FakeClient(),
+          baseURL: Uri.https('example.com', '/nextcloud'),
+        );
+
+        final response = StreamedResponse(const Stream.empty(), 200);
+        expect(interceptor.shouldInterceptResponse(response), isFalse);
+        expect(
+          () => interceptor.interceptResponse(response: response, url: Uri()),
+          throwsA(isA<AssertionError>()),
+        );
+      },
+      onPlatform: const {
+        'dart-vm': [Skip()],
+      },
+    );
+
+    test(
+      'does not intercept response on vm',
+      () {
+        final interceptor = CSRFInterceptor(
+          client: _FakeClient(),
+          baseURL: Uri.https('example.com', '/nextcloud'),
+        );
+
+        var response = StreamedResponse(const Stream.empty(), 401);
+        expect(interceptor.shouldInterceptResponse(response), isFalse);
+        expect(
+          () => interceptor.interceptResponse(response: response, url: Uri()),
+          throwsA(isA<AssertionError>()),
+        );
+
+        response = StreamedResponse(const Stream.empty(), 200);
+        expect(interceptor.shouldInterceptResponse(response), isFalse);
+        expect(
+          () => interceptor.interceptResponse(response: response, url: Uri()),
+          throwsA(isA<AssertionError>()),
+        );
+      },
+      onPlatform: const {
+        'browser': [Skip()],
+      },
+    );
+
+    test(
+      'clears token on web with a 401 ',
+      () {
+        final interceptor = CSRFInterceptor(
+          client: _FakeClient(),
+          baseURL: Uri.https('example.com', '/nextcloud'),
+        );
+
+        final response = StreamedResponse(const Stream.empty(), 401);
+        expect(
+          interceptor.interceptResponse(response: response, url: Uri()),
+          equals(response),
+        );
+        expect(
+          interceptor.token,
+          isNull,
+        );
+      },
+      onPlatform: const {
+        'dart-vm': [Skip()],
+      },
+    );
+  });
+}

--- a/packages/neon_http_client/test/neon_http_client_test.dart
+++ b/packages/neon_http_client/test/neon_http_client_test.dart
@@ -40,11 +40,12 @@ void main() {
   group(NeonHttpClient, () {
     test('adds user agent', () {
       client = NeonHttpClient(
+        baseURL: Uri(),
         userAgent: 'NeonTest',
       );
 
       expect(
-        client.interceptors.single,
+        client.interceptors.first,
         isA<BaseHeaderInterceptor>(),
       );
     });
@@ -53,12 +54,27 @@ void main() {
       final cookieStore = _MockCookieStore();
 
       client = NeonHttpClient(
+        baseURL: Uri(),
         cookieStore: cookieStore,
       );
 
       expect(
-        client.interceptors.single,
+        client.interceptors.first,
         isA<CookieStoreInterceptor>(),
+      );
+    });
+
+    test('adds csrf interceptor after cookie store', () {
+      final cookieStore = _MockCookieStore();
+
+      client = NeonHttpClient(
+        baseURL: Uri(),
+        cookieStore: cookieStore,
+      );
+
+      expect(
+        client.interceptors.last,
+        isA<CSRFInterceptor>(),
       );
     });
 
@@ -69,6 +85,7 @@ void main() {
         interceptor = _MockInterceptor();
 
         client = NeonHttpClient(
+          baseURL: Uri(),
           client: mockedClient,
           interceptors: [interceptor],
         );
@@ -160,6 +177,7 @@ void main() {
     group('timeout', () {
       test('does not time out without timeout', () async {
         client = NeonHttpClient(
+          baseURL: Uri(),
           client: MockClient((request) async {
             await Future<void>.delayed(const Duration(milliseconds: 10));
 
@@ -175,6 +193,7 @@ void main() {
 
       test('does time out', () async {
         client = NeonHttpClient(
+          baseURL: Uri(),
           timeLimit: const Duration(milliseconds: 3),
           client: MockClient((request) async {
             await Future<void>.delayed(const Duration(milliseconds: 10));

--- a/packages/nextcloud_test/lib/src/test_client.dart
+++ b/packages/nextcloud_test/lib/src/test_client.dart
@@ -46,7 +46,14 @@ extension TestNextcloudClient on NextcloudClient {
       appPassword = (result.stdout as String).split('\n')[1];
     }
 
+    final url = Uri(
+      scheme: 'http',
+      host: 'localhost',
+      port: container.port,
+    );
+
     final httpClient = NeonHttpClient(
+      baseURL: url,
       cookieStore: CookieStore(),
       client: getProxyHttpClient(
         onRequest: appendFixture,
@@ -54,11 +61,7 @@ extension TestNextcloudClient on NextcloudClient {
     );
 
     return NextcloudClient(
-      Uri(
-        scheme: 'http',
-        host: 'localhost',
-        port: container.port,
-      ),
+      url,
       loginName: username,
       password: username,
       appPassword: appPassword,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,3 +10,4 @@ dev_dependencies:
   husky: ^0.1.7
   melos: ^6.0.0
   custom_lint: ^0.6.4
+  coverage: ^1.8.0


### PR DESCRIPTION
The coverage is a bit different from the one reported by the `flutter_test` package, as they both use different coverage collectors.

Let's hope it won't be too off from the current one