### PR TITLE
ci: Fix installing yq

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -19,6 +19,7 @@ jobs:
         with:
           filters: |
             src:
+              - .github/workflows/**
               - external/**
               - tool/**
               - packages/dynamite/**
@@ -89,7 +90,7 @@ jobs:
 
       # Use https://github.com/kislyuk/yq
       - name: Install yq
-        run: pip install yq
+        run: pip install yq --break-system-packages
 
       - name: Generate specs
         run: |


### PR DESCRIPTION
Fails: https://github.com/nextcloud/neon/actions/runs/11065409908/job/30744783500?pr=2521
Introduced by https://github.com/nextcloud/neon/pull/2517