### PR TITLE
ci: Pin Dart SDK version

### DIFF
--- a/.github/workflows/conventional_commits.yaml
+++ b/.github/workflows/conventional_commits.yaml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Install dart
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1
+        with:
+          sdk: 3.4
       - name: Install commitlint_cli
         run: dart pub get
 

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Install dart
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1
+        with:
+          sdk: 3.4
       - name: Setup
         run: ./tool/setup.sh
 

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Install dart
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1
+        with:
+          sdk: 3.4
       - name: Setup
         run: ./tool/setup.sh
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Install dart
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1
+        with:
+          sdk: 3.4
       - name: Setup
         run: ./tool/setup.sh
 
@@ -101,6 +103,8 @@ jobs:
 
       - name: Install dart
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1
+        with:
+          sdk: 3.4
       - name: Setup
         run: ./tool/setup.sh
       - name: Build

--- a/.github/workflows/update_presets.yaml
+++ b/.github/workflows/update_presets.yaml
@@ -15,6 +15,8 @@ jobs:
           fetch-depth: 0
       - name: Install dart
         uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672 # v1
+        with:
+          sdk: 3.4
       - name: Setup
         run: ./tool/setup.sh
 


### PR DESCRIPTION
Dart 3.5 allows the analyzer version 6.8.0 which leads to https://github.com/invertase/dart_custom_lint/issues/261: https://github.com/nextcloud/neon/actions/runs/10272580857/job/28425098327?pr=2360
Pinning the version to 3.4 will fix the problem for now, until we use a Flutter version that uses Dart 3.5.