### PR TITLE
ci: Lint code with downgraded dependencies

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -79,3 +79,9 @@ jobs:
           melos exec --file-exists="coverage/lcov.info" --concurrency=1 -- "
             codecov --verbose upload-process --fail-on-error -F MELOS_PACKAGE_NAME -f MELOS_PACKAGE_PATH/coverage/lcov.info -t ${{ secrets.CODECOV_TOKEN }}
           "
+
+      # Run as the last step to avoid running any other steps with downgraded dependencies
+      - name: Lint code with downgraded dependencies
+        run: |
+          melos exec dart pub downgrade
+          melos run analyze

--- a/packages/neon/neon_news/pubspec.yaml
+++ b/packages/neon/neon_news/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   rxdart: ^0.27.0
   share_plus: ^10.0.0
   timezone: ^0.9.4
-  url_launcher: ^6.0.0
+  url_launcher: ^6.1.4
   wakelock_plus: ^1.0.0
   webview_flutter: ^4.0.0
 

--- a/packages/neon/neon_notes/pubspec.yaml
+++ b/packages/neon/neon_notes/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   queue: ^3.0.0
   rxdart: ^0.27.0
   timezone: ^0.9.4
-  url_launcher: ^6.0.0
+  url_launcher: ^6.1.4
   wakelock_plus: ^1.0.0
 
 dev_dependencies:

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -64,7 +64,7 @@ dependencies:
   unifiedpush: ^5.0.0
   unifiedpush_android: ^2.0.0
   universal_io: ^2.0.0
-  url_launcher: ^6.1.0
+  url_launcher: ^6.1.4
   vector_graphics: ^1.0.0
   web: ^0.5.0
   window_manager: ^0.3.0

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -67,7 +67,7 @@ dependencies:
   url_launcher: ^6.1.4
   vector_graphics: ^1.0.0
   web: ^0.5.0
-  window_manager: ^0.3.0
+  window_manager: ^0.3.8
   xml: ^6.0.0
 
 dev_dependencies:


### PR DESCRIPTION
~~The revert is only there to make the CI fail intentionally.~~
Works as expected: [nextcloud/neon/actions/runs/10235365287/job/28316108288?pr=2346](https://github.com/nextcloud/neon/actions/runs/10235365287/job/28316108288?pr=2346)