### PR TITLE
refactor(cookie_store): remove universal_io dependency.

### DIFF
--- a/packages/cookie_store/dart_test.yaml
+++ b/packages/cookie_store/dart_test.yaml
@@ -1,0 +1,10 @@
+platforms:
+  - vm
+  - chrome
+
+define_platforms:
+  chromium:
+    name: Chromium
+    extends: chrome
+    settings:
+      executable: chromium

--- a/packages/cookie_store/lib/src/cookie_persistence.dart
+++ b/packages/cookie_store/lib/src/cookie_persistence.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
+import 'dart:io' show Cookie;
 
 import 'package:cookie_store/src/storable_cookie.dart';
 import 'package:cookie_store/src/utils.dart';
 import 'package:timezone/timezone.dart' as tz;
-import 'package:universal_io/io.dart' show Cookie;
 
 /// Interface for a Storage backend persisting [StorableCookie]s.
 ///

--- a/packages/cookie_store/lib/src/cookie_store.dart
+++ b/packages/cookie_store/lib/src/cookie_store.dart
@@ -1,12 +1,12 @@
 // ignore_for_file:   prefer_final_locals, omit_local_variable_types
 
 import 'dart:async';
+import 'dart:io' show Cookie;
 
 import 'package:cookie_store/src/cookie_persistence.dart';
 import 'package:cookie_store/src/storable_cookie.dart';
 import 'package:cookie_store/src/utils.dart';
 import 'package:timezone/timezone.dart' as tz;
-import 'package:universal_io/io.dart' show Cookie;
 
 // DateTimes can represent time values that are at a distance of at most 100,000,000
 // days from epoch (1970-01-01 UTC): -271821-04-20 to 275760-09-13.

--- a/packages/cookie_store/packages/cookie_store_conformance_tests/lib/src/utils.dart
+++ b/packages/cookie_store/packages/cookie_store_conformance_tests/lib/src/utils.dart
@@ -1,5 +1,6 @@
+import 'dart:io' show Cookie, SameSite;
+
 import 'package:meta/meta.dart';
-import 'package:universal_io/io.dart';
 
 /// Converts the given cookies to strings containing only the [Cookie.name] and
 /// `Cookie.vale` and sorts the resulting list.

--- a/packages/cookie_store/packages/cookie_store_conformance_tests/pubspec.yaml
+++ b/packages/cookie_store/packages/cookie_store_conformance_tests/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
       path: packages/cookie_store
   meta: ^1.0.0
   test: ^1.21.2
-  universal_io: ^2.0.0
 
 dev_dependencies:
   neon_lints:

--- a/packages/cookie_store/pubspec.yaml
+++ b/packages/cookie_store/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dependencies:
   meta: ^1.0.0
   timezone: ^0.9.4
-  universal_io: ^2.0.0
 
 dev_dependencies:
   cookie_store_conformance_tests:


### PR DESCRIPTION
The `Cookie` does not depend on the dart vm and is therefore also usable on web.
To verify this, I've also enabled unit tests on chrome.