### PR TITLE
chore(tool): Disable custom_lint

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -36,8 +36,8 @@ scripts:
   format: dart format --fix --line-length 120 .
   format:check: dart format --output=none --set-exit-if-changed --line-length 120 .
   analyze: >
-    dart analyze --fatal-infos . &&
-    dart run custom_lint --fatal-infos .
+    dart analyze --fatal-infos . #&&
+    #dart run custom_lint --fatal-infos .
   test: >
     melos run test:dart &&
     melos run test:flutter

--- a/packages/app/pubspec.lock
+++ b/packages/app/pubspec.lock
@@ -153,22 +153,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
-  ci:
-    dependency: transitive
-    description:
-      name: ci
-      sha256: "145d095ce05cddac4d797a158bc4cf3b6016d1fe63d8c3d2fbd7212590adca13"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.1"
   clock:
     dependency: transitive
     description:
@@ -248,30 +232,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
-  custom_lint:
-    dependency: "direct dev"
-    description:
-      name: custom_lint
-      sha256: "7c0aec12df22f9082146c354692056677f1e70bc43471644d1fdb36c6fdda799"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.4"
-  custom_lint_builder:
-    dependency: transitive
-    description:
-      name: custom_lint_builder
-      sha256: d7dc41e709dde223806660268678be7993559e523eb3164e2a1425fd6f7615a9
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.4"
-  custom_lint_core:
-    dependency: transitive
-    description:
-      name: custom_lint_core
-      sha256: a85e8f78f4c52f6c63cdaf8c872eb573db0231dcdf3c3a5906d493c1f8bc20e6
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.3"
   dart_style:
     dependency: transitive
     description:
@@ -578,14 +538,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.7.0"
-  freezed_annotation:
-    dependency: transitive
-    description:
-      name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.4"
   glob:
     dependency: transitive
     description:
@@ -602,14 +554,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.2.3"
-  hotreloader:
-    dependency: transitive
-    description:
-      name: hotreloader
-      sha256: ed56fdc1f3a8ac924e717257621d09e9ec20e308ab6352a73a50a1d7a4d9158e
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.0"
   html:
     dependency: transitive
     description:

--- a/packages/app/pubspec.yaml
+++ b/packages/app/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   vector_graphics: any
 
 dev_dependencies:
-  custom_lint: ^0.6.4
+  #custom_lint: ^0.6.4
   neon_lints:
     git:
       url: https://github.com/nextcloud/neon

--- a/packages/neon/neon_dashboard/pubspec.yaml
+++ b/packages/neon/neon_dashboard/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  #custom_lint: ^0.6.4
   flutter_test:
     sdk: flutter
   go_router_builder: ^2.7.1

--- a/packages/neon/neon_files/pubspec.yaml
+++ b/packages/neon/neon_files/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  #custom_lint: ^0.6.4
   go_router_builder: ^2.7.1
   neon_lints:
     git:

--- a/packages/neon/neon_news/pubspec.yaml
+++ b/packages/neon/neon_news/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  #custom_lint: ^0.6.4
   go_router_builder: ^2.7.1
   neon_lints:
     git:

--- a/packages/neon/neon_notes/pubspec.yaml
+++ b/packages/neon/neon_notes/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  #custom_lint: ^0.6.4
   go_router_builder: ^2.7.1
   neon_lints:
     git:

--- a/packages/neon/neon_notifications/pubspec.yaml
+++ b/packages/neon/neon_notifications/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  #custom_lint: ^0.6.4
   flutter_test:
     sdk: flutter
   go_router_builder: ^2.7.1

--- a/packages/neon/neon_talk/pubspec.yaml
+++ b/packages/neon/neon_talk/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  #custom_lint: ^0.6.4
   flutter_keyboard_visibility: ^6.0.0
   flutter_test:
     sdk: flutter

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -77,7 +77,7 @@ dev_dependencies:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/cookie_store_conformance_tests
-  custom_lint: ^0.6.4
+  #custom_lint: ^0.6.4
   flutter_test:
     sdk: flutter
   go_router_builder: ^2.7.1

--- a/packages/neon_lints/example/pubspec.yaml
+++ b/packages/neon_lints/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  custom_lint: ^0.6.4
+  #custom_lint: ^0.6.4
   flutter_test:
     sdk: flutter
   meta: ^1.11.0

--- a/packages/neon_lints/lib/neon_lints.dart
+++ b/packages/neon_lints/lib/neon_lints.dart
@@ -1,3 +1,4 @@
+/*
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:neon_lints/src/avoid_dart_html.dart';
 import 'package:neon_lints/src/avoid_dart_io.dart';
@@ -22,3 +23,4 @@ class _NeonLintsPlugin extends PluginBase {
         PreferPumpWidgetWithAccessibility(),
       ];
 }
+*/

--- a/packages/neon_lints/lib/src/avoid_dart_html.dart
+++ b/packages/neon_lints/lib/src/avoid_dart_html.dart
@@ -1,3 +1,4 @@
+/*
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
@@ -26,3 +27,4 @@ final class AvoidDartHTML extends DartLintRule {
     });
   }
 }
+*/

--- a/packages/neon_lints/lib/src/avoid_dart_io.dart
+++ b/packages/neon_lints/lib/src/avoid_dart_io.dart
@@ -1,3 +1,4 @@
+/*
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
@@ -26,3 +27,4 @@ final class AvoidDartIO extends DartLintRule {
     });
   }
 }
+*/

--- a/packages/neon_lints/lib/src/avoid_debug_print.dart
+++ b/packages/neon_lints/lib/src/avoid_debug_print.dart
@@ -1,3 +1,4 @@
+/*
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
@@ -47,3 +48,4 @@ if unsure about the logging level to use.
     });
   }
 }
+*/

--- a/packages/neon_lints/lib/src/avoid_exports.dart
+++ b/packages/neon_lints/lib/src/avoid_exports.dart
@@ -1,3 +1,4 @@
+/*
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
@@ -39,3 +40,4 @@ Neon clients should not have any public api other than the 'AppImplementation'.
     });
   }
 }
+*/

--- a/packages/neon_lints/lib/src/prefer_pump_widget_with_accessibility.dart
+++ b/packages/neon_lints/lib/src/prefer_pump_widget_with_accessibility.dart
@@ -1,3 +1,4 @@
+/*
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
@@ -30,3 +31,4 @@ Use 'pumpWidgetWithAccessibility' instead to perform automatic accessibility gui
     });
   }
 }
+*/

--- a/packages/neon_lints/pubspec.yaml
+++ b/packages/neon_lints/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   analyzer: ^6.4.1
   analyzer_plugin: ^0.11.3
-  custom_lint_builder: ^0.6.2
+  #custom_lint_builder: ^0.6.2
 
 dev_dependencies:
   lint_maker: ^0.2.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,5 +9,5 @@ dev_dependencies:
   fvm: ^3.1.7
   husky: ^0.1.7
   melos: ^6.0.0
-  custom_lint: ^0.6.4
+  #custom_lint: ^0.6.4
   coverage: ^1.9.0


### PR DESCRIPTION
https://github.com/invertase/dart_custom_lint/issues/261 prevents us to upgrade to Dart 3.5/Flutter 3.24.
Once fixed this commit can be reverted.