### PR TITLE
feat(neon_lints): Add rule to prefer prefixed nextcloud imports

### DIFF
--- a/packages/neon_framework/lib/src/blocs/maintenance_mode.dart
+++ b/packages/neon_framework/lib/src/blocs/maintenance_mode.dart
@@ -4,7 +4,7 @@ import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/src/bloc/bloc.dart';
-import 'package:nextcloud/core.dart';
+import 'package:nextcloud/core.dart' as core;
 
 /// A Bloc checking if the server is in maintenance mode.
 sealed class MaintenanceModeBloc implements InteractiveBloc {

--- a/packages/neon_framework/lib/src/models/push_notification.dart
+++ b/packages/neon_framework/lib/src/models/push_notification.dart
@@ -3,7 +3,7 @@ import 'package:built_value/serializer.dart';
 import 'package:built_value/standard_json_plugin.dart';
 import 'package:crypton/crypton.dart';
 import 'package:meta/meta.dart';
-import 'package:nextcloud/notifications.dart';
+import 'package:nextcloud/notifications.dart' as notifications;
 
 part 'push_notification.g.dart';
 
@@ -22,7 +22,7 @@ abstract class PushNotification implements Built<PushNotification, PushNotificat
     String accountID,
     RSAPrivateKey privateKey,
   ) {
-    final subject = DecryptedSubject.fromEncrypted(privateKey, json['subject'] as String);
+    final subject = notifications.DecryptedSubject.fromEncrypted(privateKey, json['subject'] as String);
 
     return PushNotification(
       (b) => b
@@ -53,11 +53,11 @@ abstract class PushNotification implements Built<PushNotification, PushNotificat
   String get type;
 
   /// The subject of this notification.
-  DecryptedSubject get subject;
+  notifications.DecryptedSubject get subject;
 }
 
 @SerializersFor([
   PushNotification,
-  DecryptedSubject,
+  notifications.DecryptedSubject,
 ])
 final Serializers _serializers = (_$_serializers.toBuilder()..addPlugin(StandardJsonPlugin())).build();

--- a/packages/neon_framework/lib/src/pages/login_check_server_status.dart
+++ b/packages/neon_framework/lib/src/pages/login_check_server_status.dart
@@ -7,7 +7,6 @@ import 'package:neon_framework/src/theme/dialog.dart';
 import 'package:neon_framework/src/widgets/validation_tile.dart';
 import 'package:neon_framework/utils.dart';
 import 'package:nextcloud/core.dart' as core;
-import 'package:nextcloud/core.dart';
 
 @internal
 class LoginCheckServerStatusPage extends StatefulWidget {

--- a/packages/neon_framework/lib/src/widgets/user_avatar.dart
+++ b/packages/neon_framework/lib/src/widgets/user_avatar.dart
@@ -7,7 +7,7 @@ import 'package:neon_framework/src/theme/icons.dart';
 import 'package:neon_framework/src/theme/sizes.dart';
 import 'package:neon_framework/src/widgets/image.dart';
 import 'package:neon_framework/src/widgets/user_status_icon.dart';
-import 'package:nextcloud/core.dart';
+import 'package:nextcloud/core.dart' as core;
 import 'package:nextcloud/user_status.dart' as user_status;
 
 /// A circle that contains the user profile image and status.

--- a/packages/neon_framework/packages/files_app/lib/src/blocs/browser.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/blocs/browser.dart
@@ -7,7 +7,7 @@ import 'package:logging/logging.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/utils.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 import 'package:rxdart/rxdart.dart';
 
 /// Mode to operate the `FilesBrowserView` in.
@@ -26,12 +26,12 @@ sealed class FilesBrowserBloc implements InteractiveBloc {
     required FilesBloc filesBloc,
     required FilesOptions options,
     required Account account,
-    required PathUri uri,
+    required webdav.PathUri uri,
     required FilesBrowserMode mode,
-    PathUri? hideUri,
+    webdav.PathUri? hideUri,
   }) = _FilesBrowserBloc;
 
-  BehaviorSubject<Result<BuiltList<WebDavFile>>> get files;
+  BehaviorSubject<Result<BuiltList<webdav.WebDavFile>>> get files;
 
   /// Mode to operate the `FilesBrowserView` in.
   FilesBrowserMode get mode;
@@ -60,10 +60,10 @@ class _FilesBrowserBloc extends InteractiveBloc implements FilesBrowserBloc {
   final FilesOptions options;
   final Account account;
   late StreamSubscription<void> updatesSubscription;
-  final PathUri uri;
+  final webdav.PathUri uri;
   @override
   final FilesBrowserMode mode;
-  final PathUri? hideUri;
+  final webdav.PathUri? hideUri;
 
   @override
   void dispose() {
@@ -83,7 +83,7 @@ class _FilesBrowserBloc extends InteractiveBloc implements FilesBrowserBloc {
       subject: files,
       getRequest: () => account.client.webdav.propfind_Request(
         uri,
-        prop: const WebDavPropWithoutValues.fromBools(
+        prop: const webdav.WebDavPropWithoutValues.fromBools(
           davGetcontenttype: true,
           davGetetag: true,
           davGetlastmodified: true,
@@ -92,10 +92,10 @@ class _FilesBrowserBloc extends InteractiveBloc implements FilesBrowserBloc {
           ocSize: true,
           ocFavorite: true,
         ),
-        depth: WebDavDepth.one,
+        depth: webdav.WebDavDepth.one,
       ),
-      converter: const WebDavResponseConverter(),
-      unwrap: (response) => BuiltList<WebDavFile>.build((b) {
+      converter: const webdav.WebDavResponseConverter(),
+      unwrap: (response) => BuiltList<webdav.WebDavFile>.build((b) {
         for (final file in response.toWebDavFiles()) {
           // Do not show itself
           if (uri == file.path) {

--- a/packages/neon_framework/packages/files_app/lib/src/blocs/files.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/blocs/files.dart
@@ -10,7 +10,7 @@ import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/platform.dart';
 import 'package:neon_framework/utils.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 import 'package:open_filex/open_filex.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -26,27 +26,27 @@ sealed class FilesBloc implements InteractiveBloc {
     required Account account,
   }) = _FilesBloc;
 
-  void uploadFile(PathUri uri, String localPath);
+  void uploadFile(webdav.PathUri uri, String localPath);
 
-  void uploadMemory(PathUri uri, Uint8List bytes, {tz.TZDateTime? lastModified});
+  void uploadMemory(webdav.PathUri uri, Uint8List bytes, {tz.TZDateTime? lastModified});
 
-  void openFile(PathUri uri, String etag, String? mimeType);
+  void openFile(webdav.PathUri uri, String etag, String? mimeType);
 
-  void shareFileNative(PathUri uri, String etag, String? mimeType);
+  void shareFileNative(webdav.PathUri uri, String etag, String? mimeType);
 
-  void delete(PathUri uri);
+  void delete(webdav.PathUri uri);
 
-  void rename(PathUri uri, String name);
+  void rename(webdav.PathUri uri, String name);
 
-  void move(PathUri uri, PathUri destination);
+  void move(webdav.PathUri uri, webdav.PathUri destination);
 
-  void copy(PathUri uri, PathUri destination);
+  void copy(webdav.PathUri uri, webdav.PathUri destination);
 
-  void addFavorite(PathUri uri);
+  void addFavorite(webdav.PathUri uri);
 
-  void removeFavorite(PathUri uri);
+  void removeFavorite(webdav.PathUri uri);
 
-  void createFolder(PathUri uri);
+  void createFolder(webdav.PathUri uri);
 
   BehaviorSubject<BuiltList<FilesTask>> get tasks;
 
@@ -97,7 +97,7 @@ class _FilesBloc extends InteractiveBloc implements FilesBloc {
   }
 
   @override
-  Future<void> uploadFile(PathUri uri, String localPath) async {
+  Future<void> uploadFile(webdav.PathUri uri, String localPath) async {
     await wrapAction(
       () async {
         final task = FilesUploadTaskIO(
@@ -113,7 +113,7 @@ class _FilesBloc extends InteractiveBloc implements FilesBloc {
   }
 
   @override
-  Future<void> uploadMemory(PathUri uri, Uint8List bytes, {tz.TZDateTime? lastModified}) async {
+  Future<void> uploadMemory(webdav.PathUri uri, Uint8List bytes, {tz.TZDateTime? lastModified}) async {
     await wrapAction(
       () async {
         final task = FilesUploadTaskMemory(
@@ -131,7 +131,7 @@ class _FilesBloc extends InteractiveBloc implements FilesBloc {
   }
 
   @override
-  Future<void> openFile(PathUri uri, String etag, String? mimeType) async {
+  Future<void> openFile(webdav.PathUri uri, String etag, String? mimeType) async {
     await wrapAction(
       () async {
         if (NeonPlatform.instance.canUsePaths) {
@@ -150,7 +150,7 @@ class _FilesBloc extends InteractiveBloc implements FilesBloc {
   }
 
   @override
-  Future<void> shareFileNative(PathUri uri, String etag, String? mimeType) async {
+  Future<void> shareFileNative(webdav.PathUri uri, String etag, String? mimeType) async {
     await wrapAction(
       () async {
         if (NeonPlatform.instance.canUsePaths) {
@@ -165,12 +165,12 @@ class _FilesBloc extends InteractiveBloc implements FilesBloc {
   }
 
   @override
-  Future<void> delete(PathUri uri) async {
+  Future<void> delete(webdav.PathUri uri) async {
     await wrapAction(() async => account.client.webdav.delete(uri));
   }
 
   @override
-  Future<void> rename(PathUri uri, String name) async {
+  Future<void> rename(webdav.PathUri uri, String name) async {
     await wrapAction(
       () async => account.client.webdav.move(
         uri,
@@ -180,41 +180,41 @@ class _FilesBloc extends InteractiveBloc implements FilesBloc {
   }
 
   @override
-  Future<void> move(PathUri uri, PathUri destination) async {
+  Future<void> move(webdav.PathUri uri, webdav.PathUri destination) async {
     await wrapAction(() async => account.client.webdav.move(uri, destination));
   }
 
   @override
-  Future<void> copy(PathUri uri, PathUri destination) async {
+  Future<void> copy(webdav.PathUri uri, webdav.PathUri destination) async {
     await wrapAction(() async => account.client.webdav.copy(uri, destination));
   }
 
   @override
-  Future<void> addFavorite(PathUri uri) async {
+  Future<void> addFavorite(webdav.PathUri uri) async {
     await wrapAction(
       () async => account.client.webdav.proppatch(
         uri,
-        set: const WebDavProp(ocFavorite: true),
+        set: const webdav.WebDavProp(ocFavorite: true),
       ),
     );
   }
 
   @override
-  Future<void> removeFavorite(PathUri uri) async {
+  Future<void> removeFavorite(webdav.PathUri uri) async {
     await wrapAction(
       () async => account.client.webdav.proppatch(
         uri,
-        set: const WebDavProp(ocFavorite: false),
+        set: const webdav.WebDavProp(ocFavorite: false),
       ),
     );
   }
 
   @override
-  Future<void> createFolder(PathUri uri) async {
+  Future<void> createFolder(webdav.PathUri uri) async {
     await wrapAction(() async => account.client.webdav.mkcol(uri));
   }
 
-  Future<File> cacheFile(PathUri uri, String etag) async {
+  Future<File> cacheFile(webdav.PathUri uri, String etag) async {
     final cacheDir = await getApplicationCacheDirectory();
     final file = File(p.join(cacheDir.path, 'files', etag.replaceAll('"', ''), uri.name));
 
@@ -229,7 +229,7 @@ class _FilesBloc extends InteractiveBloc implements FilesBloc {
     return file;
   }
 
-  Future<void> downloadIO(PathUri uri, File file) async {
+  Future<void> downloadIO(webdav.PathUri uri, File file) async {
     final task = FilesDownloadTaskIO(
       uri: uri,
       file: file,
@@ -240,7 +240,7 @@ class _FilesBloc extends InteractiveBloc implements FilesBloc {
     tasks.add(tasks.value.rebuild((b) => b.remove(task)));
   }
 
-  Future<Uint8List> downloadMemory(PathUri uri) async {
+  Future<Uint8List> downloadMemory(webdav.PathUri uri) async {
     final task = FilesDownloadTaskMemory(uri: uri);
 
     // We need to listen to the stream, otherwise it will get stuck.

--- a/packages/neon_framework/packages/files_app/lib/src/models/file_details.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/models/file_details.dart
@@ -1,6 +1,6 @@
 import 'package:files_app/src/utils/task.dart';
 import 'package:meta/meta.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 import 'package:timezone/timezone.dart' as tz;
 
 @immutable
@@ -17,7 +17,7 @@ class FileDetails {
   }) : task = null;
 
   FileDetails.fromWebDav({
-    required WebDavFile file,
+    required webdav.WebDavFile file,
   })  : uri = file.path,
         size = file.size,
         etag = file.etag,
@@ -41,7 +41,7 @@ class FileDetails {
 
   FileDetails.fromDownloadTask({
     required FilesDownloadTask this.task,
-    required WebDavFile file,
+    required webdav.WebDavFile file,
   })  : uri = task.uri,
         size = file.size,
         etag = file.etag,
@@ -53,7 +53,7 @@ class FileDetails {
 
   factory FileDetails.fromTask({
     required FilesTask task,
-    required WebDavFile file,
+    required webdav.WebDavFile file,
   }) {
     switch (task) {
       case FilesUploadTask():
@@ -70,7 +70,7 @@ class FileDetails {
 
   bool get isDirectory => uri.isDirectory;
 
-  final PathUri uri;
+  final webdav.PathUri uri;
 
   final int? size;
 

--- a/packages/neon_framework/packages/files_app/lib/src/pages/main.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/pages/main.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:neon_framework/theme.dart';
 import 'package:neon_framework/utils.dart';
 import 'package:neon_framework/widgets.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 
 class FilesMainPage extends StatefulWidget {
   const FilesMainPage({
@@ -21,7 +21,7 @@ class FilesMainPage extends StatefulWidget {
 }
 
 class _FilesMainPageState extends State<FilesMainPage> {
-  PathUri uri = PathUri.cwd();
+  webdav.PathUri uri = webdav.PathUri.cwd();
   late FilesBloc bloc;
   late final StreamSubscription<Object> errorsSubscription;
 

--- a/packages/neon_framework/packages/files_app/lib/src/sort/files.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/sort/files.dart
@@ -1,9 +1,9 @@
 import 'package:files_app/src/options.dart';
 import 'package:neon_framework/sort_box.dart';
 import 'package:nextcloud/utils.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 
-final filesSortBox = SortBox<FilesSortProperty, WebDavFile>(
+final filesSortBox = SortBox<FilesSortProperty, webdav.WebDavFile>(
   properties: {
     FilesSortProperty.name: (file) => file.name.toLowerCase(),
     FilesSortProperty.modifiedDate: (file) => file.lastModified?.secondsSinceEpoch ?? 0,

--- a/packages/neon_framework/packages/files_app/lib/src/utils/dialog.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/utils/dialog.dart
@@ -7,7 +7,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:neon_framework/utils.dart';
 import 'package:neon_framework/widgets.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 
 /// Displays a [FilesCreateFolderDialog] for creating a new folder.
 ///
@@ -69,10 +69,10 @@ Future<bool> showUploadConfirmationDialog(
 /// Displays a [FilesChooseFolderDialog] to choose a new location for a file with the given [details].
 ///
 /// Returns a future with the new location.
-Future<PathUri?> showChooseFolderDialog(BuildContext context, FileDetails details) async {
+Future<webdav.PathUri?> showChooseFolderDialog(BuildContext context, FileDetails details) async {
   final filesBloc = NeonProvider.of<FilesBloc>(context);
 
-  final result = await showDialog<PathUri>(
+  final result = await showDialog<webdav.PathUri>(
     context: context,
     builder: (context) => FilesChooseFolderDialog(
       bloc: filesBloc,
@@ -103,7 +103,7 @@ Future<bool> showDeleteConfirmationDialog(BuildContext context, FileDetails deta
     false;
 
 /// Displays an adaptive modal to select or create a file.
-Future<void> showFilesCreateModal(BuildContext context, PathUri uri) {
+Future<void> showFilesCreateModal(BuildContext context, webdav.PathUri uri) {
   final theme = Theme.of(context);
   final bloc = NeonProvider.of<FilesBloc>(context);
 

--- a/packages/neon_framework/packages/files_app/lib/src/utils/task.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/utils/task.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:nextcloud/nextcloud.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 import 'package:timezone/timezone.dart' as tz;
 import 'package:universal_io/io.dart';
 
@@ -12,7 +12,7 @@ sealed class FilesTask {
     required this.uri,
   });
 
-  final PathUri uri;
+  final webdav.PathUri uri;
 
   @protected
   final progressController = StreamController<double>();

--- a/packages/neon_framework/packages/files_app/lib/src/widgets/actions.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/widgets/actions.dart
@@ -6,7 +6,7 @@ import 'package:files_app/src/utils/dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:neon_framework/platform.dart';
 import 'package:neon_framework/utils.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 
 class FileActions extends StatelessWidget {
   const FileActions({
@@ -57,7 +57,7 @@ class FileActions extends StatelessWidget {
         final result = await showChooseFolderDialog(context, details);
 
         if (result != null) {
-          bloc.move(details.uri, result.join(PathUri.parse(details.name)));
+          bloc.move(details.uri, result.join(webdav.PathUri.parse(details.name)));
         }
       case FilesFileAction.copy:
         if (!context.mounted) {
@@ -66,7 +66,7 @@ class FileActions extends StatelessWidget {
 
         final result = await showChooseFolderDialog(context, details);
         if (result != null) {
-          bloc.copy(details.uri, result.join(PathUri.parse(details.name)));
+          bloc.copy(details.uri, result.join(webdav.PathUri.parse(details.name)));
         }
       case FilesFileAction.delete:
         if (!context.mounted) {

--- a/packages/neon_framework/packages/files_app/lib/src/widgets/browser_view.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/widgets/browser_view.dart
@@ -16,7 +16,7 @@ import 'package:neon_framework/models.dart';
 import 'package:neon_framework/sort_box.dart';
 import 'package:neon_framework/utils.dart';
 import 'package:neon_framework/widgets.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 
 class FilesBrowserView extends StatefulWidget {
   FilesBrowserView({
@@ -28,10 +28,10 @@ class FilesBrowserView extends StatefulWidget {
   }) : super(key: Key(uri.toString()));
 
   final FilesBloc filesBloc;
-  final PathUri uri;
+  final webdav.PathUri uri;
   final FilesBrowserMode mode;
-  final void Function(PathUri uri) setPath;
-  final PathUri? hideUri;
+  final void Function(webdav.PathUri uri) setPath;
+  final webdav.PathUri? hideUri;
 
   @override
   State<FilesBrowserView> createState() => _FilesBrowserViewState();
@@ -131,7 +131,7 @@ class _FilesBrowserViewState extends State<FilesBrowserView> {
     );
   }
 
-  Iterable<Widget> buildUploadTasks(BuiltList<FilesTask> tasks, List<WebDavFile> files) sync* {
+  Iterable<Widget> buildUploadTasks(BuiltList<FilesTask> tasks, List<webdav.WebDavFile> files) sync* {
     for (final task in tasks) {
       if (task is! FilesUploadTask) {
         continue;

--- a/packages/neon_framework/packages/files_app/lib/src/widgets/dialog.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/widgets/dialog.dart
@@ -16,7 +16,7 @@ import 'package:neon_framework/platform.dart';
 import 'package:neon_framework/theme.dart';
 import 'package:neon_framework/utils.dart';
 import 'package:neon_framework/widgets.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 
 /// Creates an adaptive bottom sheet to select an action to add a file.
 class FilesChooseCreateModal extends StatelessWidget {
@@ -30,7 +30,7 @@ class FilesChooseCreateModal extends StatelessWidget {
   /// The bloc of the flies client.
   final FilesBloc bloc;
 
-  final PathUri uri;
+  final webdav.PathUri uri;
 
   Future<void> uploadFromPick(BuildContext context, FileType type) async {
     final result = await FilePicker.platform.pickFiles(
@@ -50,12 +50,12 @@ class FilesChooseCreateModal extends StatelessWidget {
 
         if (kIsWeb) {
           bloc.uploadMemory(
-            uri.join(PathUri.parse(file.name)),
+            uri.join(webdav.PathUri.parse(file.name)),
             file.bytes!,
           );
         } else {
           bloc.uploadFile(
-            uri.join(PathUri.parse(file.name)),
+            uri.join(webdav.PathUri.parse(file.name)),
             file.path!,
           );
         }
@@ -149,12 +149,12 @@ class FilesChooseCreateModal extends StatelessWidget {
               }
               if (kIsWeb) {
                 bloc.uploadMemory(
-                  uri.join(PathUri.parse(result.name)),
+                  uri.join(webdav.PathUri.parse(result.name)),
                   await result.readAsBytes(),
                 );
               } else {
                 bloc.uploadFile(
-                  uri.join(PathUri.parse(result.name)),
+                  uri.join(webdav.PathUri.parse(result.name)),
                   result.path,
                 );
               }
@@ -173,7 +173,7 @@ class FilesChooseCreateModal extends StatelessWidget {
 
           final result = await showFolderCreateDialog(context: context);
           if (result != null) {
-            bloc.createFolder(uri.join(PathUri.parse(result)));
+            bloc.createFolder(uri.join(webdav.PathUri.parse(result)));
           }
         },
       ),
@@ -236,16 +236,16 @@ class FilesChooseFolderDialog extends StatefulWidget {
 
   final FilesBloc bloc;
 
-  final PathUri uri;
+  final webdav.PathUri uri;
 
-  final PathUri? hideUri;
+  final webdav.PathUri? hideUri;
 
   @override
   State<FilesChooseFolderDialog> createState() => _FilesChooseFolderDialogState();
 }
 
 class _FilesChooseFolderDialogState extends State<FilesChooseFolderDialog> {
-  late PathUri uri = widget.uri;
+  late webdav.PathUri uri = widget.uri;
 
   @override
   Widget build(BuildContext context) {
@@ -257,7 +257,7 @@ class _FilesChooseFolderDialogState extends State<FilesChooseFolderDialog> {
           final result = await showFolderCreateDialog(context: context);
 
           if (result != null) {
-            widget.bloc.createFolder(uri.join(PathUri.parse(result)));
+            widget.bloc.createFolder(uri.join(webdav.PathUri.parse(result)));
           }
         },
         child: Text(

--- a/packages/neon_framework/packages/files_app/lib/src/widgets/file_list_tile.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/widgets/file_list_tile.dart
@@ -12,7 +12,7 @@ import 'package:flutter_material_design_icons/flutter_material_design_icons.dart
 import 'package:neon_framework/theme.dart';
 import 'package:neon_framework/utils.dart';
 import 'package:neon_framework/widgets.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 
 class FileListTile extends StatelessWidget {
   const FileListTile({
@@ -26,7 +26,7 @@ class FileListTile extends StatelessWidget {
   final FilesBloc bloc;
   final FilesBrowserBloc browserBloc;
   final FileDetails details;
-  final void Function(PathUri uri) setPath;
+  final void Function(webdav.PathUri uri) setPath;
 
   Future<void> _onTap(BuildContext context, FileDetails details) async {
     if (details.isDirectory) {

--- a/packages/neon_framework/packages/files_app/lib/src/widgets/file_preview.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/widgets/file_preview.dart
@@ -7,7 +7,7 @@ import 'package:neon_framework/models.dart';
 import 'package:neon_framework/theme.dart';
 import 'package:neon_framework/utils.dart';
 import 'package:neon_framework/widgets.dart';
-import 'package:nextcloud/core.dart';
+import 'package:nextcloud/core.dart' as core;
 
 class FilePreview extends StatelessWidget {
   const FilePreview({

--- a/packages/neon_framework/packages/files_app/lib/src/widgets/navigator.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/widgets/navigator.dart
@@ -2,7 +2,7 @@ import 'package:files_app/l10n/localizations.dart';
 import 'package:files_app/src/blocs/files.dart';
 import 'package:flutter/material.dart';
 import 'package:neon_framework/theme.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 
 class FilesBrowserNavigator extends StatelessWidget {
   const FilesBrowserNavigator({
@@ -12,9 +12,9 @@ class FilesBrowserNavigator extends StatelessWidget {
     super.key,
   });
 
-  final PathUri uri;
+  final webdav.PathUri uri;
   final FilesBloc bloc;
-  final void Function(PathUri uri) setPath;
+  final void Function(webdav.PathUri uri) setPath;
 
   @override
   Widget build(BuildContext context) {
@@ -36,11 +36,11 @@ class FilesBrowserNavigator extends StatelessWidget {
               ),
               tooltip: FilesLocalizations.of(context).goToPath(''),
               icon: Icon(AdaptiveIcons.house),
-              onPressed: () => setPath(PathUri.cwd()),
+              onPressed: () => setPath(webdav.PathUri.cwd()),
             );
           }
 
-          final partialPath = PathUri(
+          final partialPath = webdav.PathUri(
             isAbsolute: uri.isAbsolute,
             isDirectory: uri.isDirectory,
             pathSegments: uri.pathSegments.sublist(0, index),

--- a/packages/neon_framework/packages/neon_http_client/lib/src/interceptors/csrf_interceptor.dart
+++ b/packages/neon_framework/packages/neon_http_client/lib/src/interceptors/csrf_interceptor.dart
@@ -5,7 +5,7 @@ import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_http_client/src/interceptors/http_interceptor.dart';
 import 'package:nextcloud/nextcloud.dart';
-import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud/webdav.dart' as webdav;
 import 'package:universal_io/io.dart';
 
 /// A HttpInterceptor that works around a Nextcloud CSRF bug when cookies are sent.
@@ -44,7 +44,7 @@ final class CSRFInterceptor implements HttpInterceptor {
 
   @override
   bool shouldInterceptRequest(http.BaseRequest request) {
-    if (request.url.host != _baseURL.host || !request.url.path.startsWith('${_baseURL.path}$webdavBase')) {
+    if (request.url.host != _baseURL.host || !request.url.path.startsWith('${_baseURL.path}${webdav.webdavBase}')) {
       return false;
     }
 

--- a/packages/neon_framework/packages/news_app/lib/src/utils/dialog.dart
+++ b/packages/neon_framework/packages/news_app/lib/src/utils/dialog.dart
@@ -3,12 +3,12 @@ import 'package:neon_framework/utils.dart';
 import 'package:neon_framework/widgets.dart';
 import 'package:news_app/l10n/localizations.dart';
 import 'package:news_app/src/widgets/dialog.dart';
-import 'package:nextcloud/news.dart';
+import 'package:nextcloud/news.dart' as news;
 
 /// Displays a [NeonConfirmationDialog] to confirm the deletion of the given [feed].
 ///
 /// Returns a future whether the action has been accepted.
-Future<bool> showDeleteFeedDialog(BuildContext context, Feed feed) async {
+Future<bool> showDeleteFeedDialog(BuildContext context, news.Feed feed) async {
   final content = NewsLocalizations.of(context).feedRemoveConfirm(feed.title);
 
   final result = await showAdaptiveDialog<bool>(

--- a/packages/neon_lints/example/lib/neon_lints.dart
+++ b/packages/neon_lints/example/lib/neon_lints.dart
@@ -6,6 +6,10 @@ import 'dart:html';
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
+// expect_lint: prefer_prefixed_nextcloud_import
+import 'package:nextcloud/core.dart';
+import 'package:nextcloud/nextcloud.dart';
+import 'package:nextcloud/utils.dart';
 
 // Apparently custom_lint can not be run in the defining package. So lint tests
 // must be added here. Adding the `expect_lint: lint_name` comment suppresses

--- a/packages/neon_lints/example/pubspec.yaml
+++ b/packages/neon_lints/example/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  nextcloud: ^7.0.0
 
 dev_dependencies:
   custom_lint: ^0.6.4

--- a/packages/neon_lints/example/pubspec_overrides.yaml
+++ b/packages/neon_lints/example/pubspec_overrides.yaml
@@ -1,4 +1,8 @@
-# melos_managed_dependency_overrides: neon_lints
+# melos_managed_dependency_overrides: dynamite_runtime,neon_lints,nextcloud
 dependency_overrides:
+  dynamite_runtime:
+    path: ../../dynamite/packages/dynamite_runtime
   neon_lints:
     path: ..
+  nextcloud:
+    path: ../../nextcloud

--- a/packages/neon_lints/lib/neon_lints.dart
+++ b/packages/neon_lints/lib/neon_lints.dart
@@ -3,6 +3,7 @@ import 'package:neon_lints/src/avoid_dart_html.dart';
 import 'package:neon_lints/src/avoid_dart_io.dart';
 import 'package:neon_lints/src/avoid_debug_print.dart';
 import 'package:neon_lints/src/avoid_exports.dart';
+import 'package:neon_lints/src/prefer_prefixed_nextcloud_import.dart';
 import 'package:neon_lints/src/prefer_pump_widget_with_accessibility.dart';
 
 /// Registers the neon lints plugin.
@@ -19,6 +20,7 @@ class _NeonLintsPlugin extends PluginBase {
         AvoidDartHTML(),
         AvoidDartIO(),
         AvoidExports(),
+        PreferPrefixedNextcloudImport(),
         PreferPumpWidgetWithAccessibility(),
       ];
 }

--- a/packages/neon_lints/lib/src/prefer_prefixed_nextcloud_import.dart
+++ b/packages/neon_lints/lib/src/prefer_prefixed_nextcloud_import.dart
@@ -1,0 +1,44 @@
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// Lint rule checking that package:nextcloud imports are prefixed.
+final class PreferPrefixedNextcloudImport extends DartLintRule {
+  /// @nodoc
+  const PreferPrefixedNextcloudImport() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'prefer_prefixed_nextcloud_import',
+    problemMessage: 'Do not import from package:nextcloud without a prefix.',
+    correctionMessage: '''
+Use `import 'package:nextcloud/<id>.dart' as <id>;` instead.
+''',
+  );
+
+  static final _regex = RegExp(r'^package:nextcloud/(.*)\.dart$');
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addImportDirective((node) {
+      final match = _regex.firstMatch(node.uri.stringValue ?? '');
+      if (match == null) {
+        return;
+      }
+
+      final id = match.group(1)!;
+      if (id == 'nextcloud' || id == 'utils') {
+        return;
+      }
+
+      if (node.prefix != null && (node.prefix!.name == id || node.prefix!.name == '\$$id')) {
+        return;
+      }
+
+      // ignore: deprecated_member_use
+      reporter.reportErrorForToken(code, node.beginToken);
+    });
+  }
+}


### PR DESCRIPTION
Avoids namespace pollution and is already the way it is done almost everywhere (except for the files app it seems).