### PR TITLE
chore(tool): migrate renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,12 +29,12 @@
         "patch"
       ],
       "matchCurrentVersion": "!/^0/",
-      "excludeDepNames": [
-        "app",
-        "dynamite_end_to_end_test",
-        "dynamite_petstore_example",
-        "neon_lints",
-        "nextcloud_test"
+      "matchDepNames": [
+        "!app",
+        "!dynamite_end_to_end_test",
+        "!dynamite_petstore_example",
+        "!neon_lints",
+        "!nextcloud_test"
       ],
       "enabled": false
     },
@@ -55,19 +55,19 @@
     },
     {
       "groupName": "built_value",
-      "matchPackagePatterns": "^built"
+      "matchPackageNames": ["/^built/"]
     },
     {
       "groupName": "go_router",
-      "matchPackagePatterns": "^go_router"
+      "matchPackageNames": ["/^go_router/"]
     },
     {
       "groupName": "sqflite",
-      "matchPackagePatterns": "^sqflite"
+      "matchPackageNames": ["/^sqflite/"]
     },
     {
       "groupName": "unifiedpush",
-      "matchPackagePatterns": "^unifiedpush"
+      "matchPackageNames": ["/^unifiedpush/"]
     },
     {
       "groupName": "xml_serializable",


### PR DESCRIPTION
Renovate just force pushes https://github.com/nextcloud/neon/pull/2356, so I can remove the unnecessary formatting changes...