### PR TITLE
fix(news_app): Apply size constraint in NewsFeedIcon

### DIFF
--- a/packages/neon_framework/packages/news_app/lib/src/widgets/articles_view.dart
+++ b/packages/neon_framework/packages/news_app/lib/src/widgets/articles_view.dart
@@ -187,7 +187,6 @@ class _NewsArticlesViewState extends State<NewsArticlesView> {
                 child: NewsFeedIcon(
                   feed: feed,
                   size: smallIconSize,
-                  borderRadius: const BorderRadius.all(Radius.circular(2)),
                 ),
               ),
               RelativeTime(

--- a/packages/neon_framework/packages/news_app/lib/src/widgets/feed_icon.dart
+++ b/packages/neon_framework/packages/news_app/lib/src/widgets/feed_icon.dart
@@ -21,16 +21,19 @@ class NewsFeedIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     final faviconLink = feed.faviconLink;
 
-    return faviconLink != null && faviconLink.isNotEmpty
-        ? NeonUriImage(
-            uri: Uri.parse(faviconLink),
-            size: Size.square(size),
-            account: NeonProvider.of<Account>(context),
-          )
-        : Icon(
-            Icons.rss_feed,
-            size: size,
-            color: Theme.of(context).colorScheme.primary,
-          );
+    return SizedBox.square(
+      dimension: size,
+      child: faviconLink != null && faviconLink.isNotEmpty
+          ? NeonUriImage(
+              uri: Uri.parse(faviconLink),
+              size: Size.square(size),
+              account: NeonProvider.of<Account>(context),
+            )
+          : Icon(
+              Icons.rss_feed,
+              size: size,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+    );
   }
 }

--- a/packages/neon_framework/packages/news_app/lib/src/widgets/feed_icon.dart
+++ b/packages/neon_framework/packages/news_app/lib/src/widgets/feed_icon.dart
@@ -9,13 +9,11 @@ class NewsFeedIcon extends StatelessWidget {
   const NewsFeedIcon({
     required this.feed,
     this.size = largeIconSize,
-    this.borderRadius,
     super.key,
   });
 
   final news.Feed feed;
   final double size;
-  final BorderRadius? borderRadius;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
https://github.com/nextcloud/neon/pull/2448 accidentally removed the size constraint which lead to some jumping around while loading the icons.