### PR TITLE
chore(tool): Remove commit hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-fvm dart run commitlint_cli --edit "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,6 @@ This project uses an assortment of tools for the development.
 Currently included are:
 - [fvm](https://pub.dev/packages/fvm) for managing Flutter versions
 - [melos](https://pub.dev/packages/melos) for managing packages in this monorepo
-- [husky](https://pub.dev/packages/husky) for managing git hooks
 - [commitlint_cli](https://pub.dev/packages/commitlint_cli) for validating commits according to the conventional commits specification
 
 To set up all these tools run the `./tool/setup.sh` script.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,6 @@ environment:
 dev_dependencies:
   commitlint_cli: ^0.7.2
   fvm: ^3.2.1
-  husky: ^0.1.7
   melos: ^6.0.0
   custom_lint: ^0.6.8
   coverage: ^1.10.0

--- a/tool/setup.sh
+++ b/tool/setup.sh
@@ -15,5 +15,3 @@ else
   melos exec -c1 -- flutter pub get
   melos run format
 fi
-
-fvm dart run husky install


### PR DESCRIPTION
We already have CI to catch non-conventional commits and the hooks slow down every `git commit` command which I find pretty annoying.