### PR TITLE
ci: Fix Android signing by using pre-installed build-tools version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,6 +34,7 @@ jobs:
       - uses: ilharp/sign-android-release@2034987c31e3959f7c97e88d5e656e52e6e88bd8 # v1
         name: Sign
         with:
+          buildToolsVersion: 35.0.0
           releaseDir: packages/neon_framework/example/build/app/outputs/flutter-apk
           signingKey: ${{ secrets.SIGNING_KEY }}
           keyAlias: ${{ secrets.ALIAS }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -63,11 +63,9 @@ jobs:
           cp packages/neon_framework/example/build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk app-armeabi-v7a-debug.apk
           cp packages/neon_framework/example/build/app/outputs/flutter-apk/app-x86_64-release.apk app-x86_64-debug.apk
 
-          sudo add-apt-repository ppa:fdroid/fdroidserver
-          sudo apt-get update
-          sudo apt-get install apksigner fdroidserver python3-pip --no-install-recommends
-          sudo apt-get purge fdroidserver
-          pip3 install https://gitlab.com/fdroid/fdroidserver/-/archive/9684eade0dda3663f5fb68ca02b06f7b0bb7c086/fdroidserver.tar.gz
+          sudo apt-get update && sudo apt-get install apksigner python3-pip --no-install-recommends
+          python -m venv venv && source venv/bin/activate
+          pip install https://gitlab.com/fdroid/fdroidserver/-/archive/9684eade0dda3663f5fb68ca02b06f7b0bb7c086/fdroidserver.tar.gz
           export DEBUG_KEYSTORE=${{ secrets.DEBUG_KEYSTORE }}
           GITHUB_REPOSITORY=provokateurin/nextcloud-neon fdroid nightly -v --archive-older 10
 


### PR DESCRIPTION
Regression from https://github.com/nextcloud/neon/pull/2517
Fixes https://github.com/nextcloud/neon/actions/runs/11119127833/job/30893832380#step:7:14

[Action default is 33.0.0](https://github.com/ilharp/sign-android-release/tree/master?tab=readme-ov-file#inputs) while the [Ubuntu 24.04 image only has 34.0.0 and 35.0.0](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#android)

Also discovered https://gitlab.com/fdroid/fdroidserver/-/issues/1192 so the install method for fdroidserver was fixed as well.