### PR TITLE
fix(talk_app): Fix text overflow in message preview with rich object

### DIFF
--- a/packages/neon_framework/packages/talk_app/lib/src/widgets/message.dart
+++ b/packages/neon_framework/packages/talk_app/lib/src/widgets/message.dart
@@ -161,34 +161,36 @@ InlineSpan buildRichObjectParameter({
   required TextStyle? textStyle,
   required bool isPreview,
 }) {
+  if (isPreview) {
+    return TextSpan(
+      text: parameter.name,
+      style: textStyle,
+    );
+  }
+
   return WidgetSpan(
     alignment: PlaceholderAlignment.middle,
-    child: isPreview
-        ? Text(
-            parameter.name,
-            style: textStyle,
-          )
-        : switch (parameter.type) {
-            spreed.RichObjectParameter_Type.user ||
-            spreed.RichObjectParameter_Type.call ||
-            spreed.RichObjectParameter_Type.guest ||
-            spreed.RichObjectParameter_Type.userGroup =>
-              TalkRichObjectMention(
-                parameter: parameter,
-                textStyle: textStyle,
-              ),
-            spreed.RichObjectParameter_Type.file => TalkRichObjectFile(
-                parameter: parameter,
-                textStyle: textStyle,
-              ),
-            spreed.RichObjectParameter_Type.deckCard => TalkRichObjectDeckCard(
-                parameter: parameter,
-              ),
-            _ => TalkRichObjectFallback(
-                parameter: parameter,
-                textStyle: textStyle,
-              ),
-          },
+    child: switch (parameter.type) {
+      spreed.RichObjectParameter_Type.user ||
+      spreed.RichObjectParameter_Type.call ||
+      spreed.RichObjectParameter_Type.guest ||
+      spreed.RichObjectParameter_Type.userGroup =>
+        TalkRichObjectMention(
+          parameter: parameter,
+          textStyle: textStyle,
+        ),
+      spreed.RichObjectParameter_Type.file => TalkRichObjectFile(
+          parameter: parameter,
+          textStyle: textStyle,
+        ),
+      spreed.RichObjectParameter_Type.deckCard => TalkRichObjectDeckCard(
+          parameter: parameter,
+        ),
+      _ => TalkRichObjectFallback(
+          parameter: parameter,
+          textStyle: textStyle,
+        ),
+    },
   );
 }
 

--- a/packages/neon_framework/packages/talk_app/test/message_test.dart
+++ b/packages/neon_framework/packages/talk_app/test/message_test.dart
@@ -1558,7 +1558,7 @@ void main() {
               );
 
               expect(find.byType(TalkRichObjectMention), isPreview ? findsNothing : findsOne);
-              expect(find.text('name'), findsOne);
+              expect(find.text('name', findRichText: true), findsOne);
             });
           }
         });
@@ -1587,7 +1587,7 @@ void main() {
           );
 
           expect(find.byType(TalkRichObjectFile), isPreview ? findsNothing : findsOne);
-          expect(find.text('name'), findsOne);
+          expect(find.text('name', findRichText: true), findsOne);
         });
 
         testWidgets('Deck card', (tester) async {
@@ -1611,7 +1611,7 @@ void main() {
           );
 
           expect(find.byType(TalkRichObjectDeckCard), isPreview ? findsNothing : findsOne);
-          expect(find.text('name'), findsOne);
+          expect(find.text('name', findRichText: true), findsOne);
         });
 
         testWidgets('Fallback', (tester) async {
@@ -1633,7 +1633,7 @@ void main() {
           );
 
           expect(find.byType(TalkRichObjectFallback), isPreview ? findsNothing : findsOne);
-          expect(find.text('name'), findsOne);
+          expect(find.text('name', findRichText: true), findsOne);
         });
       });
     }


### PR DESCRIPTION
WidgetSpan+Text lead to weird results when there was a rich object that was hidden due to overflow. Just using a TextSpan directly is more performant and correctly handles the overflow.