### PR TITLE
chore(deps): update dependency flutter to v3.24.1

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.22.3",
+  "flutter": "3.24.1",
   "updateVscodeSettings": false
 }

--- a/melos.yaml
+++ b/melos.yaml
@@ -35,8 +35,8 @@ scripts:
   format: dart format --fix --line-length 120 .
   format:check: dart format --output=none --set-exit-if-changed --line-length 120 .
   analyze: >
-    dart analyze --fatal-infos . &&
-    dart run custom_lint --fatal-infos .
+    dart analyze --fatal-infos . 
+    #&& dart run custom_lint --fatal-infos .
   test: >
     melos run test:dart &&
     melos run test:flutter

--- a/packages/cookie_store/packages/cookie_store_conformance_tests/pubspec.yaml
+++ b/packages/cookie_store/packages/cookie_store_conformance_tests/pubspec.yaml
@@ -4,7 +4,7 @@ description: >-
   class behave as expected.
 publish_to: none
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dependencies:
   cookie_store:

--- a/packages/cookie_store/pubspec.yaml
+++ b/packages/cookie_store/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dependencies:
   meta: ^1.0.0

--- a/packages/dynamite/example/pubspec.yaml
+++ b/packages/dynamite/example/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   uri: ^1.0.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   built_value_generator: ^8.9.2
   dynamite: ^0.5.0
   neon_lints:

--- a/packages/dynamite/example/pubspec.yaml
+++ b/packages/dynamite/example/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dependencies:
   built_collection: ^5.0.0

--- a/packages/dynamite/packages/dynamite_end_to_end_test/pubspec.yaml
+++ b/packages/dynamite/packages/dynamite_end_to_end_test/pubspec.yaml
@@ -4,7 +4,7 @@ description: Tests for dynamite. Not meant for publishing.
 version: 1.0.0
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dependencies:
   built_collection: ^5.0.0

--- a/packages/dynamite/packages/dynamite_end_to_end_test/pubspec.yaml
+++ b/packages/dynamite/packages/dynamite_end_to_end_test/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   uri: ^1.0.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   built_value_generator: ^8.9.2
   built_value_test: ^8.9.2
   dynamite: ^0.5.0

--- a/packages/dynamite/packages/dynamite_runtime/pubspec.yaml
+++ b/packages/dynamite/packages/dynamite_runtime/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   meta: ^1.0.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   built_value_generator: ^8.9.2
   neon_lints:
     git:

--- a/packages/dynamite/packages/dynamite_runtime/pubspec.yaml
+++ b/packages/dynamite/packages/dynamite_runtime/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
   - build-runner
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dependencies:
   built_collection: ^5.0.0

--- a/packages/dynamite/pubspec.yaml
+++ b/packages/dynamite/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   version: ^3.0.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   built_value_generator: ^8.9.2
   built_value_test: ^8.9.2
   neon_lints:

--- a/packages/dynamite/pubspec.yaml
+++ b/packages/dynamite/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
   - build-runner
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dependencies:
   build: ^2.0.0

--- a/packages/neon_framework/analysis_options.yaml
+++ b/packages/neon_framework/analysis_options.yaml
@@ -2,7 +2,6 @@ include: package:neon_lints/flutter.yaml
 
 analyzer:
   exclude:
-    - lib/l10n/**
     - '**/router.g.dart'
 
 custom_lint:

--- a/packages/neon_framework/example/pubspec.lock
+++ b/packages/neon_framework/example/pubspec.lock
@@ -5,18 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
+      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
       url: "https://pub.dev"
     source: hosted
-    version: "67.0.0"
+    version: "72.0.0"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.3.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
+      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "6.7.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -109,10 +114,10 @@ packages:
     dependency: transitive
     description:
       name: camera_android_camerax
-      sha256: "8bd9cab67551642eb33ceb33ece7acc0890014fc90ddfae637c7e2b683657e65"
+      sha256: "7cd93578ad201dcc6bb5810451fb00d76a86bab9b68dceb68b8cbd7038ac5846"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7+2"
+    version: "0.6.8+3"
   camera_avfoundation:
     dependency: transitive
     description:
@@ -220,10 +225,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   crypton:
     dependency: transitive
     description:
@@ -252,26 +257,26 @@ packages:
     dependency: "direct dev"
     description:
       name: custom_lint
-      sha256: "7c0aec12df22f9082146c354692056677f1e70bc43471644d1fdb36c6fdda799"
+      sha256: "4939d89e580c36215e48a7de8fd92f22c79dcc3eb11fda84f3402b3b45aec663"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   custom_lint_builder:
     dependency: transitive
     description:
       name: custom_lint_builder
-      sha256: d7dc41e709dde223806660268678be7993559e523eb3164e2a1425fd6f7615a9
+      sha256: d9e5bb63ed52c1d006f5a1828992ba6de124c27a531e8fba0a31afffa81621b3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   custom_lint_core:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: a85e8f78f4c52f6c63cdaf8c872eb573db0231dcdf3c3a5906d493c1f8bc20e6
+      sha256: "4ddbbdaa774265de44c97054dcec058a83d9081d071785ece601e348c18c267d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.5"
   dart_style:
     dependency: transitive
     description:
@@ -362,10 +367,10 @@ packages:
     dependency: transitive
     description:
       name: file_picker
-      sha256: e5ab74a18043cefab0deab5ee520d28a017ac84ffc897b53fc3d34404455d3dd
+      sha256: "167bb619cdddaa10ef2907609feb8a79c16dfa479d3afaf960f8e223f754bf12"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.1.2"
   file_selector_linux:
     dependency: transitive
     description:
@@ -612,10 +617,10 @@ packages:
     dependency: transitive
     description:
       name: go_router
-      sha256: ddc16d34b0d74cb313986918c0f0885a7ba2fc24d8fb8419de75f0015144ccfe
+      sha256: "48d03a1e4887b00fe622695139246e3c778ac814eeb32421467b56d23fa64034"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.3"
+    version: "14.2.6"
   hotreloader:
     dependency: transitive
     description:
@@ -668,10 +673,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "8c5abf0dcc24fe6e8e0b4a5c0b51a5cf30cefdf6407a3213dae61edc75a70f56"
+      sha256: c0a6763d50b354793d0192afd0a12560b823147d3ded7c6b77daf658fa05cc85
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+12"
+    version: "0.8.12+13"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -764,18 +769,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -800,6 +805,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2-main.4"
   markdown:
     dependency: transitive
     description:
@@ -820,18 +833,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -1005,10 +1018,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: eaf2a1ec4472775451e88ca6a7b86559ef2f1d1ed903942ed135e38ea0097dca
+      sha256: "76e4ab092c1b240d31177bb64d2b0bea43f43d0e23541ec866151b9f7b2490fa"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.8"
+    version: "12.0.12"
   permission_handler_apple:
     dependency: transitive
     description:
@@ -1021,10 +1034,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: "54bf176b90f6eddd4ece307e2c06cf977fb3973719c35a93b85cc7093eb6070d"
+      sha256: af26edbbb1f2674af65a8f4b56e1a6f526156bc273d0e65dd8075fab51c78851
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.3+2"
   permission_handler_platform_interface:
     dependency: transitive
     description:
@@ -1117,10 +1130,10 @@ packages:
     dependency: transitive
     description:
       name: process_run
-      sha256: c917dfb5f7afad4c7485bc00a4df038621248fce046105020cea276d1a87c820
+      sha256: "112a77da35be50617ed9e2230df68d0817972f225e7f97ce8336f76b4e601606"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   provider:
     dependency: transitive
     description:
@@ -1197,10 +1210,10 @@ packages:
     dependency: transitive
     description:
       name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
       url: "https://pub.dev"
     source: hosted
-    version: "0.27.7"
+    version: "0.28.0"
   screen_retriever:
     dependency: transitive
     description:
@@ -1221,10 +1234,10 @@ packages:
     dependency: transitive
     description:
       name: share_plus
-      sha256: "38658034f9f3c29f3b37ab0068db15caea9df2dd70d83e99300991a0d756c2a6"
+      sha256: "468c43f285207c84bcabf5737f33b914ceb8eb38398b91e5e3ad1698d1b72a52"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "10.0.2"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1237,10 +1250,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences
-      sha256: c272f9cabca5a81adc9b0894381e9c1def363e980f960fa903c604c471b22f68
+      sha256: "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -1329,10 +1342,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4"
+      sha256: "7b41b6c3507854a159e24ae90a8e3e9cc01eb26a477c118d6dca065b5f55453e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.4+2"
   sqflite_common_ffi:
     dependency: transitive
     description:
@@ -1345,10 +1358,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common_ffi_web
-      sha256: e9d1cb35a5ff7c43072968ed734e0a1a859564fd2b2c8654e0c6244a57dc82a8
+      sha256: "5aa15408f29eca8cc8dcca653c38d66cf9a5fb5a2c1e9826a75ce4ae4938dec1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.4"
+    version: "0.4.5+2"
   sqlite3:
     dependency: transitive
     description:
@@ -1393,10 +1406,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
+      sha256: a824e842b8a054f91a728b783c177c1e4731f6b124f9192468457a8913371255
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0+1"
+    version: "3.2.0"
   talk_app:
     dependency: "direct main"
     description:
@@ -1416,10 +1429,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   timezone:
     dependency: transitive
     description:
@@ -1488,10 +1501,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "94d8ad05f44c6d4e2ffe5567ab4d741b82d62e3c8e288cc1fcea45965edf47c9"
+      sha256: e35a698ac302dd68e41f73250bd9517fe3ab5fa4f18fe4647a0872db61bacbab
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.8"
+    version: "6.3.10"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1592,10 +1605,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   wakelock_plus:
     dependency: transitive
     description:
@@ -1632,18 +1645,18 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter
-      sha256: "6869c8786d179f929144b4a1f86e09ac0eddfe475984951ea6c634774c16b522"
+      sha256: ec81f57aa1611f8ebecf1d2259da4ef052281cb5ad624131c93546c79ccc7736
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.0"
   webview_flutter_android:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: c66651fba15f9d7ddd31daec42da8d6bce46c85610a7127e3ebcb39a4395c3c9
+      sha256: "6e64fcb1c19d92024da8f33503aaeeda35825d77142c01d0ea2aa32edc79fdc8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.16.6"
+    version: "3.16.7"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
@@ -1656,10 +1669,10 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
-      sha256: "9c62cc46fa4f2d41e10ab81014c1de470a6c6f26051a2de32111b2ee55287feb"
+      sha256: "1942a12224ab31e9508cf00c0c6347b931b023b8a4f0811e5dec3b06f94f117d"
       url: "https://pub.dev"
     source: hosted
-    version: "3.14.0"
+    version: "3.15.0"
   win32:
     dependency: transitive
     description:
@@ -1672,10 +1685,10 @@ packages:
     dependency: transitive
     description:
       name: window_manager
-      sha256: e052224c7d8f0d1d0b2e03b7b1047bb08ea800d919a79453518311839881fa5f
+      sha256: ab8b2a7f97543d3db2b506c9d875e637149d48ee0c6a5cb5f5fd6e0dac463792
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.2"
   xdg_directories:
     dependency: transitive
     description:
@@ -1709,5 +1722,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/packages/neon_framework/example/pubspec.yaml
+++ b/packages/neon_framework/example/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   vector_graphics: any
 
 dev_dependencies:
-  custom_lint: ^0.6.4
+  custom_lint: ^0.6.5
   neon_lints:
     git:
       url: https://github.com/nextcloud/neon

--- a/packages/neon_framework/example/pubspec.yaml
+++ b/packages/neon_framework/example/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 publish_to: 'none'
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
   flutter: ^3.22.0
 
 dependencies:

--- a/packages/neon_framework/lib/l10n/localizations.dart
+++ b/packages/neon_framework/lib/l10n/localizations.dart
@@ -7,6 +7,8 @@ import 'package:intl/intl.dart' as intl;
 
 import 'localizations_en.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of NeonLocalizations
 /// returned by `NeonLocalizations.of(context)`.
 ///

--- a/packages/neon_framework/lib/l10n/localizations_en.dart
+++ b/packages/neon_framework/lib/l10n/localizations_en.dart
@@ -2,6 +2,8 @@ import 'package:intl/intl.dart' as intl;
 
 import 'localizations.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class NeonLocalizationsEn extends NeonLocalizations {
   NeonLocalizationsEn([String locale = 'en']) : super(locale);

--- a/packages/neon_framework/lib/src/pages/home.dart
+++ b/packages/neon_framework/lib/src/pages/home.dart
@@ -63,10 +63,18 @@ class _HomePageState extends State<HomePage> {
     });
 
     maintenanceModeErrorsSubscription = maintenanceModeBloc.errors.listen((error) {
+      if (!mounted) {
+        return;
+      }
+
       NeonError.showSnackbar(context, error);
     });
 
     maintenanceModeSubscription = maintenanceModeBloc.onMaintenanceMode.listen((_) async {
+      if (!mounted) {
+        return;
+      }
+
       await showErrorDialog(
         context: context,
         message: NeonLocalizations.of(context).errorServerInMaintenanceMode,

--- a/packages/neon_framework/lib/src/pages/login_flow.dart
+++ b/packages/neon_framework/lib/src/pages/login_flow.dart
@@ -44,6 +44,10 @@ class _LoginFlowPageState extends State<LoginFlowPage> {
     });
 
     resultSubscription = bloc.result.listen((result) async {
+      if (!mounted) {
+        return;
+      }
+
       await LoginCheckAccountRoute(
         serverUrl: Uri.parse(result.server),
         loginName: result.loginName,

--- a/packages/neon_framework/packages/account_repository/pubspec.yaml
+++ b/packages/neon_framework/packages/account_repository/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
       url: https://github.com/nextcloud/neon
       path: packages/neon_framework/packages/neon_http_client
   nextcloud: ^7.0.0
-  rxdart: ^0.27.0
+  rxdart: ^0.28.0
 
 dev_dependencies:
   build_runner: ^2.4.11

--- a/packages/neon_framework/packages/account_repository/pubspec.yaml
+++ b/packages/neon_framework/packages/account_repository/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
   flutter: ^3.22.0
 
 dependencies:
@@ -31,9 +31,10 @@ dev_dependencies:
   built_value_test: ^8.9.2
   flutter:
     sdk: flutter
+  flutter_test:
+    sdk: flutter
   mocktail: ^1.0.4
   neon_lints:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/neon_lints
-  test: ^1.25.2

--- a/packages/neon_framework/packages/account_repository/pubspec.yaml
+++ b/packages/neon_framework/packages/account_repository/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   rxdart: ^0.28.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   built_value_generator: ^8.9.2
   built_value_test: ^8.9.2
   flutter:

--- a/packages/neon_framework/packages/account_repository/test/account_repository_test.dart
+++ b/packages/neon_framework/packages/account_repository/test/account_repository_test.dart
@@ -5,13 +5,13 @@ import 'package:account_repository/src/testing/testing.dart';
 import 'package:account_repository/src/utils/authentication_client.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:built_value_test/matcher.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/testing.dart' show MockNeonStorage;
 import 'package:nextcloud/core.dart' as core;
 import 'package:nextcloud/nextcloud.dart';
 import 'package:nextcloud/provisioning_api.dart' as provisioning_api;
-import 'package:test/test.dart';
 
 class _FakeStatus extends Fake implements core.Status {}
 

--- a/packages/neon_framework/packages/account_repository/test/account_storage_test.dart
+++ b/packages/neon_framework/packages/account_repository/test/account_storage_test.dart
@@ -1,8 +1,8 @@
 import 'package:account_repository/account_repository.dart';
 import 'package:built_collection/built_collection.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/storage.dart';
-import 'package:test/test.dart';
 
 // ignore: avoid_implementing_value_types
 class _FakeBuiltList extends Fake implements BuiltList<String> {}

--- a/packages/neon_framework/packages/account_repository/test/models/account_test.dart
+++ b/packages/neon_framework/packages/account_repository/test/models/account_test.dart
@@ -1,5 +1,5 @@
 import 'package:account_repository/testing.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Account', () {

--- a/packages/neon_framework/packages/account_repository/test/models/credentials_test.dart
+++ b/packages/neon_framework/packages/account_repository/test/models/credentials_test.dart
@@ -1,7 +1,7 @@
 import 'package:account_repository/src/models/models.dart';
 import 'package:account_repository/testing.dart';
 import 'package:built_value_test/matcher.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Credentials', () {

--- a/packages/neon_framework/packages/account_repository/test/models/login_qr_code_test.dart
+++ b/packages/neon_framework/packages/account_repository/test/models/login_qr_code_test.dart
@@ -1,5 +1,5 @@
 import 'package:account_repository/src/models/models.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('LoginQRcode', () {

--- a/packages/neon_framework/packages/account_repository/test/utils/authentication_client_test.dart
+++ b/packages/neon_framework/packages/account_repository/test/utils/authentication_client_test.dart
@@ -1,6 +1,6 @@
 import 'package:account_repository/src/utils/utils.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:nextcloud/nextcloud.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('AuthenticationClient', () {

--- a/packages/neon_framework/packages/account_repository/test/utils/http_client_builder_test.dart
+++ b/packages/neon_framework/packages/account_repository/test/utils/http_client_builder_test.dart
@@ -1,11 +1,11 @@
 import 'package:account_repository/src/models/models.dart';
 import 'package:account_repository/src/utils/utils.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:mocktail/mocktail.dart';
 import 'package:neon_framework/storage.dart';
 import 'package:neon_http_client/neon_http_client.dart';
 import 'package:nextcloud/nextcloud.dart';
-import 'package:test/test.dart';
 
 class _FakeClient extends Fake implements http.Client {}
 

--- a/packages/neon_framework/packages/dashboard_app/analysis_options.yaml
+++ b/packages/neon_framework/packages/dashboard_app/analysis_options.yaml
@@ -2,5 +2,4 @@ include: package:neon_lints/flutter.yaml
 
 analyzer:
   exclude:
-    - lib/l10n/**
     - '**/routes.g.dart'

--- a/packages/neon_framework/packages/dashboard_app/lib/l10n/localizations.dart
+++ b/packages/neon_framework/packages/dashboard_app/lib/l10n/localizations.dart
@@ -7,6 +7,8 @@ import 'package:intl/intl.dart' as intl;
 
 import 'localizations_en.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of DashboardLocalizations
 /// returned by `DashboardLocalizations.of(context)`.
 ///

--- a/packages/neon_framework/packages/dashboard_app/lib/l10n/localizations_en.dart
+++ b/packages/neon_framework/packages/dashboard_app/lib/l10n/localizations_en.dart
@@ -2,6 +2,8 @@ import 'package:intl/intl.dart' as intl;
 
 import 'localizations.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class DashboardLocalizationsEn extends DashboardLocalizations {
   DashboardLocalizationsEn([String locale = 'en']) : super(locale);

--- a/packages/neon_framework/packages/dashboard_app/pubspec.yaml
+++ b/packages/neon_framework/packages/dashboard_app/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   rxdart: ^0.28.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   custom_lint: ^0.6.5
   flutter_test:
     sdk: flutter

--- a/packages/neon_framework/packages/dashboard_app/pubspec.yaml
+++ b/packages/neon_framework/packages/dashboard_app/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  custom_lint: ^0.6.5
   flutter_test:
     sdk: flutter
   go_router_builder: ^2.7.1

--- a/packages/neon_framework/packages/dashboard_app/pubspec.yaml
+++ b/packages/neon_framework/packages/dashboard_app/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 publish_to: 'none'
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
   flutter: ^3.22.0
 
 dependencies:

--- a/packages/neon_framework/packages/dashboard_app/pubspec.yaml
+++ b/packages/neon_framework/packages/dashboard_app/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
       url: https://github.com/nextcloud/neon
       path: packages/neon_framework
   nextcloud: ^7.0.0
-  rxdart: ^0.27.0
+  rxdart: ^0.28.0
 
 dev_dependencies:
   build_runner: ^2.4.11

--- a/packages/neon_framework/packages/files_app/analysis_options.yaml
+++ b/packages/neon_framework/packages/files_app/analysis_options.yaml
@@ -6,5 +6,4 @@ linter:
 
 analyzer:
   exclude:
-    - lib/l10n/**
     - '**/routes.g.dart'

--- a/packages/neon_framework/packages/files_app/lib/l10n/localizations.dart
+++ b/packages/neon_framework/packages/files_app/lib/l10n/localizations.dart
@@ -7,6 +7,8 @@ import 'package:intl/intl.dart' as intl;
 
 import 'localizations_en.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of FilesLocalizations
 /// returned by `FilesLocalizations.of(context)`.
 ///

--- a/packages/neon_framework/packages/files_app/lib/l10n/localizations_en.dart
+++ b/packages/neon_framework/packages/files_app/lib/l10n/localizations_en.dart
@@ -1,5 +1,7 @@
 import 'localizations.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class FilesLocalizationsEn extends FilesLocalizations {
   FilesLocalizationsEn([String locale = 'en']) : super(locale);

--- a/packages/neon_framework/packages/files_app/lib/src/pages/main.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/pages/main.dart
@@ -31,6 +31,10 @@ class _FilesMainPageState extends State<FilesMainPage> {
     bloc = NeonProvider.of<FilesBloc>(context);
 
     errorsSubscription = bloc.errors.listen((error) {
+      if (!mounted) {
+        return;
+      }
+
       NeonError.showSnackbar(context, error);
     });
   }

--- a/packages/neon_framework/packages/files_app/lib/src/widgets/browser_view.dart
+++ b/packages/neon_framework/packages/files_app/lib/src/widgets/browser_view.dart
@@ -56,6 +56,10 @@ class _FilesBrowserViewState extends State<FilesBrowserView> {
     );
 
     errorsSubscription = bloc.errors.listen((error) {
+      if (!mounted) {
+        return;
+      }
+
       NeonError.showSnackbar(context, error);
     });
 

--- a/packages/neon_framework/packages/files_app/pubspec.yaml
+++ b/packages/neon_framework/packages/files_app/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   path: ^1.0.0
   path_provider: ^2.0.0
   queue: ^3.0.0
-  rxdart: ^0.27.0
+  rxdart: ^0.28.0
   share_plus: ^10.0.0
   timezone: ^0.9.4
   universal_io: ^2.0.0

--- a/packages/neon_framework/packages/files_app/pubspec.yaml
+++ b/packages/neon_framework/packages/files_app/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 publish_to: 'none'
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
   flutter: ^3.22.0
 
 dependencies:

--- a/packages/neon_framework/packages/files_app/pubspec.yaml
+++ b/packages/neon_framework/packages/files_app/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  custom_lint: ^0.6.5
   go_router_builder: ^2.7.1
   neon_lints:
     git:

--- a/packages/neon_framework/packages/files_app/pubspec.yaml
+++ b/packages/neon_framework/packages/files_app/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   universal_io: ^2.0.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   custom_lint: ^0.6.5
   go_router_builder: ^2.7.1
   neon_lints:

--- a/packages/neon_framework/packages/files_icons/pubspec.yaml
+++ b/packages/neon_framework/packages/files_icons/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
   flutter: ^3.22.0
 
 dependencies:

--- a/packages/neon_framework/packages/neon_http_client/pubspec.yaml
+++ b/packages/neon_framework/packages/neon_http_client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dependencies:
   built_collection: ^5.0.0

--- a/packages/neon_framework/packages/news_app/analysis_options.yaml
+++ b/packages/neon_framework/packages/news_app/analysis_options.yaml
@@ -6,5 +6,4 @@ linter:
 
 analyzer:
   exclude:
-    - lib/l10n/**
     - '**/routes.g.dart'

--- a/packages/neon_framework/packages/news_app/lib/l10n/localizations.dart
+++ b/packages/neon_framework/packages/news_app/lib/l10n/localizations.dart
@@ -7,6 +7,8 @@ import 'package:intl/intl.dart' as intl;
 
 import 'localizations_en.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of NewsLocalizations
 /// returned by `NewsLocalizations.of(context)`.
 ///

--- a/packages/neon_framework/packages/news_app/lib/l10n/localizations_en.dart
+++ b/packages/neon_framework/packages/news_app/lib/l10n/localizations_en.dart
@@ -1,5 +1,7 @@
 import 'localizations.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class NewsLocalizationsEn extends NewsLocalizations {
   NewsLocalizationsEn([String locale = 'en']) : super(locale);

--- a/packages/neon_framework/packages/news_app/lib/src/pages/article.dart
+++ b/packages/neon_framework/packages/news_app/lib/src/pages/article.dart
@@ -47,6 +47,10 @@ class _NewsArticlePageState extends State<NewsArticlePage> {
     super.initState();
 
     errorsSubscription = widget.bloc.errors.listen((error) {
+      if (!mounted) {
+        return;
+      }
+
       NeonError.showSnackbar(context, error);
     });
 

--- a/packages/neon_framework/packages/news_app/lib/src/pages/main.dart
+++ b/packages/neon_framework/packages/news_app/lib/src/pages/main.dart
@@ -34,6 +34,10 @@ class _NewsMainPageState extends State<NewsMainPage> {
     index = NeonProvider.of<NewsOptions>(context).defaultCategoryOption.value.index;
 
     errorsSubscription = bloc.errors.listen((error) {
+      if (!mounted) {
+        return;
+      }
+
       NeonError.showSnackbar(context, error);
     });
   }

--- a/packages/neon_framework/packages/news_app/lib/src/widgets/articles_view.dart
+++ b/packages/neon_framework/packages/news_app/lib/src/widgets/articles_view.dart
@@ -48,6 +48,10 @@ class _NewsArticlesViewState extends State<NewsArticlesView> {
     super.initState();
 
     errorsSubscription = widget.bloc.errors.listen((error) {
+      if (!mounted) {
+        return;
+      }
+
       NeonError.showSnackbar(context, error);
     });
 

--- a/packages/neon_framework/packages/news_app/pubspec.yaml
+++ b/packages/neon_framework/packages/news_app/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  custom_lint: ^0.6.5
   go_router_builder: ^2.7.1
   neon_lints:
     git:

--- a/packages/neon_framework/packages/news_app/pubspec.yaml
+++ b/packages/neon_framework/packages/news_app/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   webview_flutter: ^4.0.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   custom_lint: ^0.6.5
   go_router_builder: ^2.7.1
   neon_lints:

--- a/packages/neon_framework/packages/news_app/pubspec.yaml
+++ b/packages/neon_framework/packages/news_app/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
       url: https://github.com/nextcloud/neon
       path: packages/neon_framework
   nextcloud: ^7.0.0
-  rxdart: ^0.27.0
+  rxdart: ^0.28.0
   share_plus: ^10.0.0
   timezone: ^0.9.4
   wakelock_plus: ^1.0.0

--- a/packages/neon_framework/packages/news_app/pubspec.yaml
+++ b/packages/neon_framework/packages/news_app/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 publish_to: 'none'
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
   flutter: ^3.22.0
 
 dependencies:

--- a/packages/neon_framework/packages/notes_app/analysis_options.yaml
+++ b/packages/neon_framework/packages/notes_app/analysis_options.yaml
@@ -6,5 +6,4 @@ linter:
 
 analyzer:
   exclude:
-    - lib/l10n/**
     - '**/routes.g.dart'

--- a/packages/neon_framework/packages/notes_app/lib/l10n/localizations.dart
+++ b/packages/neon_framework/packages/notes_app/lib/l10n/localizations.dart
@@ -7,6 +7,8 @@ import 'package:intl/intl.dart' as intl;
 
 import 'localizations_en.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of NotesLocalizations
 /// returned by `NotesLocalizations.of(context)`.
 ///

--- a/packages/neon_framework/packages/notes_app/lib/l10n/localizations_en.dart
+++ b/packages/neon_framework/packages/notes_app/lib/l10n/localizations_en.dart
@@ -1,5 +1,7 @@
 import 'localizations.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class NotesLocalizationsEn extends NotesLocalizations {
   NotesLocalizationsEn([String locale = 'en']) : super(locale);

--- a/packages/neon_framework/packages/notes_app/lib/src/pages/main.dart
+++ b/packages/neon_framework/packages/notes_app/lib/src/pages/main.dart
@@ -34,6 +34,10 @@ class _NotesMainPageState extends State<NotesMainPage> {
     index = NeonProvider.of<NotesOptions>(context).defaultCategoryOption.value.index;
 
     errorsSubscription = bloc.errors.listen((error) {
+      if (!mounted) {
+        return;
+      }
+
       handleNotesException(context, error);
     });
   }

--- a/packages/neon_framework/packages/notes_app/lib/src/pages/note.dart
+++ b/packages/neon_framework/packages/notes_app/lib/src/pages/note.dart
@@ -49,6 +49,10 @@ class _NotesNotePageState extends State<NotesNotePage> {
     super.initState();
 
     errorsSubscription = widget.bloc.errors.listen((error) {
+      if (!mounted) {
+        return;
+      }
+
       handleNotesException(context, error);
     });
 

--- a/packages/neon_framework/packages/notes_app/pubspec.yaml
+++ b/packages/neon_framework/packages/notes_app/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   wakelock_plus: ^1.0.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   custom_lint: ^0.6.5
   go_router_builder: ^2.7.1
   neon_lints:

--- a/packages/neon_framework/packages/notes_app/pubspec.yaml
+++ b/packages/neon_framework/packages/notes_app/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  custom_lint: ^0.6.5
   go_router_builder: ^2.7.1
   neon_lints:
     git:

--- a/packages/neon_framework/packages/notes_app/pubspec.yaml
+++ b/packages/neon_framework/packages/notes_app/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
       path: packages/neon_framework
   nextcloud: ^7.0.0
   queue: ^3.0.0
-  rxdart: ^0.27.0
+  rxdart: ^0.28.0
   timezone: ^0.9.4
   wakelock_plus: ^1.0.0
 

--- a/packages/neon_framework/packages/notes_app/pubspec.yaml
+++ b/packages/neon_framework/packages/notes_app/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 publish_to: 'none'
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
   flutter: ^3.22.0
 
 dependencies:

--- a/packages/neon_framework/packages/notifications_app/analysis_options.yaml
+++ b/packages/neon_framework/packages/notifications_app/analysis_options.yaml
@@ -6,5 +6,4 @@ linter:
 
 analyzer:
   exclude:
-    - lib/l10n/**
     - '**/routes.g.dart'

--- a/packages/neon_framework/packages/notifications_app/lib/l10n/localizations.dart
+++ b/packages/neon_framework/packages/notifications_app/lib/l10n/localizations.dart
@@ -7,6 +7,8 @@ import 'package:intl/intl.dart' as intl;
 
 import 'localizations_en.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of NotificationsLocalizations
 /// returned by `NotificationsLocalizations.of(context)`.
 ///

--- a/packages/neon_framework/packages/notifications_app/lib/l10n/localizations_en.dart
+++ b/packages/neon_framework/packages/notifications_app/lib/l10n/localizations_en.dart
@@ -1,5 +1,7 @@
 import 'localizations.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class NotificationsLocalizationsEn extends NotificationsLocalizations {
   NotificationsLocalizationsEn([String locale = 'en']) : super(locale);

--- a/packages/neon_framework/packages/notifications_app/lib/src/pages/main.dart
+++ b/packages/neon_framework/packages/notifications_app/lib/src/pages/main.dart
@@ -30,6 +30,10 @@ class _NotificationsMainPageState extends State<NotificationsMainPage> {
     bloc = NeonProvider.of<NotificationsBlocInterface>(context) as NotificationsBloc;
 
     errorsSubscription = bloc.errors.listen((error) {
+      if (!mounted) {
+        return;
+      }
+
       NeonError.showSnackbar(context, error);
     });
   }

--- a/packages/neon_framework/packages/notifications_app/pubspec.yaml
+++ b/packages/neon_framework/packages/notifications_app/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   timezone: ^0.9.4
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   custom_lint: ^0.6.5
   flutter_test:
     sdk: flutter

--- a/packages/neon_framework/packages/notifications_app/pubspec.yaml
+++ b/packages/neon_framework/packages/notifications_app/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
       url: https://github.com/nextcloud/neon
       path: packages/neon_framework
   nextcloud: ^7.0.0
-  rxdart: ^0.27.0
+  rxdart: ^0.28.0
   timezone: ^0.9.4
 
 dev_dependencies:

--- a/packages/neon_framework/packages/notifications_app/pubspec.yaml
+++ b/packages/neon_framework/packages/notifications_app/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 publish_to: 'none'
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
   flutter: ^3.22.0
 
 dependencies:

--- a/packages/neon_framework/packages/notifications_app/pubspec.yaml
+++ b/packages/neon_framework/packages/notifications_app/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  custom_lint: ^0.6.5
   flutter_test:
     sdk: flutter
   go_router_builder: ^2.7.1

--- a/packages/neon_framework/packages/sort_box/pubspec.yaml
+++ b/packages/neon_framework/packages/sort_box/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dependencies:
   built_collection: ^5.0.0

--- a/packages/neon_framework/packages/talk_app/analysis_options.yaml
+++ b/packages/neon_framework/packages/talk_app/analysis_options.yaml
@@ -2,5 +2,4 @@ include: package:neon_lints/flutter.yaml
 
 analyzer:
   exclude:
-    - lib/l10n/**
     - '**/routes.g.dart'

--- a/packages/neon_framework/packages/talk_app/lib/l10n/localizations.dart
+++ b/packages/neon_framework/packages/talk_app/lib/l10n/localizations.dart
@@ -7,6 +7,8 @@ import 'package:intl/intl.dart' as intl;
 
 import 'localizations_en.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of TalkLocalizations
 /// returned by `TalkLocalizations.of(context)`.
 ///

--- a/packages/neon_framework/packages/talk_app/lib/l10n/localizations_en.dart
+++ b/packages/neon_framework/packages/talk_app/lib/l10n/localizations_en.dart
@@ -2,6 +2,8 @@ import 'package:intl/intl.dart' as intl;
 
 import 'localizations.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class TalkLocalizationsEn extends TalkLocalizations {
   TalkLocalizationsEn([String locale = 'en']) : super(locale);

--- a/packages/neon_framework/packages/talk_app/lib/src/pages/main.dart
+++ b/packages/neon_framework/packages/talk_app/lib/src/pages/main.dart
@@ -40,6 +40,10 @@ class _TalkMainPageState extends State<TalkMainPage> {
 
     bloc = NeonProvider.of<TalkBloc>(context);
     errorsSubscription = bloc.errors.listen((error) {
+      if (!mounted) {
+        return;
+      }
+
       NeonError.showSnackbar(context, error);
     });
   }

--- a/packages/neon_framework/packages/talk_app/lib/src/pages/room.dart
+++ b/packages/neon_framework/packages/talk_app/lib/src/pages/room.dart
@@ -38,6 +38,10 @@ class _TalkRoomPageState extends State<TalkRoomPage> {
     bloc = NeonProvider.of<TalkRoomBloc>(context);
 
     errorsSubscription = bloc.errors.listen((error) {
+      if (!mounted) {
+        return;
+      }
+
       NeonError.showSnackbar(context, error);
     });
   }

--- a/packages/neon_framework/packages/talk_app/pubspec.yaml
+++ b/packages/neon_framework/packages/talk_app/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  custom_lint: ^0.6.5
   flutter_keyboard_visibility: ^6.0.0
   flutter_test:
     sdk: flutter

--- a/packages/neon_framework/packages/talk_app/pubspec.yaml
+++ b/packages/neon_framework/packages/talk_app/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   timezone: ^0.9.4
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   custom_lint: ^0.6.5
   flutter_keyboard_visibility: ^6.0.0
   flutter_test:

--- a/packages/neon_framework/packages/talk_app/pubspec.yaml
+++ b/packages/neon_framework/packages/talk_app/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
       url: https://github.com/nextcloud/neon
       path: packages/neon_framework
   nextcloud: ^7.0.0
-  rxdart: ^0.27.0
+  rxdart: ^0.28.0
   timezone: ^0.9.4
 
 dev_dependencies:

--- a/packages/neon_framework/packages/talk_app/pubspec.yaml
+++ b/packages/neon_framework/packages/talk_app/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 publish_to: 'none'
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
   flutter: ^3.22.0
 
 dependencies:

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -71,7 +71,7 @@ dependencies:
   xml: ^6.0.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   built_value_generator: ^8.9.2
   cookie_store_conformance_tests:
     git:

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -77,7 +77,7 @@ dev_dependencies:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/cookie_store_conformance_tests
-  custom_lint: ^0.6.4
+  custom_lint: ^0.6.5
   flutter_test:
     sdk: flutter
   go_router_builder: ^2.7.1

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 publish_to: 'none'
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
   flutter: ^3.22.0
 
 dependencies:

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   permission_handler: ^11.0.0
   provider: ^6.0.0
   quick_actions: ^1.0.0
-  rxdart: ^0.27.0
+  rxdart: ^0.28.0
   scrollable_positioned_list: ^0.3.0
   shared_preferences_platform_interface: ^2.3.2
   sort_box:

--- a/packages/neon_lints/example/pubspec.yaml
+++ b/packages/neon_lints/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: neon_lints_test
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
   flutter: ^3.22.0
 
 dependencies:

--- a/packages/neon_lints/example/pubspec.yaml
+++ b/packages/neon_lints/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   nextcloud: ^7.0.0
 
 dev_dependencies:
-  custom_lint: ^0.6.4
+  custom_lint: ^0.6.5
   flutter_test:
     sdk: flutter
   meta: ^1.11.0

--- a/packages/neon_lints/pubspec.yaml
+++ b/packages/neon_lints/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dependencies:
   analyzer: ^6.4.1

--- a/packages/nextcloud/lib/src/models/version_check.dart
+++ b/packages/nextcloud/lib/src/models/version_check.dart
@@ -27,7 +27,7 @@ class VersionCheck {
   /// Only one of the [versions] has to be supported to return `true`.
   bool get isSupported {
     if (_isSupportedOverride != null) {
-      return _isSupportedOverride!;
+      return _isSupportedOverride;
     }
 
     if (versions == null || versions!.isEmpty) {

--- a/packages/nextcloud/packages/nextcloud_test/pubspec.yaml
+++ b/packages/nextcloud/packages/nextcloud_test/pubspec.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dependencies:
   built_collection: ^5.1.1

--- a/packages/nextcloud/pubspec.yaml
+++ b/packages/nextcloud/pubspec.yaml
@@ -9,7 +9,7 @@ topics:
   - webdav
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dependencies:
   built_collection: ^5.0.0

--- a/packages/nextcloud/pubspec.yaml
+++ b/packages/nextcloud/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   xml_annotation: ^2.1.0
 
 dev_dependencies:
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   built_value_generator: ^8.9.2
   built_value_test: ^8.9.2
   code_builder: ^4.10.0

--- a/packages/nextcloud/pubspec.yaml
+++ b/packages/nextcloud/pubspec.yaml
@@ -53,7 +53,7 @@ dev_dependencies:
       url: https://github.com/nextcloud/neon
       path: packages/nextcloud/packages/nextcloud_test
   path: ^1.9.0
-  process_run: ^1.1.0
+  process_run: ^1.2.0
   test: ^1.25.8
   test_api: ^0.7.3
   xml_serializable: ^2.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: neon_workspace
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.5.0
 
 dev_dependencies:
   commitlint_cli: ^0.7.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,5 +9,5 @@ dev_dependencies:
   fvm: ^3.1.7
   husky: ^0.1.7
   melos: ^6.0.0
-  custom_lint: ^0.6.4
+  custom_lint: ^0.6.5
   coverage: ^1.9.0


### PR DESCRIPTION
fixes: #2391
replaces: #2399, #2404, #2415, #2400, #2406, #2397, #2398

Once reviewed, I'll sqash all commits together.
I had to disable custom_lint in our CI as it started analyzing files outside the package scope (mainly the symlinks to the pub cache with all our dependencies).

Now that we require dart 3.5 I'm looking into using dart workspaces.