### PR TITLE
fix(tool): Group custom_lint packages in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,6 +58,13 @@
       "matchPackageNames": ["/^built/"]
     },
     {
+      "groupName": "custom_lint",
+      "matchPackageNames": [
+        "custom_lint",
+        "custom_lint_builder"
+      ]
+    },
+    {
       "groupName": "go_router",
       "matchPackageNames": ["/^go_router/"]
     },


### PR DESCRIPTION
should unblock #2596 and #2559