### PR TITLE
fix(neon_framework): account switching

### DIFF
--- a/packages/neon_framework/lib/src/router.dart
+++ b/packages/neon_framework/lib/src/router.dart
@@ -109,8 +109,8 @@ class HomeRoute extends GoRouteData {
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return FutureBuilder(
-      future: context.read<AccountRepository>().accounts.first,
+    return StreamBuilder(
+      stream: context.read<AccountRepository>().accounts,
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           return const SizedBox.shrink();


### PR DESCRIPTION
I forgot that go_router will cache the route you are already on.
This fixes the 401 issues I had when switching accounts.