### PR TITLE
ci: Use fdroidserver patch for publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,7 @@
 name: Publish
 
 on:
+  pull_request:
   schedule:
     - cron:  '0 5 * * *'
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,7 +66,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install apksigner fdroidserver python3-pip --no-install-recommends
           sudo apt-get purge fdroidserver
-          pip3 install https://gitlab.com/fdroid/fdroidserver/-/archive/master/fdroidserver.tar.gz
+          # https://gitlab.com/fdroid/fdroidserver/-/merge_requests/1511
+          pip3 install https://gitlab.com/wrenix/fdroidserver/-/archive/3a4a8f53ea11b6dc5852a3324f44413fb1b6835d/fdroidserver-3a4a8f53ea11b6dc5852a3324f44413fb1b6835d.tar.gz
+          # pip3 install https://gitlab.com/fdroid/fdroidserver/-/archive/master/fdroidserver.tar.gz
           export DEBUG_KEYSTORE=${{ secrets.DEBUG_KEYSTORE }}
           GITHUB_REPOSITORY=provokateurin/nextcloud-neon fdroid nightly -v --archive-older 10
 


### PR DESCRIPTION
https://github.com/nextcloud/neon/issues/18

To test out the patch https://gitlab.com/fdroid/fdroidserver/-/merge_requests/1511 made by @wrenix