### PR TITLE
fix(talk_app): Remove broken message text selection

### DIFF
--- a/packages/neon_framework/packages/talk_app/lib/src/widgets/message.dart
+++ b/packages/neon_framework/packages/talk_app/lib/src/widgets/message.dart
@@ -544,11 +544,6 @@ class _TalkCommentMessageState extends State<TalkCommentMessage> {
           maxLines: widget.isParent ? 1 : null,
           overflow: widget.isParent ? TextOverflow.ellipsis : TextOverflow.visible,
         );
-        if (!widget.isParent && widget.chatMessage.messageType != spreed.MessageType.commentDeleted) {
-          text = SelectionArea(
-            child: text,
-          );
-        }
         if (widget.chatMessage.messageType == spreed.MessageType.commentDeleted) {
           text = Row(
             children: [

--- a/packages/neon_framework/packages/talk_app/test/message_test.dart
+++ b/packages/neon_framework/packages/talk_app/test/message_test.dart
@@ -426,7 +426,6 @@ void main() {
       ),
     );
     expect(find.byType(TalkCommentMessage), findsOne);
-    expect(find.byType(SelectionArea), findsNothing);
     await expectLater(find.byType(TalkParentMessage), matchesGoldenFile('goldens/message_parent_message.png'));
   });
 
@@ -477,7 +476,6 @@ void main() {
       expect(find.text('abc', findRichText: true), findsOne);
       expect(find.byType(TalkReactions), findsOne);
       expect(find.byType(TalkReadIndicator), findsOne);
-      expect(find.byType(SelectionArea), findsOne);
       await expectLater(
         find.byType(TalkCommentMessage),
         matchesGoldenFile('goldens/message_comment_message_self.png'),
@@ -530,7 +528,6 @@ void main() {
       expect(find.text('abc', findRichText: true), findsOne);
       expect(find.byType(TalkReactions), findsOne);
       expect(find.byType(TalkReadIndicator), findsNothing);
-      expect(find.byType(SelectionArea), findsOne);
       await expectLater(
         find.byType(TalkCommentMessage),
         matchesGoldenFile('goldens/message_comment_message_other.png'),
@@ -574,7 +571,6 @@ void main() {
       expect(find.text('abc', findRichText: true), findsOne);
       expect(find.byIcon(AdaptiveIcons.cancel), findsOne);
       expect(find.byType(TalkReactions), findsNothing);
-      expect(find.byType(SelectionArea), findsNothing);
       await expectLater(
         find.byType(TalkCommentMessage),
         matchesGoldenFile('goldens/message_comment_message_deleted.png'),
@@ -612,7 +608,6 @@ void main() {
       expect(find.text('test'), findsOne);
       expect(find.text('abc', findRichText: true), findsOne);
       expect(find.byType(TalkReactions), findsNothing);
-      expect(find.byType(SelectionArea), findsNothing);
       await expectLater(
         find.byType(TalkCommentMessage),
         matchesGoldenFile('goldens/message_comment_message_as_parent.png'),
@@ -668,7 +663,6 @@ void main() {
       );
       expect(find.byType(TalkParentMessage), findsOne);
       expect(find.byType(TalkReactions), findsNothing);
-      expect(find.byType(SelectionArea), findsOne);
       await expectLater(
         find.byType(TalkCommentMessage).first,
         matchesGoldenFile('goldens/message_comment_message_with_parent.png'),
@@ -801,7 +795,6 @@ void main() {
         expect(find.text('test'), findsOne);
         expect(find.text('abc', findRichText: true), findsOne);
         expect(find.byType(TalkReactions), findsOne);
-        expect(find.byType(SelectionArea), findsOne);
         await expectLater(
           find.byType(TalkCommentMessage),
           matchesGoldenFile('goldens/message_comment_message_separate_actor.png'),
@@ -851,7 +844,6 @@ void main() {
         expect(find.text('test'), findsOne);
         expect(find.text('abc', findRichText: true), findsOne);
         expect(find.byType(TalkReactions), findsOne);
-        expect(find.byType(SelectionArea), findsOne);
         await expectLater(
           find.byType(TalkCommentMessage),
           matchesGoldenFile('goldens/message_comment_message_separate_time.png'),
@@ -902,7 +894,6 @@ void main() {
         expect(find.text('test'), findsOne);
         expect(find.text('abc', findRichText: true), findsOne);
         expect(find.byType(TalkReactions), findsOne);
-        expect(find.byType(SelectionArea), findsOne);
         await expectLater(
           find.byType(TalkCommentMessage),
           matchesGoldenFile('goldens/message_comment_message_separate_system_message.png'),
@@ -957,7 +948,6 @@ void main() {
         expect(find.byTooltip('Last edited by test at 1/1/1970 1:00 AM'), findsOne);
         expect(find.text('abc', findRichText: true), findsOne);
         expect(find.byType(TalkReactions), findsOne);
-        expect(find.byType(SelectionArea), findsOne);
         await expectLater(
           find.byType(TalkCommentMessage),
           matchesGoldenFile('goldens/message_comment_message_separate_edited.png'),


### PR DESCRIPTION
Message text selection is broken in different ways on both mobile and desktop, so removing it for now.