### PR TITLE
fix(neon_framework): Fix login flow not launching URL

### DIFF
--- a/packages/neon_framework/lib/src/pages/login_flow.dart
+++ b/packages/neon_framework/lib/src/pages/login_flow.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
-import 'package:neon_framework/models.dart';
 import 'package:neon_framework/src/bloc/result.dart';
 import 'package:neon_framework/src/blocs/login_flow.dart';
 import 'package:neon_framework/src/router.dart';
@@ -39,7 +38,7 @@ class _LoginFlowPageState extends State<LoginFlowPage> {
 
     initSubscription = bloc.init.listen((result) async {
       if (result.hasData) {
-        await launchUrl(NeonProvider.of<Account>(context), result.requireData.login);
+        await launchUrl(null, result.requireData.login);
       }
     });
 

--- a/packages/neon_framework/lib/src/utils/launch_url.dart
+++ b/packages/neon_framework/lib/src/utils/launch_url.dart
@@ -2,9 +2,14 @@ import 'package:neon_framework/models.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
 /// Completes the [url] using the [account] if necessary and launches it in an external application.
-Future<bool> launchUrl(Account account, String url) async {
+Future<bool> launchUrl(Account? account, String url) async {
+  var uri = Uri.parse(url);
+  if (account != null) {
+    uri = account.completeUri(uri);
+  }
+
   return url_launcher.launchUrl(
-    account.completeUri(Uri.parse(url)),
+    uri,
     mode: url_launcher.LaunchMode.externalApplication,
   );
 }


### PR DESCRIPTION
Using the active account could be going wrong in two ways:
1. no account in the context (first login), error
2. account preset, but it's an already existing one and not the one we want to log into

Given https://github.com/nextcloud/neon/pull/2407 I'm not adding a test for this right now.

There is no other place where we call launchUrl() and possibly give it no/a wrong account.