### PR TITLE
feat(neon_talk): Allow using message actions on touch-only devices

### DIFF
--- a/packages/neon/neon_talk/lib/src/widgets/message.dart
+++ b/packages/neon/neon_talk/lib/src/widgets/message.dart
@@ -26,6 +26,9 @@ import 'package:timezone/timezone.dart' as tz;
 final _timeFormat = DateFormat.jm();
 final _dateTimeFormat = DateFormat.yMd().add_jm();
 
+/// Action that can be performed on a [TalkCommentMessage].
+typedef TalkMessageAction = ({Widget icon, Widget child, VoidCallback onPressed});
+
 /// Returns the display name of the actor of the [chatMessage].
 ///
 /// In case the actor is a guest and has no display name set a default display name will be returned.
@@ -609,57 +612,56 @@ class _TalkCommentMessageState extends State<TalkCommentMessage> {
         );
 
         if (!widget.isParent) {
-          message = MouseRegion(
-            onEnter: (_) {
-              setState(() {
-                hoverState = true;
-              });
-            },
-            onExit: (_) {
-              setState(() {
-                hoverState = false;
-              });
-            },
-            child: Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(5),
-                color: (hoverState || menuOpen) ? Theme.of(context).colorScheme.surfaceDim : null,
-              ),
-              padding: const EdgeInsets.all(5),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.only(right: 10),
-                    child: SizedBox(
-                      width: 40,
-                      child: avatar,
-                    ),
+          final actions = _buildMessageActions(widget.room, widget.chatMessage);
+
+          message = Padding(
+            padding: const EdgeInsets.all(5),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(right: 10),
+                  child: SizedBox(
+                    width: 40,
+                    child: avatar,
                   ),
-                  Expanded(
-                    child: message,
+                ),
+                Expanded(
+                  child: message,
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(left: 5),
+                  child: SizedBox(
+                    width: 14,
+                    child: readIndicator,
                   ),
-                  Padding(
-                    padding: const EdgeInsets.only(left: 5),
-                    child: SizedBox(
-                      width: 14,
-                      child: readIndicator,
-                    ),
-                  ),
-                  SizedBox.square(
-                    dimension: 32,
-                    child:
-                        widget.chatMessage.messageType != spreed.MessageType.commentDeleted && (hoverState || menuOpen)
-                            ? _buildPopupMenuButton(
-                                widget.room,
-                                widget.chatMessage,
-                              )
-                            : null,
-                  ),
-                ],
-              ),
+                ),
+                SizedBox.square(
+                  dimension: 32,
+                  child: actions.isNotEmpty && (hoverState || menuOpen) ? _buildPopupMenuButton(actions) : null,
+                ),
+              ],
             ),
           );
+
+          if (actions.isNotEmpty) {
+            message = MouseRegion(
+              onEnter: (_) {
+                setState(() {
+                  hoverState = true;
+                });
+              },
+              onExit: (_) {
+                setState(() {
+                  hoverState = false;
+                });
+              },
+              child: InkWell(
+                onLongPress: () async => _showActionsModal(actions),
+                child: message,
+              ),
+            );
+          }
         }
 
         return Container(
@@ -673,7 +675,7 @@ class _TalkCommentMessageState extends State<TalkCommentMessage> {
     );
   }
 
-  Widget? _buildPopupMenuButton(
+  List<TalkMessageAction> _buildMessageActions(
     spreed.Room room,
     spreed.$ChatMessageInterface chatMessage,
   ) {
@@ -681,10 +683,14 @@ class _TalkCommentMessageState extends State<TalkCommentMessage> {
     final permissions = spreed.ParticipantPermission.values.byBinary(room.permissions);
     final hasChatPermission = permissions.contains(spreed.ParticipantPermission.canSendMessageAndShareAndReact);
 
-    final children = [
-      if (chatMessage.isReplyable && !readOnly && hasChatPermission)
-        MenuItemButton(
-          leadingIcon: const Icon(Icons.add_reaction_outlined),
+    return [
+      if (widget.chatMessage.messageType != spreed.MessageType.commentDeleted &&
+          chatMessage.isReplyable &&
+          !readOnly &&
+          hasChatPermission)
+        (
+          icon: const Icon(Icons.add_reaction_outlined),
+          child: Text(TalkLocalizations.of(context).roomMessageReaction),
           onPressed: () async {
             final reaction = await showDialog<String>(
               context: context,
@@ -701,51 +707,49 @@ class _TalkCommentMessageState extends State<TalkCommentMessage> {
             // ignore: use_build_context_synchronously
             NeonProvider.of<TalkRoomBloc>(context).addReaction(chatMessage, reaction);
           },
-          child: Text(TalkLocalizations.of(context).roomMessageReaction),
         ),
-      if (chatMessage.isReplyable && !readOnly && hasChatPermission)
-        MenuItemButton(
-          leadingIcon: const Icon(Icons.reply),
+      if (widget.chatMessage.messageType != spreed.MessageType.commentDeleted &&
+          chatMessage.isReplyable &&
+          !readOnly &&
+          hasChatPermission)
+        (
+          icon: const Icon(Icons.reply),
           child: Text(TalkLocalizations.of(context).roomMessageReply),
-          onPressed: () {
-            setState(() {
-              menuOpen = false;
-            });
-
-            NeonProvider.of<TalkRoomBloc>(context).setReplyChatMessage(chatMessage);
-          },
+          onPressed: () => NeonProvider.of<TalkRoomBloc>(context).setReplyChatMessage(chatMessage),
         ),
       if (chatMessage.messageType != spreed.MessageType.commentDeleted &&
           chatMessage.actorId == room.actorId &&
           hasFeature(context, 'edit-messages'))
-        MenuItemButton(
-          leadingIcon: const Icon(Icons.edit),
+        (
+          icon: const Icon(Icons.edit),
           child: Text(TalkLocalizations.of(context).roomMessageEdit),
-          onPressed: () {
-            setState(() {
-              menuOpen = false;
-            });
-
-            NeonProvider.of<TalkRoomBloc>(context).setEditChatMessage(chatMessage);
-          },
+          onPressed: () => NeonProvider.of<TalkRoomBloc>(context).setEditChatMessage(chatMessage),
         ),
       if (chatMessage.messageType != spreed.MessageType.commentDeleted && chatMessage.actorId == room.actorId)
-        MenuItemButton(
-          leadingIcon: const Icon(Icons.delete_forever),
+        (
+          icon: const Icon(Icons.delete_forever),
           child: Text(TalkLocalizations.of(context).roomMessageDelete),
-          onPressed: () {
-            setState(() {
-              menuOpen = false;
-            });
-
-            NeonProvider.of<TalkRoomBloc>(context).deleteMessage(chatMessage);
-          },
+          onPressed: () => NeonProvider.of<TalkRoomBloc>(context).deleteMessage(chatMessage),
         ),
     ];
+  }
 
-    if (children.isEmpty) {
-      return null;
-    }
+  Widget? _buildPopupMenuButton(List<TalkMessageAction> actions) {
+    final children = actions
+        .map(
+          (action) => MenuItemButton(
+            leadingIcon: action.icon,
+            onPressed: () {
+              setState(() {
+                menuOpen = false;
+              });
+
+              action.onPressed();
+            },
+            child: action.child,
+          ),
+        )
+        .toList();
 
     return MenuAnchor(
       menuChildren: children,
@@ -769,6 +773,43 @@ class _TalkCommentMessageState extends State<TalkCommentMessage> {
         },
         padding: const EdgeInsets.all(4),
         icon: const Icon(Icons.more_vert),
+      ),
+    );
+  }
+
+  Future<void> _showActionsModal(List<TalkMessageAction> actions) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: Align(
+                  alignment: AlignmentDirectional.centerStart,
+                  child: TalkParentMessage(
+                    room: widget.room,
+                    parentChatMessage: widget.chatMessage,
+                    lastCommonRead: widget.lastCommonRead,
+                  ),
+                ),
+              ),
+              for (final action in actions)
+                ListTile(
+                  leading: action.icon,
+                  title: action.child,
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    action.onPressed();
+                  },
+                ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/packages/neon/neon_talk/test/message_test.dart
+++ b/packages/neon/neon_talk/test/message_test.dart
@@ -87,6 +87,8 @@ core.OcsGetCapabilitiesResponseApplicationJson_Ocs_Data buildCapabilities(core.S
 void main() {
   late spreed.Room room;
   late ReferencesBloc referencesBloc;
+  late CapabilitiesBloc capabilitiesBloc;
+  late core.SpreedCapabilities capabilities;
 
   setUpAll(() {
     FakeNeonStorage.setup();
@@ -99,10 +101,61 @@ void main() {
 
   setUp(() {
     room = MockRoom();
+    when(() => room.readOnly).thenReturn(0);
+    when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
+    when(() => room.actorId).thenReturn('test');
 
     referencesBloc = MockReferencesBloc();
     when(() => referencesBloc.referenceRegex).thenAnswer((_) => BehaviorSubject.seeded(Result.success(null)));
     when(() => referencesBloc.references).thenAnswer((_) => BehaviorSubject.seeded(BuiltMap()));
+
+    capabilities = core.SpreedCapabilities(
+      (b) => b
+        ..features.replace(['edit-messages'])
+        ..config.update(
+          (b) => b
+            ..attachments.update(
+              (b) => b.allowed = false,
+            )
+            ..call.update(
+              (b) => b
+                ..enabled = false
+                ..breakoutRooms = false
+                ..recording = false
+                ..recordingConsent = 0
+                ..canUploadBackground = false
+                ..sipEnabled = false
+                ..sipDialoutEnabled = false
+                ..canEnableSip = false,
+            )
+            ..chat.update(
+              (b) => b
+                ..maxLength = 0
+                ..readPrivacy = 0
+                ..hasTranslationProviders = false
+                ..typingPrivacy = 0,
+            )
+            ..conversations.update(
+              (b) => b.canCreate = false,
+            )
+            ..previews.update(
+              (b) => b..maxGifSize = 0,
+            )
+            ..signaling.update(
+              (b) => b..sessionPingLimit = 0,
+            ),
+        )
+        ..version = '',
+    );
+
+    capabilitiesBloc = MockCapabilitiesBloc();
+    when(() => capabilitiesBloc.capabilities).thenAnswer(
+      (_) => BehaviorSubject.seeded(
+        Result.success(
+          buildCapabilities(capabilities),
+        ),
+      ),
+    );
   });
 
   group('getActorDisplayName', () {
@@ -275,6 +328,7 @@ void main() {
       when(() => chatMessage.message).thenReturn('');
       when(() => chatMessage.reactions).thenReturn(BuiltMap());
       when(() => chatMessage.messageParameters).thenReturn(BuiltMap());
+      when(() => chatMessage.isReplyable).thenReturn(true);
 
       final roomBloc = MockRoomBloc();
       when(() => roomBloc.reactions).thenAnswer((_) => BehaviorSubject.seeded(BuiltMap()));
@@ -285,6 +339,7 @@ void main() {
             Provider<Account>.value(value: account),
             NeonProvider<TalkRoomBloc>.value(value: roomBloc),
             NeonProvider<ReferencesBloc>.value(value: referencesBloc),
+            NeonProvider<CapabilitiesBloc>.value(value: capabilitiesBloc),
           ],
           child: TalkMessage(
             room: room,
@@ -398,6 +453,7 @@ void main() {
       when(() => chatMessage.reactions).thenReturn(BuiltMap({'😀': 1, '😊': 23}));
       when(() => chatMessage.messageParameters).thenReturn(BuiltMap());
       when(() => chatMessage.id).thenReturn(0);
+      when(() => chatMessage.isReplyable).thenReturn(true);
 
       final roomBloc = MockRoomBloc();
       when(() => roomBloc.reactions).thenAnswer((_) => BehaviorSubject.seeded(BuiltMap()));
@@ -408,6 +464,7 @@ void main() {
             Provider<Account>.value(value: account),
             NeonProvider<TalkRoomBloc>.value(value: roomBloc),
             NeonProvider<ReferencesBloc>.value(value: referencesBloc),
+            NeonProvider<CapabilitiesBloc>.value(value: capabilitiesBloc),
           ],
           child: TalkCommentMessage(
             room: room,
@@ -452,6 +509,7 @@ void main() {
       when(() => chatMessage.reactions).thenReturn(BuiltMap({'😀': 1, '😊': 23}));
       when(() => chatMessage.messageParameters).thenReturn(BuiltMap());
       when(() => chatMessage.id).thenReturn(0);
+      when(() => chatMessage.isReplyable).thenReturn(true);
 
       final roomBloc = MockRoomBloc();
       when(() => roomBloc.reactions).thenAnswer((_) => BehaviorSubject.seeded(BuiltMap()));
@@ -462,6 +520,7 @@ void main() {
             Provider<Account>.value(value: account),
             NeonProvider<TalkRoomBloc>.value(value: roomBloc),
             NeonProvider<ReferencesBloc>.value(value: referencesBloc),
+            NeonProvider<CapabilitiesBloc>.value(value: capabilitiesBloc),
           ],
           child: TalkCommentMessage(
             room: room,
@@ -504,12 +563,14 @@ void main() {
       when(() => chatMessage.message).thenReturn('abc');
       when(() => chatMessage.reactions).thenReturn(BuiltMap());
       when(() => chatMessage.messageParameters).thenReturn(BuiltMap());
+      when(() => chatMessage.isReplyable).thenReturn(true);
 
       await tester.pumpWidgetWithAccessibility(
         wrapWidget(
           providers: [
             Provider<Account>.value(value: account),
             NeonProvider<ReferencesBloc>.value(value: referencesBloc),
+            NeonProvider<CapabilitiesBloc>.value(value: capabilitiesBloc),
           ],
           child: TalkCommentMessage(
             room: room,
@@ -597,6 +658,7 @@ void main() {
       when(() => chatMessage.reactions).thenReturn(BuiltMap());
       when(() => chatMessage.parent).thenReturn(parentChatMessage);
       when(() => chatMessage.messageParameters).thenReturn(BuiltMap());
+      when(() => chatMessage.isReplyable).thenReturn(true);
 
       final roomBloc = MockRoomBloc();
       when(() => roomBloc.reactions).thenAnswer((_) => BehaviorSubject.seeded(BuiltMap()));
@@ -607,6 +669,7 @@ void main() {
             Provider<Account>.value(value: account),
             NeonProvider<TalkRoomBloc>.value(value: roomBloc),
             NeonProvider<ReferencesBloc>.value(value: referencesBloc),
+            NeonProvider<CapabilitiesBloc>.value(value: capabilitiesBloc),
           ],
           child: TalkCommentMessage(
             room: room,
@@ -668,6 +731,7 @@ void main() {
       when(() => chatMessage.message).thenReturn('a b c');
       when(() => chatMessage.reactions).thenReturn(BuiltMap());
       when(() => chatMessage.messageParameters).thenReturn(BuiltMap());
+      when(() => chatMessage.isReplyable).thenReturn(true);
 
       final roomBloc = MockRoomBloc();
       when(() => roomBloc.reactions).thenAnswer((_) => BehaviorSubject.seeded(BuiltMap()));
@@ -678,6 +742,7 @@ void main() {
             Provider<Account>.value(value: account),
             NeonProvider<TalkRoomBloc>.value(value: roomBloc),
             NeonProvider<ReferencesBloc>.value(value: referencesBloc),
+            NeonProvider<CapabilitiesBloc>.value(value: capabilitiesBloc),
           ],
           child: TalkCommentMessage(
             room: room,
@@ -726,6 +791,7 @@ void main() {
         when(() => chatMessage.message).thenReturn('abc');
         when(() => chatMessage.reactions).thenReturn(BuiltMap({'😀': 1, '😊': 23}));
         when(() => chatMessage.messageParameters).thenReturn(BuiltMap());
+        when(() => chatMessage.isReplyable).thenReturn(true);
 
         final roomBloc = MockRoomBloc();
         when(() => roomBloc.reactions).thenAnswer((_) => BehaviorSubject.seeded(BuiltMap()));
@@ -736,6 +802,7 @@ void main() {
               Provider<Account>.value(value: account),
               NeonProvider<TalkRoomBloc>.value(value: roomBloc),
               NeonProvider<ReferencesBloc>.value(value: referencesBloc),
+              NeonProvider<CapabilitiesBloc>.value(value: capabilitiesBloc),
             ],
             child: TalkCommentMessage(
               room: room,
@@ -777,6 +844,7 @@ void main() {
         when(() => chatMessage.message).thenReturn('abc');
         when(() => chatMessage.reactions).thenReturn(BuiltMap({'😀': 1, '😊': 23}));
         when(() => chatMessage.messageParameters).thenReturn(BuiltMap());
+        when(() => chatMessage.isReplyable).thenReturn(true);
 
         final roomBloc = MockRoomBloc();
         when(() => roomBloc.reactions).thenAnswer((_) => BehaviorSubject.seeded(BuiltMap()));
@@ -787,6 +855,7 @@ void main() {
               Provider<Account>.value(value: account),
               NeonProvider<TalkRoomBloc>.value(value: roomBloc),
               NeonProvider<ReferencesBloc>.value(value: referencesBloc),
+              NeonProvider<CapabilitiesBloc>.value(value: capabilitiesBloc),
             ],
             child: TalkCommentMessage(
               room: room,
@@ -827,6 +896,7 @@ void main() {
         when(() => chatMessage.message).thenReturn('abc');
         when(() => chatMessage.reactions).thenReturn(BuiltMap({'😀': 1, '😊': 23}));
         when(() => chatMessage.messageParameters).thenReturn(BuiltMap());
+        when(() => chatMessage.isReplyable).thenReturn(true);
 
         final roomBloc = MockRoomBloc();
         when(() => roomBloc.reactions).thenAnswer((_) => BehaviorSubject.seeded(BuiltMap()));
@@ -837,6 +907,7 @@ void main() {
               Provider<Account>.value(value: account),
               NeonProvider<TalkRoomBloc>.value(value: roomBloc),
               NeonProvider<ReferencesBloc>.value(value: referencesBloc),
+              NeonProvider<CapabilitiesBloc>.value(value: capabilitiesBloc),
             ],
             child: TalkCommentMessage(
               room: room,
@@ -880,6 +951,7 @@ void main() {
         when(() => chatMessage.messageParameters).thenReturn(BuiltMap());
         when(() => chatMessage.lastEditTimestamp).thenReturn(0);
         when(() => chatMessage.lastEditActorDisplayName).thenReturn('test');
+        when(() => chatMessage.isReplyable).thenReturn(true);
 
         final roomBloc = MockRoomBloc();
         when(() => roomBloc.reactions).thenAnswer((_) => BehaviorSubject.seeded(BuiltMap()));
@@ -890,6 +962,7 @@ void main() {
               Provider<Account>.value(value: account),
               NeonProvider<TalkRoomBloc>.value(value: roomBloc),
               NeonProvider<ReferencesBloc>.value(value: referencesBloc),
+              NeonProvider<CapabilitiesBloc>.value(value: capabilitiesBloc),
             ],
             child: TalkCommentMessage(
               room: room,
@@ -919,8 +992,6 @@ void main() {
       late Account account;
       late spreed.ChatMessage chatMessage;
       late TalkRoomBloc roomBloc;
-      late core.SpreedCapabilities capabilities;
-      late CapabilitiesBloc capabilitiesBloc;
 
       setUp(() {
         account = MockAccount();
@@ -942,63 +1013,11 @@ void main() {
 
         roomBloc = MockRoomBloc();
         when(() => roomBloc.reactions).thenAnswer((_) => BehaviorSubject.seeded(BuiltMap()));
-
-        capabilities = core.SpreedCapabilities(
-          (b) => b
-            ..features.replace(['edit-messages'])
-            ..config.update(
-              (b) => b
-                ..attachments.update(
-                  (b) => b.allowed = false,
-                )
-                ..call.update(
-                  (b) => b
-                    ..enabled = false
-                    ..breakoutRooms = false
-                    ..recording = false
-                    ..recordingConsent = 0
-                    ..canUploadBackground = false
-                    ..sipEnabled = false
-                    ..sipDialoutEnabled = false
-                    ..canEnableSip = false,
-                )
-                ..chat.update(
-                  (b) => b
-                    ..maxLength = 0
-                    ..readPrivacy = 0
-                    ..hasTranslationProviders = false
-                    ..typingPrivacy = 0,
-                )
-                ..conversations.update(
-                  (b) => b.canCreate = false,
-                )
-                ..previews.update(
-                  (b) => b..maxGifSize = 0,
-                )
-                ..signaling.update(
-                  (b) => b..sessionPingLimit = 0,
-                ),
-            )
-            ..version = '',
-        );
-
-        capabilitiesBloc = MockCapabilitiesBloc();
-        when(() => capabilitiesBloc.capabilities).thenAnswer(
-          (_) => BehaviorSubject.seeded(
-            Result.success(
-              buildCapabilities(capabilities),
-            ),
-          ),
-        );
       });
 
       group('Add reaction', () {
         testWidgets('Allowed', (tester) async {
           SharedPreferences.setMockInitialValues({});
-
-          when(() => room.readOnly).thenReturn(0);
-          when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
-          when(() => room.actorId).thenReturn('test');
 
           await tester.pumpWidgetWithAccessibility(
             wrapWidget(
@@ -1022,10 +1041,8 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           await tester.tap(find.byIcon(Icons.more_vert));
           await tester.pumpAndSettle();
-
           await tester.runAsync(() async {
             await tester.tap(find.byIcon(Icons.add_reaction_outlined));
             await tester.pumpAndSettle();
@@ -1033,7 +1050,19 @@ void main() {
             await tester.pumpAndSettle();
             await tester.tap(find.text('😂'));
             await tester.pumpAndSettle();
+            verify(() => roomBloc.addReaction(chatMessage, '😂')).called(1);
+          });
 
+          await tester.longPress(find.byType(TalkCommentMessage));
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsOne);
+          await tester.runAsync(() async {
+            await tester.tap(find.byIcon(Icons.add_reaction_outlined));
+            await tester.pumpAndSettle();
+            await tester.tap(find.byIcon(Icons.tag_faces));
+            await tester.pumpAndSettle();
+            await tester.tap(find.text('😂'));
+            await tester.pumpAndSettle();
             verify(() => roomBloc.addReaction(chatMessage, '😂')).called(1);
           });
         });
@@ -1042,8 +1071,6 @@ void main() {
           SharedPreferences.setMockInitialValues({});
 
           when(() => room.readOnly).thenReturn(1);
-          when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
-          when(() => room.actorId).thenReturn('test');
 
           await tester.pumpWidgetWithAccessibility(
             wrapWidget(
@@ -1067,18 +1094,20 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           await tester.tap(find.byIcon(Icons.more_vert));
           await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.add_reaction_outlined), findsNothing);
+
+          await tester.longPress(find.byType(TalkCommentMessage));
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsOne);
           expect(find.byIcon(Icons.add_reaction_outlined), findsNothing);
         });
 
         testWidgets('No permission', (tester) async {
           SharedPreferences.setMockInitialValues({});
 
-          when(() => room.readOnly).thenReturn(0);
           when(() => room.permissions).thenReturn(0);
-          when(() => room.actorId).thenReturn('test');
 
           await tester.pumpWidgetWithAccessibility(
             wrapWidget(
@@ -1102,19 +1131,19 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           await tester.tap(find.byIcon(Icons.more_vert));
           await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.add_reaction_outlined), findsNothing);
+
+          await tester.longPress(find.byType(TalkCommentMessage));
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsOne);
           expect(find.byIcon(Icons.add_reaction_outlined), findsNothing);
         });
       });
 
       group('Reply', () {
         testWidgets('Allowed', (tester) async {
-          when(() => room.readOnly).thenReturn(0);
-          when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
-          when(() => room.actorId).thenReturn('test');
-
           await tester.pumpWidgetWithAccessibility(
             wrapWidget(
               providers: [
@@ -1137,22 +1166,26 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           await tester.tap(find.byIcon(Icons.more_vert));
           await tester.pumpAndSettle();
-
           await tester.runAsync(() async {
             await tester.tap(find.byIcon(Icons.reply));
             await tester.pumpAndSettle();
+            verify(() => roomBloc.setReplyChatMessage(chatMessage)).called(1);
+          });
 
+          await tester.longPress(find.byType(TalkCommentMessage));
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsOne);
+          await tester.runAsync(() async {
+            await tester.tap(find.byIcon(Icons.reply));
+            await tester.pumpAndSettle();
             verify(() => roomBloc.setReplyChatMessage(chatMessage)).called(1);
           });
         });
 
         testWidgets('Read-only', (tester) async {
           when(() => room.readOnly).thenReturn(1);
-          when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
-          when(() => room.actorId).thenReturn('test');
 
           await tester.pumpWidgetWithAccessibility(
             wrapWidget(
@@ -1176,16 +1209,18 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           await tester.tap(find.byIcon(Icons.more_vert));
           await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.reply), findsNothing);
+
+          await tester.longPress(find.byType(TalkCommentMessage));
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsOne);
           expect(find.byIcon(Icons.reply), findsNothing);
         });
 
         testWidgets('No permission', (tester) async {
-          when(() => room.readOnly).thenReturn(0);
           when(() => room.permissions).thenReturn(0);
-          when(() => room.actorId).thenReturn('test');
 
           await tester.pumpWidgetWithAccessibility(
             wrapWidget(
@@ -1209,19 +1244,19 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           await tester.tap(find.byIcon(Icons.more_vert));
           await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.reply), findsNothing);
+
+          await tester.longPress(find.byType(TalkCommentMessage));
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsOne);
           expect(find.byIcon(Icons.reply), findsNothing);
         });
       });
 
       group('Edit', () {
         testWidgets('Comment self', (tester) async {
-          when(() => room.readOnly).thenReturn(0);
-          when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
-          when(() => room.actorId).thenReturn('test');
-
           await tester.pumpWidgetWithAccessibility(
             wrapWidget(
               providers: [
@@ -1244,21 +1279,25 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           await tester.tap(find.byIcon(Icons.more_vert));
           await tester.pumpAndSettle();
-
           await tester.runAsync(() async {
             await tester.tap(find.byIcon(Icons.edit));
             await tester.pumpAndSettle();
+            verify(() => roomBloc.setEditChatMessage(chatMessage)).called(1);
+          });
 
+          await tester.longPress(find.byType(TalkCommentMessage));
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsOne);
+          await tester.runAsync(() async {
+            await tester.tap(find.byIcon(Icons.edit));
+            await tester.pumpAndSettle();
             verify(() => roomBloc.setEditChatMessage(chatMessage)).called(1);
           });
         });
 
         testWidgets('Comment other', (tester) async {
-          when(() => room.readOnly).thenReturn(0);
-          when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
           when(() => room.actorId).thenReturn('other');
 
           await tester.pumpWidgetWithAccessibility(
@@ -1283,17 +1322,17 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           await tester.tap(find.byIcon(Icons.more_vert));
           await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.edit), findsNothing);
 
+          await tester.longPress(find.byType(TalkCommentMessage));
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsOne);
           expect(find.byIcon(Icons.edit), findsNothing);
         });
 
         testWidgets('Deleted', (tester) async {
-          when(() => room.readOnly).thenReturn(0);
-          when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
-
           when(() => chatMessage.messageType).thenReturn(spreed.MessageType.commentDeleted);
 
           await tester.pumpWidgetWithAccessibility(
@@ -1318,15 +1357,14 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           expect(find.byIcon(Icons.more_vert), findsNothing);
+
+          await tester.longPress(find.byType(TalkCommentMessage), warnIfMissed: false);
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsNothing);
         });
 
         testWidgets('No feature', (tester) async {
-          when(() => room.readOnly).thenReturn(0);
-          when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
-          when(() => room.actorId).thenReturn('test');
-
           capabilities = capabilities.rebuild((b) => b.features.clear());
 
           await tester.pumpWidgetWithAccessibility(
@@ -1351,20 +1389,19 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           await tester.tap(find.byIcon(Icons.more_vert));
           await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.edit), findsNothing);
 
+          await tester.longPress(find.byType(TalkCommentMessage));
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsOne);
           expect(find.byIcon(Icons.edit), findsNothing);
         });
       });
 
       group('Delete', () {
         testWidgets('Comment self', (tester) async {
-          when(() => room.readOnly).thenReturn(0);
-          when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
-          when(() => room.actorId).thenReturn('test');
-
           await tester.pumpWidgetWithAccessibility(
             wrapWidget(
               providers: [
@@ -1387,21 +1424,25 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           await tester.tap(find.byIcon(Icons.more_vert));
           await tester.pumpAndSettle();
-
           await tester.runAsync(() async {
             await tester.tap(find.byIcon(Icons.delete_forever));
             await tester.pumpAndSettle();
+            verify(() => roomBloc.deleteMessage(chatMessage)).called(1);
+          });
 
+          await tester.longPress(find.byType(TalkCommentMessage));
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsOne);
+          await tester.runAsync(() async {
+            await tester.tap(find.byIcon(Icons.delete_forever));
+            await tester.pumpAndSettle();
             verify(() => roomBloc.deleteMessage(chatMessage)).called(1);
           });
         });
 
         testWidgets('Comment other', (tester) async {
-          when(() => room.readOnly).thenReturn(0);
-          when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
           when(() => room.actorId).thenReturn('other');
 
           await tester.pumpWidgetWithAccessibility(
@@ -1426,17 +1467,17 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           await tester.tap(find.byIcon(Icons.more_vert));
           await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.delete_forever), findsNothing);
 
+          await tester.longPress(find.byType(TalkCommentMessage));
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsOne);
           expect(find.byIcon(Icons.delete_forever), findsNothing);
         });
 
         testWidgets('Deleted', (tester) async {
-          when(() => room.readOnly).thenReturn(0);
-          when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
-
           when(() => chatMessage.messageType).thenReturn(spreed.MessageType.commentDeleted);
 
           await tester.pumpWidgetWithAccessibility(
@@ -1461,8 +1502,11 @@ void main() {
           await tester.pump();
           await gesture.moveTo(tester.getCenter(find.byType(TalkCommentMessage)));
           await tester.pumpAndSettle();
-
           expect(find.byIcon(Icons.more_vert), findsNothing);
+
+          await tester.longPress(find.byType(TalkCommentMessage), warnIfMissed: false);
+          await tester.pumpAndSettle();
+          expect(find.byType(BottomSheet), findsNothing);
         });
       });
     });

--- a/packages/neon/neon_talk/test/room_page_test.dart
+++ b/packages/neon/neon_talk/test/room_page_test.dart
@@ -46,6 +46,7 @@ void main() {
     when(() => room.isCustomAvatar).thenReturn(false);
     when(() => room.type).thenReturn(spreed.RoomType.group.value);
     when(() => room.actorId).thenReturn('');
+    when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
 
     bloc = MockRoomBloc();
     when(() => bloc.errors).thenAnswer((_) => StreamController<Object>().stream);
@@ -120,6 +121,7 @@ void main() {
     when(() => chatMessage1.reactions).thenReturn(BuiltMap());
     when(() => chatMessage1.messageParameters).thenReturn(BuiltMap());
     when(() => chatMessage1.systemMessage).thenReturn('');
+    when(() => chatMessage1.isReplyable).thenReturn(true);
 
     final chatMessage2 = MockChatMessageWithParent();
     when(() => chatMessage2.id).thenReturn(2);
@@ -132,6 +134,7 @@ void main() {
     when(() => chatMessage2.reactions).thenReturn(BuiltMap());
     when(() => chatMessage2.messageParameters).thenReturn(BuiltMap());
     when(() => chatMessage2.systemMessage).thenReturn('');
+    when(() => chatMessage2.isReplyable).thenReturn(true);
 
     final chatMessage3 = MockChatMessageWithParent();
     when(() => chatMessage3.id).thenReturn(3);
@@ -144,6 +147,7 @@ void main() {
     when(() => chatMessage3.reactions).thenReturn(BuiltMap());
     when(() => chatMessage3.messageParameters).thenReturn(BuiltMap());
     when(() => chatMessage3.systemMessage).thenReturn('');
+    when(() => chatMessage3.isReplyable).thenReturn(true);
 
     when(() => bloc.messages).thenAnswer(
       (_) => BehaviorSubject.seeded(


### PR DESCRIPTION
Closes https://github.com/nextcloud/neon/issues/2314

I could go even further and detect if the device doesn't have any mouse attached and then omit the button entirely (instead of whitespace), which would give more space to the message itself. This would probably be a win, since touch devices usually have smaller screens and can make use of the extra space. What do you think?