### PR TITLE
test(nextcloud): Fix news fixture not allowing varying hosts

### DIFF
--- a/packages/nextcloud/test/fixtures/news/items/mark_multiple_articles_as_read_and_unread.regexp
+++ b/packages/nextcloud/test/fixtures/news/items/mark_multiple_articles_as_read_and_unread.regexp
@@ -1,4 +1,4 @@
-POST http://localhost/index\.php/apps/news/api/v1-3/feeds\?url=http%3A%2F%2Flocalhost%2Fstatic%2Fwikipedia\.xml
+POST http://localhost/index\.php/apps/news/api/v1-3/feeds\?url=http%3A%2F%2F.*%2Fstatic%2Fwikipedia\.xml
 accept: application/json
 authorization: Basic mock
 GET http://localhost/index\.php/apps/news/api/v1-3/items\?type=6&id=0&getRead=1&batchSize=-1&offset=0&oldestFirst=0

--- a/packages/nextcloud/test/fixtures/news/items/star_and_unstar_multiple_articles.regexp
+++ b/packages/nextcloud/test/fixtures/news/items/star_and_unstar_multiple_articles.regexp
@@ -1,4 +1,4 @@
-POST http://localhost/index\.php/apps/news/api/v1-3/feeds\?url=http%3A%2F%2Flocalhost%2Fstatic%2Fwikipedia\.xml
+POST http://localhost/index\.php/apps/news/api/v1-3/feeds\?url=http%3A%2F%2F.*%2Fstatic%2Fwikipedia\.xml
 accept: application/json
 authorization: Basic mock
 GET http://localhost/index\.php/apps/news/api/v1-3/items\?type=3&id=0&getRead=1&batchSize=-1&offset=0&oldestFirst=0


### PR DESCRIPTION
When testing locally the host is `localhost:8080` and not `localhost`