### PR TITLE
fix(app): Add custom bootstrapping to bring back web color emojis

### DIFF
--- a/packages/app/web/flutter_bootstrap.js
+++ b/packages/app/web/flutter_bootstrap.js
@@ -1,0 +1,12 @@
+{{flutter_js}}
+{{flutter_build_config}}
+
+_flutter.loader.load({
+    onEntrypointLoaded: async function(engineInitializer) {
+        const appRunner = await engineInitializer.initializeEngine({
+            useColorEmoji: true,
+        });
+
+        await appRunner.runApp();
+    }
+});


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/2382