### PR TITLE
test(nextcloud): Add checks to ensure that all available props are parsed

### DIFF
--- a/.cspell/nextcloud.txt
+++ b/.cspell/nextcloud.txt
@@ -50,6 +50,7 @@ requesttoken
 reshares
 resharing
 rgdnvw
+rgdnvck
 roomid
 rowocs
 setsip

--- a/packages/nextcloud/packages/nextcloud_test/lib/nextcloud_test.dart
+++ b/packages/nextcloud/packages/nextcloud_test/lib/nextcloud_test.dart
@@ -1,2 +1,3 @@
 export 'src/fixtures.dart' hide appendFixture;
+export 'src/models/nextcloud_tester.dart';
 export 'src/presets.dart';

--- a/packages/nextcloud/packages/nextcloud_test/lib/nextcloud_test.dart
+++ b/packages/nextcloud/packages/nextcloud_test/lib/nextcloud_test.dart
@@ -1,3 +1,4 @@
 export 'src/fixtures.dart' hide appendFixture;
+export 'src/matchers/webdav_props.dart';
 export 'src/models/nextcloud_tester.dart';
 export 'src/presets.dart';

--- a/packages/nextcloud/packages/nextcloud_test/lib/src/matchers/webdav_props.dart
+++ b/packages/nextcloud/packages/nextcloud_test/lib/src/matchers/webdav_props.dart
@@ -1,0 +1,72 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:collection/collection.dart';
+import 'package:http/http.dart' as http;
+// ignore: implementation_imports
+import 'package:matcher/src/expect/async_matcher.dart';
+import 'package:nextcloud/webdav.dart';
+import 'package:nextcloud_test/src/models/models.dart';
+import 'package:test/test.dart';
+import 'package:xml/xml.dart';
+
+class _ContainsAllAvailableProps extends AsyncMatcher {
+  _ContainsAllAvailableProps(
+    this.tester,
+    this.uri,
+  );
+
+  final NextcloudTester tester;
+  final PathUri uri;
+
+  @override
+  Description describe(Description description) {
+    return description;
+  }
+
+  @override
+  Future<String?> matchAsync(dynamic item) async {
+    if (item is! XmlElement) {
+      return 'Expected XmlElement, got ${item.runtimeType}.';
+    }
+
+    final parsedProps = _getMultistatusPropNames(item);
+    if (parsedProps.isEmpty) {
+      return 'Parsed props were empty';
+    }
+
+    final streamedResponse = await tester.client.webdav.httpClient.send(tester.client.webdav.propfind_Request(uri));
+    if (streamedResponse.statusCode != 207) {
+      return 'PROPFIND response status code was not 207';
+    }
+    final rawResponse = await http.Response.fromStream(streamedResponse);
+
+    final expectedProps = _getMultistatusPropNames(XmlDocument.parse(rawResponse.body).rootElement);
+    if (expectedProps.isEmpty) {
+      return 'Expected props were empty';
+    }
+
+    if (parsedProps != expectedProps) {
+      return 'Missing props: ${expectedProps.where((p) => !parsedProps.contains(p)).join(', ')}';
+    }
+
+    return null;
+  }
+
+  BuiltList<String> _getMultistatusPropNames(XmlElement root) {
+    return root.firstElementChild!.childElements
+        .singleWhere(
+          (node) =>
+              node.name.local == 'propstat' &&
+              node.childElements.singleWhere((node) => node.name.local == 'status').innerText.contains('200 OK'),
+        )
+        .childElements
+        .singleWhere((node) => node.name.local == 'prop')
+        .childElements
+        .map((el) => '{${el.name.namespaceUri}}${el.name.local}')
+        .toList()
+        .sorted()
+        .toBuiltList();
+  }
+}
+
+/// Checks that all props have been parsed, by comparing them to a raw PROPFIND response of a request to [uri].
+Matcher containsAllAvailableProps(NextcloudTester tester, PathUri uri) => _ContainsAllAvailableProps(tester, uri);

--- a/packages/nextcloud/packages/nextcloud_test/lib/src/presets.dart
+++ b/packages/nextcloud/packages/nextcloud_test/lib/src/presets.dart
@@ -1,6 +1,5 @@
 import 'package:meta/meta.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
-import 'package:nextcloud_test/src/models/models.dart';
 import 'package:nextcloud_test/src/test_target/test_target.dart';
 import 'package:test/test.dart';
 

--- a/packages/nextcloud/packages/nextcloud_test/pubspec.yaml
+++ b/packages/nextcloud/packages/nextcloud_test/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 
 dependencies:
   built_collection: ^5.1.1
+  collection: ^1.0.0
   cookie_store:
     git:
       url: https://github.com/nextcloud/neon
@@ -17,6 +18,7 @@ dependencies:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/interceptor_http_client
+  matcher: ^0.12.0
   meta: ^1.0.0
   nextcloud: ^8.1.0
   path: ^1.9.0
@@ -25,6 +27,7 @@ dependencies:
   test_api: ^0.7.0
   universal_io: ^2.0.0
   version: ^3.0.0
+  xml: ^6.0.0
 
 dev_dependencies:
   neon_lints:

--- a/packages/nextcloud/test/api/webdav/webdav_test.dart
+++ b/packages/nextcloud/test/api/webdav/webdav_test.dart
@@ -14,6 +14,7 @@ import 'package:nextcloud/webdav.dart';
 import 'package:nextcloud_test/nextcloud_test.dart';
 import 'package:test/test.dart';
 import 'package:universal_io/io.dart';
+import 'package:version/version.dart';
 
 class MockCallbackFunction extends Mock {
   void progressCallback(double progress);
@@ -161,7 +162,7 @@ void main() {
       final file = File('test/files/test.png');
       await tester.client.webdav.putFile(file, file.statSync(), PathUri.parse('test/test.png'));
 
-      final result = await tester.client.webdav.propfind(
+      final response = await tester.client.webdav.propfind(
         PathUri.parse('test/test.png'),
         prop: const WebDavPropWithoutValues.fromBools(
           davCreationdate: true,
@@ -224,121 +225,195 @@ void main() {
           ocsSharePermissions: true,
         ),
       );
-      final response = result.toWebDavFiles().single;
 
-      expect(response.path, PathUri.parse('test/test.png'));
-      expect(response.id, isNotEmpty);
-      expect(response.fileId, greaterThan(0));
-      expect(response.isCollection, isFalse);
-      expect(response.mimeType, 'image/png');
-      expect(response.etag, isNotEmpty);
-      expect(response.size, 8650);
-      expect(response.ownerId, 'user1');
-      expect(response.ownerDisplay, 'User One');
-      expect(response.lastModified!.isBefore(DateTime.timestamp()), isTrue);
-      expect(response.isDirectory, isFalse);
-      expect(response.uploadedDate!.isBefore(DateTime.timestamp()), isTrue);
-      expect(response.createdDate!.isBefore(DateTime.timestamp()), isTrue);
-      expect(response.favorite, isFalse);
-      expect(response.hasPreview, isTrue);
-      expect(response.name, 'test.png');
-      expect(response.isDirectory, isFalse);
-
-      expect(response.props.davCreationdate!.isBefore(DateTime.timestamp()), isTrue);
-      expect(response.props.davDisplayname, 'test.png');
-      expect(response.props.davGetcontentlanguage, isNull);
-      expect(response.props.davGetcontentlength, 8650);
-      expect(response.props.davGetcontenttype, 'image/png');
-      expect(response.props.davGetetag, isNotEmpty);
-      expect(response.props.davGetlastmodified!.isBefore(DateTime.timestamp()), isTrue);
-      expect(response.props.davQuotaAvailableBytes, isNull);
-      expect(response.props.davQuotaUsedBytes, isNull);
-      expect(response.props.davResourcetype!.collection, isNull);
-      expect(response.props.ncCreationTime!.isBefore(DateTime.timestamp()), isTrue);
-      expect(response.props.ncAclCanManage, isNull);
-      expect(response.props.ncAclEnabled, isNull);
-      expect(response.props.ncAclList, isNull);
-      expect(response.props.ncContainedFileCount, isNull);
-      expect(response.props.ncContainedFolderCount, isNull);
-      expect(response.props.ncDataFingerprint, isNull);
-      expect(response.props.ncGroupFolderId, isNull);
-      expect(response.props.ncHasPreview, isTrue);
-      expect(response.props.ncHidden, isFalse);
-      expect(response.props.ncInheritedAclList, isNull);
-      expect(response.props.ncIsEncrypted, isNull);
-      expect(response.props.ncIsMountRoot, isFalse);
-      expect(response.props.ncLock, isNull);
-      expect(response.props.ncLockOwner, isNull);
-      expect(response.props.ncLockOwnerDisplayname, isNull);
-      expect(response.props.ncLockOwnerType, isNull);
-      expect(response.props.ncLockTime, isNull);
-      expect(response.props.ncLockTimeout, isNull);
-      expect(response.props.ncLockToken, isNull);
-      expect(response.props.ncMountType, isNull);
-      expect(response.props.ncNote, isNull);
-      expect(response.props.ncReminderDueDate, isNull);
-      expect(response.props.ncRichWorkspace, isNull);
-      expect(response.props.ncRichWorkspaceFile, isNull);
-      expect(json.decode(response.props.ncShareAttributes!), <String>[]);
-      expect(response.props.ncSharees!.sharees, isNull);
-      expect(response.props.ncUploadTime!.isBefore(DateTime.timestamp()), isTrue);
-      expect(response.props.ncVersionAuthor, isNull);
-      expect(response.props.ncVersionLabel, isNull);
-      expect(response.props.ncMetadataBlurhash, isNull);
-      expect(response.props.ocChecksums, isNull);
-      expect(response.props.ocCommentsCount, 0);
-      expect(response.props.ocCommentsHref, isNotEmpty);
-      expect(response.props.ocCommentsUnread, 0);
-      expect(response.props.ocDownloadURL, isNull);
-      expect(response.props.ocFavorite, false);
-      expect(response.props.ocFileid, greaterThan(0));
-      expect(response.props.ocId, isNotEmpty);
-      expect(response.props.ocOwnerDisplayName, 'User One');
-      expect(response.props.ocOwnerId, 'user1');
-      expect(response.props.ocPermissions, 'RGDNVW');
-      expect(response.props.ocShareTypes!.shareTypes, isNull);
-      expect(response.props.ocSize, 8650);
-      expect(response.props.ocTags!.tags, isNull);
-      expect(json.decode(response.props.ocmSharePermissions!), ['share', 'read', 'write']);
-      expect(response.props.ocsSharePermissions, 19);
+      final props = response.responses.first.propstats.first.prop;
+      expect(props.davCreationdate!.isBefore(DateTime.timestamp()), isTrue);
+      expect(props.davDisplayname, 'test.png');
+      expect(props.davGetcontentlanguage, isNull);
+      expect(props.davGetcontentlength, 8650);
+      expect(props.davGetcontenttype, 'image/png');
+      expect(props.davGetetag, isNotEmpty);
+      expect(props.davGetlastmodified!.isBefore(DateTime.timestamp()), isTrue);
+      expect(props.davQuotaAvailableBytes, isNull);
+      expect(props.davQuotaUsedBytes, isNull);
+      expect(props.davResourcetype!.collection, isNull);
+      expect(props.ncCreationTime!.isBefore(DateTime.timestamp()), isTrue);
+      expect(props.ncAclCanManage, isNull);
+      expect(props.ncAclEnabled, isNull);
+      expect(props.ncAclList, isNull);
+      expect(props.ncContainedFileCount, isNull);
+      expect(props.ncContainedFolderCount, isNull);
+      expect(props.ncDataFingerprint, isNull);
+      expect(props.ncGroupFolderId, isNull);
+      expect(props.ncHasPreview, isTrue);
+      expect(props.ncHidden, isFalse);
+      expect(props.ncInheritedAclList, isNull);
+      expect(props.ncIsEncrypted, isNull);
+      expect(props.ncIsMountRoot, isFalse);
+      expect(props.ncLock, isNull);
+      expect(props.ncLockOwner, isNull);
+      expect(props.ncLockOwnerDisplayname, isNull);
+      expect(props.ncLockOwnerType, isNull);
+      expect(props.ncLockTime, isNull);
+      expect(props.ncLockTimeout, isNull);
+      expect(props.ncLockToken, isNull);
+      expect(props.ncMountType, isNull);
+      expect(props.ncNote, isNull);
+      expect(props.ncReminderDueDate, isNull);
+      expect(props.ncRichWorkspace, isNull);
+      expect(props.ncRichWorkspaceFile, isNull);
+      expect(json.decode(props.ncShareAttributes!), <String>[]);
+      expect(props.ncSharees!.sharees, isNull);
+      expect(props.ncUploadTime!.isBefore(DateTime.timestamp()), isTrue);
+      expect(props.ncVersionAuthor, isNull);
+      expect(props.ncVersionLabel, isNull);
+      expect(props.ncMetadataBlurhash, isNull);
+      expect(props.ocChecksums, isNull);
+      expect(props.ocCommentsCount, 0);
+      expect(props.ocCommentsHref, isNotEmpty);
+      expect(props.ocCommentsUnread, 0);
+      expect(props.ocDownloadURL, isNull);
+      expect(props.ocFavorite, false);
+      expect(props.ocFileid, greaterThan(0));
+      expect(props.ocId, isNotEmpty);
+      expect(props.ocOwnerDisplayName, 'User One');
+      expect(props.ocOwnerId, 'user1');
+      expect(props.ocPermissions, 'RGDNVW');
+      expect(props.ocShareTypes!.shareTypes, isNull);
+      expect(props.ocSize, 8650);
+      expect(props.ocTags!.tags, isNull);
+      expect(json.decode(props.ocmSharePermissions!), ['share', 'read', 'write']);
+      expect(props.ocsSharePermissions, 19);
     });
 
     test('Get directory props', () async {
-      final data = utf8.encode('test');
       await tester.client.webdav.mkcol(PathUri.parse('test/dir-props'));
-      await tester.client.webdav.put(data, PathUri.parse('test/dir-props/test.txt'));
+      final file = File('test/files/test.png');
+      await tester.client.webdav.putFile(file, file.statSync(), PathUri.parse('test/dir-props/test.png'));
 
-      final response = (await tester.client.webdav.propfind(
+      final response = await tester.client.webdav.propfind(
         PathUri.parse('test/dir-props'),
         prop: const WebDavPropWithoutValues.fromBools(
+          davCreationdate: true,
+          davDisplayname: true,
+          davGetcontentlanguage: true,
+          davGetcontentlength: true,
           davGetcontenttype: true,
+          davGetetag: true,
           davGetlastmodified: true,
+          davQuotaAvailableBytes: true,
+          davQuotaUsedBytes: true,
           davResourcetype: true,
+          ncAclCanManage: true,
+          ncAclEnabled: true,
+          ncAclList: true,
+          ncContainedFileCount: true,
+          ncContainedFolderCount: true,
+          ncCreationTime: true,
+          ncDataFingerprint: true,
+          ncGroupFolderId: true,
+          ncHasPreview: true,
+          ncHidden: true,
+          ncInheritedAclList: true,
+          ncIsEncrypted: true,
+          ncIsMountRoot: true,
+          ncLock: true,
+          ncLockOwner: true,
+          ncLockOwnerDisplayname: true,
+          ncLockOwnerEditor: true,
+          ncLockOwnerType: true,
+          ncLockTime: true,
+          ncLockTimeout: true,
+          ncLockToken: true,
+          ncMountType: true,
+          ncNote: true,
+          ncReminderDueDate: true,
+          ncRichWorkspace: true,
+          ncRichWorkspaceFile: true,
+          ncShareAttributes: true,
+          ncSharees: true,
+          ncUploadTime: true,
+          ncVersionAuthor: true,
+          ncVersionLabel: true,
+          ncMetadataBlurhash: true,
+          ocChecksums: true,
+          ocCommentsCount: true,
+          ocCommentsHref: true,
+          ocCommentsUnread: true,
+          ocDownloadURL: true,
+          ocFavorite: true,
+          ocFileid: true,
+          ocId: true,
+          ocOwnerDisplayName: true,
+          ocOwnerId: true,
+          ocPermissions: true,
+          ocShareTypes: true,
           ocSize: true,
+          ocTags: true,
+          ocmSharePermissions: true,
+          ocsSharePermissions: true,
         ),
         depth: WebDavDepth.zero,
-      ))
-          .toWebDavFiles()
-          .single;
-
-      expect(response.path, PathUri.parse('test/dir-props/'));
-      expect(response.isCollection, isTrue);
-      expect(response.mimeType, isNull);
-      expect(response.size, data.lengthInBytes);
-      expect(
-        response.lastModified!.secondsSinceEpoch,
-        closeTo(DateTime.timestamp().secondsSinceEpoch, 10),
       );
-      expect(response.name, 'dir-props');
-      expect(response.isDirectory, isTrue);
 
-      expect(response.props.davGetcontenttype, isNull);
-      expect(
-        response.props.davGetlastmodified!.secondsSinceEpoch,
-        closeTo(DateTime.timestamp().secondsSinceEpoch, 10),
-      );
-      expect(response.props.davResourcetype!.collection, isNotNull);
-      expect(response.props.ocSize, data.lengthInBytes);
+      final props = response.responses.first.propstats.first.prop;
+      expect(props.davCreationdate!.isBefore(DateTime.timestamp()), isTrue);
+      expect(props.davDisplayname, 'dir-props');
+      expect(props.davGetcontentlanguage, isNull);
+      expect(props.davGetcontentlength, isNull);
+      expect(props.davGetcontenttype, isNull);
+      expect(props.davGetetag, isNotEmpty);
+      expect(props.davGetlastmodified!.isBefore(DateTime.timestamp()), isTrue);
+      expect(props.davQuotaAvailableBytes, -3);
+      expect(props.davQuotaUsedBytes, 8650);
+      expect(props.davResourcetype!.collection, <dynamic>[]);
+      expect(props.ncCreationTime!.isBefore(DateTime.timestamp()), isTrue);
+      expect(props.ncAclCanManage, isNull);
+      expect(props.ncAclEnabled, isNull);
+      expect(props.ncAclList, isNull);
+      expect(props.ncContainedFileCount, 1);
+      expect(props.ncContainedFolderCount, 0);
+      expect(props.ncDataFingerprint, isNull);
+      expect(props.ncGroupFolderId, isNull);
+      expect(props.ncHasPreview, isFalse);
+      expect(props.ncHidden, isFalse);
+      expect(props.ncInheritedAclList, isNull);
+      expect(props.ncIsEncrypted, tester.version < Version(30, 0, 0) ? isFalse : isNull);
+      expect(props.ncIsMountRoot, isFalse);
+      expect(props.ncLock, isNull);
+      expect(props.ncLockOwner, isNull);
+      expect(props.ncLockOwnerDisplayname, isNull);
+      expect(props.ncLockOwnerType, isNull);
+      expect(props.ncLockTime, isNull);
+      expect(props.ncLockTimeout, isNull);
+      expect(props.ncLockToken, isNull);
+      expect(props.ncMountType, isNull);
+      expect(props.ncNote, isNull);
+      expect(props.ncReminderDueDate, isNull);
+      expect(props.ncRichWorkspace, isNull);
+      expect(props.ncRichWorkspaceFile, isNull);
+      expect(json.decode(props.ncShareAttributes!), <String>[]);
+      expect(props.ncSharees!.sharees, isNull);
+      expect(props.ncUploadTime, isNull);
+      expect(props.ncVersionAuthor, isNull);
+      expect(props.ncVersionLabel, isNull);
+      expect(props.ncMetadataBlurhash, isNull);
+      expect(props.ocChecksums, isNull);
+      expect(props.ocCommentsCount, 0);
+      expect(props.ocCommentsHref, isNotEmpty);
+      expect(props.ocCommentsUnread, 0);
+      expect(props.ocDownloadURL, isNull);
+      expect(props.ocFavorite, false);
+      expect(props.ocFileid, greaterThan(0));
+      expect(props.ocId, isNotEmpty);
+      expect(props.ocOwnerDisplayName, 'User One');
+      expect(props.ocOwnerId, 'user1');
+      expect(props.ocPermissions, 'RGDNVCK');
+      expect(props.ocShareTypes!.shareTypes, isNull);
+      expect(props.ocSize, 8650);
+      expect(props.ocTags!.tags, isNull);
+      expect(json.decode(props.ocmSharePermissions!), ['share', 'read', 'write']);
+      expect(props.ocsSharePermissions, 31);
     });
 
     test('Create share', () async {

--- a/packages/nextcloud/test/api/webdav/webdav_test.dart
+++ b/packages/nextcloud/test/api/webdav/webdav_test.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:http/http.dart';
+import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nextcloud/core.dart' as core;
@@ -82,10 +82,10 @@ void main() {
     late FileStat fileStat;
 
     setUpAll(() {
-      registerFallbackValue(Request('get', Uri()) as BaseRequest);
+      registerFallbackValue(http.Request('get', Uri()) as http.BaseRequest);
 
       final mockClient = MockClient((request) async {
-        return Response('', 400);
+        return http.Response('', 400);
       });
 
       client = WebDavClient(
@@ -162,7 +162,7 @@ void main() {
       final file = File('test/files/test.png');
       await tester.client.webdav.putFile(file, file.statSync(), PathUri.parse('test/test.png'));
 
-      final response = await tester.client.webdav.propfind(
+      var response = await tester.client.webdav.propfind(
         PathUri.parse('test/test.png'),
         prop: const WebDavPropWithoutValues.fromBools(
           davCreationdate: true,
@@ -226,7 +226,7 @@ void main() {
         ),
       );
 
-      final props = response.responses.first.propstats.first.prop;
+      var props = response.responses.first.propstats.first.prop;
       expect(props.davCreationdate!.isBefore(DateTime.timestamp()), isTrue);
       expect(props.davDisplayname, 'test.png');
       expect(props.davGetcontentlanguage, isNull);
@@ -284,6 +284,73 @@ void main() {
       expect(props.ocTags!.tags, isNull);
       expect(json.decode(props.ocmSharePermissions!), ['share', 'read', 'write']);
       expect(props.ocsSharePermissions, 19);
+
+      response = await tester.client.webdav.propfind(PathUri.parse('test/test.png'));
+
+      props = response.responses.first.propstats.first.prop;
+      expect(props.davCreationdate, isNull);
+      expect(props.davDisplayname, isNull);
+      expect(props.davGetcontentlanguage, isNull);
+      expect(props.davGetcontentlength, 8650);
+      expect(props.davGetcontenttype, 'image/png');
+      expect(props.davGetetag, isNotEmpty);
+      expect(props.davGetlastmodified!.isBefore(DateTime.timestamp()), isTrue);
+      expect(props.davQuotaAvailableBytes, isNull);
+      expect(props.davQuotaUsedBytes, isNull);
+      expect(props.davResourcetype!.collection, isNull);
+      expect(props.ncCreationTime, isNull);
+      expect(props.ncAclCanManage, isNull);
+      expect(props.ncAclEnabled, isNull);
+      expect(props.ncAclList, isNull);
+      expect(props.ncContainedFileCount, isNull);
+      expect(props.ncContainedFolderCount, isNull);
+      expect(props.ncDataFingerprint, isNull);
+      expect(props.ncGroupFolderId, isNull);
+      expect(props.ncHasPreview, isNull);
+      expect(props.ncHidden, isNull);
+      expect(props.ncInheritedAclList, isNull);
+      expect(props.ncIsEncrypted, isNull);
+      expect(props.ncIsMountRoot, isNull);
+      expect(props.ncLock, isNull);
+      expect(props.ncLockOwner, isNull);
+      expect(props.ncLockOwnerDisplayname, isNull);
+      expect(props.ncLockOwnerType, isNull);
+      expect(props.ncLockTime, isNull);
+      expect(props.ncLockTimeout, isNull);
+      expect(props.ncLockToken, isNull);
+      expect(props.ncMountType, isNull);
+      expect(props.ncNote, isNull);
+      expect(props.ncReminderDueDate, isNull);
+      expect(props.ncRichWorkspace, isNull);
+      expect(props.ncRichWorkspaceFile, isNull);
+      expect(props.ncShareAttributes, isNull);
+      expect(props.ncSharees, isNull);
+      expect(props.ncUploadTime, isNull);
+      expect(props.ncVersionAuthor, isNull);
+      expect(props.ncVersionLabel, isNull);
+      expect(props.ncMetadataBlurhash, isNull);
+      expect(props.ocChecksums, isNull);
+      expect(props.ocCommentsCount, isNull);
+      expect(props.ocCommentsHref, isNull);
+      expect(props.ocCommentsUnread, isNull);
+      expect(props.ocDownloadURL, isNull);
+      expect(props.ocFavorite, isNull);
+      expect(props.ocFileid, isNull);
+      expect(props.ocId, isNull);
+      expect(props.ocOwnerDisplayName, isNull);
+      expect(props.ocOwnerId, isNull);
+      expect(props.ocPermissions, isNull);
+      expect(props.ocShareTypes, isNull);
+      expect(props.ocSize, isNull);
+      expect(props.ocTags, isNull);
+      expect(props.ocmSharePermissions, isNull);
+      expect(props.ocsSharePermissions, isNull);
+
+      closeFixture();
+      expect(
+        response.toXmlElement(namespaces: namespaces),
+        containsAllAvailableProps(tester, PathUri.parse('test/test.png')),
+      );
     });
 
     test('Get directory props', () async {
@@ -291,7 +358,7 @@ void main() {
       final file = File('test/files/test.png');
       await tester.client.webdav.putFile(file, file.statSync(), PathUri.parse('test/dir-props/test.png'));
 
-      final response = await tester.client.webdav.propfind(
+      var response = await tester.client.webdav.propfind(
         PathUri.parse('test/dir-props'),
         prop: const WebDavPropWithoutValues.fromBools(
           davCreationdate: true,
@@ -356,7 +423,7 @@ void main() {
         depth: WebDavDepth.zero,
       );
 
-      final props = response.responses.first.propstats.first.prop;
+      var props = response.responses.first.propstats.first.prop;
       expect(props.davCreationdate!.isBefore(DateTime.timestamp()), isTrue);
       expect(props.davDisplayname, 'dir-props');
       expect(props.davGetcontentlanguage, isNull);
@@ -414,6 +481,73 @@ void main() {
       expect(props.ocTags!.tags, isNull);
       expect(json.decode(props.ocmSharePermissions!), ['share', 'read', 'write']);
       expect(props.ocsSharePermissions, 31);
+
+      response = await tester.client.webdav.propfind(PathUri.parse('test/dir-props'));
+
+      props = response.responses.first.propstats.first.prop;
+      expect(props.davCreationdate, isNull);
+      expect(props.davDisplayname, isNull);
+      expect(props.davGetcontentlanguage, isNull);
+      expect(props.davGetcontentlength, isNull);
+      expect(props.davGetcontenttype, isNull);
+      expect(props.davGetetag, isNotEmpty);
+      expect(props.davGetlastmodified!.isBefore(DateTime.timestamp()), isTrue);
+      expect(props.davQuotaAvailableBytes, -3);
+      expect(props.davQuotaUsedBytes, 8650);
+      expect(props.davResourcetype!.collection, <dynamic>[]);
+      expect(props.ncCreationTime, isNull);
+      expect(props.ncAclCanManage, isNull);
+      expect(props.ncAclEnabled, isNull);
+      expect(props.ncAclList, isNull);
+      expect(props.ncContainedFileCount, isNull);
+      expect(props.ncContainedFolderCount, isNull);
+      expect(props.ncDataFingerprint, isNull);
+      expect(props.ncGroupFolderId, isNull);
+      expect(props.ncHasPreview, isNull);
+      expect(props.ncHidden, isNull);
+      expect(props.ncInheritedAclList, isNull);
+      expect(props.ncIsEncrypted, isNull);
+      expect(props.ncIsMountRoot, isNull);
+      expect(props.ncLock, isNull);
+      expect(props.ncLockOwner, isNull);
+      expect(props.ncLockOwnerDisplayname, isNull);
+      expect(props.ncLockOwnerType, isNull);
+      expect(props.ncLockTime, isNull);
+      expect(props.ncLockTimeout, isNull);
+      expect(props.ncLockToken, isNull);
+      expect(props.ncMountType, isNull);
+      expect(props.ncNote, isNull);
+      expect(props.ncReminderDueDate, isNull);
+      expect(props.ncRichWorkspace, isNull);
+      expect(props.ncRichWorkspaceFile, isNull);
+      expect(props.ncShareAttributes, isNull);
+      expect(props.ncSharees, isNull);
+      expect(props.ncUploadTime, isNull);
+      expect(props.ncVersionAuthor, isNull);
+      expect(props.ncVersionLabel, isNull);
+      expect(props.ncMetadataBlurhash, isNull);
+      expect(props.ocChecksums, isNull);
+      expect(props.ocCommentsCount, isNull);
+      expect(props.ocCommentsHref, isNull);
+      expect(props.ocCommentsUnread, isNull);
+      expect(props.ocDownloadURL, isNull);
+      expect(props.ocFavorite, isNull);
+      expect(props.ocFileid, isNull);
+      expect(props.ocId, isNull);
+      expect(props.ocOwnerDisplayName, isNull);
+      expect(props.ocOwnerId, isNull);
+      expect(props.ocPermissions, isNull);
+      expect(props.ocShareTypes, isNull);
+      expect(props.ocSize, isNull);
+      expect(props.ocTags, isNull);
+      expect(props.ocmSharePermissions, isNull);
+      expect(props.ocsSharePermissions, isNull);
+
+      closeFixture();
+      expect(
+        response.toXmlElement(namespaces: namespaces),
+        containsAllAvailableProps(tester, PathUri.parse('test/dir-props')),
+      );
     });
 
     test('Create share', () async {

--- a/packages/nextcloud/test/fixtures/webdav/get_directory_props.regexp
+++ b/packages/nextcloud/test/fixtures/webdav/get_directory_props.regexp
@@ -3,17 +3,17 @@ authorization: Bearer mock
 content-type: application/xml
 ocs-apirequest: true
 requesttoken: token
-PUT http://localhost/remote\.php/webdav/test/dir-props/test\.txt
+PUT http://localhost/remote\.php/webdav/test/dir-props/test\.png
 authorization: Bearer mock
-content-length: 4
+content-length: 8650
 content-type: application/xml
 ocs-apirequest: true
 requesttoken: token
-test
+.+
 PROPFIND http://localhost/remote\.php/webdav/test/dir-props
 authorization: Bearer mock
 content-type: application/xml
 depth: 0
 ocs-apirequest: true
 requesttoken: token
-<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud\.org/ns" xmlns:nc="http://nextcloud\.org/ns" xmlns:ocs="http://open-collaboration-services\.org/ns" xmlns:ocm="http://open-cloud-mesh\.org/ns"><d:prop><d:getcontenttype/><d:getlastmodified/><d:resourcetype/><oc:size/></d:prop></d:propfind>
+<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud\.org/ns" xmlns:nc="http://nextcloud\.org/ns" xmlns:ocs="http://open-collaboration-services\.org/ns" xmlns:ocm="http://open-cloud-mesh\.org/ns"><d:prop><d:creationdate/><d:displayname/><d:getcontentlanguage/><d:getcontentlength/><d:getcontenttype/><d:getetag/><d:getlastmodified/><d:quota-available-bytes/><d:quota-used-bytes/><d:resourcetype/><nc:acl-can-manage/><nc:acl-enabled/><nc:acl-list/><nc:contained-file-count/><nc:contained-folder-count/><nc:creation_time/><nc:data-fingerprint/><nc:group-folder-id/><nc:has-preview/><nc:hidden/><nc:inherited-acl-list/><nc:is-encrypted/><nc:is-mount-root/><nc:lock/><nc:lock-owner/><nc:lock-owner-displayname/><nc:lock-owner-editor/><nc:lock-owner-type/><nc:lock-time/><nc:lock-timeout/><nc:lock-token/><nc:mount-type/><nc:note/><nc:reminder-due-date/><nc:rich-workspace/><nc:rich-workspace-file/><nc:share-attributes/><nc:sharees/><nc:upload_time/><nc:version-author/><nc:version-label/><nc:metadata-blurhash/><oc:checksums/><oc:comments-count/><oc:comments-href/><oc:comments-unread/><oc:downloadURL/><oc:favorite/><oc:fileid/><oc:id/><oc:owner-display-name/><oc:owner-id/><oc:permissions/><oc:share-types/><oc:size/><oc:tags/><ocm:share-permissions/><ocs:share-permissions/></d:prop></d:propfind>

--- a/packages/nextcloud/test/fixtures/webdav/get_directory_props.regexp
+++ b/packages/nextcloud/test/fixtures/webdav/get_directory_props.regexp
@@ -17,3 +17,9 @@ depth: 0
 ocs-apirequest: true
 requesttoken: token
 <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud\.org/ns" xmlns:nc="http://nextcloud\.org/ns" xmlns:ocs="http://open-collaboration-services\.org/ns" xmlns:ocm="http://open-cloud-mesh\.org/ns"><d:prop><d:creationdate/><d:displayname/><d:getcontentlanguage/><d:getcontentlength/><d:getcontenttype/><d:getetag/><d:getlastmodified/><d:quota-available-bytes/><d:quota-used-bytes/><d:resourcetype/><nc:acl-can-manage/><nc:acl-enabled/><nc:acl-list/><nc:contained-file-count/><nc:contained-folder-count/><nc:creation_time/><nc:data-fingerprint/><nc:group-folder-id/><nc:has-preview/><nc:hidden/><nc:inherited-acl-list/><nc:is-encrypted/><nc:is-mount-root/><nc:lock/><nc:lock-owner/><nc:lock-owner-displayname/><nc:lock-owner-editor/><nc:lock-owner-type/><nc:lock-time/><nc:lock-timeout/><nc:lock-token/><nc:mount-type/><nc:note/><nc:reminder-due-date/><nc:rich-workspace/><nc:rich-workspace-file/><nc:share-attributes/><nc:sharees/><nc:upload_time/><nc:version-author/><nc:version-label/><nc:metadata-blurhash/><oc:checksums/><oc:comments-count/><oc:comments-href/><oc:comments-unread/><oc:downloadURL/><oc:favorite/><oc:fileid/><oc:id/><oc:owner-display-name/><oc:owner-id/><oc:permissions/><oc:share-types/><oc:size/><oc:tags/><ocm:share-permissions/><ocs:share-permissions/></d:prop></d:propfind>
+PROPFIND http://localhost/remote\.php/webdav/test/dir-props
+authorization: Bearer mock
+content-type: application/xml
+ocs-apirequest: true
+requesttoken: token
+<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud\.org/ns" xmlns:nc="http://nextcloud\.org/ns" xmlns:ocs="http://open-collaboration-services\.org/ns" xmlns:ocm="http://open-cloud-mesh\.org/ns"><d:prop/></d:propfind>

--- a/packages/nextcloud/test/fixtures/webdav/get_file_props.regexp
+++ b/packages/nextcloud/test/fixtures/webdav/get_file_props.regexp
@@ -11,3 +11,9 @@ content-type: application/xml
 ocs-apirequest: true
 requesttoken: token
 <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud\.org/ns" xmlns:nc="http://nextcloud\.org/ns" xmlns:ocs="http://open-collaboration-services\.org/ns" xmlns:ocm="http://open-cloud-mesh\.org/ns"><d:prop><d:creationdate/><d:displayname/><d:getcontentlanguage/><d:getcontentlength/><d:getcontenttype/><d:getetag/><d:getlastmodified/><d:quota-available-bytes/><d:quota-used-bytes/><d:resourcetype/><nc:acl-can-manage/><nc:acl-enabled/><nc:acl-list/><nc:contained-file-count/><nc:contained-folder-count/><nc:creation_time/><nc:data-fingerprint/><nc:group-folder-id/><nc:has-preview/><nc:hidden/><nc:inherited-acl-list/><nc:is-encrypted/><nc:is-mount-root/><nc:lock/><nc:lock-owner/><nc:lock-owner-displayname/><nc:lock-owner-editor/><nc:lock-owner-type/><nc:lock-time/><nc:lock-timeout/><nc:lock-token/><nc:mount-type/><nc:note/><nc:reminder-due-date/><nc:rich-workspace/><nc:rich-workspace-file/><nc:share-attributes/><nc:sharees/><nc:upload_time/><nc:version-author/><nc:version-label/><nc:metadata-blurhash/><oc:checksums/><oc:comments-count/><oc:comments-href/><oc:comments-unread/><oc:downloadURL/><oc:favorite/><oc:fileid/><oc:id/><oc:owner-display-name/><oc:owner-id/><oc:permissions/><oc:share-types/><oc:size/><oc:tags/><ocm:share-permissions/><ocs:share-permissions/></d:prop></d:propfind>
+PROPFIND http://localhost/remote\.php/webdav/test/test\.png
+authorization: Bearer mock
+content-type: application/xml
+ocs-apirequest: true
+requesttoken: token
+<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud\.org/ns" xmlns:nc="http://nextcloud\.org/ns" xmlns:ocs="http://open-collaboration-services\.org/ns" xmlns:ocm="http://open-cloud-mesh\.org/ns"><d:prop/></d:propfind>


### PR DESCRIPTION
This is going to become a lot more useful when https://github.com/sabre-io/dav/pull/1564 is merged and in a released Nextcloud version, as we are currently missing out on a lot of props when requesting all available props.