### PR TITLE
fix(neon_framework): Bump example flatpak SDK

### DIFF
--- a/packages/neon_framework/example/de.provokateurin.neon.yaml
+++ b/packages/neon_framework/example/de.provokateurin.neon.yaml
@@ -1,6 +1,6 @@
 app-id: de.provokateurin.neon
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: nextcloud-neon
 finish-args:


### PR DESCRIPTION
22.08 is no longer maintained and trying to run the app with the old SDK leads to `nextcloud-neon: symbol lookup error: nextcloud-neon: undefined symbol: g_once_init_enter_pointer` on my system.