### PR TITLE
ci: Use patched fdroidserver to fix publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,7 +66,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install apksigner fdroidserver python3-pip --no-install-recommends
           sudo apt-get purge fdroidserver
-          pip3 install https://gitlab.com/fdroid/fdroidserver/-/archive/master/fdroidserver.tar.gz
+          # See https://gitlab.com/fdroid/fdroidserver/-/merge_requests/1512
+          pip3 install https://gitlab.com/wrenix/fdroidserver/-/archive/d1d1eb4c53adb490662925c083bf81feed6e760f/fdroidserver.tar.gz
           export DEBUG_KEYSTORE=${{ secrets.DEBUG_KEYSTORE }}
           GITHUB_REPOSITORY=provokateurin/nextcloud-neon fdroid nightly -v --archive-older 10
 


### PR DESCRIPTION
Same as https://github.com/nextcloud/neon/pull/2435, but from me :P