### PR TITLE
fix(example): Fix window icon on wayland

### DIFF
--- a/.cspell/tools.txt
+++ b/.cspell/tools.txt
@@ -53,6 +53,7 @@ openrelayprojectsecret
 petstore
 plantuml
 precache
+prgname
 puml
 realpath
 rpath

--- a/packages/neon_framework/example/linux/my_application.cc
+++ b/packages/neon_framework/example/linux/my_application.cc
@@ -104,6 +104,12 @@ static void my_application_class_init(MyApplicationClass* klass) {
 static void my_application_init(MyApplication* self) {}
 
 MyApplication* my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,
                                      "flags", G_APPLICATION_NON_UNIQUE,


### PR DESCRIPTION
Copied from https://github.com/flutter/flutter/pull/154522

Now the icon properly shows up for the flatpak:
![image](https://github.com/user-attachments/assets/6a81846f-9c71-4031-b6d0-bb1386ace602)
