### PR TITLE
fix(neon_http_client): Make authorization throttling less agressive

### DIFF
--- a/packages/neon_framework/packages/neon_http_client/pubspec.yaml
+++ b/packages/neon_framework/packages/neon_http_client/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
       url: https://github.com/nextcloud/neon
       path: packages/cookie_store
   http: ^1.0.0
+  http_parser: ^4.0.0
   interceptor_http_client:
     git:
       url: https://github.com/nextcloud/neon


### PR DESCRIPTION
The detection flagged some responses that were fine (even though I believe nothing should really use the 401 status code except the authentication middleware), which resulted in the app becoming unusable due to the blocking.

I limited it to OCS responses for now as most requests use that format and we can correctly detect invalid credentials 100% of the time through the custom status code 997.
For non-OCS APIs and WebDAV it might be possible as well, but I think they are not so important and we can add them if ever needed.

I know there are those really ugly nested if blocks, but the alternative would be to chain null-aware casts and I don't think that is much better than this.