### PR TITLE
ci: Run all Dart steps with both upgraded and downgraded dependencies

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -8,10 +8,16 @@ concurrency:
 
 jobs:
   dart-ci:
-    name: Dart CI
+    name: Dart CI (${{ matrix.dependencies }})
     runs-on: ubuntu-24.04
     permissions:
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        dependencies:
+          - upgrade
+          - downgrade
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -35,6 +41,12 @@ jobs:
       - name: Setup
         run: ./tool/setup.sh
 
+      - name: Downgrade dependencies
+        if: ${{ matrix.dependencies == 'downgrade' }}
+        run: |
+          git apply .github/workflows/dependency_overrides.patch
+          git add .
+          melos exec dart pub downgrade
       - name: Check up-to-date pubspec.lock
         run: git --no-pager diff --exit-code
       - name: Check formatting
@@ -60,6 +72,7 @@ jobs:
           fi
 
       - name: Setup Codecov
+        if: ${{ matrix.dependencies == 'upgrade' }}
         run: |
           cd /tmp
           curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
@@ -73,14 +86,9 @@ jobs:
           mkdir /tmp/bin
           mv codecov /tmp/bin
       - name: Upload coverage to Codecov
+        if: ${{ matrix.dependencies == 'upgrade' }}
         run: |
           export PATH="$PATH:/tmp/bin"
           melos exec --file-exists="coverage/lcov.info" --concurrency=1 -- "
             codecov --verbose upload-process --fail-on-error -F MELOS_PACKAGE_NAME -f MELOS_PACKAGE_PATH/coverage/lcov.info -t ${{ secrets.CODECOV_TOKEN }}
           "
-
-      # Run as the last step to avoid running any other steps with downgraded dependencies
-      - name: Lint code with downgraded dependencies
-        run: |
-          melos exec dart pub downgrade
-          melos run analyze

--- a/.github/workflows/dependency_overrides.patch
+++ b/.github/workflows/dependency_overrides.patch
@@ -1,0 +1,1956 @@
+diff --git a/packages/cookie_store/pubspec.yaml b/packages/cookie_store/pubspec.yaml
+--- a/packages/cookie_store/pubspec.yaml
++++ b/packages/cookie_store/pubspec.yaml
+@@ -20,3 +20,6 @@ dev_dependencies:
+       url: https://github.com/nextcloud/neon
+       path: packages/neon_lints
+   test: ^1.25.8
++
++dependency_overrides:
++  frontend_server_client: ^4.0.0
+diff --git a/packages/cookie_store/pubspec_overrides.yaml b/packages/cookie_store/pubspec_overrides.yaml
+--- a/packages/cookie_store/pubspec_overrides.yaml
++++ b/packages/cookie_store/pubspec_overrides.yaml
+@@ -1,6 +1,7 @@
+-# melos_managed_dependency_overrides: cookie_store_conformance_tests,neon_lints
++# melos_managed_dependency_overrides: cookie_store_conformance_tests,neon_lints,frontend_server_client
+ dependency_overrides:
+   cookie_store_conformance_tests:
+     path: packages/cookie_store_conformance_tests
++  frontend_server_client: ^4.0.0
+   neon_lints:
+     path: ../neon_lints
+diff --git a/packages/dynamite/packages/dynamite_end_to_end_test/pubspec.yaml b/packages/dynamite/packages/dynamite_end_to_end_test/pubspec.yaml
+--- a/packages/dynamite/packages/dynamite_end_to_end_test/pubspec.yaml
++++ b/packages/dynamite/packages/dynamite_end_to_end_test/pubspec.yaml
+@@ -25,3 +25,7 @@ dev_dependencies:
+       url: https://github.com/nextcloud/neon
+       path: packages/neon_lints
+   test: ^1.25.8
++
++dependency_overrides:
++  frontend_server_client: ^4.0.0
++  quiver: ^3.2.1
+diff --git a/packages/dynamite/packages/dynamite_end_to_end_test/pubspec_overrides.yaml b/packages/dynamite/packages/dynamite_end_to_end_test/pubspec_overrides.yaml
+--- a/packages/dynamite/packages/dynamite_end_to_end_test/pubspec_overrides.yaml
++++ b/packages/dynamite/packages/dynamite_end_to_end_test/pubspec_overrides.yaml
+@@ -1,8 +1,10 @@
+-# melos_managed_dependency_overrides: dynamite,dynamite_runtime,neon_lints
++# melos_managed_dependency_overrides: dynamite,dynamite_runtime,neon_lints,frontend_server_client,quiver
+ dependency_overrides:
+   dynamite:
+     path: ../..
+   dynamite_runtime:
+     path: ../dynamite_runtime
++  frontend_server_client: ^4.0.0
+   neon_lints:
+     path: ../../../neon_lints
++  quiver: ^3.2.1
+diff --git a/packages/dynamite/packages/dynamite_runtime/pubspec.yaml b/packages/dynamite/packages/dynamite_runtime/pubspec.yaml
+--- a/packages/dynamite/packages/dynamite_runtime/pubspec.yaml
++++ b/packages/dynamite/packages/dynamite_runtime/pubspec.yaml
+@@ -29,6 +29,9 @@ dev_dependencies:
+       path: packages/neon_lints
+   test: ^1.25.8
+
++dependency_overrides:
++  frontend_server_client: ^4.0.0
++
+ platforms:
+   windows:
+   linux:
+diff --git a/packages/dynamite/packages/dynamite_runtime/pubspec_overrides.yaml b/packages/dynamite/packages/dynamite_runtime/pubspec_overrides.yaml
+--- a/packages/dynamite/packages/dynamite_runtime/pubspec_overrides.yaml
++++ b/packages/dynamite/packages/dynamite_runtime/pubspec_overrides.yaml
+@@ -1,4 +1,5 @@
+-# melos_managed_dependency_overrides: neon_lints
++# melos_managed_dependency_overrides: neon_lints,frontend_server_client
+ dependency_overrides:
++  frontend_server_client: ^4.0.0
+   neon_lints:
+     path: ../../../neon_lints
+diff --git a/packages/dynamite/pubspec.yaml b/packages/dynamite/pubspec.yaml
+--- a/packages/dynamite/pubspec.yaml
++++ b/packages/dynamite/pubspec.yaml
+@@ -39,3 +39,7 @@ dev_dependencies:
+       url: https://github.com/nextcloud/neon
+       path: packages/neon_lints
+   test: ^1.25.8
++
++dependency_overrides:
++  frontend_server_client: ^4.0.0
++  quiver: ^3.2.1
+diff --git a/packages/dynamite/pubspec_overrides.yaml b/packages/dynamite/pubspec_overrides.yaml
+--- a/packages/dynamite/pubspec_overrides.yaml
++++ b/packages/dynamite/pubspec_overrides.yaml
+@@ -1,4 +1,6 @@
+-# melos_managed_dependency_overrides: neon_lints
++# melos_managed_dependency_overrides: neon_lints,frontend_server_client,quiver
+ dependency_overrides:
++  frontend_server_client: ^4.0.0
+   neon_lints:
+     path: ../neon_lints
++  quiver: ^3.2.1
+diff --git a/packages/interceptor_http_client/pubspec.yaml b/packages/interceptor_http_client/pubspec.yaml
+--- a/packages/interceptor_http_client/pubspec.yaml
++++ b/packages/interceptor_http_client/pubspec.yaml
+@@ -27,3 +27,7 @@ dev_dependencies:
+       url: https://github.com/nextcloud/neon
+       path: packages/neon_lints
+   test: ^1.25.8
++
++dependency_overrides:
++  frontend_server_client: ^4.0.0
++  web: ">=0.5.0 <2.0.0"
+diff --git a/packages/interceptor_http_client/pubspec_overrides.yaml b/packages/interceptor_http_client/pubspec_overrides.yaml
+--- a/packages/interceptor_http_client/pubspec_overrides.yaml
++++ b/packages/interceptor_http_client/pubspec_overrides.yaml
+@@ -1,6 +1,8 @@
+-# melos_managed_dependency_overrides: cookie_store,neon_lints
++# melos_managed_dependency_overrides: cookie_store,neon_lints,frontend_server_client,web
+ dependency_overrides:
+   cookie_store:
+     path: ../cookie_store
++  frontend_server_client: ^4.0.0
+   neon_lints:
+     path: ../neon_lints
++  web: ">=0.5.0 <2.0.0"
+diff --git a/packages/neon_framework/example/pubspec.lock b/packages/neon_framework/example/pubspec.lock
+--- a/packages/neon_framework/example/pubspec.lock
++++ b/packages/neon_framework/example/pubspec.lock
+@@ -37,38 +37,30 @@ packages:
+       url: "https://pub.dev"
+     source: hosted
+     version: "0.11.3"
+-  ansicolor:
+-    dependency: transitive
+-    description:
+-      name: ansicolor
+-      sha256: "50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f"
+-      url: "https://pub.dev"
+-    source: hosted
+-    version: "2.0.3"
+   archive:
+     dependency: transitive
+     description:
+       name: archive
+-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
++      sha256: a92e39b291073bb840a72cf43d96d2a63c74e9a485d227833e8ea0054d16ad16
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.6.1"
++    version: "3.1.2"
+   args:
+     dependency: transitive
+     description:
+       name: args
+-      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
++      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.6.0"
++    version: "2.4.2"
+   asn1lib:
+     dependency: transitive
+     description:
+       name: asn1lib
+-      sha256: "6b151826fcc95ff246cd219a0bf4c753ea14f4081ad71c61939becf3aba27f70"
++      sha256: "3fe6429f90bf78422becd2234212148b4911863260eb53c088cd154d39c5b049"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.5.5"
++    version: "1.0.0"
+   async:
+     dependency: transitive
+     description:
+@@ -121,42 +113,26 @@ packages:
+     dependency: transitive
+     description:
+       name: camera
+-      sha256: "26ff41045772153f222ffffecba711a206f670f5834d40ebf5eed3811692f167"
+-      url: "https://pub.dev"
+-    source: hosted
+-    version: "0.11.0+2"
+-  camera_android_camerax:
+-    dependency: transitive
+-    description:
+-      name: camera_android_camerax
+-      sha256: e3627fdc2132d89212b8a8676679f5b07008c7e3d8ae00cea775c3397f9e742b
++      sha256: "6465594950547dbbe3f51142f9a24b2b4dffc2a54cb0f91e4b86f2f3427120c9"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.6.10"
+-  camera_avfoundation:
+-    dependency: transitive
+-    description:
+-      name: camera_avfoundation
+-      sha256: "0d04cec8715b59fb6dc60eefb47e69024f51233c570e475b886dc9290568bca7"
+-      url: "https://pub.dev"
+-    source: hosted
+-    version: "0.9.17+4"
++    version: "0.9.7"
+   camera_platform_interface:
+     dependency: transitive
+     description:
+       name: camera_platform_interface
+-      sha256: b3ede1f171532e0d83111fe0980b46d17f1aa9788a07a2fbed07366bbdbb9061
++      sha256: "50cee64830e009e2213a4d1e57ba5b7cad18d258742f29f3f65feb1b1e599db3"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.8.0"
++    version: "2.1.0"
+   camera_web:
+     dependency: transitive
+     description:
+       name: camera_web
+-      sha256: "595f28c89d1fb62d77c73c633193755b781c6d2e0ebcd8dc25b763b514e6ba8f"
++      sha256: "550ec9007c0ce14c091270044c1ea1f81ede89b33f8137c63f6b2c85a23ff0f3"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.3.5"
++    version: "0.2.1"
+   characters:
+     dependency: transitive
+     description:
+@@ -165,14 +141,22 @@ packages:
+       url: "https://pub.dev"
+     source: hosted
+     version: "1.3.0"
++  charcode:
++    dependency: transitive
++    description:
++      name: charcode
++      sha256: "8e36feea6de5ea69f2199f29cf42a450a855738c498b57c0b980e2d3cca9c362"
++      url: "https://pub.dev"
++    source: hosted
++    version: "1.2.0"
+   checked_yaml:
+     dependency: transitive
+     description:
+       name: checked_yaml
+-      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
++      sha256: dd007e4fb8270916820a0d66e24f619266b60773cddd082c6439341645af2659
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.0.3"
++    version: "2.0.1"
+   ci:
+     dependency: transitive
+     description:
+@@ -185,10 +169,10 @@ packages:
+     dependency: transitive
+     description:
+       name: cli_util
+-      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
++      sha256: b8db3080e59b2503ca9e7922c3df2072cf13992354d5e944074ffa836fba43b7
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.4.1"
++    version: "0.4.0"
+   clock:
+     dependency: transitive
+     description:
+@@ -209,10 +193,10 @@ packages:
+     dependency: transitive
+     description:
+       name: convert
+-      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
++      sha256: df567b950053d83b4dba3e8c5799c411895d146f82b2147114b666a4fd9a80dd
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.1.2"
++    version: "3.0.0"
+   cookie_store:
+     dependency: "direct overridden"
+     description:
+@@ -232,34 +216,34 @@ packages:
+     dependency: transitive
+     description:
+       name: crypto
+-      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
++      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.0.6"
++    version: "3.0.3"
+   crypton:
+     dependency: transitive
+     description:
+       name: crypton
+-      sha256: "17b6631fbf89e389d421b46629132287ed37d601b2ad1357445826ab85022271"
++      sha256: "88d8012cac4588041b9ce2bcc82877564a4c3d0b1b3f5c4d5eb61d461add8373"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.2.1"
++    version: "2.0.0"
+   csslib:
+     dependency: transitive
+     description:
+       name: csslib
+-      sha256: "831883fb353c8bdc1d71979e5b342c7d88acfbc643113c14ae51e2442ea0f20f"
++      sha256: b36c7f7e24c0bdf1bf9a3da461c837d1de64b9f8beb190c9011d8c72a3dfd745
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.17.3"
++    version: "0.17.2"
+   cupertino_icons:
+     dependency: transitive
+     description:
+       name: cupertino_icons
+-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
++      sha256: "5fbfae177f2c844e3ca80f401ff8fd6c60ee301e2dfd67fe8fb97a7307459a6b"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.0.8"
++    version: "1.0.1"
+   custom_lint:
+     dependency: "direct dev"
+     description:
+@@ -296,10 +280,10 @@ packages:
+     dependency: transitive
+     description:
+       name: dart_style
+-      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
++      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.3.7"
++    version: "2.3.2"
+   dashboard_app:
+     dependency: "direct main"
+     description:
+@@ -319,18 +303,18 @@ packages:
+     dependency: transitive
+     description:
+       name: dev_build
+-      sha256: "91aefce06d4c80c3c8a6c04af6a60ca8e5c01ec6780410ab82e07bfb4f8c49f2"
++      sha256: cb7508354e4adacad06dd86b115ae82dd741a1c1a0911f21acd4a0c30eb17588
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.1.0+2"
++    version: "0.16.3+1"
+   dynamic_color:
+     dependency: transitive
+     description:
+       name: dynamic_color
+-      sha256: eae98052fa6e2826bdac3dd2e921c6ce2903be15c6b7f8b6d8a5d49b5086298d
++      sha256: "8b8bd1d798bd393e11eddeaa8ae95b12ff028bf7d5998fc5d003488cd5f4ce2f"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.7.0"
++    version: "1.6.8"
+   dynamite_runtime:
+     dependency: "direct overridden"
+     description:
+@@ -342,10 +326,10 @@ packages:
+     dependency: transitive
+     description:
+       name: emoji_picker_flutter
+-      sha256: "08567e6f914d36c32091a96cf2f51d2558c47aa2bd47a590dc4f50e42e0965f6"
++      sha256: "3bf6d4cadc188215570a15c80fd7aeecec312b1cb3168ab08394e0faa4161fcb"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.1.0"
++    version: "3.0.0"
+   equatable:
+     dependency: transitive
+     description:
+@@ -366,58 +350,58 @@ packages:
+     dependency: transitive
+     description:
+       name: ffi
+-      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
++      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.1.3"
++    version: "2.1.2"
+   file:
+     dependency: transitive
+     description:
+       name: file
+-      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
++      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "7.0.1"
++    version: "6.1.4"
+   file_picker:
+     dependency: transitive
+     description:
+       name: file_picker
+-      sha256: aac85f20436608e01a6ffd1fdd4e746a7f33c93a2c83752e626bdfaea139b877
++      sha256: d1d0ac3966b36dc3e66eeefb40280c17feb87fa2099c6e22e6a1fc959327bd03
+       url: "https://pub.dev"
+     source: hosted
+-    version: "8.1.3"
++    version: "8.0.0+1"
+   file_selector_linux:
+     dependency: transitive
+     description:
+       name: file_selector_linux
+-      sha256: "712ce7fab537ba532c8febdb1a8f167b32441e74acd68c3ccb2e36dcb52c4ab2"
++      sha256: d17c5e450192cdc40b718804dfb4eaf79a71bed60ee9530703900879ba50baa3
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.9.3"
++    version: "0.9.1+3"
+   file_selector_macos:
+     dependency: transitive
+     description:
+       name: file_selector_macos
+-      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
++      sha256: "48ec16f6d0423bfb5c2ff712f4a282e8def40404d5c4b3c0bd64d19c6c3c8796"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.9.4+2"
++    version: "0.9.1+1"
+   file_selector_platform_interface:
+     dependency: transitive
+     description:
+       name: file_selector_platform_interface
+-      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
++      sha256: "2a7f4bbf7bd2f022ecea85bfb1754e87f7dd403a9abc17a84a4fa2ddfe2abc0a"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.6.2"
++    version: "2.5.1"
+   file_selector_windows:
+     dependency: transitive
+     description:
+       name: file_selector_windows
+-      sha256: "8f5d2f6590d51ecd9179ba39c64f722edc15226cc93dcc8698466ad36a4a85a4"
++      sha256: "72942d3bd81de6e91418eb3876703605b2a3419cb5e102a09b444945cc807cd2"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.9.3+3"
++    version: "0.9.0"
+   files_app:
+     dependency: "direct main"
+     description:
+@@ -429,18 +413,18 @@ packages:
+     dependency: transitive
+     description:
+       name: filesize
+-      sha256: f53df1f27ff60e466eefcd9df239e02d4722d5e2debee92a87dfd99ac66de2af
++      sha256: d146970e6839263b497b647b59c8c65398facc06890390089c5671d8f48aea5d
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.0.1"
++    version: "2.0.0"
+   fixnum:
+     dependency: transitive
+     description:
+       name: fixnum
+-      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
++      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.1.1"
++    version: "1.1.0"
+   flutter:
+     dependency: "direct main"
+     description: flutter
+@@ -552,42 +536,42 @@ packages:
+     dependency: transitive
+     description:
+       name: flutter_markdown
+-      sha256: f0e599ba89c9946c8e051780f0ec99aba4ba15895e0380a7ab68f420046fc44e
++      sha256: "15f39b20486760f9b85531ed2ef7f63e3a376210d2ff83614119ee93fda5670c"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.7.4+1"
++    version: "0.7.0"
+   flutter_material_design_icons:
+     dependency: transitive
+     description:
+       name: flutter_material_design_icons
+-      sha256: ffb0be14d206cb4cd8501ce738bdfc5654130cb5f70911905694a2c1ee9f05b1
++      sha256: "2b000c56e4ea38bc785fe143404ace0ae0a98b86501ec80a52ec840cd07597cf"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.1.7447"
++    version: "1.1.7296"
+   flutter_native_splash:
+     dependency: transitive
+     description:
+       name: flutter_native_splash
+-      sha256: ee5c9bd2b74ea8676442fd4ab876b5d41681df49276488854d6c81a5377c0ef1
++      sha256: "048bd1f1dc0e5ea25899f702815934d9a9e916fe23451c320e7dd94d5e3ad933"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.4.2"
++    version: "2.2.17"
+   flutter_plugin_android_lifecycle:
+     dependency: transitive
+     description:
+       name: flutter_plugin_android_lifecycle
+-      sha256: "9b78450b89f059e96c9ebb355fa6b3df1d6b330436e0b885fb49594c41721398"
++      sha256: b068ffc46f82a55844acfa4fdbb61fad72fa2aef0905548419d97f0f95c456da
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.0.23"
++    version: "2.0.17"
+   flutter_svg:
+     dependency: transitive
+     description:
+       name: flutter_svg
+-      sha256: "7b4ca6cf3304575fe9c8ec64813c8d02ee41d2afe60bcfe0678bcb5375d596a2"
++      sha256: "98caa3d15cf524eefb48f173ebc64d818f6c017d6616220b63983d8526a4dd8c"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.0.10+1"
++    version: "2.0.0"
+   flutter_test:
+     dependency: transitive
+     description: flutter
+@@ -610,18 +594,18 @@ packages:
+     dependency: transitive
+     description:
+       name: flutter_zxing
+-      sha256: "7ced1ebb196a5361964f03af37a8f51120271982698ff7befe34f7e35f0babbc"
++      sha256: "495c520cafd4d4cce1a8f378a0a0ee048677580d55d6996575092f59a8d9330d"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.7.0"
++    version: "1.4.0"
+   freezed_annotation:
+     dependency: transitive
+     description:
+       name: freezed_annotation
+-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
++      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.4.4"
++    version: "2.2.0"
+   glob:
+     dependency: transitive
+     description:
+@@ -634,10 +618,10 @@ packages:
+     dependency: transitive
+     description:
+       name: go_router
+-      sha256: "6f1b756f6e863259a99135ff3c95026c3cdca17d10ebef2bba2261a25ddc8bbc"
++      sha256: "28ef8a8320ab3bf5752424e6bca6961ce25108afc344f3127b5155caf7a792c8"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "14.3.0"
++    version: "14.0.0"
+   hotreloader:
+     dependency: transitive
+     description:
+@@ -650,10 +634,10 @@ packages:
+     dependency: transitive
+     description:
+       name: html
+-      sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"
++      sha256: "58e3491f7bf0b6a4ea5110c0c688877460d1a6366731155c4a4580e7ded773e8"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.15.4"
++    version: "0.15.3"
+   http:
+     dependency: transitive
+     description:
+@@ -666,82 +650,82 @@ packages:
+     dependency: transitive
+     description:
+       name: http_parser
+-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
++      sha256: e362d639ba3bc07d5a71faebb98cde68c05bfbcfbbb444b60b6f60bb67719185
+       url: "https://pub.dev"
+     source: hosted
+-    version: "4.0.2"
++    version: "4.0.0"
+   image:
+     dependency: transitive
+     description:
+       name: image
+-      sha256: f31d52537dc417fdcde36088fdf11d191026fd5e4fae742491ebd40e5a8bea7d
++      sha256: "3f0cd7ca37d54521ad0f527f3c939c951ee2de9b4680c36388e46a99a56beda0"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "4.3.0"
++    version: "4.0.10"
+   image_picker:
+     dependency: transitive
+     description:
+       name: image_picker
+-      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
++      sha256: b9603755b35253ccfad4be0762bb74d5e8bf9ff75edebf0ac3beec24fac1c5b5
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.1.2"
++    version: "1.0.0"
+   image_picker_android:
+     dependency: transitive
+     description:
+       name: image_picker_android
+-      sha256: "8faba09ba361d4b246dc0a17cb4289b3324c2b9f6db7b3d457ee69106a86bd32"
++      sha256: "3ebd6bb2f6ddd4b9c7175b7f0fb1c7d12ac3c342eef9638ad7c7298013fca4fe"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.8.12+17"
++    version: "0.8.4+11"
+   image_picker_for_web:
+     dependency: transitive
+     description:
+       name: image_picker_for_web
+-      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
++      sha256: "1a21500e2d043a7ba4b6655b91400b888bef21cd231a90d413500aa3e797f53e"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.0.6"
++    version: "2.1.0"
+   image_picker_ios:
+     dependency: transitive
+     description:
+       name: image_picker_ios
+-      sha256: "4f0568120c6fcc0aaa04511cb9f9f4d29fc3d0139884b1d06be88dcec7641d6b"
++      sha256: "1768087441bd69ca632249d212c26fa8d530552d37b4896a4dd8d6781435c147"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.8.12+1"
++    version: "0.8.6+1"
+   image_picker_linux:
+     dependency: transitive
+     description:
+       name: image_picker_linux
+-      sha256: "4ed1d9bb36f7cd60aa6e6cd479779cc56a4cb4e4de8f49d487b1aaad831300fa"
++      sha256: "1d8f9a97178d6b8a035f1d2765f17f8ca3d36a40d5594e742a481b1e002f20be"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.2.1+1"
++    version: "0.2.0"
+   image_picker_macos:
+     dependency: transitive
+     description:
+       name: image_picker_macos
+-      sha256: "3f5ad1e8112a9a6111c46d0b57a7be2286a9a07fc6e1976fdf5be2bd31d4ff62"
++      sha256: ff094b36d6c06200808f733144a033e45b4e17d59524e1cf7d2af7e4cb94e1ab
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.2.1+1"
++    version: "0.2.0"
+   image_picker_platform_interface:
+     dependency: transitive
+     description:
+       name: image_picker_platform_interface
+-      sha256: "9ec26d410ff46f483c5519c29c02ef0e02e13a543f882b152d4bfd2f06802f80"
++      sha256: "7c7b96bb9413a9c28229e717e6fd1e3edd1cc5569c1778fcca060ecf729b65ee"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.10.0"
++    version: "2.8.0"
+   image_picker_windows:
+     dependency: transitive
+     description:
+       name: image_picker_windows
+-      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
++      sha256: bf77b819eb62c487e6af53b9eb213adc12bd060ef7e43f3b1dd69c53cc24a61d
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.2.1+1"
++    version: "0.2.0"
+   interceptor_http_client:
+     dependency: "direct overridden"
+     description:
+@@ -769,18 +753,18 @@ packages:
+     dependency: transitive
+     description:
+       name: js
+-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
++      sha256: a5e201311cb08bf3912ebbe9a2be096e182d703f881136ec1e81a2338a9e120d
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.7.1"
++    version: "0.6.4"
+   json_annotation:
+     dependency: transitive
+     description:
+       name: json_annotation
+-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
++      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+       url: "https://pub.dev"
+     source: hosted
+-    version: "4.9.0"
++    version: "4.8.0"
+   leak_tracker:
+     dependency: transitive
+     description:
+@@ -817,10 +801,10 @@ packages:
+     dependency: transitive
+     description:
+       name: logging
+-      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
++      sha256: "3730d4c02b0c2d1db80ef9904e27fa796d75474f572a70011e0e616ee6bfc0ff"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.3.0"
++    version: "1.0.0"
+   macros:
+     dependency: transitive
+     description:
+@@ -833,10 +817,10 @@ packages:
+     dependency: transitive
+     description:
+       name: markdown
+-      sha256: ef2a1298144e3f985cc736b22e0ccdaf188b5b3970648f2d9dc13efd1d9df051
++      sha256: acf35edccc0463a9d7384e437c015a3535772e09714cf60e07eeef3a15870dcd
+       url: "https://pub.dev"
+     source: hosted
+-    version: "7.2.2"
++    version: "7.1.1"
+   matcher:
+     dependency: transitive
+     description:
+@@ -865,10 +849,10 @@ packages:
+     dependency: transitive
+     description:
+       name: mime
+-      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
++      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.0.0"
++    version: "1.0.4"
+   neon_framework:
+     dependency: "direct main"
+     description:
+@@ -937,10 +921,10 @@ packages:
+     dependency: transitive
+     description:
+       name: open_filex
+-      sha256: ba425ea49affd0a98a234aa9344b9ea5d4c4f7625a1377961eae9fe194c3d523
++      sha256: "74e2280754cf8161e860746c3181db2c996d6c1909c7057b738ede4a469816b8"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "4.5.0"
++    version: "4.4.0"
+   package_config:
+     dependency: transitive
+     description:
+@@ -953,10 +937,10 @@ packages:
+     dependency: transitive
+     description:
+       name: package_info_plus
+-      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
++      sha256: a75164ade98cb7d24cfd0a13c6408927c6b217fa60dee5a7ff5c116a58f28918
+       url: "https://pub.dev"
+     source: hosted
+-    version: "8.1.0"
++    version: "8.0.2"
+   package_info_plus_platform_interface:
+     dependency: transitive
+     description:
+@@ -977,122 +961,114 @@ packages:
+     dependency: transitive
+     description:
+       name: path_parsing
+-      sha256: "45f7d6bba1128761de5540f39d5ca000ea8a1f22f06b76b61094a60a2997bd0e"
++      sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.0.2"
++    version: "1.0.1"
+   path_provider:
+     dependency: transitive
+     description:
+       name: path_provider
+-      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
++      sha256: "909b84830485dbcd0308edf6f7368bc8fd76afa26a270420f34cabea2a6467a0"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.1.4"
++    version: "2.1.0"
+   path_provider_android:
+     dependency: transitive
+     description:
+       name: path_provider_android
+-      sha256: c464428172cb986b758c6d1724c603097febb8fb855aa265aeecc9280c294d4a
++      sha256: "5d44fc3314d969b84816b569070d7ace0f1dea04bd94a83f74c4829615d22ad8"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.2.12"
++    version: "2.1.0"
+   path_provider_foundation:
+     dependency: transitive
+     description:
+       name: path_provider_foundation
+-      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
++      sha256: "1b744d3d774e5a879bb76d6cd1ecee2ba2c6960c03b1020cd35212f6aa267ac5"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.4.0"
++    version: "2.3.0"
+   path_provider_linux:
+     dependency: transitive
+     description:
+       name: path_provider_linux
+-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
++      sha256: ba2b77f0c52a33db09fc8caf85b12df691bf28d983e84cf87ff6d693cfa007b3
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.2.1"
++    version: "2.2.0"
+   path_provider_platform_interface:
+     dependency: transitive
+     description:
+       name: path_provider_platform_interface
+-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
++      sha256: bced5679c7df11190e1ddc35f3222c858f328fff85c3942e46e7f5589bf9eb84
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.1.2"
++    version: "2.1.0"
+   path_provider_windows:
+     dependency: transitive
+     description:
+       name: path_provider_windows
+-      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
++      sha256: ee0e0d164516b90ae1f970bdf29f726f1aa730d7cfc449ecc74c495378b705da
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.3.0"
++    version: "2.2.0"
+   permission_handler:
+     dependency: transitive
+     description:
+       name: permission_handler
+-      sha256: "18bf33f7fefbd812f37e72091a15575e72d5318854877e0e4035a24ac1113ecb"
++      sha256: ad65ba9af42a3d067203641de3fd9f547ded1410bad3b84400c2b4899faede70
+       url: "https://pub.dev"
+     source: hosted
+-    version: "11.3.1"
++    version: "11.0.0"
+   permission_handler_android:
+     dependency: transitive
+     description:
+       name: permission_handler_android
+-      sha256: "71bbecfee799e65aff7c744761a57e817e73b738fedf62ab7afd5593da21f9f1"
++      sha256: "6901d50f4d4b9a27e1749dbd4adbf06aa00d90a21a2db563405d5ce27ee120ac"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "12.0.13"
++    version: "11.0.0"
+   permission_handler_apple:
+     dependency: transitive
+     description:
+       name: permission_handler_apple
+-      sha256: e6f6d73b12438ef13e648c4ae56bd106ec60d17e90a59c4545db6781229082a0
++      sha256: "99e220bce3f8877c78e4ace901082fb29fa1b4ebde529ad0932d8d664b34f3f5"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "9.4.5"
+-  permission_handler_html:
+-    dependency: transitive
+-    description:
+-      name: permission_handler_html
+-      sha256: af26edbbb1f2674af65a8f4b56e1a6f526156bc273d0e65dd8075fab51c78851
+-      url: "https://pub.dev"
+-    source: hosted
+-    version: "0.1.3+2"
++    version: "9.1.4"
+   permission_handler_platform_interface:
+     dependency: transitive
+     description:
+       name: permission_handler_platform_interface
+-      sha256: e9c8eadee926c4532d0305dff94b85bf961f16759c3af791486613152af4b4f9
++      sha256: f2343e9fa9c22ae4fd92d4732755bfe452214e7189afcc097380950cf567b4b2
+       url: "https://pub.dev"
+     source: hosted
+-    version: "4.2.3"
++    version: "3.11.5"
+   permission_handler_windows:
+     dependency: transitive
+     description:
+       name: permission_handler_windows
+-      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
++      sha256: cc074aace208760f1eee6aa4fae766b45d947df85bc831cde77009cdb4720098
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.2.1"
++    version: "0.1.3"
+   petitparser:
+     dependency: transitive
+     description:
+       name: petitparser
+-      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
++      sha256: cb3798bef7fc021ac45b308f4b51208a152792445cce0448c9a4ba5879dd8750
+       url: "https://pub.dev"
+     source: hosted
+-    version: "6.0.2"
++    version: "5.4.0"
+   platform:
+     dependency: transitive
+     description:
+       name: platform
+-      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
++      sha256: ebc79f16b5f6b609aad4a5e63447d4795d16f7adee46e93ed03200848c006735
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.1.6"
++    version: "3.0.0"
+   plugin_platform_interface:
+     dependency: transitive
+     description:
+@@ -1105,42 +1081,42 @@ packages:
+     dependency: transitive
+     description:
+       name: pointer_interceptor
+-      sha256: "57210410680379aea8b1b7ed6ae0c3ad349bfd56fe845b8ea934a53344b9d523"
++      sha256: fda979f3eb65558a389517521c8315060289dda5a1a6087f3892bdea9550eade
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.10.1+2"
++    version: "0.10.0"
+   pointer_interceptor_ios:
+     dependency: transitive
+     description:
+       name: pointer_interceptor_ios
+-      sha256: a6906772b3205b42c44614fcea28f818b1e5fdad73a4ca742a7bd49818d9c917
++      sha256: "4282ebfe21b54e21e26ab982c6086f0a67dc63423026bfba8db39a2e22045f26"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.10.1"
++    version: "0.10.0"
+   pointer_interceptor_platform_interface:
+     dependency: transitive
+     description:
+       name: pointer_interceptor_platform_interface
+-      sha256: "0597b0560e14354baeb23f8375cd612e8bd4841bf8306ecb71fcd0bb78552506"
++      sha256: "59a446ead3be360bde72c3725f5ecacbba203c8a760e3061024c20f7da53f825"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.10.0+1"
++    version: "0.10.0"
+   pointer_interceptor_web:
+     dependency: transitive
+     description:
+       name: pointer_interceptor_web
+-      sha256: "7a7087782110f8c1827170660b09f8aa893e0e9a61431dbbe2ac3fc482e8c044"
++      sha256: "2a8a069206f7b234a895d30ccab8b18ea267eeb79a832e5e3d1b6464d659eb6a"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.10.2+1"
++    version: "0.10.0"
+   pointycastle:
+     dependency: transitive
+     description:
+       name: pointycastle
+-      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
++      sha256: a74ed4039c152dd319514f142768d93ad3973860b240d90160cec727c8155f65
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.9.1"
++    version: "3.0.1"
+   pool:
+     dependency: transitive
+     description:
+@@ -1149,22 +1125,30 @@ packages:
+       url: "https://pub.dev"
+     source: hosted
+     version: "1.5.1"
++  process:
++    dependency: transitive
++    description:
++      name: process
++      sha256: "7009fcaa731943cfd124f11e23428bf9ceb38f08df079fb79c915fa726a5a739"
++      url: "https://pub.dev"
++    source: hosted
++    version: "4.0.0"
+   process_run:
+     dependency: transitive
+     description:
+       name: process_run
+-      sha256: "6eacd833f593a7904c32bafd837d7d1f3651e233a33816621f663be53ad1ca07"
++      sha256: ceacfac6d566a36c895d64edc7e429efb2d6b6303b5e28d5c13bc59fe6e8974e
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.2.1+1"
++    version: "0.13.1"
+   provider:
+     dependency: transitive
+     description:
+       name: provider
+-      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
++      sha256: "109bee81b76e9f175d70572e8d8160b224d7fda6152062423a4134d50fcdfbaa"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "6.1.2"
++    version: "6.0.0"
+   pub_semver:
+     dependency: transitive
+     description:
+@@ -1177,58 +1161,58 @@ packages:
+     dependency: transitive
+     description:
+       name: pubspec_parse
+-      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
++      sha256: ec85d7d55339d85f44ec2b682a82fea340071e8978257e5a43e69f79e98ef50c
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.3.0"
++    version: "1.2.2"
+   queue:
+     dependency: transitive
+     description:
+       name: queue
+-      sha256: "9a41ecadc15db79010108c06eae229a45c56b18db699760f34e8c9ac9b831ff9"
++      sha256: "7769f97fc751475610b75b29eda02b88365691a1eb41d388e3a94e745d1f6c45"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.1.0+2"
++    version: "3.0.0"
+   quick_actions:
+     dependency: transitive
+     description:
+       name: quick_actions
+-      sha256: "2c1d9a91f3218b4e987a7e1e95ba0415b7f48a2cb3ffacc027a1e3d3c117223f"
++      sha256: "03d5e9c3f1f5579b9bdad25b2479f253020ee7c73100d87b5c46ed6733564248"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.0.8"
++    version: "1.0.0"
+   quick_actions_android:
+     dependency: transitive
+     description:
+       name: quick_actions_android
+-      sha256: "926e50d6f879287b34d21934e6c9457f0d851f554179f2a9e8136c4acd1b7062"
++      sha256: "51d9ec93f0dd00b24c1ab555b96a1457bf8c9854cf0baa0551e80d11c4c5da91"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.0.18"
++    version: "0.6.0+9"
+   quick_actions_ios:
+     dependency: transitive
+     description:
+       name: quick_actions_ios
+-      sha256: "402596dea62a1028960b93f7651ec22be0e2a91e4fbf92a1c62d3b95f8ff95a5"
++      sha256: bc7cdb90cd3dcbe7b1e53bffe69b83a4229f457eb1006c0c64c210690fde09d3
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.1.1"
++    version: "0.6.0+9"
+   quick_actions_platform_interface:
+     dependency: transitive
+     description:
+       name: quick_actions_platform_interface
+-      sha256: "81a1e40c519bb3cacfec38b3008b13cef665a75bd270da94f40091b57f0f9236"
++      sha256: d003b23245e1f372cd433299c66ac42c6a6d098617d0797bc125d39f28ccac2a
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.0.6"
++    version: "1.0.0"
+   quiver:
+     dependency: transitive
+     description:
+       name: quiver
+-      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
++      sha256: ca3ae1a9b6c2a7712f6818c8ce6bbcc6cf999115f4fb51b1fa8b7bfe1037d70e
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.2.2"
++    version: "3.0.0"
+   rxdart:
+     dependency: transitive
+     description:
+@@ -1241,122 +1225,90 @@ packages:
+     dependency: transitive
+     description:
+       name: screen_retriever
+-      sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"
+-      url: "https://pub.dev"
+-    source: hosted
+-    version: "0.2.0"
+-  screen_retriever_linux:
+-    dependency: transitive
+-    description:
+-      name: screen_retriever_linux
+-      sha256: f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18
+-      url: "https://pub.dev"
+-    source: hosted
+-    version: "0.2.0"
+-  screen_retriever_macos:
+-    dependency: transitive
+-    description:
+-      name: screen_retriever_macos
+-      sha256: "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149"
+-      url: "https://pub.dev"
+-    source: hosted
+-    version: "0.2.0"
+-  screen_retriever_platform_interface:
+-    dependency: transitive
+-    description:
+-      name: screen_retriever_platform_interface
+-      sha256: ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0
++      sha256: "6ee02c8a1158e6dae7ca430da79436e3b1c9563c8cf02f524af997c201ac2b90"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.2.0"
+-  screen_retriever_windows:
+-    dependency: transitive
+-    description:
+-      name: screen_retriever_windows
+-      sha256: "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13"
+-      url: "https://pub.dev"
+-    source: hosted
+-    version: "0.2.0"
++    version: "0.1.9"
+   scrollable_positioned_list:
+     dependency: transitive
+     description:
+       name: scrollable_positioned_list
+-      sha256: "1b54d5f1329a1e263269abc9e2543d90806131aa14fe7c6062a8054d57249287"
++      sha256: ad179ca65c05e1c9c10d61c597891596b3b91b9151edb253dbea0481b87e6800
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.3.8"
++    version: "0.3.1"
+   share_plus:
+     dependency: transitive
+     description:
+       name: share_plus
+-      sha256: "3af2cda1752e5c24f2fc04b6083b40f013ffe84fb90472f30c6499a9213d5442"
++      sha256: "38658034f9f3c29f3b37ab0068db15caea9df2dd70d83e99300991a0d756c2a6"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "10.1.1"
++    version: "10.0.1"
+   share_plus_platform_interface:
+     dependency: transitive
+     description:
+       name: share_plus_platform_interface
+-      sha256: c57c0bbfec7142e3a0f55633be504b796af72e60e3c791b44d5a017b985f7a48
++      sha256: "6ababf341050edff57da8b6990f11f4e99eaba837865e2e6defe16d039619db5"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "5.0.1"
++    version: "5.0.0"
+   shared_preferences:
+     dependency: transitive
+     description:
+       name: shared_preferences
+-      sha256: "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051"
++      sha256: c272f9cabca5a81adc9b0894381e9c1def363e980f960fa903c604c471b22f68
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.3.2"
++    version: "2.3.1"
+   shared_preferences_android:
+     dependency: transitive
+     description:
+       name: shared_preferences_android
+-      sha256: "3b9febd815c9ca29c9e3520d50ec32f49157711e143b7a4ca039eb87e8ade5ab"
++      sha256: "041be4d9d2dc6079cf342bc8b761b03787e3b71192d658220a56cac9c04a0294"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.3.3"
++    version: "2.3.0"
+   shared_preferences_foundation:
+     dependency: transitive
+     description:
+       name: shared_preferences_foundation
+-      sha256: "07e050c7cd39bad516f8d64c455f04508d09df104be326d8c02551590a0d513d"
++      sha256: "671e7a931f55a08aa45be2a13fe7247f2a41237897df434b30d2012388191833"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.5.3"
++    version: "2.5.0"
+   shared_preferences_linux:
+     dependency: transitive
+     description:
+       name: shared_preferences_linux
+-      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
++      sha256: "2ba0510d3017f91655b7543e9ee46d48619de2a2af38e5c790423f7007c7ccc1"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.4.1"
++    version: "2.4.0"
+   shared_preferences_platform_interface:
+     dependency: transitive
+     description:
+       name: shared_preferences_platform_interface
+-      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
++      sha256: "034650b71e73629ca08a0bd789fd1d83cc63c2d1e405946f7cef7bc37432f93a"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.4.1"
++    version: "2.4.0"
+   shared_preferences_web:
+     dependency: transitive
+     description:
+       name: shared_preferences_web
+-      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
++      sha256: "59dc807b94d29d52ddbb1b3c0d3b9d0a67fc535a64e62a5542c8db0513fcb6c2"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.4.2"
++    version: "2.4.1"
+   shared_preferences_windows:
+     dependency: transitive
+     description:
+       name: shared_preferences_windows
+-      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
++      sha256: "398084b47b7f92110683cac45c6dc4aae853db47e470e5ddcd52cab7f7196ab2"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.4.1"
++    version: "2.4.0"
+   sky_engine:
+     dependency: transitive
+     description: flutter
+@@ -1389,66 +1341,42 @@ packages:
+     dependency: transitive
+     description:
+       name: sqflite
+-      sha256: "79a297dc3cc137e758c6a4baf83342b039e5a6d2436fcdf3f96a00adaaf2ad62"
++      sha256: "591f1602816e9c31377d5f008c2d9ef7b8aca8941c3f89cc5fd9d84da0c38a9a"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.4.0"
+-  sqflite_android:
+-    dependency: transitive
+-    description:
+-      name: sqflite_android
+-      sha256: "78f489aab276260cdd26676d2169446c7ecd3484bbd5fead4ca14f3ed4dd9ee3"
+-      url: "https://pub.dev"
+-    source: hosted
+-    version: "2.4.0"
++    version: "2.3.0"
+   sqflite_common:
+     dependency: transitive
+     description:
+       name: sqflite_common
+-      sha256: "4468b24876d673418a7b7147e5a08a715b4998a7ae69227acafaab762e0e5490"
++      sha256: "28d8c66baee4968519fb8bd6cdbedad982d6e53359091f0b74544a9f32ec72d5"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.5.4+5"
++    version: "2.5.3"
+   sqflite_common_ffi:
+     dependency: transitive
+     description:
+       name: sqflite_common_ffi
+-      sha256: d316908f1537725427ff2827a5c5f3b2c1bc311caed985fe3c9b10939c9e11ca
++      sha256: d0e3f0d04fdf668e57db8db1df758f56c4193cb429092c708e7bfcc6ab04b27e
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.3.4"
++    version: "2.3.2"
+   sqflite_common_ffi_web:
+     dependency: transitive
+     description:
+       name: sqflite_common_ffi_web
+-      sha256: f540ad769e5fd31aabe77bfa6e774fdd36145a83e33cdc39239f310c5f8559c3
++      sha256: "0c2921454d2e4a227675fb952be9fef916cf65fb9e9b606b54cfdf080d3e9450"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.4.5+3"
+-  sqflite_darwin:
+-    dependency: transitive
+-    description:
+-      name: sqflite_darwin
+-      sha256: "769733dddf94622d5541c73e4ddc6aa7b252d865285914b6fcd54a63c4b4f027"
+-      url: "https://pub.dev"
+-    source: hosted
+-    version: "2.4.1-1"
+-  sqflite_platform_interface:
+-    dependency: transitive
+-    description:
+-      name: sqflite_platform_interface
+-      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+-      url: "https://pub.dev"
+-    source: hosted
+-    version: "2.4.0"
++    version: "0.4.2+3"
+   sqlite3:
+     dependency: transitive
+     description:
+       name: sqlite3
+-      sha256: bb174b3ec2527f9c5f680f73a89af8149dd99782fbb56ea88ad0807c5638f2ed
++      sha256: c4a4c5a4b2a32e2d0f6837b33d7c91a67903891a5b7dbe706cf4b1f6b0c798c5
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.4.7"
++    version: "2.3.0"
+   stack_trace:
+     dependency: transitive
+     description:
+@@ -1469,10 +1397,10 @@ packages:
+     dependency: transitive
+     description:
+       name: stream_transform
+-      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
++      sha256: ed464977cb26a1f41537e177e190c67223dbd9f4f683489b6ab2e5d211ec564e
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.1.0"
++    version: "2.0.0"
+   string_scanner:
+     dependency: transitive
+     description:
+@@ -1485,10 +1413,10 @@ packages:
+     dependency: transitive
+     description:
+       name: synchronized
+-      sha256: "69fe30f3a8b04a0be0c15ae6490fc859a78ef4c43ae2dd5e8a623d45bfcf9225"
++      sha256: "7b530acd9cb7c71b0019a1e7fa22c4105e675557a4400b6a401c71c5e0ade1ac"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.3.0+3"
++    version: "3.0.0+3"
+   talk_app:
+     dependency: "direct main"
+     description:
+@@ -1524,42 +1452,42 @@ packages:
+     dependency: transitive
+     description:
+       name: typed_data
+-      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
++      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.4.0"
++    version: "1.3.0"
+   unifiedpush:
+     dependency: transitive
+     description:
+       name: unifiedpush
+-      sha256: "6dbed5a6305ca33f1865c7a3d814ae39476b79a2d23ca76a5708f023f405730f"
++      sha256: "083863337eae48a3d5e30b41964c7c025a6e0e77c3f9c74340d5ff7bfa4e8c85"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "5.0.2"
++    version: "5.0.0"
+   unifiedpush_android:
+     dependency: transitive
+     description:
+       name: unifiedpush_android
+-      sha256: "7443dece0a850ae956514f809983eb2b39fc518c2c7d24dbfe817198bec89134"
++      sha256: "8e49d305019b31bd8d1da2c36e466e76bc11558628908d7bc66f83fb51a6eefc"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.3.0"
++    version: "2.0.1"
+   unifiedpush_platform_interface:
+     dependency: transitive
+     description:
+       name: unifiedpush_platform_interface
+-      sha256: dd588d78a8b2bfc10430e30035526e98caa543d0b7364a6344b5eb4815721c6d
++      sha256: b973137572f84b67656b18032f5047d327cffc5ab77ec4230d2459b1144ccf84
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.0.2"
++    version: "2.0.0"
+   universal_io:
+     dependency: transitive
+     description:
+       name: universal_io
+-      sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
++      sha256: "79f78ddad839ee3aae3ec7c01eb4575faf0d5c860f8e5223bc9f9c17f7f03cef"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.2.2"
++    version: "2.0.4"
+   uri:
+     dependency: transitive
+     description:
+@@ -1572,42 +1500,42 @@ packages:
+     dependency: transitive
+     description:
+       name: url_launcher
+-      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
++      sha256: "638e195d333ff9d8314410edfb3f860c6e7e87b8898e593834cf72974c6761e3"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "6.3.1"
++    version: "6.1.4"
+   url_launcher_android:
+     dependency: transitive
+     description:
+       name: url_launcher_android
+-      sha256: "0dea215895a4d254401730ca0ba8204b29109a34a99fb06ae559a2b60988d2de"
++      sha256: "55b921b486e0153aacd57aef18940c4ff427faa469a108af31d24a098a43ebd4"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "6.3.13"
++    version: "6.0.13"
+   url_launcher_ios:
+     dependency: transitive
+     description:
+       name: url_launcher_ios
+-      sha256: e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e
++      sha256: "31bbb50e00b80848767c4e8fd72143ca14df677e8c827ce0dc84a7a49dd1eb77"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "6.3.1"
++    version: "6.0.13"
+   url_launcher_linux:
+     dependency: transitive
+     description:
+       name: url_launcher_linux
+-      sha256: e2b9622b4007f97f504cd64c0128309dfb978ae66adbe944125ed9e1750f06af
++      sha256: ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.2.0"
++    version: "3.1.1"
+   url_launcher_macos:
+     dependency: transitive
+     description:
+       name: url_launcher_macos
+-      sha256: "769549c999acdb42b8bcfa7c43d72bf79a382ca7441ab18a808e101149daf672"
++      sha256: f72b523da791d519aed53c12fd99c7dc50fdd1e4913da904081f3666d06334b5
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.2.1"
++    version: "2.0.0"
+   url_launcher_platform_interface:
+     dependency: transitive
+     description:
+@@ -1620,18 +1548,18 @@ packages:
+     dependency: transitive
+     description:
+       name: url_launcher_web
+-      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
++      sha256: a36e2d7981122fa185006b216eb6b5b97ede3f9a54b7a511bc966971ab98d049
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.3.3"
++    version: "2.3.2"
+   url_launcher_windows:
+     dependency: transitive
+     description:
+       name: url_launcher_windows
+-      sha256: "44cf3aabcedde30f2dba119a9dea3b0f2672fbe6fa96e85536251d678216b3c4"
++      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.1.3"
++    version: "3.1.2"
+   uuid:
+     dependency: transitive
+     description:
+@@ -1644,26 +1572,26 @@ packages:
+     dependency: "direct main"
+     description:
+       name: vector_graphics
+-      sha256: "32c3c684e02f9bc0afb0ae0aa653337a2fe022e8ab064bcd7ffda27a74e288e3"
++      sha256: "09562ef5f47aa84f6567495adb6b9cb2a3192b82c352623b8bd00b300d62603b"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.1.11+1"
++    version: "1.0.1"
+   vector_graphics_codec:
+     dependency: transitive
+     description:
+       name: vector_graphics_codec
+-      sha256: c86987475f162fadff579e7320c7ddda04cd2fdeffbe1129227a85d9ac9e03da
++      sha256: "886e57742644ebed024dc3ade29712e37eea1b03d294fb314c0a3386243fe5a6"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.1.11+1"
++    version: "1.0.1"
+   vector_graphics_compiler:
+     dependency: "direct dev"
+     description:
+       name: vector_graphics_compiler
+-      sha256: "12faff3f73b1741a36ca7e31b292ddeb629af819ca9efe9953b70bd63fc8cd81"
++      sha256: "5d9010c4a292766c55395b2288532579a85673f8148460d1e233d98ffe10d24e"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.1.11+1"
++    version: "1.0.1"
+   vector_math:
+     dependency: transitive
+     description:
+@@ -1676,10 +1604,10 @@ packages:
+     dependency: transitive
+     description:
+       name: version
+-      sha256: "3d4140128e6ea10d83da32fef2fa4003fccbf6852217bb854845802f04191f94"
++      sha256: "2307e23a45b43f96469eeab946208ed63293e8afca9c28cd8b5241ff31c55f55"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.0.2"
++    version: "3.0.0"
+   vm_service:
+     dependency: transitive
+     description:
+@@ -1716,74 +1644,74 @@ packages:
+     dependency: transitive
+     description:
+       name: web
+-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
++      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.1.0"
++    version: "1.0.0"
+   webview_flutter:
+     dependency: transitive
+     description:
+       name: webview_flutter
+-      sha256: "889a0a678e7c793c308c68739996227c9661590605e70b1f6cf6b9a6634f7aec"
++      sha256: "85557bf0a4a7cee48566da129a8f7ab3d62b6b6e8c4b9e49be977b2fe8f66c60"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "4.10.0"
++    version: "4.0.0"
+   webview_flutter_android:
+     dependency: transitive
+     description:
+       name: webview_flutter_android
+-      sha256: "74693a212d990b32e0b7055d27db973a18abf31c53942063948cdfaaef9787ba"
++      sha256: ec9596e4fa02b1cd4e1bedf3f9a58eba9d8e406c2228f124af70aa905ee9a174
+       url: "https://pub.dev"
+     source: hosted
+-    version: "4.0.0"
++    version: "3.0.0"
+   webview_flutter_platform_interface:
+     dependency: transitive
+     description:
+       name: webview_flutter_platform_interface
+-      sha256: d937581d6e558908d7ae3dc1989c4f87b786891ab47bb9df7de548a151779d8d
++      sha256: "461c4b749048761f8677f529e0841e634e987bd2251c83a9d9b066216818fc7c"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "2.10.0"
++    version: "2.0.0"
+   webview_flutter_wkwebview:
+     dependency: transitive
+     description:
+       name: webview_flutter_wkwebview
+-      sha256: d4034901d96357beb1b6717ebf7d583c88e40cfc6eb85fe76dd1bf0979a9f251
++      sha256: a78acba1a64f831c482faedb8c82447fa2ee5858bb36d44310915efde5f1e965
+       url: "https://pub.dev"
+     source: hosted
+-    version: "3.16.0"
++    version: "3.0.0"
+   win32:
+     dependency: transitive
+     description:
+       name: win32
+-      sha256: e1d0cc62e65dc2561f5071fcbccecf58ff20c344f8f3dc7d4922df372a11df1f
++      sha256: "0a989dc7ca2bb51eac91e8fd00851297cfffd641aa7538b165c62637ca0eaa4a"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "5.7.1"
++    version: "5.4.0"
+   window_manager:
+     dependency: transitive
+     description:
+       name: window_manager
+-      sha256: "732896e1416297c63c9e3fb95aea72d0355f61390263982a47fd519169dc5059"
++      sha256: e052224c7d8f0d1d0b2e03b7b1047bb08ea800d919a79453518311839881fa5f
+       url: "https://pub.dev"
+     source: hosted
+-    version: "0.4.3"
++    version: "0.4.0"
+   xdg_directories:
+     dependency: transitive
+     description:
+       name: xdg_directories
+-      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
++      sha256: "060b6e1c891d956f72b5ac9463466c37cce3fa962a921532fc001e86fe93438e"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "1.1.0"
++    version: "0.2.0+1"
+   xml:
+     dependency: transitive
+     description:
+       name: xml
+-      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
++      sha256: "5bc72e1e45e941d825fd7468b9b4cc3b9327942649aeb6fc5cdbf135f0a86e84"
+       url: "https://pub.dev"
+     source: hosted
+-    version: "6.5.0"
++    version: "6.3.0"
+   xml_annotation:
+     dependency: transitive
+     description:
+@@ -1801,5 +1729,5 @@ packages:
+     source: hosted
+     version: "3.1.2"
+ sdks:
+-  dart: ">=3.5.0 <4.0.0"
+-  flutter: ">=3.24.0"
++  dart: ">=3.4.0 <4.0.0"
++  flutter: ">=3.22.0"
+diff --git a/packages/neon_framework/packages/account_repository/pubspec.yaml b/packages/neon_framework/packages/account_repository/pubspec.yaml
+--- a/packages/neon_framework/packages/account_repository/pubspec.yaml
++++ b/packages/neon_framework/packages/account_repository/pubspec.yaml
+@@ -37,3 +37,10 @@ dev_dependencies:
+       url: https://github.com/nextcloud/neon
+       path: packages/neon_lints
+   test: ^1.25.2
++
++dependency_overrides:
++  archive: ^3.5.0
++  image_picker: ^0.8.2
++  platform: ^3.1.0
++  quiver: ^3.2.1
++  win32: ^5.5.1
+diff --git a/packages/neon_framework/packages/account_repository/pubspec_overrides.yaml b/packages/neon_framework/packages/account_repository/pubspec_overrides.yaml
+--- a/packages/neon_framework/packages/account_repository/pubspec_overrides.yaml
++++ b/packages/neon_framework/packages/account_repository/pubspec_overrides.yaml
+@@ -1,9 +1,11 @@
+-# melos_managed_dependency_overrides: cookie_store,dynamite_runtime,interceptor_http_client,neon_framework,neon_http_client,neon_lints,nextcloud,notifications_push_repository,sort_box
++# melos_managed_dependency_overrides: cookie_store,dynamite_runtime,interceptor_http_client,neon_framework,neon_http_client,neon_lints,nextcloud,notifications_push_repository,sort_box,archive,image_picker,platform,quiver,win32
+ dependency_overrides:
++  archive: ^3.5.0
+   cookie_store:
+     path: ../../../cookie_store
+   dynamite_runtime:
+     path: ../../../dynamite/packages/dynamite_runtime
++  image_picker: ^0.8.2
+   interceptor_http_client:
+     path: ../../../interceptor_http_client
+   neon_framework:
+@@ -16,5 +18,8 @@ dependency_overrides:
+     path: ../../../nextcloud
+   notifications_push_repository:
+     path: ../notifications_push_repository
++  platform: ^3.1.0
++  quiver: ^3.2.1
+   sort_box:
+     path: ../sort_box
++  win32: ^5.5.1
+diff --git a/packages/neon_framework/packages/dashboard_app/pubspec.yaml b/packages/neon_framework/packages/dashboard_app/pubspec.yaml
+--- a/packages/neon_framework/packages/dashboard_app/pubspec.yaml
++++ b/packages/neon_framework/packages/dashboard_app/pubspec.yaml
+@@ -39,6 +39,13 @@ dev_dependencies:
+   url_launcher_platform_interface: ^2.3.2
+   vector_graphics_compiler: ^1.1.12
+
++dependency_overrides:
++  archive: ^3.5.0
++  image_picker: ^0.8.2
++  platform: ^3.1.0
++  quiver: ^3.2.1
++  win32: ^5.5.1
++
+ flutter:
+   uses-material-design: true
+   assets:
+diff --git a/packages/neon_framework/packages/dashboard_app/pubspec_overrides.yaml b/packages/neon_framework/packages/dashboard_app/pubspec_overrides.yaml
+--- a/packages/neon_framework/packages/dashboard_app/pubspec_overrides.yaml
++++ b/packages/neon_framework/packages/dashboard_app/pubspec_overrides.yaml
+@@ -1,11 +1,13 @@
+-# melos_managed_dependency_overrides: account_repository,cookie_store,dynamite_runtime,interceptor_http_client,neon_framework,neon_http_client,neon_lints,nextcloud,notifications_push_repository,sort_box
++# melos_managed_dependency_overrides: account_repository,cookie_store,dynamite_runtime,interceptor_http_client,neon_framework,neon_http_client,neon_lints,nextcloud,notifications_push_repository,sort_box,archive,image_picker,platform,quiver,win32
+ dependency_overrides:
+   account_repository:
+     path: ../account_repository
++  archive: ^3.5.0
+   cookie_store:
+     path: ../../../cookie_store
+   dynamite_runtime:
+     path: ../../../dynamite/packages/dynamite_runtime
++  image_picker: ^0.8.2
+   interceptor_http_client:
+     path: ../../../interceptor_http_client
+   neon_framework:
+@@ -18,5 +20,8 @@ dependency_overrides:
+     path: ../../../nextcloud
+   notifications_push_repository:
+     path: ../notifications_push_repository
++  platform: ^3.1.0
++  quiver: ^3.2.1
+   sort_box:
+     path: ../sort_box
++  win32: ^5.5.1
+diff --git a/packages/neon_framework/packages/neon_http_client/pubspec.yaml b/packages/neon_framework/packages/neon_http_client/pubspec.yaml
+--- a/packages/neon_framework/packages/neon_http_client/pubspec.yaml
++++ b/packages/neon_framework/packages/neon_http_client/pubspec.yaml
+@@ -34,3 +34,8 @@ dev_dependencies:
+       url: https://github.com/nextcloud/neon
+       path: packages/neon_lints
+   test: ^1.25.8
++
++dependency_overrides:
++  frontend_server_client: ^4.0.0
++  quiver: ^3.2.1
++  web: ">=0.5.0 <2.0.0"
+diff --git a/packages/neon_framework/packages/neon_http_client/pubspec_overrides.yaml b/packages/neon_framework/packages/neon_http_client/pubspec_overrides.yaml
+--- a/packages/neon_framework/packages/neon_http_client/pubspec_overrides.yaml
++++ b/packages/neon_framework/packages/neon_http_client/pubspec_overrides.yaml
+@@ -1,12 +1,15 @@
+-# melos_managed_dependency_overrides: cookie_store,dynamite_runtime,interceptor_http_client,neon_lints,nextcloud
++# melos_managed_dependency_overrides: cookie_store,dynamite_runtime,interceptor_http_client,neon_lints,nextcloud,frontend_server_client,quiver,web
+ dependency_overrides:
+   cookie_store:
+     path: ../../../cookie_store
+   dynamite_runtime:
+     path: ../../../dynamite/packages/dynamite_runtime
++  frontend_server_client: ^4.0.0
+   interceptor_http_client:
+     path: ../../../interceptor_http_client
+   neon_lints:
+     path: ../../../neon_lints
+   nextcloud:
+     path: ../../../nextcloud
++  quiver: ^3.2.1
++  web: ">=0.5.0 <2.0.0"
+diff --git a/packages/neon_framework/packages/neon_storage/pubspec.yaml b/packages/neon_framework/packages/neon_storage/pubspec.yaml
+--- a/packages/neon_framework/packages/neon_storage/pubspec.yaml
++++ b/packages/neon_framework/packages/neon_storage/pubspec.yaml
+@@ -32,3 +32,6 @@ dev_dependencies:
+       url: https://github.com/nextcloud/neon
+       path: packages/neon_lints
+   test: ^1.25.8
++
++dependency_overrides:
++  frontend_server_client: ^4.0.0
+diff --git a/packages/neon_framework/packages/neon_storage/pubspec_overrides.yaml b/packages/neon_framework/packages/neon_storage/pubspec_overrides.yaml
+--- a/packages/neon_framework/packages/neon_storage/pubspec_overrides.yaml
++++ b/packages/neon_framework/packages/neon_storage/pubspec_overrides.yaml
+@@ -1,4 +1,4 @@
+-# melos_managed_dependency_overrides: cookie_store,cookie_store_conformance_tests,dynamite_runtime,neon_lints,nextcloud
++# melos_managed_dependency_overrides: cookie_store,cookie_store_conformance_tests,dynamite_runtime,neon_lints,nextcloud,frontend_server_client
+ dependency_overrides:
+   cookie_store:
+     path: ../../../cookie_store
+@@ -6,6 +6,7 @@ dependency_overrides:
+     path: ../../../cookie_store/packages/cookie_store_conformance_tests
+   dynamite_runtime:
+     path: ../../../dynamite/packages/dynamite_runtime
++  frontend_server_client: ^4.0.0
+   neon_lints:
+     path: ../../../neon_lints
+   nextcloud:
+diff --git a/packages/neon_framework/packages/notifications_app/pubspec.yaml b/packages/neon_framework/packages/notifications_app/pubspec.yaml
+--- a/packages/neon_framework/packages/notifications_app/pubspec.yaml
++++ b/packages/neon_framework/packages/notifications_app/pubspec.yaml
+@@ -44,6 +44,13 @@ dev_dependencies:
+   url_launcher_platform_interface: ^2.3.2
+   vector_graphics_compiler: ^1.1.12
+
++dependency_overrides:
++  archive: ^3.5.0
++  image_picker: ^0.8.2
++  platform: ^3.1.0
++  quiver: ^3.2.1
++  win32: ^5.5.1
++
+ flutter:
+   uses-material-design: true
+   assets:
+diff --git a/packages/neon_framework/packages/notifications_app/pubspec_overrides.yaml b/packages/neon_framework/packages/notifications_app/pubspec_overrides.yaml
+--- a/packages/neon_framework/packages/notifications_app/pubspec_overrides.yaml
++++ b/packages/neon_framework/packages/notifications_app/pubspec_overrides.yaml
+@@ -1,11 +1,13 @@
+-# melos_managed_dependency_overrides: account_repository,cookie_store,dynamite_runtime,interceptor_http_client,neon_framework,neon_http_client,neon_lints,nextcloud,notifications_push_repository,sort_box
++# melos_managed_dependency_overrides: account_repository,cookie_store,dynamite_runtime,interceptor_http_client,neon_framework,neon_http_client,neon_lints,nextcloud,notifications_push_repository,sort_box,archive,image_picker,platform,quiver,win32
+ dependency_overrides:
+   account_repository:
+     path: ../account_repository
++  archive: ^3.5.0
+   cookie_store:
+     path: ../../../cookie_store
+   dynamite_runtime:
+     path: ../../../dynamite/packages/dynamite_runtime
++  image_picker: ^0.8.2
+   interceptor_http_client:
+     path: ../../../interceptor_http_client
+   neon_framework:
+@@ -18,5 +20,8 @@ dependency_overrides:
+     path: ../../../nextcloud
+   notifications_push_repository:
+     path: ../notifications_push_repository
++  platform: ^3.1.0
++  quiver: ^3.2.1
+   sort_box:
+     path: ../sort_box
++  win32: ^5.5.1
+diff --git a/packages/neon_framework/packages/notifications_push_repository/pubspec.yaml b/packages/neon_framework/packages/notifications_push_repository/pubspec.yaml
+--- a/packages/neon_framework/packages/notifications_push_repository/pubspec.yaml
++++ b/packages/neon_framework/packages/notifications_push_repository/pubspec.yaml
+@@ -44,3 +44,10 @@ dev_dependencies:
+       path: packages/neon_lints
+   plugin_platform_interface: ^2.1.8
+   unifiedpush_platform_interface: ^2.0.2
++
++dependency_overrides:
++  archive: ^3.5.0
++  image_picker: ^0.8.2
++  platform: ^3.1.0
++  quiver: ^3.2.1
++  win32: ^5.5.1
+diff --git a/packages/neon_framework/packages/notifications_push_repository/pubspec_overrides.yaml b/packages/neon_framework/packages/notifications_push_repository/pubspec_overrides.yaml
+--- a/packages/neon_framework/packages/notifications_push_repository/pubspec_overrides.yaml
++++ b/packages/neon_framework/packages/notifications_push_repository/pubspec_overrides.yaml
+@@ -1,11 +1,13 @@
+-# melos_managed_dependency_overrides: account_repository,cookie_store,dynamite_runtime,interceptor_http_client,neon_framework,neon_http_client,neon_lints,nextcloud,sort_box
++# melos_managed_dependency_overrides: account_repository,cookie_store,dynamite_runtime,interceptor_http_client,neon_framework,neon_http_client,neon_lints,nextcloud,sort_box,archive,image_picker,platform,quiver,win32
+ dependency_overrides:
+   account_repository:
+     path: ../account_repository
++  archive: ^3.5.0
+   cookie_store:
+     path: ../../../cookie_store
+   dynamite_runtime:
+     path: ../../../dynamite/packages/dynamite_runtime
++  image_picker: ^0.8.2
+   interceptor_http_client:
+     path: ../../../interceptor_http_client
+   neon_framework:
+@@ -16,5 +18,8 @@ dependency_overrides:
+     path: ../../../neon_lints
+   nextcloud:
+     path: ../../../nextcloud
++  platform: ^3.1.0
++  quiver: ^3.2.1
+   sort_box:
+     path: ../sort_box
++  win32: ^5.5.1
+diff --git a/packages/neon_framework/packages/sort_box/pubspec.yaml b/packages/neon_framework/packages/sort_box/pubspec.yaml
+--- a/packages/neon_framework/packages/sort_box/pubspec.yaml
++++ b/packages/neon_framework/packages/sort_box/pubspec.yaml
+@@ -15,3 +15,6 @@ dev_dependencies:
+       url: https://github.com/nextcloud/neon
+       path: packages/neon_lints
+   test: ^1.25.8
++
++dependency_overrides:
++  frontend_server_client: ^4.0.0
+diff --git a/packages/neon_framework/packages/sort_box/pubspec_overrides.yaml b/packages/neon_framework/packages/sort_box/pubspec_overrides.yaml
+--- a/packages/neon_framework/packages/sort_box/pubspec_overrides.yaml
++++ b/packages/neon_framework/packages/sort_box/pubspec_overrides.yaml
+@@ -1,4 +1,5 @@
+-# melos_managed_dependency_overrides: neon_lints
++# melos_managed_dependency_overrides: neon_lints,frontend_server_client
+ dependency_overrides:
++  frontend_server_client: ^4.0.0
+   neon_lints:
+     path: ../../../neon_lints
+diff --git a/packages/neon_framework/packages/talk_app/pubspec.yaml b/packages/neon_framework/packages/talk_app/pubspec.yaml
+--- a/packages/neon_framework/packages/talk_app/pubspec.yaml
++++ b/packages/neon_framework/packages/talk_app/pubspec.yaml
+@@ -48,6 +48,14 @@ dev_dependencies:
+   url_launcher_platform_interface: ^2.3.2
+   vector_graphics_compiler: ^1.1.12
+
++dependency_overrides:
++  archive: ^3.5.0
++  image_picker: ^0.8.2
++  platform: ^3.1.0
++  pointer_interceptor: ^0.10.1+1
++  quiver: ^3.2.1
++  win32: ^5.5.1
++
+ flutter:
+   uses-material-design: true
+   assets:
+diff --git a/packages/neon_framework/packages/talk_app/pubspec_overrides.yaml b/packages/neon_framework/packages/talk_app/pubspec_overrides.yaml
+--- a/packages/neon_framework/packages/talk_app/pubspec_overrides.yaml
++++ b/packages/neon_framework/packages/talk_app/pubspec_overrides.yaml
+@@ -1,11 +1,13 @@
+-# melos_managed_dependency_overrides: account_repository,cookie_store,dynamite_runtime,interceptor_http_client,neon_framework,neon_http_client,neon_lints,nextcloud,notifications_push_repository,sort_box
++# melos_managed_dependency_overrides: account_repository,cookie_store,dynamite_runtime,interceptor_http_client,neon_framework,neon_http_client,neon_lints,nextcloud,notifications_push_repository,sort_box,archive,image_picker,platform,pointer_interceptor,quiver,win32
+ dependency_overrides:
+   account_repository:
+     path: ../account_repository
++  archive: ^3.5.0
+   cookie_store:
+     path: ../../../cookie_store
+   dynamite_runtime:
+     path: ../../../dynamite/packages/dynamite_runtime
++  image_picker: ^0.8.2
+   interceptor_http_client:
+     path: ../../../interceptor_http_client
+   neon_framework:
+@@ -18,5 +20,9 @@ dependency_overrides:
+     path: ../../../nextcloud
+   notifications_push_repository:
+     path: ../notifications_push_repository
++  platform: ^3.1.0
++  pointer_interceptor: ^0.10.1+1
++  quiver: ^3.2.1
+   sort_box:
+     path: ../sort_box
++  win32: ^5.5.1
+diff --git a/packages/neon_framework/pubspec.yaml b/packages/neon_framework/pubspec.yaml
+--- a/packages/neon_framework/pubspec.yaml
++++ b/packages/neon_framework/pubspec.yaml
+@@ -111,6 +111,13 @@ dev_dependencies:
+   vector_graphics_compiler: ^1.1.12
+   version: ^3.0.2
+
++dependency_overrides:
++  archive: ^3.5.0
++  image_picker: ^0.8.2
++  platform: ^3.1.0
++  quiver: ^3.2.1
++  win32: ^5.5.1
++
+ flutter:
+   uses-material-design: true
+   assets:
+diff --git a/packages/neon_framework/pubspec_overrides.yaml b/packages/neon_framework/pubspec_overrides.yaml
+--- a/packages/neon_framework/pubspec_overrides.yaml
++++ b/packages/neon_framework/pubspec_overrides.yaml
+@@ -1,13 +1,15 @@
+-# melos_managed_dependency_overrides: account_repository,cookie_store,cookie_store_conformance_tests,dynamite_runtime,interceptor_http_client,neon_http_client,neon_lints,nextcloud,notifications_push_repository,sort_box
++# melos_managed_dependency_overrides: account_repository,cookie_store,cookie_store_conformance_tests,dynamite_runtime,interceptor_http_client,neon_http_client,neon_lints,nextcloud,notifications_push_repository,sort_box,archive,image_picker,platform,quiver,win32
+ dependency_overrides:
+   account_repository:
+     path: packages/account_repository
++  archive: ^3.5.0
+   cookie_store:
+     path: ../cookie_store
+   cookie_store_conformance_tests:
+     path: ../cookie_store/packages/cookie_store_conformance_tests
+   dynamite_runtime:
+     path: ../dynamite/packages/dynamite_runtime
++  image_picker: ^0.8.2
+   interceptor_http_client:
+     path: ../interceptor_http_client
+   neon_http_client:
+@@ -18,5 +20,8 @@ dependency_overrides:
+     path: ../nextcloud
+   notifications_push_repository:
+     path: packages/notifications_push_repository
++  platform: ^3.1.0
++  quiver: ^3.2.1
+   sort_box:
+     path: packages/sort_box
++  win32: ^5.5.1
+diff --git a/packages/nextcloud/pubspec.yaml b/packages/nextcloud/pubspec.yaml
+--- a/packages/nextcloud/pubspec.yaml
++++ b/packages/nextcloud/pubspec.yaml
+@@ -57,6 +57,10 @@ dev_dependencies:
+   test_api: ^0.7.3
+   xml_serializable: ^2.5.2
+
++dependency_overrides:
++  frontend_server_client: ^4.0.0
++  quiver: ^3.2.1
++
+ platforms:
+   windows:
+   linux:
+diff --git a/packages/nextcloud/pubspec_overrides.yaml b/packages/nextcloud/pubspec_overrides.yaml
+--- a/packages/nextcloud/pubspec_overrides.yaml
++++ b/packages/nextcloud/pubspec_overrides.yaml
+@@ -1,4 +1,4 @@
+-# melos_managed_dependency_overrides: cookie_store,dynamite,dynamite_runtime,interceptor_http_client,neon_lints,nextcloud_test
++# melos_managed_dependency_overrides: cookie_store,dynamite,dynamite_runtime,interceptor_http_client,neon_lints,nextcloud_test,frontend_server_client,quiver
+ dependency_overrides:
+   cookie_store:
+     path: ../cookie_store
+@@ -6,9 +6,11 @@ dependency_overrides:
+     path: ../dynamite
+   dynamite_runtime:
+     path: ../dynamite/packages/dynamite_runtime
++  frontend_server_client: ^4.0.0
+   interceptor_http_client:
+     path: ../interceptor_http_client
+   neon_lints:
+     path: ../neon_lints
+   nextcloud_test:
+     path: packages/nextcloud_test
++  quiver: ^3.2.1

--- a/packages/neon_framework/packages/files_app/pubspec.yaml
+++ b/packages/neon_framework/packages/files_app/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  flutter_material_design_icons: ^1.0.0
+  flutter_material_design_icons: ^1.1.7296
   go_router: ^14.0.0
   image_picker: ^1.0.0
   intl: ^0.19.0

--- a/packages/neon_framework/packages/notifications_app/pubspec.yaml
+++ b/packages/neon_framework/packages/notifications_app/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  flutter_material_design_icons: ^1.0.0
+  flutter_material_design_icons: ^1.1.7296
   go_router: ^14.0.0
   intersperse: ^2.0.0
   intl: ^0.19.0

--- a/packages/neon_framework/packages/talk_app/pubspec.yaml
+++ b/packages/neon_framework/packages/talk_app/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  flutter_material_design_icons: ^1.0.0
+  flutter_material_design_icons: ^1.1.7296
   flutter_typeahead: ^5.2.0
   go_router: ^14.0.0
   intersperse: ^2.0.0

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
       path: flutter_local_notifications
   flutter_localizations:
     sdk: flutter
-  flutter_material_design_icons: ^1.0.0
+  flutter_material_design_icons: ^1.1.7296
   flutter_native_splash: ^2.0.0
   flutter_svg: ^2.0.0
   flutter_zxing: ^1.0.0

--- a/packages/nextcloud/pubspec.yaml
+++ b/packages/nextcloud/pubspec.yaml
@@ -26,8 +26,8 @@ dependencies:
   universal_io: ^2.0.0
   uri: ^1.0.0
   version: ^3.0.0
-  xml: ^6.0.0
-  xml_annotation: ^2.1.0
+  xml: ^6.3.0
+  xml_annotation: ^2.4.0
 
 dev_dependencies:
   build_runner: ^2.4.13


### PR DESCRIPTION
Running the tests also ensures the code actually works and it's not just throwing no linting errors.

I only added the overrides to packages with tests as there is no way to automatically verify the overrides fix the build issues otherwise.
There seem to be some runtime issues with flutter_svg and vector_graphics, but I didn't look further into those.
This is only a step in the right direction and to verify that everything is fine with downgraded dependencies we need to have tests for every package.