### PR TITLE
fix(neon_framework): Add localization for spreed app ID

### DIFF
--- a/packages/neon_framework/lib/l10n/en.arb
+++ b/packages/neon_framework/lib/l10n/en.arb
@@ -2,7 +2,7 @@
   "@@locale": "en",
   "nextcloud": "Nextcloud",
   "nextcloudLogo": "Nextcloud logo",
-  "appImplementationName": "{app, select, nextcloud{Nextcloud} core{Server} dashboard{Dashboard} files{Files} news{News} notes{Notes} notifications{Notifications} talk{Talk} other{}}",
+  "appImplementationName": "{app, select, nextcloud{Nextcloud} core{Server} dashboard{Dashboard} files{Files} news{News} notes{Notes} notifications{Notifications} spreed{Talk} talk{Talk} other{}}",
   "@appImplementationName": {
     "placeholders": {
       "app": {}

--- a/packages/neon_framework/lib/l10n/localizations.dart
+++ b/packages/neon_framework/lib/l10n/localizations.dart
@@ -106,7 +106,7 @@ abstract class NeonLocalizations {
   /// No description provided for @appImplementationName.
   ///
   /// In en, this message translates to:
-  /// **'{app, select, nextcloud{Nextcloud} core{Server} dashboard{Dashboard} files{Files} news{News} notes{Notes} notifications{Notifications} talk{Talk} other{}}'**
+  /// **'{app, select, nextcloud{Nextcloud} core{Server} dashboard{Dashboard} files{Files} news{News} notes{Notes} notifications{Notifications} spreed{Talk} talk{Talk} other{}}'**
   String appImplementationName(String app);
 
   /// No description provided for @loginAgain.

--- a/packages/neon_framework/lib/l10n/localizations_en.dart
+++ b/packages/neon_framework/lib/l10n/localizations_en.dart
@@ -26,6 +26,7 @@ class NeonLocalizationsEn extends NeonLocalizations {
         'news': 'News',
         'notes': 'Notes',
         'notifications': 'Notifications',
+        'spreed': 'Talk',
         'talk': 'Talk',
         'other': '',
       },


### PR DESCRIPTION
When receiving push notifications the app ID will be `spreed` so we need a localization for that ID such that it can be correctly displayed in the Android notification channel list and the notification title.