### PR TITLE
fix(dynamite)!: Do not assume subtypes of someOfs are always nullable

### DIFF
--- a/packages/dynamite/lib/src/builder/generate_ofs.dart
+++ b/packages/dynamite/lib/src/builder/generate_ofs.dart
@@ -281,7 +281,7 @@ Iterable<Spec> generateSomeOf(
           final buffer = StringBuffer();
           for (final field in fields.entries) {
             final result = field.key;
-            final dartName = result.nullableName;
+            final dartName = result.asNullable.nullableName;
             final fieldName = field.value;
 
             buffer.write('''

--- a/packages/dynamite/lib/src/builder/resolve_interface.dart
+++ b/packages/dynamite/lib/src/builder/resolve_interface.dart
@@ -238,7 +238,7 @@ void _generateProperty(
         }
 
         if (result is TypeResultSomeOf && result.isSingleValue) {
-          b.returns = refer(result.dartType.name);
+          b.returns = refer(result.dartType.nullableName);
         } else {
           b.returns = refer(result.nullableName);
         }

--- a/packages/dynamite/lib/src/builder/resolve_ofs.dart
+++ b/packages/dynamite/lib/src/builder/resolve_ofs.dart
@@ -15,9 +15,7 @@ TypeResult resolveSomeOf(State state, json_schema.JsonSchema schema) {
       return resolveType(
         state,
         schema.rebuild((b) {
-          b
-            ..identifier = '$identifier$index'
-            ..nullable = true;
+          b.identifier = '$identifier$index';
         }),
       );
     }).toBuiltSet();

--- a/packages/dynamite/lib/src/models/type_result/base.dart
+++ b/packages/dynamite/lib/src/models/type_result/base.dart
@@ -52,4 +52,11 @@ class TypeResultBase extends TypeResult {
 
     return TypeResultBase(dartName, nullable: nullable);
   }
+
+  @override
+  TypeResultBase get asNullable => TypeResultBase(
+        className,
+        nullable: true,
+        isTypeDef: isTypeDef,
+      );
 }

--- a/packages/dynamite/lib/src/models/type_result/enum.dart
+++ b/packages/dynamite/lib/src/models/type_result/enum.dart
@@ -27,4 +27,12 @@ class TypeResultEnum extends TypeResult {
 
   @override
   int get hashCode => className.hashCode + subType.hashCode;
+
+  @override
+  TypeResultEnum get asNullable => TypeResultEnum(
+        className,
+        subType,
+        nullable: true,
+        isTypeDef: isTypeDef,
+      );
 }

--- a/packages/dynamite/lib/src/models/type_result/list.dart
+++ b/packages/dynamite/lib/src/models/type_result/list.dart
@@ -24,4 +24,13 @@ class TypeResultList extends TypeResult {
 
   @override
   int get hashCode => className.hashCode + generics.hashCode + subType.hashCode;
+
+  @override
+  TypeResultList get asNullable => TypeResultList(
+        className,
+        subType,
+        nullable: true,
+        isTypeDef: isTypeDef,
+        builderName: builderName,
+      );
 }

--- a/packages/dynamite/lib/src/models/type_result/map.dart
+++ b/packages/dynamite/lib/src/models/type_result/map.dart
@@ -24,4 +24,13 @@ class TypeResultMap extends TypeResult {
 
   @override
   int get hashCode => className.hashCode + generics.hashCode + subType.hashCode;
+
+  @override
+  TypeResultMap get asNullable => TypeResultMap(
+        className,
+        subType,
+        nullable: true,
+        isTypeDef: isTypeDef,
+        builderName: builderName,
+      );
 }

--- a/packages/dynamite/lib/src/models/type_result/object.dart
+++ b/packages/dynamite/lib/src/models/type_result/object.dart
@@ -40,4 +40,12 @@ class TypeResultObject extends TypeResult {
       isTypeDef: isTypeDef,
     );
   }
+
+  @override
+  TypeResultObject get asNullable => TypeResultObject(
+        className,
+        generics: generics,
+        nullable: true,
+        isTypeDef: isTypeDef,
+      );
 }

--- a/packages/dynamite/lib/src/models/type_result/some_of.dart
+++ b/packages/dynamite/lib/src/models/type_result/some_of.dart
@@ -33,11 +33,11 @@ abstract class TypeResultSomeOf extends TypeResult {
   @override
   TypeResult get dartType {
     if (isSingleValue) {
-      return optimizedSubTypes.single;
+      return nullable ? optimizedSubTypes.single.asNullable : optimizedSubTypes.single;
     }
 
     final record = optimizedSubTypes.map((type) {
-      final dartType = type.nullableName;
+      final dartType = type.asNullable.nullableName;
       final dartName = toDartName(dartType);
 
       return '$dartType $dartName';
@@ -77,7 +77,7 @@ abstract class TypeResultSomeOf extends TypeResult {
     final optimizeNum = subTypes.where(_isNumber).length >= 2;
 
     if (optimizeNum) {
-      optimized.add(TypeResultBase('num', nullable: true));
+      optimized.add(TypeResultBase('num'));
     }
 
     optimized.addAll(
@@ -131,6 +131,13 @@ class TypeResultAnyOf extends TypeResultSomeOf {
 
   @override
   int get hashCode => className.hashCode + generics.hashCode + dartType.hashCode;
+
+  @override
+  TypeResultAnyOf get asNullable => TypeResultAnyOf(
+        className,
+        subTypes: subTypes,
+        nullable: true,
+      );
 }
 
 class TypeResultOneOf extends TypeResultSomeOf {
@@ -153,4 +160,11 @@ class TypeResultOneOf extends TypeResultSomeOf {
 
   @override
   int get hashCode => className.hashCode + generics.hashCode + dartType.hashCode;
+
+  @override
+  TypeResultOneOf get asNullable => TypeResultOneOf(
+        className,
+        subTypes: subTypes,
+        nullable: true,
+      );
 }

--- a/packages/dynamite/lib/src/models/type_result/type_result.dart
+++ b/packages/dynamite/lib/src/models/type_result/type_result.dart
@@ -197,6 +197,8 @@ sealed class TypeResult {
     };
   }
 
+  TypeResult get asNullable;
+
   @override
   bool operator ==(Object other) => other is TypeResult && other.className == className && other.generics == generics;
 

--- a/packages/dynamite/packages/dynamite_end_to_end_test/lib/some_of.openapi.dart
+++ b/packages/dynamite/packages/dynamite_end_to_end_test/lib/some_of.openapi.dart
@@ -23,66 +23,72 @@ typedef OneOfIntDoubleOther = ({num? $num, String? string});
 
 /// One of with an integer, double and other value.
 typedef AnyOfIntDoubleOther = ({num? $num, String? string});
-typedef OneValueSomeOfInObject_IntDoubleString = ({num? $num, String? string});
+typedef OneOfInObject_IntDoubleOther = ({num? $num, String? string});
+typedef OneOfInObject_IntDoubleOtherRequired = ({num? $num, String? string});
 
 /// Object with someOfs that only contain a single value (or are optimized to such).
 /// Should use the single member directly.
 @BuiltValue(instantiable: false)
-sealed class $OneValueSomeOfInObjectInterface {
+sealed class $OneOfInObjectInterface {
   @BuiltValueField(wireName: 'OneValue')
-  int get oneValue;
+  int? get oneValue;
+  @BuiltValueField(wireName: 'OneValueRequired')
+  int get oneValueRequired;
   @BuiltValueField(wireName: 'IntDouble')
-  num get intDouble;
-  @BuiltValueField(wireName: 'IntDoubleString')
-  OneValueSomeOfInObject_IntDoubleString? get intDoubleString;
+  num? get intDouble;
+  @BuiltValueField(wireName: 'IntDoubleRequired')
+  num get intDoubleRequired;
+  @BuiltValueField(wireName: 'IntDoubleOther')
+  OneOfInObject_IntDoubleOther? get intDoubleOther;
+  @BuiltValueField(wireName: 'IntDoubleOtherRequired')
+  OneOfInObject_IntDoubleOtherRequired get intDoubleOtherRequired;
 
   /// Rebuilds the instance.
   ///
   /// The result is the same as this instance but with [updates] applied.
-  /// [updates] is a function that takes a builder [$OneValueSomeOfInObjectInterfaceBuilder].
-  $OneValueSomeOfInObjectInterface rebuild(void Function($OneValueSomeOfInObjectInterfaceBuilder) updates);
+  /// [updates] is a function that takes a builder [$OneOfInObjectInterfaceBuilder].
+  $OneOfInObjectInterface rebuild(void Function($OneOfInObjectInterfaceBuilder) updates);
 
-  /// Converts the instance to a builder [$OneValueSomeOfInObjectInterfaceBuilder].
-  $OneValueSomeOfInObjectInterfaceBuilder toBuilder();
+  /// Converts the instance to a builder [$OneOfInObjectInterfaceBuilder].
+  $OneOfInObjectInterfaceBuilder toBuilder();
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults($OneValueSomeOfInObjectInterfaceBuilder b) {}
+  static void _defaults($OneOfInObjectInterfaceBuilder b) {}
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate($OneValueSomeOfInObjectInterfaceBuilder b) {
-    b.intDoubleString?.validateOneOf();
+  static void _validate($OneOfInObjectInterfaceBuilder b) {
+    b.intDoubleOther?.validateOneOf();
+    b.intDoubleOtherRequired?.validateOneOf();
   }
 }
 
 /// Object with someOfs that only contain a single value (or are optimized to such).
 /// Should use the single member directly.
-abstract class OneValueSomeOfInObject
-    implements $OneValueSomeOfInObjectInterface, Built<OneValueSomeOfInObject, OneValueSomeOfInObjectBuilder> {
-  /// Creates a new OneValueSomeOfInObject object using the builder pattern.
-  factory OneValueSomeOfInObject([void Function(OneValueSomeOfInObjectBuilder)? b]) = _$OneValueSomeOfInObject;
+abstract class OneOfInObject implements $OneOfInObjectInterface, Built<OneOfInObject, OneOfInObjectBuilder> {
+  /// Creates a new OneOfInObject object using the builder pattern.
+  factory OneOfInObject([void Function(OneOfInObjectBuilder)? b]) = _$OneOfInObject;
 
-  const OneValueSomeOfInObject._();
+  const OneOfInObject._();
 
   /// Creates a new object from the given [json] data.
   ///
   /// Use [toJson] to serialize it back into json.
-  factory OneValueSomeOfInObject.fromJson(Map<String, dynamic> json) =>
-      _$jsonSerializers.deserializeWith(serializer, json)!;
+  factory OneOfInObject.fromJson(Map<String, dynamic> json) => _$jsonSerializers.deserializeWith(serializer, json)!;
 
   /// Parses this object into a json like map.
   ///
   /// Use the fromJson factory to revive it again.
   Map<String, dynamic> toJson() => _$jsonSerializers.serializeWith(serializer, this)! as Map<String, dynamic>;
 
-  /// Serializer for OneValueSomeOfInObject.
-  static Serializer<OneValueSomeOfInObject> get serializer => _$oneValueSomeOfInObjectSerializer;
+  /// Serializer for OneOfInObject.
+  static Serializer<OneOfInObject> get serializer => _$oneOfInObjectSerializer;
 
   @BuiltValueHook(initializeBuilder: true)
-  static void _defaults(OneValueSomeOfInObjectBuilder b) {
-    $OneValueSomeOfInObjectInterface._defaults(b);
+  static void _defaults(OneOfInObjectBuilder b) {
+    $OneOfInObjectInterface._defaults(b);
   }
 
   @BuiltValueHook(finalizeBuilder: true)
-  static void _validate(OneValueSomeOfInObjectBuilder b) {
-    $OneValueSomeOfInObjectInterface._validate(b);
+  static void _validate(OneOfInObjectBuilder b) {
+    $OneOfInObjectInterface._validate(b);
   }
 }
 
@@ -110,17 +116,31 @@ extension $AnyOfIntDoubleOtherExtension on AnyOfIntDoubleOther {
   static AnyOfIntDoubleOther fromJson(Object? json) => $b6d67dc2a96424d2f407f8e51557f3deExtension._fromJson(json);
 }
 
-/// Serialization extension for `OneValueSomeOfInObject_IntDoubleString`.
-extension $OneValueSomeOfInObject_IntDoubleStringExtension on OneValueSomeOfInObject_IntDoubleString {
-  /// Serializer for OneValueSomeOfInObject_IntDoubleString.
+/// Serialization extension for `OneOfInObject_IntDoubleOther`.
+extension $OneOfInObject_IntDoubleOtherExtension on OneOfInObject_IntDoubleOther {
+  /// Serializer for OneOfInObject_IntDoubleOther.
   @BuiltValueSerializer(custom: true)
-  static Serializer<OneValueSomeOfInObject_IntDoubleString> get serializer =>
+  static Serializer<OneOfInObject_IntDoubleOther> get serializer =>
       $b6d67dc2a96424d2f407f8e51557f3deExtension._serializer;
 
   /// Creates a new object from the given [json] data.
   ///
   /// Use `toJson` to serialize it back into json.
-  static OneValueSomeOfInObject_IntDoubleString fromJson(Object? json) =>
+  static OneOfInObject_IntDoubleOther fromJson(Object? json) =>
+      $b6d67dc2a96424d2f407f8e51557f3deExtension._fromJson(json);
+}
+
+/// Serialization extension for `OneOfInObject_IntDoubleOtherRequired`.
+extension $OneOfInObject_IntDoubleOtherRequiredExtension on OneOfInObject_IntDoubleOtherRequired {
+  /// Serializer for OneOfInObject_IntDoubleOtherRequired.
+  @BuiltValueSerializer(custom: true)
+  static Serializer<OneOfInObject_IntDoubleOtherRequired> get serializer =>
+      $b6d67dc2a96424d2f407f8e51557f3deExtension._serializer;
+
+  /// Creates a new object from the given [json] data.
+  ///
+  /// Use `toJson` to serialize it back into json.
+  static OneOfInObject_IntDoubleOtherRequired fromJson(Object? json) =>
       $b6d67dc2a96424d2f407f8e51557f3deExtension._fromJson(json);
 }
 
@@ -215,8 +235,8 @@ class _$b6d67dc2a96424d2f407f8e51557f3deSerializer implements PrimitiveSerialize
 final Serializers $serializers = _$serializers;
 final Serializers _$serializers = (Serializers().toBuilder()
       ..add($b6d67dc2a96424d2f407f8e51557f3deExtension._serializer)
-      ..addBuilderFactory(const FullType(OneValueSomeOfInObject), OneValueSomeOfInObjectBuilder.new)
-      ..add(OneValueSomeOfInObject.serializer))
+      ..addBuilderFactory(const FullType(OneOfInObject), OneOfInObjectBuilder.new)
+      ..add(OneOfInObject.serializer))
     .build();
 
 /// Serializer for all values in this library.

--- a/packages/dynamite/packages/dynamite_end_to_end_test/lib/some_of.openapi.g.dart
+++ b/packages/dynamite/packages/dynamite_end_to_end_test/lib/some_of.openapi.g.dart
@@ -6,37 +6,52 @@ part of 'some_of.openapi.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<OneValueSomeOfInObject> _$oneValueSomeOfInObjectSerializer = _$OneValueSomeOfInObjectSerializer();
+Serializer<OneOfInObject> _$oneOfInObjectSerializer = _$OneOfInObjectSerializer();
 
-class _$OneValueSomeOfInObjectSerializer implements StructuredSerializer<OneValueSomeOfInObject> {
+class _$OneOfInObjectSerializer implements StructuredSerializer<OneOfInObject> {
   @override
-  final Iterable<Type> types = const [OneValueSomeOfInObject, _$OneValueSomeOfInObject];
+  final Iterable<Type> types = const [OneOfInObject, _$OneOfInObject];
   @override
-  final String wireName = 'OneValueSomeOfInObject';
+  final String wireName = 'OneOfInObject';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, OneValueSomeOfInObject object,
+  Iterable<Object?> serialize(Serializers serializers, OneOfInObject object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
-      'OneValue',
-      serializers.serialize(object.oneValue, specifiedType: const FullType(int)),
-      'IntDouble',
-      serializers.serialize(object.intDouble, specifiedType: const FullType(num)),
+      'OneValueRequired',
+      serializers.serialize(object.oneValueRequired, specifiedType: const FullType(int)),
+      'IntDoubleRequired',
+      serializers.serialize(object.intDoubleRequired, specifiedType: const FullType(num)),
+      'IntDoubleOtherRequired',
+      serializers.serialize(object.intDoubleOtherRequired,
+          specifiedType: const FullType(OneOfInObject_IntDoubleOtherRequired)),
     ];
     Object? value;
-    value = object.intDoubleString;
+    value = object.oneValue;
     if (value != null) {
       result
-        ..add('IntDoubleString')
-        ..add(serializers.serialize(value, specifiedType: const FullType(OneValueSomeOfInObject_IntDoubleString)));
+        ..add('OneValue')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.intDouble;
+    if (value != null) {
+      result
+        ..add('IntDouble')
+        ..add(serializers.serialize(value, specifiedType: const FullType(num)));
+    }
+    value = object.intDoubleOther;
+    if (value != null) {
+      result
+        ..add('IntDoubleOther')
+        ..add(serializers.serialize(value, specifiedType: const FullType(OneOfInObject_IntDoubleOther)));
     }
     return result;
   }
 
   @override
-  OneValueSomeOfInObject deserialize(Serializers serializers, Iterable<Object?> serialized,
+  OneOfInObject deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = OneValueSomeOfInObjectBuilder();
+    final result = OneOfInObjectBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -45,15 +60,25 @@ class _$OneValueSomeOfInObjectSerializer implements StructuredSerializer<OneValu
       final Object? value = iterator.current;
       switch (key) {
         case 'OneValue':
-          result.oneValue = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
+          result.oneValue = serializers.deserialize(value, specifiedType: const FullType(int)) as int?;
+          break;
+        case 'OneValueRequired':
+          result.oneValueRequired = serializers.deserialize(value, specifiedType: const FullType(int))! as int;
           break;
         case 'IntDouble':
-          result.intDouble = serializers.deserialize(value, specifiedType: const FullType(num))! as num;
+          result.intDouble = serializers.deserialize(value, specifiedType: const FullType(num)) as num?;
           break;
-        case 'IntDoubleString':
-          result.intDoubleString =
-              serializers.deserialize(value, specifiedType: const FullType(OneValueSomeOfInObject_IntDoubleString))
-                  as OneValueSomeOfInObject_IntDoubleString?;
+        case 'IntDoubleRequired':
+          result.intDoubleRequired = serializers.deserialize(value, specifiedType: const FullType(num))! as num;
+          break;
+        case 'IntDoubleOther':
+          result.intDoubleOther = serializers.deserialize(value,
+              specifiedType: const FullType(OneOfInObject_IntDoubleOther)) as OneOfInObject_IntDoubleOther?;
+          break;
+        case 'IntDoubleOtherRequired':
+          result.intDoubleOtherRequired =
+              serializers.deserialize(value, specifiedType: const FullType(OneOfInObject_IntDoubleOtherRequired))!
+                  as OneOfInObject_IntDoubleOtherRequired;
           break;
       }
     }
@@ -62,125 +87,176 @@ class _$OneValueSomeOfInObjectSerializer implements StructuredSerializer<OneValu
   }
 }
 
-abstract mixin class $OneValueSomeOfInObjectInterfaceBuilder {
-  void replace($OneValueSomeOfInObjectInterface other);
-  void update(void Function($OneValueSomeOfInObjectInterfaceBuilder) updates);
+abstract mixin class $OneOfInObjectInterfaceBuilder {
+  void replace($OneOfInObjectInterface other);
+  void update(void Function($OneOfInObjectInterfaceBuilder) updates);
   int? get oneValue;
   set oneValue(int? oneValue);
+
+  int? get oneValueRequired;
+  set oneValueRequired(int? oneValueRequired);
 
   num? get intDouble;
   set intDouble(num? intDouble);
 
-  OneValueSomeOfInObject_IntDoubleString? get intDoubleString;
-  set intDoubleString(OneValueSomeOfInObject_IntDoubleString? intDoubleString);
+  num? get intDoubleRequired;
+  set intDoubleRequired(num? intDoubleRequired);
+
+  OneOfInObject_IntDoubleOther? get intDoubleOther;
+  set intDoubleOther(OneOfInObject_IntDoubleOther? intDoubleOther);
+
+  OneOfInObject_IntDoubleOtherRequired? get intDoubleOtherRequired;
+  set intDoubleOtherRequired(OneOfInObject_IntDoubleOtherRequired? intDoubleOtherRequired);
 }
 
-class _$OneValueSomeOfInObject extends OneValueSomeOfInObject {
+class _$OneOfInObject extends OneOfInObject {
   @override
-  final int oneValue;
+  final int? oneValue;
   @override
-  final num intDouble;
+  final int oneValueRequired;
   @override
-  final OneValueSomeOfInObject_IntDoubleString? intDoubleString;
+  final num? intDouble;
+  @override
+  final num intDoubleRequired;
+  @override
+  final OneOfInObject_IntDoubleOther? intDoubleOther;
+  @override
+  final OneOfInObject_IntDoubleOtherRequired intDoubleOtherRequired;
 
-  factory _$OneValueSomeOfInObject([void Function(OneValueSomeOfInObjectBuilder)? updates]) =>
-      (OneValueSomeOfInObjectBuilder()..update(updates))._build();
+  factory _$OneOfInObject([void Function(OneOfInObjectBuilder)? updates]) =>
+      (OneOfInObjectBuilder()..update(updates))._build();
 
-  _$OneValueSomeOfInObject._({required this.oneValue, required this.intDouble, this.intDoubleString}) : super._() {
-    BuiltValueNullFieldError.checkNotNull(oneValue, r'OneValueSomeOfInObject', 'oneValue');
-    BuiltValueNullFieldError.checkNotNull(intDouble, r'OneValueSomeOfInObject', 'intDouble');
+  _$OneOfInObject._(
+      {this.oneValue,
+      required this.oneValueRequired,
+      this.intDouble,
+      required this.intDoubleRequired,
+      this.intDoubleOther,
+      required this.intDoubleOtherRequired})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(oneValueRequired, r'OneOfInObject', 'oneValueRequired');
+    BuiltValueNullFieldError.checkNotNull(intDoubleRequired, r'OneOfInObject', 'intDoubleRequired');
+    BuiltValueNullFieldError.checkNotNull(intDoubleOtherRequired, r'OneOfInObject', 'intDoubleOtherRequired');
   }
 
   @override
-  OneValueSomeOfInObject rebuild(void Function(OneValueSomeOfInObjectBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
+  OneOfInObject rebuild(void Function(OneOfInObjectBuilder) updates) => (toBuilder()..update(updates)).build();
 
   @override
-  OneValueSomeOfInObjectBuilder toBuilder() => OneValueSomeOfInObjectBuilder()..replace(this);
+  OneOfInObjectBuilder toBuilder() => OneOfInObjectBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     final dynamic _$dynamicOther = other;
-    return other is OneValueSomeOfInObject &&
+    return other is OneOfInObject &&
         oneValue == other.oneValue &&
+        oneValueRequired == other.oneValueRequired &&
         intDouble == other.intDouble &&
-        intDoubleString == _$dynamicOther.intDoubleString;
+        intDoubleRequired == other.intDoubleRequired &&
+        intDoubleOther == _$dynamicOther.intDoubleOther &&
+        intDoubleOtherRequired == _$dynamicOther.intDoubleOtherRequired;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
     _$hash = $jc(_$hash, oneValue.hashCode);
+    _$hash = $jc(_$hash, oneValueRequired.hashCode);
     _$hash = $jc(_$hash, intDouble.hashCode);
-    _$hash = $jc(_$hash, intDoubleString.hashCode);
+    _$hash = $jc(_$hash, intDoubleRequired.hashCode);
+    _$hash = $jc(_$hash, intDoubleOther.hashCode);
+    _$hash = $jc(_$hash, intDoubleOtherRequired.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'OneValueSomeOfInObject')
+    return (newBuiltValueToStringHelper(r'OneOfInObject')
           ..add('oneValue', oneValue)
+          ..add('oneValueRequired', oneValueRequired)
           ..add('intDouble', intDouble)
-          ..add('intDoubleString', intDoubleString))
+          ..add('intDoubleRequired', intDoubleRequired)
+          ..add('intDoubleOther', intDoubleOther)
+          ..add('intDoubleOtherRequired', intDoubleOtherRequired))
         .toString();
   }
 }
 
-class OneValueSomeOfInObjectBuilder
-    implements Builder<OneValueSomeOfInObject, OneValueSomeOfInObjectBuilder>, $OneValueSomeOfInObjectInterfaceBuilder {
-  _$OneValueSomeOfInObject? _$v;
+class OneOfInObjectBuilder implements Builder<OneOfInObject, OneOfInObjectBuilder>, $OneOfInObjectInterfaceBuilder {
+  _$OneOfInObject? _$v;
 
   int? _oneValue;
   int? get oneValue => _$this._oneValue;
   set oneValue(covariant int? oneValue) => _$this._oneValue = oneValue;
 
+  int? _oneValueRequired;
+  int? get oneValueRequired => _$this._oneValueRequired;
+  set oneValueRequired(covariant int? oneValueRequired) => _$this._oneValueRequired = oneValueRequired;
+
   num? _intDouble;
   num? get intDouble => _$this._intDouble;
   set intDouble(covariant num? intDouble) => _$this._intDouble = intDouble;
 
-  OneValueSomeOfInObject_IntDoubleString? _intDoubleString;
-  OneValueSomeOfInObject_IntDoubleString? get intDoubleString => _$this._intDoubleString;
-  set intDoubleString(covariant OneValueSomeOfInObject_IntDoubleString? intDoubleString) =>
-      _$this._intDoubleString = intDoubleString;
+  num? _intDoubleRequired;
+  num? get intDoubleRequired => _$this._intDoubleRequired;
+  set intDoubleRequired(covariant num? intDoubleRequired) => _$this._intDoubleRequired = intDoubleRequired;
 
-  OneValueSomeOfInObjectBuilder() {
-    OneValueSomeOfInObject._defaults(this);
+  OneOfInObject_IntDoubleOther? _intDoubleOther;
+  OneOfInObject_IntDoubleOther? get intDoubleOther => _$this._intDoubleOther;
+  set intDoubleOther(covariant OneOfInObject_IntDoubleOther? intDoubleOther) => _$this._intDoubleOther = intDoubleOther;
+
+  OneOfInObject_IntDoubleOtherRequired? _intDoubleOtherRequired;
+  OneOfInObject_IntDoubleOtherRequired? get intDoubleOtherRequired => _$this._intDoubleOtherRequired;
+  set intDoubleOtherRequired(covariant OneOfInObject_IntDoubleOtherRequired? intDoubleOtherRequired) =>
+      _$this._intDoubleOtherRequired = intDoubleOtherRequired;
+
+  OneOfInObjectBuilder() {
+    OneOfInObject._defaults(this);
   }
 
-  OneValueSomeOfInObjectBuilder get _$this {
+  OneOfInObjectBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
       _oneValue = $v.oneValue;
+      _oneValueRequired = $v.oneValueRequired;
       _intDouble = $v.intDouble;
-      _intDoubleString = $v.intDoubleString;
+      _intDoubleRequired = $v.intDoubleRequired;
+      _intDoubleOther = $v.intDoubleOther;
+      _intDoubleOtherRequired = $v.intDoubleOtherRequired;
       _$v = null;
     }
     return this;
   }
 
   @override
-  void replace(covariant OneValueSomeOfInObject other) {
+  void replace(covariant OneOfInObject other) {
     ArgumentError.checkNotNull(other, 'other');
-    _$v = other as _$OneValueSomeOfInObject;
+    _$v = other as _$OneOfInObject;
   }
 
   @override
-  void update(void Function(OneValueSomeOfInObjectBuilder)? updates) {
+  void update(void Function(OneOfInObjectBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  OneValueSomeOfInObject build() => _build();
+  OneOfInObject build() => _build();
 
-  _$OneValueSomeOfInObject _build() {
-    OneValueSomeOfInObject._validate(this);
+  _$OneOfInObject _build() {
+    OneOfInObject._validate(this);
     final _$result = _$v ??
-        _$OneValueSomeOfInObject._(
-            oneValue: BuiltValueNullFieldError.checkNotNull(oneValue, r'OneValueSomeOfInObject', 'oneValue'),
-            intDouble: BuiltValueNullFieldError.checkNotNull(intDouble, r'OneValueSomeOfInObject', 'intDouble'),
-            intDoubleString: intDoubleString);
+        _$OneOfInObject._(
+            oneValue: oneValue,
+            oneValueRequired:
+                BuiltValueNullFieldError.checkNotNull(oneValueRequired, r'OneOfInObject', 'oneValueRequired'),
+            intDouble: intDouble,
+            intDoubleRequired:
+                BuiltValueNullFieldError.checkNotNull(intDoubleRequired, r'OneOfInObject', 'intDoubleRequired'),
+            intDoubleOther: intDoubleOther,
+            intDoubleOtherRequired: BuiltValueNullFieldError.checkNotNull(
+                intDoubleOtherRequired, r'OneOfInObject', 'intDoubleOtherRequired'));
     replace(_$result);
     return _$result;
   }

--- a/packages/dynamite/packages/dynamite_end_to_end_test/lib/some_of.openapi.json
+++ b/packages/dynamite/packages/dynamite_end_to_end_test/lib/some_of.openapi.json
@@ -36,14 +36,23 @@
                     }
                 ]
             },
-            "OneValueSomeOfInObject": {
+            "OneOfInObject": {
                 "description": "Object with someOfs that only contain a single value (or are optimized to such).\n Should use the single member directly.",
                 "type": "object",
                 "required": [
-                    "someOf"
+                    "OneValueRequired",
+                    "IntDoubleRequired",
+                    "IntDoubleOtherRequired"
                 ],
                 "properties": {
                     "OneValue": {
+                        "oneOf": [
+                            {
+                                "type": "integer"
+                            }
+                        ]
+                    },
+                    "OneValueRequired": {
                         "oneOf": [
                             {
                                 "type": "integer"
@@ -61,7 +70,32 @@
                             }
                         ]
                     },
-                    "IntDoubleString": {
+                    "IntDoubleRequired": {
+                        "oneOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number",
+                                "format": "float"
+                            }
+                        ]
+                    },
+                    "IntDoubleOther": {
+                        "oneOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "number",
+                                "format": "float"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    },
+                    "IntDoubleOtherRequired": {
                         "oneOf": [
                             {
                                 "type": "integer"

--- a/packages/nextcloud/lib/src/api/provisioning_api/provisioning_api.openapi.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api/provisioning_api.openapi.dart
@@ -6232,11 +6232,11 @@ typedef UserDetailsQuota_Quota = ({num? $num, String? string});
 
 @BuiltValue(instantiable: false)
 sealed class $UserDetailsQuotaInterface {
-  num get free;
+  num? get free;
   UserDetailsQuota_Quota? get quota;
-  num get relative;
-  num get total;
-  num get used;
+  num? get relative;
+  num? get total;
+  num? get used;
 
   /// Rebuilds the instance.
   ///

--- a/packages/nextcloud/lib/src/api/provisioning_api/provisioning_api.openapi.g.dart
+++ b/packages/nextcloud/lib/src/api/provisioning_api/provisioning_api.openapi.g.dart
@@ -1880,22 +1880,37 @@ class _$UserDetailsQuotaSerializer implements StructuredSerializer<UserDetailsQu
   @override
   Iterable<Object?> serialize(Serializers serializers, UserDetailsQuota object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[
-      'free',
-      serializers.serialize(object.free, specifiedType: const FullType(num)),
-      'relative',
-      serializers.serialize(object.relative, specifiedType: const FullType(num)),
-      'total',
-      serializers.serialize(object.total, specifiedType: const FullType(num)),
-      'used',
-      serializers.serialize(object.used, specifiedType: const FullType(num)),
-    ];
+    final result = <Object?>[];
     Object? value;
+    value = object.free;
+    if (value != null) {
+      result
+        ..add('free')
+        ..add(serializers.serialize(value, specifiedType: const FullType(num)));
+    }
     value = object.quota;
     if (value != null) {
       result
         ..add('quota')
         ..add(serializers.serialize(value, specifiedType: const FullType(UserDetailsQuota_Quota)));
+    }
+    value = object.relative;
+    if (value != null) {
+      result
+        ..add('relative')
+        ..add(serializers.serialize(value, specifiedType: const FullType(num)));
+    }
+    value = object.total;
+    if (value != null) {
+      result
+        ..add('total')
+        ..add(serializers.serialize(value, specifiedType: const FullType(num)));
+    }
+    value = object.used;
+    if (value != null) {
+      result
+        ..add('used')
+        ..add(serializers.serialize(value, specifiedType: const FullType(num)));
     }
     return result;
   }
@@ -1912,20 +1927,20 @@ class _$UserDetailsQuotaSerializer implements StructuredSerializer<UserDetailsQu
       final Object? value = iterator.current;
       switch (key) {
         case 'free':
-          result.free = serializers.deserialize(value, specifiedType: const FullType(num))! as num;
+          result.free = serializers.deserialize(value, specifiedType: const FullType(num)) as num?;
           break;
         case 'quota':
           result.quota = serializers.deserialize(value, specifiedType: const FullType(UserDetailsQuota_Quota))
               as UserDetailsQuota_Quota?;
           break;
         case 'relative':
-          result.relative = serializers.deserialize(value, specifiedType: const FullType(num))! as num;
+          result.relative = serializers.deserialize(value, specifiedType: const FullType(num)) as num?;
           break;
         case 'total':
-          result.total = serializers.deserialize(value, specifiedType: const FullType(num))! as num;
+          result.total = serializers.deserialize(value, specifiedType: const FullType(num)) as num?;
           break;
         case 'used':
-          result.used = serializers.deserialize(value, specifiedType: const FullType(num))! as num;
+          result.used = serializers.deserialize(value, specifiedType: const FullType(num)) as num?;
           break;
       }
     }
@@ -9679,27 +9694,20 @@ abstract mixin class $UserDetailsQuotaInterfaceBuilder {
 
 class _$UserDetailsQuota extends UserDetailsQuota {
   @override
-  final num free;
+  final num? free;
   @override
   final UserDetailsQuota_Quota? quota;
   @override
-  final num relative;
+  final num? relative;
   @override
-  final num total;
+  final num? total;
   @override
-  final num used;
+  final num? used;
 
   factory _$UserDetailsQuota([void Function(UserDetailsQuotaBuilder)? updates]) =>
       (UserDetailsQuotaBuilder()..update(updates))._build();
 
-  _$UserDetailsQuota._(
-      {required this.free, this.quota, required this.relative, required this.total, required this.used})
-      : super._() {
-    BuiltValueNullFieldError.checkNotNull(free, r'UserDetailsQuota', 'free');
-    BuiltValueNullFieldError.checkNotNull(relative, r'UserDetailsQuota', 'relative');
-    BuiltValueNullFieldError.checkNotNull(total, r'UserDetailsQuota', 'total');
-    BuiltValueNullFieldError.checkNotNull(used, r'UserDetailsQuota', 'used');
-  }
+  _$UserDetailsQuota._({this.free, this.quota, this.relative, this.total, this.used}) : super._();
 
   @override
   UserDetailsQuota rebuild(void Function(UserDetailsQuotaBuilder) updates) => (toBuilder()..update(updates)).build();
@@ -9800,13 +9808,8 @@ class UserDetailsQuotaBuilder
 
   _$UserDetailsQuota _build() {
     UserDetailsQuota._validate(this);
-    final _$result = _$v ??
-        _$UserDetailsQuota._(
-            free: BuiltValueNullFieldError.checkNotNull(free, r'UserDetailsQuota', 'free'),
-            quota: quota,
-            relative: BuiltValueNullFieldError.checkNotNull(relative, r'UserDetailsQuota', 'relative'),
-            total: BuiltValueNullFieldError.checkNotNull(total, r'UserDetailsQuota', 'total'),
-            used: BuiltValueNullFieldError.checkNotNull(used, r'UserDetailsQuota', 'used'));
+    final _$result =
+        _$v ?? _$UserDetailsQuota._(free: free, quota: quota, relative: relative, total: total, used: used);
     replace(_$result);
     return _$result;
   }


### PR DESCRIPTION
I hit this problem with the provisioning_api change you can see in the diff.
Resolving the subtypes of someOfs assumed they would be always nullable which is reasonable for the records.
However that does not work in case we optimize the type into a single Dart type.
If that happens it has to follow different rules and only be optionally nullable depending on then nullablility of the someOf schema itself.

Pretty nasty bug especially given the single place where it actually failed and the low chance to hit that. There was a change in Nextcloud 30 which can now actually return null for those fields (ofc I first thought this was an issue of the spec).