### PR TITLE
fix(account_repository): Change active account after logging in with a new one

### DIFF
--- a/packages/neon_framework/packages/account_repository/lib/src/account_repository.dart
+++ b/packages/neon_framework/packages/account_repository/lib/src/account_repository.dart
@@ -260,7 +260,7 @@ class AccountRepository {
   Future<void> logIn(Account account) async {
     final value = _accounts.value;
 
-    final active = value.active ?? account.credentials.id;
+    final active = account.credentials.id;
     final accounts = value.accounts.rebuild((b) {
       b[account.credentials.id] = account;
     });

--- a/packages/neon_framework/packages/account_repository/test/account_repository_test.dart
+++ b/packages/neon_framework/packages/account_repository/test/account_repository_test.dart
@@ -475,19 +475,19 @@ void main() {
         credentials: credentialsList.first,
       );
 
-      test('adds account and sets active if null', () async {
+      test('adds account and sets active', () async {
         await repository.logIn(account);
 
         await expectLater(
           repository.accounts,
           emits(
             isA<_AccountStream>()
-                .having((e) => e.accounts, 'accounts', equals([accountsList.first]))
-                .having((e) => e.active, 'active', equals(accountsList.first)),
+                .having((e) => e.accounts, 'accounts', equals([account]))
+                .having((e) => e.active, 'active', equals(account)),
           ),
         );
-        verify(() => storage.saveCredentials(any(that: contains(credentialsList.first)))).called(1);
-        verify(() => storage.saveLastAccount(credentialsList.first.id)).called(1);
+        verify(() => storage.saveCredentials(any(that: contains(account.credentials)))).called(1);
+        verify(() => storage.saveLastAccount(account.id)).called(1);
       });
     });
 


### PR DESCRIPTION
This is how it used to work before and it is a lot more intuitive to the user as they otherwise might think the account was not added properly.