### PR TITLE
perf(nextcloud_test_presets): Use docker image digests to improve caching

### DIFF
--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/Dockerfile
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG SERVER_VERSION
-FROM nextcloud:${SERVER_VERSION}-fpm-alpine AS nextcloud
+FROM nextcloud:${SERVER_VERSION} AS nextcloud
 
 WORKDIR /usr/src/nextcloud
 

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/cookbook/0.11
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/cookbook/0.11
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/cookbook/0.11
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/cookbook/0.11
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/drop_account/2.4
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/drop_account/2.4
@@ -1,4 +1,4 @@
-SERVER_VERSION=28.0.9
+SERVER_VERSION=28.0.9-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.4.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/drop_account/2.4
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/drop_account/2.4
@@ -1,4 +1,4 @@
-SERVER_VERSION=28.0.9-fpm-alpine
+SERVER_VERSION=28.0.9-fpm-alpine@sha256:03bb2b251184cf288987419f65bbd42a66d708b8ac0cf437e7bc878aef37599e
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.4.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/drop_account/2.5
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/drop_account/2.5
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.5.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/drop_account/2.5
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/drop_account/2.5
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.5.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/drop_account/2.6
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/drop_account/2.6
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/drop_account/2.6
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/drop_account/2.6
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/news/25.0
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/news/25.0
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/news/25.0
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/news/25.0
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/notes/4.10
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/notes/4.10
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/notes/4.10
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/notes/4.10
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/notes/4.8
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/notes/4.8
@@ -1,4 +1,4 @@
-SERVER_VERSION=28.0.9-fpm-alpine
+SERVER_VERSION=28.0.9-fpm-alpine@sha256:03bb2b251184cf288987419f65bbd42a66d708b8ac0cf437e7bc878aef37599e
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/notes/4.8
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/notes/4.8
@@ -1,4 +1,4 @@
-SERVER_VERSION=28.0.9
+SERVER_VERSION=28.0.9-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/notes/4.9
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/notes/4.9
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/notes/4.9
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/notes/4.9
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/server/28.0
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/server/28.0
@@ -1,4 +1,4 @@
-SERVER_VERSION=28.0.9-fpm-alpine
+SERVER_VERSION=28.0.9-fpm-alpine@sha256:03bb2b251184cf288987419f65bbd42a66d708b8ac0cf437e7bc878aef37599e
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/server/28.0
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/server/28.0
@@ -1,4 +1,4 @@
-SERVER_VERSION=28.0.9
+SERVER_VERSION=28.0.9-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/server/29.0
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/server/29.0
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/server/29.0
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/server/29.0
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/spreed/18.0
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/spreed/18.0
@@ -1,4 +1,4 @@
-SERVER_VERSION=28.0.9-fpm-alpine
+SERVER_VERSION=28.0.9-fpm-alpine@sha256:03bb2b251184cf288987419f65bbd42a66d708b8ac0cf437e7bc878aef37599e
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/spreed/18.0
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/spreed/18.0
@@ -1,4 +1,4 @@
-SERVER_VERSION=28.0.9
+SERVER_VERSION=28.0.9-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/spreed/19.0
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/spreed/19.0
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/spreed/19.0
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/spreed/19.0
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/tables/0.6
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/tables/0.6
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/tables/0.6
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/tables/0.6
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/tables/0.7
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/tables/0.7
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/tables/0.7
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/tables/0.7
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/tables/0.8
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/tables/0.8
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/tables/0.8
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/tables/0.8
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/uppush/1.4
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/uppush/1.4
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/uppush/1.4
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/uppush/1.4
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/uppush/1.5
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/uppush/1.5
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6
+SERVER_VERSION=29.0.6-fpm-alpine
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/uppush/1.5
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/presets/uppush/1.5
@@ -1,4 +1,4 @@
-SERVER_VERSION=29.0.6-fpm-alpine
+SERVER_VERSION=29.0.6-fpm-alpine@sha256:c20bea91562e329a61ebdc5105f83295910beddd05285785f05a474ec96a0aa8
 COOKBOOK_URL=https://github.com/christianlupus-nextcloud/cookbook-releases/releases/download/v0.11.1/cookbook-0.11.1.tar.gz
 DROP_ACCOUNT_URL=https://packages.framasoft.org/projects/nextcloud-apps/drop-account/drop_account-2.6.0.tar.gz
 NEWS_URL=https://github.com/nextcloud/news/releases/download/25.0.0-alpha8/news.tar.gz

--- a/packages/nextcloud/packages/nextcloud_test_presets/lib/src/generate_presets.dart
+++ b/packages/nextcloud/packages/nextcloud_test_presets/lib/src/generate_presets.dart
@@ -108,7 +108,12 @@ Future<List<Version>> _getServerVersions(http.Client httpClient) async {
       try {
         final tag = result as Map<String, dynamic>;
 
-        final version = Version.parse(tag['name'] as String);
+        final name = tag['name'] as String;
+        if (!name.endsWith('-fpm-alpine')) {
+          continue;
+        }
+
+        final version = Version.parse(name);
         final normalizedVersion = Version(version.major, version.minor, 0);
 
         if (version < core.minVersion) {

--- a/packages/nextcloud/packages/nextcloud_test_presets/lib/src/generate_presets.dart
+++ b/packages/nextcloud/packages/nextcloud_test_presets/lib/src/generate_presets.dart
@@ -19,8 +19,8 @@ Future<void> generatePresets() async {
 
   final httpClient = http.Client();
 
-  final serverVersions = await _getServerVersions(httpClient);
-  serverVersions.sort((a, b) => b.compareTo(a));
+  final serverReleases = await _getServerReleases(httpClient);
+  serverReleases.sort((a, b) => b.compareTo(a));
   final apps = await _getApps(appIDs, httpClient);
 
   for (final app in apps) {
@@ -31,12 +31,12 @@ Future<void> generatePresets() async {
     appPresetsDir.createSync();
 
     for (final release in app.releases) {
-      final serverVersion = release.findLatestServerVersion(serverVersions);
-      if (serverVersion == null) {
+      final serverRelease = release.findLatestServerRelease(serverReleases);
+      if (serverRelease == null) {
         continue;
       }
 
-      final buffer = StringBuffer()..writeln('SERVER_VERSION=$serverVersion');
+      final buffer = StringBuffer()..writeln('SERVER_VERSION=${serverRelease.dockerImageTag}');
 
       for (final a in apps) {
         buffer
@@ -45,15 +45,14 @@ Future<void> generatePresets() async {
         if (a == app) {
           buffer.writeln(release.url);
         } else {
-          final release = a.findLatestCompatibleRelease(serverVersion) ??
-              a.findLatestCompatibleRelease(serverVersion, allowUnstable: true) ??
+          final release = a.findLatestCompatibleRelease(serverRelease) ??
+              a.findLatestCompatibleRelease(serverRelease, allowUnstable: true) ??
               a.findLatestRelease();
           buffer.writeln(release.url);
         }
       }
 
-      File('${appPresetsDir.path}/${release.version.major}.${release.version.minor}')
-          .writeAsStringSync(buffer.toString());
+      File('${appPresetsDir.path}/${release.presetVersion}').writeAsStringSync(buffer.toString());
     }
   }
 
@@ -63,31 +62,31 @@ Future<void> generatePresets() async {
   }
   serverPresetsDir.createSync();
 
-  for (final serverVersion in serverVersions) {
-    final buffer = StringBuffer()..writeln('SERVER_VERSION=$serverVersion');
+  for (final serverRelease in serverReleases) {
+    final buffer = StringBuffer()..writeln('SERVER_VERSION=${serverRelease.dockerImageTag}');
 
     for (final app in apps) {
-      final release = app.findLatestCompatibleRelease(serverVersion) ??
-          app.findLatestCompatibleRelease(serverVersion, allowUnstable: true) ??
+      final release = app.findLatestCompatibleRelease(serverRelease) ??
+          app.findLatestCompatibleRelease(serverRelease, allowUnstable: true) ??
           app.findLatestRelease();
       buffer.writeln('${app.id.toUpperCase()}_URL=${release.url}');
     }
 
-    File('${serverPresetsDir.path}/${serverVersion.major}.${serverVersion.minor}').writeAsStringSync(buffer.toString());
+    File('${serverPresetsDir.path}/${serverRelease.presetVersion}').writeAsStringSync(buffer.toString());
   }
 
   final latestPresetLink = Link('docker/presets/latest');
   if (latestPresetLink.existsSync()) {
-    latestPresetLink.updateSync('server/${serverVersions.first.major}.${serverVersions.first.minor}');
+    latestPresetLink.updateSync('server/${serverReleases.first.presetVersion}');
   } else {
-    latestPresetLink.createSync('server/${serverVersions.first.major}.${serverVersions.first.minor}');
+    latestPresetLink.createSync('server/${serverReleases.first.presetVersion}');
   }
 
   httpClient.close();
 }
 
-Future<List<Version>> _getServerVersions(http.Client httpClient) async {
-  final versions = <Version, Version>{};
+Future<List<ServerRelease>> _getServerReleases(http.Client httpClient) async {
+  final versions = <Version, ServerRelease>{};
   String? next = 'https://hub.docker.com/v2/repositories/library/nextcloud/tags?page_size=1000';
 
   while (next != null) {
@@ -120,10 +119,15 @@ Future<List<Version>> _getServerVersions(http.Client httpClient) async {
           continue;
         }
 
+        final release = ServerRelease(
+          version: version,
+          dockerImageDigest: tag['digest'] as String,
+        );
+
         if (!versions.containsKey(normalizedVersion)) {
-          versions[normalizedVersion] = version;
+          versions[normalizedVersion] = release;
         } else if (version > versions[normalizedVersion]) {
-          versions[normalizedVersion] = version;
+          versions[normalizedVersion] = release;
         }
       } catch (_) {}
     }

--- a/packages/nextcloud/packages/nextcloud_test_presets/lib/src/models/app.dart
+++ b/packages/nextcloud/packages/nextcloud_test_presets/lib/src/models/app.dart
@@ -12,21 +12,20 @@ class App {
   final String id;
   final List<AppRelease> releases;
 
-  AppRelease? findLatestCompatibleRelease(Version serverVersion, {bool allowUnstable = false}) {
+  AppRelease? findLatestCompatibleRelease(ServerRelease serverRelease, {bool allowUnstable = false}) {
     final compatibleReleases = releases
         .where(
           (release) =>
-              serverVersion >= release.minimumServerVersion &&
-              serverVersion < release.maximumServerVersion.incrementMajor() &&
+              serverRelease.isCompatible(release.minimumServerVersion, release.maximumServerVersion) &&
               (allowUnstable || !release.version.isPreRelease),
         )
         .toList()
-      ..sort((a, b) => b.version.compareTo(a.version));
+      ..sort((a, b) => b.compareTo(a));
     return compatibleReleases.firstOrNull;
   }
 
   AppRelease findLatestRelease() {
-    final sortedReleases = releases..sort((a, b) => b.version.compareTo(a.version));
+    final sortedReleases = releases..sort((a, b) => b.compareTo(a));
     return sortedReleases.first;
   }
 }

--- a/packages/nextcloud/packages/nextcloud_test_presets/lib/src/models/app_release.dart
+++ b/packages/nextcloud/packages/nextcloud_test_presets/lib/src/models/app_release.dart
@@ -3,7 +3,7 @@ import 'package:nextcloud_test_presets/src/models/models.dart';
 
 /// Describes a release of an [App] from https://apps.nextcloud.com
 @internal
-class AppRelease {
+class AppRelease implements Comparable<AppRelease> {
   const AppRelease({
     required this.version,
     required this.url,
@@ -16,14 +16,16 @@ class AppRelease {
   final Version minimumServerVersion;
   final Version maximumServerVersion;
 
-  Version? findLatestServerVersion(List<Version> serverVersions) {
-    final compatibleReleases = serverVersions
-        .where(
-          (serverVersion) =>
-              serverVersion >= minimumServerVersion && serverVersion < maximumServerVersion.incrementMajor(),
-        )
+  ServerRelease? findLatestServerRelease(List<ServerRelease> serverReleases) {
+    final compatibleReleases = serverReleases
+        .where((serverRelease) => serverRelease.isCompatible(minimumServerVersion, maximumServerVersion))
         .toList()
       ..sort((a, b) => b.compareTo(a));
     return compatibleReleases.firstOrNull;
   }
+
+  String get presetVersion => '${version.major}.${version.minor}';
+
+  @override
+  int compareTo(AppRelease other) => version.compareTo(other.version);
 }

--- a/packages/nextcloud/packages/nextcloud_test_presets/lib/src/models/models.dart
+++ b/packages/nextcloud/packages/nextcloud_test_presets/lib/src/models/models.dart
@@ -1,3 +1,5 @@
 export 'package:version/version.dart';
+
 export 'app.dart';
 export 'app_release.dart';
+export 'server_release.dart';

--- a/packages/nextcloud/packages/nextcloud_test_presets/lib/src/models/server_release.dart
+++ b/packages/nextcloud/packages/nextcloud_test_presets/lib/src/models/server_release.dart
@@ -1,0 +1,23 @@
+import 'package:meta/meta.dart';
+import 'package:version/version.dart';
+
+@internal
+class ServerRelease implements Comparable<ServerRelease> {
+  ServerRelease({
+    required this.version,
+    required this.dockerImageDigest,
+  });
+
+  final Version version;
+
+  final String dockerImageDigest;
+
+  String get dockerImageTag => '$version@$dockerImageDigest';
+
+  String get presetVersion => '${version.major}.${version.minor}';
+
+  bool isCompatible(Version min, Version max) => version >= min && version < max.incrementMajor();
+
+  @override
+  int compareTo(ServerRelease other) => version.compareTo(other.version);
+}


### PR DESCRIPTION
Locally it helps docker a lot to detect that images didn't change and it should also help in CI to avoid unnecessary build time.
The only downside is that we get more preset updates, but it's not too often and the benefits outweigh this downside.