### PR TITLE
ci: Simplify git diff checks

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -36,11 +36,7 @@ jobs:
         run: ./tool/setup.sh
 
       - name: Check up-to-date pubspec.lock
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            git --no-pager diff
-            exit 1
-          fi
+        run: git --no-pager diff --exit-code
       - name: Check formatting
         run: melos run format:check
       - name: Lint code

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -48,26 +48,17 @@ jobs:
       - name: Generate dynamite end to end test
         run: |
           ./tool/generate-dynamite-e2e-test.sh
-          if [ -n "$(git status --porcelain)" ]; then
-            git --no-pager diff
-            exit 1
-          fi
+          git --no-pager diff --exit-code
 
       - name: Generate dynamite petstore example
         run: |
           ./tool/generate-dynamite-petstore-example.sh
-          if [ -n "$(git status --porcelain)" ]; then
-            git --no-pager diff
-            exit 1
-          fi
+          git --no-pager diff --exit-code
 
       - name: Generate nextcloud
         run: |
           ./tool/generate-nextcloud.sh
-          if [ -n "$(git status --porcelain)" ]; then
-            git --no-pager diff
-            exit 1
-          fi
+          git --no-pager diff --exit-code
 
   openapi:
     name: OpenAPI
@@ -95,7 +86,4 @@ jobs:
       - name: Generate specs
         run: |
           ./tool/generate-specs.sh
-          if [ -n "$(git status --porcelain)" ]; then
-            git --no-pager diff
-            exit 1
-          fi
+          git --no-pager diff --exit-code


### PR DESCRIPTION
Just learned about the `--exit-code` option last week, so if there is any diff it will automatically show it and fail as well.