### PR TITLE
fix(nextcloud): Use correct WebDAV namespaces for oc:checksum, oc:share-type and oc:tags

### DIFF
--- a/packages/nextcloud/lib/src/api/webdav/models/webdav.dart
+++ b/packages/nextcloud/lib/src/api/webdav/models/webdav.dart
@@ -248,7 +248,7 @@ class WebDavOcChecksums with _$WebDavOcChecksumsXmlSerializableMixin {
 
   factory WebDavOcChecksums.fromXmlElement(XmlElement element) => _$WebDavOcChecksumsFromXmlElement(element);
 
-  @annotation.XmlElement(name: 'checksum', namespace: namespaceNextcloud)
+  @annotation.XmlElement(name: 'checksum', namespace: namespaceOwncloud)
   final List<String>? checksums;
 }
 
@@ -262,7 +262,7 @@ class WebDavOcShareTypes with _$WebDavOcShareTypesXmlSerializableMixin {
 
   factory WebDavOcShareTypes.fromXmlElement(XmlElement element) => _$WebDavOcShareTypesFromXmlElement(element);
 
-  @annotation.XmlElement(name: 'share-type', namespace: namespaceNextcloud)
+  @annotation.XmlElement(name: 'share-type', namespace: namespaceOwncloud)
   final List<int>? shareTypes;
 }
 
@@ -276,6 +276,6 @@ class WebDavOcTags with _$WebDavOcTagsXmlSerializableMixin {
 
   factory WebDavOcTags.fromXmlElement(XmlElement element) => _$WebDavOcTagsFromXmlElement(element);
 
-  @annotation.XmlElement(name: 'tag', namespace: namespaceNextcloud)
+  @annotation.XmlElement(name: 'tag', namespace: namespaceOwncloud)
   final List<String>? tags;
 }

--- a/packages/nextcloud/lib/src/api/webdav/models/webdav.g.dart
+++ b/packages/nextcloud/lib/src/api/webdav/models/webdav.g.dart
@@ -968,7 +968,7 @@ void _$WebDavOcChecksumsBuildXmlChildren(WebDavOcChecksums instance, XmlBuilder 
   final checksumsSerialized = checksums;
   if (checksumsSerialized != null) {
     for (final value in checksumsSerialized) {
-      builder.element('checksum', namespace: 'http://nextcloud.org/ns', nest: () {
+      builder.element('checksum', namespace: 'http://owncloud.org/ns', nest: () {
         builder.text(value);
       });
     }
@@ -983,10 +983,8 @@ void _$WebDavOcChecksumsBuildXmlElement(WebDavOcChecksums instance, XmlBuilder b
 }
 
 WebDavOcChecksums _$WebDavOcChecksumsFromXmlElement(XmlElement element) {
-  final checksums = element
-      .getElements('checksum', namespace: 'http://nextcloud.org/ns')
-      ?.map((e) => e.getText())
-      .whereType<String>();
+  final checksums =
+      element.getElements('checksum', namespace: 'http://owncloud.org/ns')?.map((e) => e.getText()).whereType<String>();
   return WebDavOcChecksums(checksums: checksums?.toList());
 }
 
@@ -1002,7 +1000,7 @@ List<XmlNode> _$WebDavOcChecksumsToXmlChildren(WebDavOcChecksums instance,
   final checksums = instance.checksums;
   final checksumsSerialized = checksums;
   final checksumsConstructed = checksumsSerialized
-      ?.map((e) => XmlElement(XmlName('checksum', namespaces['http://nextcloud.org/ns']), [], [XmlText(e)]));
+      ?.map((e) => XmlElement(XmlName('checksum', namespaces['http://owncloud.org/ns']), [], [XmlText(e)]));
   if (checksumsConstructed != null) {
     children.addAll(checksumsConstructed);
   }
@@ -1039,7 +1037,7 @@ void _$WebDavOcShareTypesBuildXmlChildren(WebDavOcShareTypes instance, XmlBuilde
   final shareTypesSerialized = shareTypes?.map((e) => e.toString());
   if (shareTypesSerialized != null) {
     for (final value in shareTypesSerialized) {
-      builder.element('share-type', namespace: 'http://nextcloud.org/ns', nest: () {
+      builder.element('share-type', namespace: 'http://owncloud.org/ns', nest: () {
         builder.text(value);
       });
     }
@@ -1055,7 +1053,7 @@ void _$WebDavOcShareTypesBuildXmlElement(WebDavOcShareTypes instance, XmlBuilder
 
 WebDavOcShareTypes _$WebDavOcShareTypesFromXmlElement(XmlElement element) {
   final shareTypes = element
-      .getElements('share-type', namespace: 'http://nextcloud.org/ns')
+      .getElements('share-type', namespace: 'http://owncloud.org/ns')
       ?.map((e) => e.getText())
       .whereType<String>();
   return WebDavOcShareTypes(shareTypes: shareTypes?.map((e) => int.parse(e)).toList());
@@ -1073,7 +1071,7 @@ List<XmlNode> _$WebDavOcShareTypesToXmlChildren(WebDavOcShareTypes instance,
   final shareTypes = instance.shareTypes;
   final shareTypesSerialized = shareTypes?.map((e) => e.toString());
   final shareTypesConstructed = shareTypesSerialized
-      ?.map((e) => XmlElement(XmlName('share-type', namespaces['http://nextcloud.org/ns']), [], [XmlText(e)]));
+      ?.map((e) => XmlElement(XmlName('share-type', namespaces['http://owncloud.org/ns']), [], [XmlText(e)]));
   if (shareTypesConstructed != null) {
     children.addAll(shareTypesConstructed);
   }
@@ -1110,7 +1108,7 @@ void _$WebDavOcTagsBuildXmlChildren(WebDavOcTags instance, XmlBuilder builder,
   final tagsSerialized = tags;
   if (tagsSerialized != null) {
     for (final value in tagsSerialized) {
-      builder.element('tag', namespace: 'http://nextcloud.org/ns', nest: () {
+      builder.element('tag', namespace: 'http://owncloud.org/ns', nest: () {
         builder.text(value);
       });
     }
@@ -1126,7 +1124,7 @@ void _$WebDavOcTagsBuildXmlElement(WebDavOcTags instance, XmlBuilder builder,
 
 WebDavOcTags _$WebDavOcTagsFromXmlElement(XmlElement element) {
   final tags =
-      element.getElements('tag', namespace: 'http://nextcloud.org/ns')?.map((e) => e.getText()).whereType<String>();
+      element.getElements('tag', namespace: 'http://owncloud.org/ns')?.map((e) => e.getText()).whereType<String>();
   return WebDavOcTags(tags: tags?.toList());
 }
 
@@ -1140,7 +1138,7 @@ List<XmlNode> _$WebDavOcTagsToXmlChildren(WebDavOcTags instance, {Map<String, St
   final tags = instance.tags;
   final tagsSerialized = tags;
   final tagsConstructed =
-      tagsSerialized?.map((e) => XmlElement(XmlName('tag', namespaces['http://nextcloud.org/ns']), [], [XmlText(e)]));
+      tagsSerialized?.map((e) => XmlElement(XmlName('tag', namespaces['http://owncloud.org/ns']), [], [XmlText(e)]));
   if (tagsConstructed != null) {
     children.addAll(tagsConstructed);
   }

--- a/packages/nextcloud/test/api/webdav/webdav_test.dart
+++ b/packages/nextcloud/test/api/webdav/webdav_test.dart
@@ -427,6 +427,30 @@ void main() {
       expect(props.ocFavorite, false);
     });
 
+    test('Set and get tags', () async {
+      await tester.client.webdav.put(
+        utf8.encode('test'),
+        PathUri.parse('test/tags.txt'),
+      );
+
+      final updated = await tester.client.webdav.proppatch(
+        PathUri.parse('test/tags.txt'),
+        set: const WebDavProp(
+          ocTags: WebDavOcTags(tags: ['example']),
+        ),
+      );
+      expect(updated, isTrue);
+
+      final response = await tester.client.webdav.propfind(
+        PathUri.parse('test/tags.txt'),
+        prop: const WebDavPropWithoutValues.fromBools(
+          ocTags: true,
+        ),
+      );
+      final props = response.responses.single.propstats.first.prop;
+      expect(props.ocTags!.tags!.single, 'example');
+    });
+
     test('Upload and download file', () async {
       final destinationDir = Directory.systemTemp.createTempSync();
       final destination = File('${destinationDir.path}/test.png');

--- a/packages/nextcloud/test/fixtures/webdav/create_share.regexp
+++ b/packages/nextcloud/test/fixtures/webdav/create_share.regexp
@@ -1,0 +1,19 @@
+PUT http://localhost/remote\.php/webdav/test/share\.png
+authorization: Bearer mock
+content-length: 8650
+content-type: application/xml
+ocs-apirequest: true
+requesttoken: token
+.+
+POST http://localhost/ocs/v2\.php/apps/files_sharing/api/v1/shares
+accept: application/json
+authorization: Bearer mock
+content-type: application/json; charset=utf-8
+ocs-apirequest: true
+\{"shareType":0,"publicUpload":"false","password":"","expireDate":"","note":"","label":"","path":"/test/share\.png","shareWith":"user2"\}
+PROPFIND http://localhost/remote\.php/webdav/test/share\.png
+authorization: Bearer mock
+content-type: application/xml
+ocs-apirequest: true
+requesttoken: token
+<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud\.org/ns" xmlns:nc="http://nextcloud\.org/ns" xmlns:ocs="http://open-collaboration-services\.org/ns" xmlns:ocm="http://open-cloud-mesh\.org/ns"><d:prop><nc:share-attributes/><nc:sharees/><oc:share-types/></d:prop></d:propfind>

--- a/packages/nextcloud/test/fixtures/webdav/set_and_get_tags.regexp
+++ b/packages/nextcloud/test/fixtures/webdav/set_and_get_tags.regexp
@@ -1,0 +1,19 @@
+PUT http://localhost/remote\.php/webdav/test/tags\.txt
+authorization: Bearer mock
+content-length: 4
+content-type: application/xml
+ocs-apirequest: true
+requesttoken: token
+test
+PROPPATCH http://localhost/remote\.php/webdav/test/tags\.txt
+authorization: Bearer mock
+content-type: application/xml
+ocs-apirequest: true
+requesttoken: token
+<d:propertyupdate xmlns:d="DAV:" xmlns:oc="http://owncloud\.org/ns" xmlns:nc="http://nextcloud\.org/ns" xmlns:ocs="http://open-collaboration-services\.org/ns" xmlns:ocm="http://open-cloud-mesh\.org/ns"><d:set><d:prop><oc:tags><oc:tag>example</oc:tag></oc:tags></d:prop></d:set></d:propertyupdate>
+PROPFIND http://localhost/remote\.php/webdav/test/tags\.txt
+authorization: Bearer mock
+content-type: application/xml
+ocs-apirequest: true
+requesttoken: token
+<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud\.org/ns" xmlns:nc="http://nextcloud\.org/ns" xmlns:ocs="http://open-collaboration-services\.org/ns" xmlns:ocm="http://open-cloud-mesh\.org/ns"><d:prop><oc:tags/></d:prop></d:propfind>


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/2410

Just some stupid copy-pasta. To be fair the code in that file is not really readable because of all the annotations, fields and parameters...