### PR TITLE
fix(neon_framework): Only request avatars in valid sizes

### DIFF
--- a/packages/neon_framework/lib/src/widgets/user_avatar.dart
+++ b/packages/neon_framework/lib/src/widgets/user_avatar.dart
@@ -62,7 +62,12 @@ class _UserAvatarState extends State<NeonUserAvatar> {
       builder: (context, constraints) {
         final brightness = Theme.of(context).brightness;
         size = constraints.constrain(Size.square(widget.size ?? largeIconSize)).shortestSide;
-        final pixelSize = (size * MediaQuery.of(context).devicePixelRatio).toInt();
+        var pixelSize = (size * MediaQuery.of(context).devicePixelRatio).toInt();
+        if (pixelSize <= 64) {
+          pixelSize = 64;
+        } else {
+          pixelSize = 512;
+        }
 
         final avatar = CircleAvatar(
           radius: size / 2,


### PR DESCRIPTION
The server restricts the valid sizes to 64 and 512: https://github.com/nextcloud/server/blob/21db61817467169d225af1e4a96bb37f9feaf70e/core/Controller/AvatarController.php#L70-L80

To avoid multiple cache entries with the same content we can already apply this limitation on the client side.