### PR TITLE
refactor(neon_framework): Implement a custom emoji picker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "external/nextcloud-tables"]
 	path = external/nextcloud-tables
 	url = https://github.com/nextcloud/tables
+[submodule "external/emoji-metadata"]
+	path = external/emoji-metadata
+	url = https://github.com/googlefonts/emoji-metadata

--- a/cspell.json
+++ b/cspell.json
@@ -16,6 +16,7 @@
     "**/CHANGELOG.md",
     "external",
     "packages/dynamite/example/lib",
+    "packages/neon_framework/lib/src/utils/emojis.dart",
     "packages/neon_framework/example/web/sqflite_sw.js",
     "packages/neon_framework/example/web/sqlite3.wasm",
     "packages/neon_lints/lib",

--- a/packages/neon_framework/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/neon_framework/example/linux/flutter/generated_plugin_registrant.cc
@@ -7,7 +7,6 @@
 #include "generated_plugin_registrant.h"
 
 #include <dynamic_color/dynamic_color_plugin.h>
-#include <emoji_picker_flutter/emoji_picker_flutter_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
@@ -17,9 +16,6 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
   dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
-  g_autoptr(FlPluginRegistrar) emoji_picker_flutter_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "EmojiPickerFlutterPlugin");
-  emoji_picker_flutter_plugin_register_with_registrar(emoji_picker_flutter_registrar);
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);

--- a/packages/neon_framework/example/linux/flutter/generated_plugins.cmake
+++ b/packages/neon_framework/example/linux/flutter/generated_plugins.cmake
@@ -4,7 +4,6 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
-  emoji_picker_flutter
   file_selector_linux
   screen_retriever_linux
   url_launcher_linux

--- a/packages/neon_framework/example/pubspec.lock
+++ b/packages/neon_framework/example/pubspec.lock
@@ -338,14 +338,6 @@ packages:
       relative: true
     source: path
     version: "0.5.0+1"
-  emoji_picker_flutter:
-    dependency: transitive
-    description:
-      name: emoji_picker_flutter
-      sha256: "08567e6f914d36c32091a96cf2f51d2558c47aa2bd47a590dc4f50e42e0965f6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
   equatable:
     dependency: transitive
     description:

--- a/packages/neon_framework/generate_emojis.dart
+++ b/packages/neon_framework/generate_emojis.dart
@@ -1,0 +1,225 @@
+import 'dart:convert';
+
+import 'package:code_builder/code_builder.dart';
+import 'package:collection/collection.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:string_normalizer/string_normalizer.dart';
+import 'package:universal_io/io.dart';
+
+/// Android 14 only supports Unicode 15.0, so we use that for now, even though newer versions are available:
+/// https://developer.android.com/guide/topics/resources/internationalization#versioning-nougat
+const unicodeVersion = '15_0';
+
+void main() {
+  final formatter = DartFormatter(pageWidth: 120);
+  final emitter = DartEmitter(
+    orderDirectives: true,
+    useNullSafetySyntax: true,
+  );
+
+  final inputFile = File('../../external/emoji-metadata/emoji_${unicodeVersion}_ordering.json');
+  final input = json.decode(inputFile.readAsStringSync());
+
+  final library = Library((b) {
+    b.docs.add('// GENERATED CODE - DO NOT MODIFY BY HAND');
+
+    b.body.add(
+      Class(
+        (b) => b
+          ..name = 'Emoji'
+          ..docs.add('/// Holds the metadata of a Unicode emoji.')
+          ..constructors.add(
+            Constructor(
+              (b) => b
+                ..constant = true
+                ..docs.add('/// Creates a new [Emoji].')
+                ..optionalParameters.addAll([
+                  Parameter(
+                    (b) => b
+                      ..name = 'base'
+                      ..named = true
+                      ..toThis = true
+                      ..required = true,
+                  ),
+                  Parameter(
+                    (b) => b
+                      ..name = 'alternates'
+                      ..named = true
+                      ..toThis = true
+                      ..required = true,
+                  ),
+                  Parameter(
+                    (b) => b
+                      ..name = 'emoticons'
+                      ..named = true
+                      ..toThis = true
+                      ..required = true,
+                  ),
+                  Parameter(
+                    (b) => b
+                      ..name = 'shortcodes'
+                      ..named = true
+                      ..toThis = true
+                      ..required = true,
+                  ),
+                  Parameter(
+                    (b) => b
+                      ..name = 'animated'
+                      ..named = true
+                      ..toThis = true
+                      ..required = true,
+                  ),
+                ]),
+            ),
+          )
+          ..fields.addAll([
+            Field(
+              (b) => b
+                ..name = 'base'
+                ..type = refer('String')
+                ..modifier = FieldModifier.final$
+                ..docs.add('/// The base emoji symbol.'),
+            ),
+            Field(
+              (b) => b
+                ..name = 'alternates'
+                ..type = refer('List<String>')
+                ..modifier = FieldModifier.final$
+                ..docs.add('/// The associated alternate emoji symbols.'),
+            ),
+            Field(
+              (b) => b
+                ..name = 'emoticons'
+                ..type = refer('List<String>')
+                ..modifier = FieldModifier.final$
+                ..docs.add('/// The associated emoticons.'),
+            ),
+            Field(
+              (b) => b
+                ..name = 'shortcodes'
+                ..type = refer('List<String>')
+                ..modifier = FieldModifier.final$
+                ..docs.add('/// The associated short codes.'),
+            ),
+            Field(
+              (b) => b
+                ..name = 'animated'
+                ..type = refer('bool')
+                ..modifier = FieldModifier.final$
+                ..docs.add('/// Whether the emoji can be animated.'),
+            ),
+          ]),
+      ),
+    );
+
+    final names = <String, String>{};
+    const groupIds = <String, String>{
+      'Smileys and emotions': 'smileysAndEmotions',
+      'People': 'people',
+      'Animals and nature': 'animalsAndNature',
+      'Food and drink': 'foodAndDrink',
+      'Travel and places': 'travelAndPlaces',
+      'Activities and events': 'activitiesAndEvents',
+      'Objects': 'objects',
+      'Symbols': 'symbols',
+      'Flags': 'flags',
+    };
+    final emojiGroups = <String, List<String>>{};
+
+    for (final group in (input as List).map((t) => t as Map<String, dynamic>)) {
+      final groupName = group['group'] as String;
+      final groupId = groupIds[groupName]!;
+
+      for (final emoji in (group['emoji'] as List).map((t) => t as Map<String, dynamic>)) {
+        final base = String.fromCharCodes((emoji['base'] as List).cast<int>());
+        final alternates = (emoji['alternates'] as List)
+            .map((alternate) => String.fromCharCodes((alternate as List).cast<int>()))
+            .toList();
+        final emoticons = (emoji['emoticons'] as List).cast<String>();
+        final shortcodes = (emoji['shortcodes'] as List).cast<String>();
+        final animated = emoji['animated'] as bool;
+
+        var name = '';
+        for (final shortcode in shortcodes) {
+          name = shortcode.substring(1, shortcode.length - 1).toLowerCase();
+          name = name
+              .split('-')
+              .map(
+                (t) => switch (t) {
+                  '1' => 'one',
+                  '2' => 'two',
+                  '3' => 'three',
+                  '4' => 'four',
+                  '5' => 'five',
+                  '6' => 'six',
+                  '7' => 'seven',
+                  '8' => 'eight',
+                  '9' => 'nine',
+                  _ => t,
+                },
+              )
+              .mapIndexed((i, t) => i == 0 ? t : '${t.substring(0, 1).toUpperCase()}${t.substring(1)}')
+              .join();
+          name = StringNormalizer.normalize(name);
+          name = name.replaceAll(RegExp('[^a-z]', caseSensitive: false), '');
+          if (name.isNotEmpty) {
+            break;
+          }
+        }
+
+        if (name == 'new') {
+          name = r'$new';
+        }
+
+        emojiGroups[groupId] ??= [];
+        emojiGroups[groupId]!.add(name);
+
+        // Some emojis are in multiple groups
+        if (names.containsKey(name)) {
+          if (names[name] != base) {
+            throw Exception('Conflicting name $name for different emojis: $base ${names[name]}');
+          }
+          continue;
+        }
+        names[name] = base;
+
+        b.body.add(
+          Code('''
+/// The $base emoji.
+const $name = Emoji(
+  base: '$base',
+  alternates: [${alternates.isNotEmpty ? "'${alternates.join("', '")}'," : ''}],
+  emoticons: [${emoticons.isNotEmpty ? "'${emoticons.join("', '").replaceAll("'", r"\'").replaceAll(r'$', r'\$')}'," : ''}],
+  shortcodes: ['${shortcodes.join("', '")}',],
+  animated: $animated,
+);
+
+'''),
+        );
+      }
+    }
+
+    for (final groupId in emojiGroups.keys) {
+      final emojis = emojiGroups[groupId]!;
+
+      b.body.add(
+        Code('''
+/// The "${groupIds.entries.firstWhere((e) => e.value == groupId).key}" emojis.
+const ${groupId}Group = [${emojis.join(', ')},];
+
+'''),
+      );
+    }
+
+    b.body.add(
+      Code('''
+/// All emojis.
+const all = [${emojiGroups.values.expand((t) => [...t]).join(', ')},];
+
+'''),
+    );
+  });
+
+  final output = library.accept(emitter).toString();
+  File('lib/src/utils/emojis.dart').writeAsStringSync(formatter.format(output));
+}

--- a/packages/neon_framework/lib/l10n/en.arb
+++ b/packages/neon_framework/lib/l10n/en.arb
@@ -294,5 +294,14 @@
   "userStatusClearAtThisWeek": "This week",
   "userStatusActionClear": "Clear status",
   "userStatusStatusMessage": "Status message",
-  "userStatusOnlineStatus": "Online status"
+  "userStatusOnlineStatus": "Online status",
+  "emojisCategorySmileysAndEmotions": "Smileys and emotions",
+  "emojisCategoryPeople": "People",
+  "emojisCategoryAnimalsAndNature": "Animals and nature",
+  "emojisCategoryFoodAndDrink": "Food and drink",
+  "emojisCategoryTravelAndPlaces": "Travel and places",
+  "emojisCategoryActivitiesAndEvents": "Activities and events",
+  "emojisCategoryObjects": "Objects",
+  "emojisCategorySymbols": "Symbols",
+  "emojisCategoryFlags": "Flags"
 }

--- a/packages/neon_framework/lib/l10n/localizations.dart
+++ b/packages/neon_framework/lib/l10n/localizations.dart
@@ -870,6 +870,60 @@ abstract class NeonLocalizations {
   /// In en, this message translates to:
   /// **'Online status'**
   String get userStatusOnlineStatus;
+
+  /// No description provided for @emojisCategorySmileysAndEmotions.
+  ///
+  /// In en, this message translates to:
+  /// **'Smileys and emotions'**
+  String get emojisCategorySmileysAndEmotions;
+
+  /// No description provided for @emojisCategoryPeople.
+  ///
+  /// In en, this message translates to:
+  /// **'People'**
+  String get emojisCategoryPeople;
+
+  /// No description provided for @emojisCategoryAnimalsAndNature.
+  ///
+  /// In en, this message translates to:
+  /// **'Animals and nature'**
+  String get emojisCategoryAnimalsAndNature;
+
+  /// No description provided for @emojisCategoryFoodAndDrink.
+  ///
+  /// In en, this message translates to:
+  /// **'Food and drink'**
+  String get emojisCategoryFoodAndDrink;
+
+  /// No description provided for @emojisCategoryTravelAndPlaces.
+  ///
+  /// In en, this message translates to:
+  /// **'Travel and places'**
+  String get emojisCategoryTravelAndPlaces;
+
+  /// No description provided for @emojisCategoryActivitiesAndEvents.
+  ///
+  /// In en, this message translates to:
+  /// **'Activities and events'**
+  String get emojisCategoryActivitiesAndEvents;
+
+  /// No description provided for @emojisCategoryObjects.
+  ///
+  /// In en, this message translates to:
+  /// **'Objects'**
+  String get emojisCategoryObjects;
+
+  /// No description provided for @emojisCategorySymbols.
+  ///
+  /// In en, this message translates to:
+  /// **'Symbols'**
+  String get emojisCategorySymbols;
+
+  /// No description provided for @emojisCategoryFlags.
+  ///
+  /// In en, this message translates to:
+  /// **'Flags'**
+  String get emojisCategoryFlags;
 }
 
 class _NeonLocalizationsDelegate extends LocalizationsDelegate<NeonLocalizations> {

--- a/packages/neon_framework/lib/l10n/localizations_en.dart
+++ b/packages/neon_framework/lib/l10n/localizations_en.dart
@@ -507,4 +507,31 @@ class NeonLocalizationsEn extends NeonLocalizations {
 
   @override
   String get userStatusOnlineStatus => 'Online status';
+
+  @override
+  String get emojisCategorySmileysAndEmotions => 'Smileys and emotions';
+
+  @override
+  String get emojisCategoryPeople => 'People';
+
+  @override
+  String get emojisCategoryAnimalsAndNature => 'Animals and nature';
+
+  @override
+  String get emojisCategoryFoodAndDrink => 'Food and drink';
+
+  @override
+  String get emojisCategoryTravelAndPlaces => 'Travel and places';
+
+  @override
+  String get emojisCategoryActivitiesAndEvents => 'Activities and events';
+
+  @override
+  String get emojisCategoryObjects => 'Objects';
+
+  @override
+  String get emojisCategorySymbols => 'Symbols';
+
+  @override
+  String get emojisCategoryFlags => 'Flags';
 }

--- a/packages/neon_framework/lib/src/utils/emojis.dart
+++ b/packages/neon_framework/lib/src/utils/emojis.dart
@@ -1,0 +1,24720 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+/// Holds the metadata of a Unicode emoji.
+class Emoji {
+  /// Creates a new [Emoji].
+  const Emoji({
+    required this.base,
+    required this.alternates,
+    required this.emoticons,
+    required this.shortcodes,
+    required this.animated,
+  });
+
+  /// The base emoji symbol.
+  final String base;
+
+  /// The associated alternate emoji symbols.
+  final List<String> alternates;
+
+  /// The associated emoticons.
+  final List<String> emoticons;
+
+  /// The associated short codes.
+  final List<String> shortcodes;
+
+  /// Whether the emoji can be animated.
+  final bool animated;
+}
+
+/// The 😀 emoji.
+const smile = Emoji(
+  base: '😀',
+  alternates: [],
+  emoticons: [
+    ':D',
+  ],
+  shortcodes: [
+    ':smile:',
+  ],
+  animated: true,
+);
+
+/// The 😃 emoji.
+const smileWithBigEyes = Emoji(
+  base: '😃',
+  alternates: [],
+  emoticons: [
+    ':-D',
+  ],
+  shortcodes: [
+    ':smile-with-big-eyes:',
+  ],
+  animated: true,
+);
+
+/// The 😄 emoji.
+const grin = Emoji(
+  base: '😄',
+  alternates: [],
+  emoticons: [
+    '^_^',
+  ],
+  shortcodes: [
+    ':grin:',
+  ],
+  animated: true,
+);
+
+/// The 😁 emoji.
+const grinning = Emoji(
+  base: '😁',
+  alternates: [],
+  emoticons: [
+    '*^_^*',
+  ],
+  shortcodes: [
+    ':grinning:',
+  ],
+  animated: true,
+);
+
+/// The 😆 emoji.
+const laughing = Emoji(
+  base: '😆',
+  alternates: [],
+  emoticons: [
+    'X-D',
+  ],
+  shortcodes: [
+    ':laughing:',
+  ],
+  animated: true,
+);
+
+/// The 😅 emoji.
+const grinSweat = Emoji(
+  base: '😅',
+  alternates: [],
+  emoticons: [
+    '^_^;',
+  ],
+  shortcodes: [
+    ':grin-sweat:',
+  ],
+  animated: true,
+);
+
+/// The 😂 emoji.
+const joy = Emoji(
+  base: '😂',
+  alternates: [],
+  emoticons: [
+    '>w<',
+  ],
+  shortcodes: [
+    ':joy:',
+  ],
+  animated: true,
+);
+
+/// The 🤣 emoji.
+const rofl = Emoji(
+  base: '🤣',
+  alternates: [],
+  emoticons: [
+    '*>w<*',
+  ],
+  shortcodes: [
+    ':rofl:',
+  ],
+  animated: true,
+);
+
+/// The 😭 emoji.
+const loudlyCrying = Emoji(
+  base: '😭',
+  alternates: [],
+  emoticons: [
+    ';_;',
+  ],
+  shortcodes: [
+    ':loudly-crying:',
+  ],
+  animated: true,
+);
+
+/// The 😉 emoji.
+const wink = Emoji(
+  base: '😉',
+  alternates: [],
+  emoticons: [
+    ';)',
+  ],
+  shortcodes: [
+    ':wink:',
+  ],
+  animated: true,
+);
+
+/// The 😗 emoji.
+const kissing = Emoji(
+  base: '😗',
+  alternates: [],
+  emoticons: [
+    ':*',
+  ],
+  shortcodes: [
+    ':kissing:',
+  ],
+  animated: true,
+);
+
+/// The 😙 emoji.
+const kissingSmilingEyes = Emoji(
+  base: '😙',
+  alternates: [],
+  emoticons: [
+    '^3^',
+  ],
+  shortcodes: [
+    ':kissing-smiling-eyes:',
+  ],
+  animated: true,
+);
+
+/// The 😚 emoji.
+const kissingClosedEyes = Emoji(
+  base: '😚',
+  alternates: [],
+  emoticons: [
+    ':**',
+  ],
+  shortcodes: [
+    ':kissing-closed-eyes:',
+  ],
+  animated: true,
+);
+
+/// The 😘 emoji.
+const kissingHeart = Emoji(
+  base: '😘',
+  alternates: [],
+  emoticons: [
+    ';*',
+  ],
+  shortcodes: [
+    ':kissing-heart:',
+  ],
+  animated: true,
+);
+
+/// The 🥰 emoji.
+const heartFace = Emoji(
+  base: '🥰',
+  alternates: [],
+  emoticons: [
+    '<3:)',
+  ],
+  shortcodes: [
+    ':heart-face:',
+    ':3-hearts:',
+  ],
+  animated: true,
+);
+
+/// The 😍 emoji.
+const heartEyes = Emoji(
+  base: '😍',
+  alternates: [],
+  emoticons: [
+    '♥_♥',
+  ],
+  shortcodes: [
+    ':heart-eyes:',
+  ],
+  animated: true,
+);
+
+/// The 🤩 emoji.
+const starStruck = Emoji(
+  base: '🤩',
+  alternates: [],
+  emoticons: [
+    '*_*',
+  ],
+  shortcodes: [
+    ':star-struck:',
+  ],
+  animated: true,
+);
+
+/// The 🥳 emoji.
+const partyingFace = Emoji(
+  base: '🥳',
+  alternates: [],
+  emoticons: [
+    '(ﾉ◕ヮ◕)♬♪',
+  ],
+  shortcodes: [
+    ':partying-face:',
+  ],
+  animated: true,
+);
+
+/// The 🫠 emoji.
+const melting = Emoji(
+  base: '🫠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':melting:',
+  ],
+  animated: true,
+);
+
+/// The 🙃 emoji.
+const upsideDownFace = Emoji(
+  base: '🙃',
+  alternates: [],
+  emoticons: [
+    '(:',
+  ],
+  shortcodes: [
+    ':upside-down-face:',
+  ],
+  animated: true,
+);
+
+/// The 🙂 emoji.
+const slightlyHappy = Emoji(
+  base: '🙂',
+  alternates: [],
+  emoticons: [
+    ":)', ':-)",
+  ],
+  shortcodes: [
+    ':slightly-happy:',
+  ],
+  animated: true,
+);
+
+/// The 🥲 emoji.
+const happyCry = Emoji(
+  base: '🥲',
+  alternates: [],
+  emoticons: [
+    ':,)',
+  ],
+  shortcodes: [
+    ':happy-cry:',
+  ],
+  animated: true,
+);
+
+/// The 🥹 emoji.
+const holdingBackTears = Emoji(
+  base: '🥹',
+  alternates: [],
+  emoticons: [
+    '(；人；)',
+  ],
+  shortcodes: [
+    ':holding-back-tears:',
+  ],
+  animated: true,
+);
+
+/// The 😊 emoji.
+const blush = Emoji(
+  base: '😊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':blush:',
+  ],
+  animated: true,
+);
+
+/// The ☺️ emoji.
+const warmSmile = Emoji(
+  base: '☺️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':warm-smile:',
+  ],
+  animated: true,
+);
+
+/// The 😌 emoji.
+const relieved = Emoji(
+  base: '😌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':relieved:',
+  ],
+  animated: true,
+);
+
+/// The 😏 emoji.
+const smirk = Emoji(
+  base: '😏',
+  alternates: [],
+  emoticons: [
+    '>~>',
+  ],
+  shortcodes: [
+    ':smirk:',
+  ],
+  animated: true,
+);
+
+/// The 😴 emoji.
+const sleep = Emoji(
+  base: '😴',
+  alternates: [],
+  emoticons: [
+    'Z_Z',
+  ],
+  shortcodes: [
+    ':sleep:',
+    ':tired:',
+  ],
+  animated: true,
+);
+
+/// The 😪 emoji.
+const sleepy = Emoji(
+  base: '😪',
+  alternates: [],
+  emoticons: [
+    '(-.-)zzZZ',
+  ],
+  shortcodes: [
+    ':sleepy:',
+  ],
+  animated: true,
+);
+
+/// The 🤤 emoji.
+const drool = Emoji(
+  base: '🤤',
+  alternates: [],
+  emoticons: [
+    '(¯﹃¯)',
+  ],
+  shortcodes: [
+    ':drool:',
+  ],
+  animated: true,
+);
+
+/// The 😋 emoji.
+const yum = Emoji(
+  base: '😋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':yum:',
+  ],
+  animated: true,
+);
+
+/// The 😛 emoji.
+const stuckOutTongue = Emoji(
+  base: '😛',
+  alternates: [],
+  emoticons: [
+    ":P', ':p', ':-P', ':-p",
+  ],
+  shortcodes: [
+    ':stuck-out-tongue:',
+  ],
+  animated: true,
+);
+
+/// The 😝 emoji.
+const squintingTongue = Emoji(
+  base: '😝',
+  alternates: [],
+  emoticons: [
+    '>q<',
+  ],
+  shortcodes: [
+    ':squinting-tongue:',
+  ],
+  animated: true,
+);
+
+/// The 😜 emoji.
+const winkyTongue = Emoji(
+  base: '😜',
+  alternates: [],
+  emoticons: [
+    ';p',
+  ],
+  shortcodes: [
+    ':winky-tongue:',
+  ],
+  animated: true,
+);
+
+/// The 🤪 emoji.
+const zanyFace = Emoji(
+  base: '🤪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':zany-face:',
+  ],
+  animated: true,
+);
+
+/// The 🥴 emoji.
+const woozy = Emoji(
+  base: '🥴',
+  alternates: [],
+  emoticons: [
+    '>﹏☉',
+  ],
+  shortcodes: [
+    ':woozy:',
+  ],
+  animated: true,
+);
+
+/// The 😔 emoji.
+const pensive = Emoji(
+  base: '😔',
+  alternates: [],
+  emoticons: [
+    '._.',
+  ],
+  shortcodes: [
+    ':pensive:',
+  ],
+  animated: true,
+);
+
+/// The 🥺 emoji.
+const pleading = Emoji(
+  base: '🥺',
+  alternates: [],
+  emoticons: [
+    '◕﹏◕',
+  ],
+  shortcodes: [
+    ':pleading:',
+  ],
+  animated: true,
+);
+
+/// The 😬 emoji.
+const grimacing = Emoji(
+  base: '😬',
+  alternates: [],
+  emoticons: [
+    ':-|',
+  ],
+  shortcodes: [
+    ':grimacing:',
+  ],
+  animated: true,
+);
+
+/// The 😑 emoji.
+const expressionless = Emoji(
+  base: '😑',
+  alternates: [],
+  emoticons: [
+    '-_-',
+  ],
+  shortcodes: [
+    ':expressionless:',
+  ],
+  animated: true,
+);
+
+/// The 😐 emoji.
+const neutralFace = Emoji(
+  base: '😐',
+  alternates: [],
+  emoticons: [
+    ':|',
+  ],
+  shortcodes: [
+    ':neutral-face:',
+  ],
+  animated: true,
+);
+
+/// The 😶 emoji.
+const mouthNone = Emoji(
+  base: '😶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mouth-none:',
+  ],
+  animated: true,
+);
+
+/// The 😶‍🌫️ emoji.
+const faceInClouds = Emoji(
+  base: '😶‍🌫️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':face-in-clouds:',
+    ':lost:',
+  ],
+  animated: true,
+);
+
+/// The 🫥 emoji.
+const dottedLineFace = Emoji(
+  base: '🫥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dotted-line-face:',
+    ':invisible:',
+  ],
+  animated: true,
+);
+
+/// The 🤐 emoji.
+const zipperFace = Emoji(
+  base: '🤐',
+  alternates: [],
+  emoticons: [
+    ':#',
+  ],
+  shortcodes: [
+    ':zipper-face:',
+  ],
+  animated: true,
+);
+
+/// The 🫡 emoji.
+const salute = Emoji(
+  base: '🫡',
+  alternates: [],
+  emoticons: [
+    '(・д・ゝ）',
+  ],
+  shortcodes: [
+    ':salute:',
+  ],
+  animated: true,
+);
+
+/// The 🤔 emoji.
+const thinkingFace = Emoji(
+  base: '🤔',
+  alternates: [],
+  emoticons: [
+    '=L',
+  ],
+  shortcodes: [
+    ':thinking-face:',
+  ],
+  animated: true,
+);
+
+/// The 🤫 emoji.
+const shushingFace = Emoji(
+  base: '🤫',
+  alternates: [],
+  emoticons: [
+    '(￣b￣)',
+  ],
+  shortcodes: [
+    ':shushing-face:',
+  ],
+  animated: true,
+);
+
+/// The 🫢 emoji.
+const handOverMouth = Emoji(
+  base: '🫢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hand-over-mouth:',
+  ],
+  animated: true,
+);
+
+/// The 🤭 emoji.
+const smilingEyesWithHandOverMouth = Emoji(
+  base: '🤭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':smiling-eyes-with-hand-over-mouth:',
+    ':chuckling:',
+  ],
+  animated: true,
+);
+
+/// The 🥱 emoji.
+const yawn = Emoji(
+  base: '🥱',
+  alternates: [],
+  emoticons: [
+    '~O~',
+  ],
+  shortcodes: [
+    ':yawn:',
+  ],
+  animated: true,
+);
+
+/// The 🤗 emoji.
+const hugFace = Emoji(
+  base: '🤗',
+  alternates: [],
+  emoticons: [
+    '(^o^)/',
+  ],
+  shortcodes: [
+    ':hug-face:',
+  ],
+  animated: true,
+);
+
+/// The 🫣 emoji.
+const peeking = Emoji(
+  base: '🫣',
+  alternates: [],
+  emoticons: [
+    '(*/。＼)',
+  ],
+  shortcodes: [
+    ':peeking:',
+  ],
+  animated: true,
+);
+
+/// The 😱 emoji.
+const screaming = Emoji(
+  base: '😱',
+  alternates: [],
+  emoticons: [
+    '@0@',
+  ],
+  shortcodes: [
+    ':screaming:',
+  ],
+  animated: true,
+);
+
+/// The 🤨 emoji.
+const raisedEyebrow = Emoji(
+  base: '🤨',
+  alternates: [],
+  emoticons: [
+    "(', '͝סּ', '͜ʖ͡סּ)",
+  ],
+  shortcodes: [
+    ':raised-eyebrow:',
+  ],
+  animated: true,
+);
+
+/// The 🧐 emoji.
+const monocle = Emoji(
+  base: '🧐',
+  alternates: [],
+  emoticons: [
+    'o~O',
+  ],
+  shortcodes: [
+    ':monocle:',
+  ],
+  animated: true,
+);
+
+/// The 😒 emoji.
+const unamused = Emoji(
+  base: '😒',
+  alternates: [],
+  emoticons: [
+    '>->',
+  ],
+  shortcodes: [
+    ':unamused:',
+  ],
+  animated: true,
+);
+
+/// The 🙄 emoji.
+const rollingEyes = Emoji(
+  base: '🙄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rolling-eyes:',
+  ],
+  animated: true,
+);
+
+/// The 😮‍💨 emoji.
+const exhale = Emoji(
+  base: '😮‍💨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':exhale:',
+  ],
+  animated: true,
+);
+
+/// The 😤 emoji.
+const triumph = Emoji(
+  base: '😤',
+  alternates: [],
+  emoticons: [
+    '(((╬◣﹏◢)))',
+  ],
+  shortcodes: [
+    ':triumph:',
+  ],
+  animated: true,
+);
+
+/// The 😠 emoji.
+const angry = Emoji(
+  base: '😠',
+  alternates: [],
+  emoticons: [
+    'X-(',
+  ],
+  shortcodes: [
+    ':angry:',
+  ],
+  animated: true,
+);
+
+/// The 😡 emoji.
+const rage = Emoji(
+  base: '😡',
+  alternates: [],
+  emoticons: [
+    '>:O',
+  ],
+  shortcodes: [
+    ':rage:',
+  ],
+  animated: true,
+);
+
+/// The 🤬 emoji.
+const cursing = Emoji(
+  base: '🤬',
+  alternates: [],
+  emoticons: [
+    r'#$@!',
+  ],
+  shortcodes: [
+    ':cursing:',
+  ],
+  animated: true,
+);
+
+/// The 😞 emoji.
+const sad = Emoji(
+  base: '😞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sad:',
+  ],
+  animated: true,
+);
+
+/// The 😓 emoji.
+const sweat = Emoji(
+  base: '😓',
+  alternates: [],
+  emoticons: [
+    '(0へ0)',
+  ],
+  shortcodes: [
+    ':sweat:',
+    ':downcast:',
+  ],
+  animated: true,
+);
+
+/// The 😟 emoji.
+const worried = Emoji(
+  base: '😟',
+  alternates: [],
+  emoticons: [
+    ':S',
+  ],
+  shortcodes: [
+    ':worried:',
+  ],
+  animated: true,
+);
+
+/// The 😥 emoji.
+const concerned = Emoji(
+  base: '😥',
+  alternates: [],
+  emoticons: [
+    "•_•'",
+  ],
+  shortcodes: [
+    ':concerned:',
+  ],
+  animated: true,
+);
+
+/// The 😢 emoji.
+const cry = Emoji(
+  base: '😢',
+  alternates: [],
+  emoticons: [
+    ":'(",
+  ],
+  shortcodes: [
+    ':cry:',
+  ],
+  animated: true,
+);
+
+/// The ☹️ emoji.
+const bigFrown = Emoji(
+  base: '☹️',
+  alternates: [],
+  emoticons: [
+    ':-(',
+  ],
+  shortcodes: [
+    ':big-frown:',
+  ],
+  animated: true,
+);
+
+/// The 🙁 emoji.
+const frown = Emoji(
+  base: '🙁',
+  alternates: [],
+  emoticons: [
+    ':(',
+  ],
+  shortcodes: [
+    ':frown:',
+  ],
+  animated: true,
+);
+
+/// The 🫤 emoji.
+const diagonalMouth = Emoji(
+  base: '🫤',
+  alternates: [],
+  emoticons: [
+    ':/',
+  ],
+  shortcodes: [
+    ':diagonal-mouth:',
+  ],
+  animated: true,
+);
+
+/// The 😕 emoji.
+const slightlyFrowning = Emoji(
+  base: '😕',
+  alternates: [],
+  emoticons: [
+    ':-/',
+  ],
+  shortcodes: [
+    ':slightly-frowning:',
+  ],
+  animated: true,
+);
+
+/// The 😰 emoji.
+const anxiousWithSweat = Emoji(
+  base: '😰',
+  alternates: [],
+  emoticons: [
+    "D-':",
+  ],
+  shortcodes: [
+    ':anxious-with-sweat:',
+  ],
+  animated: true,
+);
+
+/// The 😨 emoji.
+const scared = Emoji(
+  base: '😨',
+  alternates: [],
+  emoticons: [
+    'D-:',
+  ],
+  shortcodes: [
+    ':scared:',
+  ],
+  animated: true,
+);
+
+/// The 😧 emoji.
+const anguished = Emoji(
+  base: '😧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':anguished:',
+  ],
+  animated: true,
+);
+
+/// The 😦 emoji.
+const gasp = Emoji(
+  base: '😦',
+  alternates: [],
+  emoticons: [
+    'D=',
+  ],
+  shortcodes: [
+    ':gasp:',
+  ],
+  animated: true,
+);
+
+/// The 😮 emoji.
+const mouthOpen = Emoji(
+  base: '😮',
+  alternates: [],
+  emoticons: [
+    ':O',
+  ],
+  shortcodes: [
+    ':mouth-open:',
+  ],
+  animated: true,
+);
+
+/// The 😯 emoji.
+const surprised = Emoji(
+  base: '😯',
+  alternates: [],
+  emoticons: [
+    ':o',
+  ],
+  shortcodes: [
+    ':surprised:',
+    ':hushed:',
+  ],
+  animated: true,
+);
+
+/// The 😲 emoji.
+const astonished = Emoji(
+  base: '😲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':astonished:',
+  ],
+  animated: true,
+);
+
+/// The 😳 emoji.
+const flushed = Emoji(
+  base: '😳',
+  alternates: [],
+  emoticons: [
+    '8‑0',
+  ],
+  shortcodes: [
+    ':flushed:',
+  ],
+  animated: true,
+);
+
+/// The 🤯 emoji.
+const mindBlown = Emoji(
+  base: '🤯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mind-blown:',
+    ':exploding-head:',
+  ],
+  animated: true,
+);
+
+/// The 😖 emoji.
+const scrunchedMouth = Emoji(
+  base: '😖',
+  alternates: [],
+  emoticons: [
+    '>:[',
+  ],
+  shortcodes: [
+    ':scrunched-mouth:',
+    ':confounded:',
+    ':zigzag-mouth:',
+  ],
+  animated: true,
+);
+
+/// The 😣 emoji.
+const scrunchedEyes = Emoji(
+  base: '😣',
+  alternates: [],
+  emoticons: [
+    '>:(',
+  ],
+  shortcodes: [
+    ':scrunched-eyes:',
+    ':persevering:',
+  ],
+  animated: true,
+);
+
+/// The 😩 emoji.
+const weary = Emoji(
+  base: '😩',
+  alternates: [],
+  emoticons: [
+    'D:',
+  ],
+  shortcodes: [
+    ':weary:',
+  ],
+  animated: true,
+);
+
+/// The 😫 emoji.
+const distraught = Emoji(
+  base: '😫',
+  alternates: [],
+  emoticons: [
+    'D-X',
+  ],
+  shortcodes: [
+    ':distraught:',
+  ],
+  animated: true,
+);
+
+/// The 😵 emoji.
+const xEyes = Emoji(
+  base: '😵',
+  alternates: [],
+  emoticons: [
+    'X_o',
+  ],
+  shortcodes: [
+    ':x-eyes:',
+  ],
+  animated: true,
+);
+
+/// The 😵‍💫 emoji.
+const dizzyFace = Emoji(
+  base: '😵‍💫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dizzy-face:',
+  ],
+  animated: true,
+);
+
+/// The 🫨 emoji.
+const shakingFace = Emoji(
+  base: '🫨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shaking-face:',
+  ],
+  animated: true,
+);
+
+/// The 🥶 emoji.
+const coldFace = Emoji(
+  base: '🥶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cold-face:',
+  ],
+  animated: true,
+);
+
+/// The 🥵 emoji.
+const hotFace = Emoji(
+  base: '🥵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hot-face:',
+    ':sweat-face:',
+  ],
+  animated: true,
+);
+
+/// The 🤢 emoji.
+const sick = Emoji(
+  base: '🤢',
+  alternates: [],
+  emoticons: [
+    ':-###',
+  ],
+  shortcodes: [
+    ':sick:',
+    ':nauseated:',
+  ],
+  animated: true,
+);
+
+/// The 🤮 emoji.
+const vomit = Emoji(
+  base: '🤮',
+  alternates: [],
+  emoticons: [
+    ':-O##',
+  ],
+  shortcodes: [
+    ':vomit:',
+  ],
+  animated: true,
+);
+
+/// The 🤧 emoji.
+const sneeze = Emoji(
+  base: '🤧',
+  alternates: [],
+  emoticons: [
+    '(*´台｀*)',
+  ],
+  shortcodes: [
+    ':sneeze:',
+  ],
+  animated: true,
+);
+
+/// The 🤒 emoji.
+const thermometerFace = Emoji(
+  base: '🤒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':thermometer-face:',
+  ],
+  animated: true,
+);
+
+/// The 🤕 emoji.
+const bandageFace = Emoji(
+  base: '🤕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bandage-face:',
+  ],
+  animated: true,
+);
+
+/// The 😷 emoji.
+const mask = Emoji(
+  base: '😷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mask:',
+  ],
+  animated: true,
+);
+
+/// The 🤥 emoji.
+const liar = Emoji(
+  base: '🤥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':liar:',
+  ],
+  animated: true,
+);
+
+/// The 😇 emoji.
+const halo = Emoji(
+  base: '😇',
+  alternates: [],
+  emoticons: [
+    'O:)',
+  ],
+  shortcodes: [
+    ':halo:',
+    ':innocent:',
+  ],
+  animated: true,
+);
+
+/// The 🤠 emoji.
+const cowboy = Emoji(
+  base: '🤠',
+  alternates: [],
+  emoticons: [
+    '<):)',
+  ],
+  shortcodes: [
+    ':cowboy:',
+  ],
+  animated: true,
+);
+
+/// The 🤑 emoji.
+const moneyFace = Emoji(
+  base: '🤑',
+  alternates: [],
+  emoticons: [
+    r'$_$',
+  ],
+  shortcodes: [
+    ':money-face:',
+  ],
+  animated: true,
+);
+
+/// The 🤓 emoji.
+const nerdFace = Emoji(
+  base: '🤓',
+  alternates: [],
+  emoticons: [
+    ':-B',
+  ],
+  shortcodes: [
+    ':nerd-face:',
+  ],
+  animated: true,
+);
+
+/// The 😎 emoji.
+const sunglassesFace = Emoji(
+  base: '😎',
+  alternates: [],
+  emoticons: [
+    'B-)',
+  ],
+  shortcodes: [
+    ':sunglasses-face:',
+  ],
+  animated: true,
+);
+
+/// The 🥸 emoji.
+const disguise = Emoji(
+  base: '🥸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':disguise:',
+  ],
+  animated: true,
+);
+
+/// The 🤡 emoji.
+const clown = Emoji(
+  base: '🤡',
+  alternates: [],
+  emoticons: [
+    ':o)',
+  ],
+  shortcodes: [
+    ':clown:',
+  ],
+  animated: true,
+);
+
+/// The 😈 emoji.
+const impSmile = Emoji(
+  base: '😈',
+  alternates: [],
+  emoticons: [
+    '3:)',
+  ],
+  shortcodes: [
+    ':imp-smile:',
+  ],
+  animated: true,
+);
+
+/// The 👿 emoji.
+const impFrown = Emoji(
+  base: '👿',
+  alternates: [],
+  emoticons: [
+    '3:(',
+  ],
+  shortcodes: [
+    ':imp-frown:',
+  ],
+  animated: true,
+);
+
+/// The 👻 emoji.
+const ghost = Emoji(
+  base: '👻',
+  alternates: [],
+  emoticons: [
+    '⊂(´・◡・⊂)∘˚˳°',
+  ],
+  shortcodes: [
+    ':ghost:',
+  ],
+  animated: true,
+);
+
+/// The 🎃 emoji.
+const jackOLantern = Emoji(
+  base: '🎃',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':jack-o-lantern:',
+  ],
+  animated: true,
+);
+
+/// The 💩 emoji.
+const poop = Emoji(
+  base: '💩',
+  alternates: [],
+  emoticons: [
+    '༼^-^༽',
+  ],
+  shortcodes: [
+    ':poop:',
+  ],
+  animated: true,
+);
+
+/// The 🤖 emoji.
+const robot = Emoji(
+  base: '🤖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':robot:',
+  ],
+  animated: true,
+);
+
+/// The 👽 emoji.
+const alien = Emoji(
+  base: '👽',
+  alternates: [],
+  emoticons: [
+    '(<>..<>)',
+  ],
+  shortcodes: [
+    ':alien:',
+  ],
+  animated: true,
+);
+
+/// The 👾 emoji.
+const alienMonster = Emoji(
+  base: '👾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':alien-monster:',
+  ],
+  animated: false,
+);
+
+/// The 🌛 emoji.
+const moonFaceFirstQuarter = Emoji(
+  base: '🌛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':moon-face-first-quarter:',
+  ],
+  animated: true,
+);
+
+/// The 🌜 emoji.
+const moonFaceLastQuarter = Emoji(
+  base: '🌜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':moon-face-last-quarter:',
+  ],
+  animated: true,
+);
+
+/// The 🌚 emoji.
+const moonFaceNew = Emoji(
+  base: '🌚',
+  alternates: [],
+  emoticons: [
+    '>_>',
+  ],
+  shortcodes: [
+    ':moon-face-new:',
+  ],
+  animated: false,
+);
+
+/// The 🌝 emoji.
+const moonFaceFull = Emoji(
+  base: '🌝',
+  alternates: [],
+  emoticons: [
+    '<_<',
+  ],
+  shortcodes: [
+    ':moon-face-full:',
+  ],
+  animated: false,
+);
+
+/// The 🌞 emoji.
+const sunWithFace = Emoji(
+  base: '🌞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sun-with-face:',
+  ],
+  animated: true,
+);
+
+/// The ☠️ emoji.
+const skullAndCrossbones = Emoji(
+  base: '☠️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':skull-and-crossbones:',
+  ],
+  animated: false,
+);
+
+/// The 👹 emoji.
+const ogre = Emoji(
+  base: '👹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ogre:',
+  ],
+  animated: false,
+);
+
+/// The 👺 emoji.
+const goblin = Emoji(
+  base: '👺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':goblin:',
+  ],
+  animated: false,
+);
+
+/// The 🔥 emoji.
+const fire = Emoji(
+  base: '🔥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fire:',
+    ':burn:',
+    ':lit:',
+  ],
+  animated: true,
+);
+
+/// The 💯 emoji.
+const oneHundred = Emoji(
+  base: '💯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':100:',
+    ':one-hundred:',
+    ':hundred:',
+    ':points:',
+  ],
+  animated: true,
+);
+
+/// The 💫 emoji.
+const dizzy = Emoji(
+  base: '💫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dizzy:',
+  ],
+  animated: false,
+);
+
+/// The ⭐ emoji.
+const star = Emoji(
+  base: '⭐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':star:',
+  ],
+  animated: false,
+);
+
+/// The 🌟 emoji.
+const glowingStar = Emoji(
+  base: '🌟',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':glowing-star:',
+  ],
+  animated: true,
+);
+
+/// The ✨ emoji.
+const sparkles = Emoji(
+  base: '✨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sparkles:',
+  ],
+  animated: true,
+);
+
+/// The 💥 emoji.
+const collision = Emoji(
+  base: '💥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':collision:',
+  ],
+  animated: true,
+);
+
+/// The 💨 emoji.
+const dash = Emoji(
+  base: '💨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dash:',
+    ':poof:',
+  ],
+  animated: false,
+);
+
+/// The 💦 emoji.
+const sweatDroplets = Emoji(
+  base: '💦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sweat-droplets:',
+  ],
+  animated: false,
+);
+
+/// The 💤 emoji.
+const zzz = Emoji(
+  base: '💤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':zzz:',
+  ],
+  animated: false,
+);
+
+/// The 🕳️ emoji.
+const hole = Emoji(
+  base: '🕳️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hole:',
+  ],
+  animated: false,
+);
+
+/// The 🎉 emoji.
+const partyPopper = Emoji(
+  base: '🎉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':party-popper:',
+  ],
+  animated: true,
+);
+
+/// The 🙈 emoji.
+const seeNoEvilMonkey = Emoji(
+  base: '🙈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':see-no-evil-monkey:',
+  ],
+  animated: true,
+);
+
+/// The 🙉 emoji.
+const hearNoEvilMonkey = Emoji(
+  base: '🙉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hear-no-evil-monkey:',
+  ],
+  animated: true,
+);
+
+/// The 🙊 emoji.
+const speakNoEvilMonkey = Emoji(
+  base: '🙊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':speak-no-evil-monkey:',
+  ],
+  animated: true,
+);
+
+/// The 😺 emoji.
+const smileyCat = Emoji(
+  base: '😺',
+  alternates: [],
+  emoticons: [
+    ':3',
+  ],
+  shortcodes: [
+    ':smiley-cat:',
+  ],
+  animated: true,
+);
+
+/// The 😸 emoji.
+const smileCat = Emoji(
+  base: '😸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':smile-cat:',
+  ],
+  animated: true,
+);
+
+/// The 😹 emoji.
+const joyCat = Emoji(
+  base: '😹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':joy-cat:',
+  ],
+  animated: true,
+);
+
+/// The 😻 emoji.
+const heartEyesCat = Emoji(
+  base: '😻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':heart-eyes-cat:',
+  ],
+  animated: true,
+);
+
+/// The 😼 emoji.
+const smirkCat = Emoji(
+  base: '😼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':smirk-cat:',
+  ],
+  animated: true,
+);
+
+/// The 😽 emoji.
+const kissingCat = Emoji(
+  base: '😽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':kissing-cat:',
+  ],
+  animated: true,
+);
+
+/// The 🙀 emoji.
+const screamCat = Emoji(
+  base: '🙀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':scream-cat:',
+  ],
+  animated: true,
+);
+
+/// The 😿 emoji.
+const cryingCatFace = Emoji(
+  base: '😿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':crying-cat-face:',
+  ],
+  animated: true,
+);
+
+/// The 😾 emoji.
+const poutingCat = Emoji(
+  base: '😾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pouting-cat:',
+  ],
+  animated: true,
+);
+
+/// The ❤️ emoji.
+const redHeart = Emoji(
+  base: '❤️',
+  alternates: [],
+  emoticons: [
+    '<3',
+  ],
+  shortcodes: [
+    ':red-heart:',
+  ],
+  animated: true,
+);
+
+/// The 🧡 emoji.
+const orangeHeart = Emoji(
+  base: '🧡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':orange-heart:',
+  ],
+  animated: true,
+);
+
+/// The 💛 emoji.
+const yellowHeart = Emoji(
+  base: '💛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':yellow-heart:',
+  ],
+  animated: true,
+);
+
+/// The 💚 emoji.
+const greenHeart = Emoji(
+  base: '💚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':green-heart:',
+  ],
+  animated: true,
+);
+
+/// The 🩵 emoji.
+const lightBlueHeart = Emoji(
+  base: '🩵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':light-blue-heart:',
+  ],
+  animated: true,
+);
+
+/// The 💙 emoji.
+const blueHeart = Emoji(
+  base: '💙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':blue-heart:',
+  ],
+  animated: true,
+);
+
+/// The 💜 emoji.
+const purpleHeart = Emoji(
+  base: '💜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':purple-heart:',
+  ],
+  animated: true,
+);
+
+/// The 🤎 emoji.
+const brownHeart = Emoji(
+  base: '🤎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':brown-heart:',
+  ],
+  animated: true,
+);
+
+/// The 🖤 emoji.
+const blackHeart = Emoji(
+  base: '🖤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':black-heart:',
+  ],
+  animated: true,
+);
+
+/// The 🩶 emoji.
+const greyHeart = Emoji(
+  base: '🩶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':grey-heart:',
+  ],
+  animated: true,
+);
+
+/// The 🤍 emoji.
+const whiteHeart = Emoji(
+  base: '🤍',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':white-heart:',
+  ],
+  animated: true,
+);
+
+/// The 🩷 emoji.
+const pinkHeart = Emoji(
+  base: '🩷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pink-heart:',
+  ],
+  animated: true,
+);
+
+/// The 💘 emoji.
+const cupid = Emoji(
+  base: '💘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cupid:',
+  ],
+  animated: true,
+);
+
+/// The 💝 emoji.
+const giftHeart = Emoji(
+  base: '💝',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':gift-heart:',
+  ],
+  animated: true,
+);
+
+/// The 💖 emoji.
+const sparklingHeart = Emoji(
+  base: '💖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sparkling-heart:',
+  ],
+  animated: true,
+);
+
+/// The 💗 emoji.
+const heartGrow = Emoji(
+  base: '💗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':heart-grow:',
+  ],
+  animated: true,
+);
+
+/// The 💓 emoji.
+const beatingHeart = Emoji(
+  base: '💓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':beating-heart:',
+  ],
+  animated: true,
+);
+
+/// The 💞 emoji.
+const revolvingHearts = Emoji(
+  base: '💞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':revolving-hearts:',
+  ],
+  animated: true,
+);
+
+/// The 💕 emoji.
+const twoHearts = Emoji(
+  base: '💕',
+  alternates: [],
+  emoticons: [
+    '<3<3',
+  ],
+  shortcodes: [
+    ':two-hearts:',
+  ],
+  animated: true,
+);
+
+/// The 💌 emoji.
+const loveLetter = Emoji(
+  base: '💌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':love-letter:',
+  ],
+  animated: true,
+);
+
+/// The 💟 emoji.
+const heartBox = Emoji(
+  base: '💟',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':heart-box:',
+  ],
+  animated: false,
+);
+
+/// The ♥️ emoji.
+const heart = Emoji(
+  base: '♥️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':heart:',
+  ],
+  animated: false,
+);
+
+/// The ❣️ emoji.
+const heartExclamationPoint = Emoji(
+  base: '❣️',
+  alternates: [],
+  emoticons: [
+    '<3!',
+  ],
+  shortcodes: [
+    ':heart-exclamation-point:',
+  ],
+  animated: true,
+);
+
+/// The ❤️‍🩹 emoji.
+const bandagedHeart = Emoji(
+  base: '❤️‍🩹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bandaged-heart:',
+  ],
+  animated: true,
+);
+
+/// The 💔 emoji.
+const brokenHeart = Emoji(
+  base: '💔',
+  alternates: [],
+  emoticons: [
+    '</3',
+  ],
+  shortcodes: [
+    ':broken-heart:',
+  ],
+  animated: true,
+);
+
+/// The ❤️‍🔥 emoji.
+const fireHeart = Emoji(
+  base: '❤️‍🔥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fire-heart:',
+  ],
+  animated: true,
+);
+
+/// The 💋 emoji.
+const kiss = Emoji(
+  base: '💋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':kiss:',
+  ],
+  animated: true,
+);
+
+/// The 🫂 emoji.
+const hugging = Emoji(
+  base: '🫂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hugging:',
+  ],
+  animated: false,
+);
+
+/// The 👥 emoji.
+const bustsInSilhouette = Emoji(
+  base: '👥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':busts-in-silhouette:',
+  ],
+  animated: false,
+);
+
+/// The 👤 emoji.
+const bustInSilhouette = Emoji(
+  base: '👤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bust-in-silhouette:',
+  ],
+  animated: false,
+);
+
+/// The 🗣️ emoji.
+const speakingHead = Emoji(
+  base: '🗣️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':speaking-head:',
+  ],
+  animated: false,
+);
+
+/// The 👣 emoji.
+const footprints = Emoji(
+  base: '👣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':footprints:',
+  ],
+  animated: true,
+);
+
+/// The 🧠 emoji.
+const brain = Emoji(
+  base: '🧠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':brain:',
+  ],
+  animated: false,
+);
+
+/// The 🫀 emoji.
+const anatomicalHeart = Emoji(
+  base: '🫀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':anatomical-heart:',
+  ],
+  animated: true,
+);
+
+/// The 🫁 emoji.
+const lungs = Emoji(
+  base: '🫁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lungs:',
+  ],
+  animated: false,
+);
+
+/// The 🩸 emoji.
+const blood = Emoji(
+  base: '🩸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':blood:',
+  ],
+  animated: true,
+);
+
+/// The 🦠 emoji.
+const microbe = Emoji(
+  base: '🦠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':microbe:',
+    ':virus:',
+  ],
+  animated: true,
+);
+
+/// The 🦷 emoji.
+const tooth = Emoji(
+  base: '🦷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tooth:',
+  ],
+  animated: false,
+);
+
+/// The 🦴 emoji.
+const bone = Emoji(
+  base: '🦴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bone:',
+  ],
+  animated: false,
+);
+
+/// The 💀 emoji.
+const skull = Emoji(
+  base: '💀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':skull:',
+  ],
+  animated: true,
+);
+
+/// The 👀 emoji.
+const eyes = Emoji(
+  base: '👀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eyes:',
+  ],
+  animated: true,
+);
+
+/// The 👁️ emoji.
+const eye = Emoji(
+  base: '👁️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eye:',
+  ],
+  animated: true,
+);
+
+/// The 👄 emoji.
+const mouth = Emoji(
+  base: '👄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mouth:',
+  ],
+  animated: false,
+);
+
+/// The 🫦 emoji.
+const bitingLip = Emoji(
+  base: '🫦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':biting-lip:',
+  ],
+  animated: true,
+);
+
+/// The 👅 emoji.
+const tongue = Emoji(
+  base: '👅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tongue:',
+  ],
+  animated: false,
+);
+
+/// The 👃 emoji.
+const nose = Emoji(
+  base: '👃',
+  alternates: [
+    '👃',
+    '👃🏻',
+    '👃🏼',
+    '👃🏽',
+    '👃🏾',
+    '👃🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':nose:',
+  ],
+  animated: false,
+);
+
+/// The 👂 emoji.
+const ear = Emoji(
+  base: '👂',
+  alternates: [
+    '👂',
+    '👂🏻',
+    '👂🏼',
+    '👂🏽',
+    '👂🏾',
+    '👂🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':ear:',
+  ],
+  animated: false,
+);
+
+/// The 🦻 emoji.
+const hearingAid = Emoji(
+  base: '🦻',
+  alternates: [
+    '🦻',
+    '🦻🏻',
+    '🦻🏼',
+    '🦻🏽',
+    '🦻🏾',
+    '🦻🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':hearing-aid:',
+  ],
+  animated: false,
+);
+
+/// The 🦶 emoji.
+const foot = Emoji(
+  base: '🦶',
+  alternates: [
+    '🦶',
+    '🦶🏻',
+    '🦶🏼',
+    '🦶🏽',
+    '🦶🏾',
+    '🦶🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':foot:',
+  ],
+  animated: false,
+);
+
+/// The 🦵 emoji.
+const leg = Emoji(
+  base: '🦵',
+  alternates: [
+    '🦵',
+    '🦵🏻',
+    '🦵🏼',
+    '🦵🏽',
+    '🦵🏾',
+    '🦵🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':leg:',
+  ],
+  animated: false,
+);
+
+/// The 🦿 emoji.
+const legMechanical = Emoji(
+  base: '🦿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':leg-mechanical:',
+  ],
+  animated: true,
+);
+
+/// The 🦾 emoji.
+const armMechanical = Emoji(
+  base: '🦾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':arm-mechanical:',
+  ],
+  animated: true,
+);
+
+/// The 💪 emoji.
+const muscle = Emoji(
+  base: '💪',
+  alternates: [
+    '💪',
+    '💪🏻',
+    '💪🏼',
+    '💪🏽',
+    '💪🏾',
+    '💪🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':muscle:',
+    ':flex:',
+    ':bicep:',
+    ':strong:',
+  ],
+  animated: true,
+);
+
+/// The 👏 emoji.
+const clap = Emoji(
+  base: '👏',
+  alternates: [
+    '👏',
+    '👏🏻',
+    '👏🏼',
+    '👏🏽',
+    '👏🏾',
+    '👏🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':clap:',
+  ],
+  animated: true,
+);
+
+/// The 👍 emoji.
+const thumbsUp = Emoji(
+  base: '👍',
+  alternates: [
+    '👍',
+    '👍🏻',
+    '👍🏼',
+    '👍🏽',
+    '👍🏾',
+    '👍🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':thumbs-up:',
+    ':+1:',
+  ],
+  animated: true,
+);
+
+/// The 👎 emoji.
+const thumbsDown = Emoji(
+  base: '👎',
+  alternates: [
+    '👎',
+    '👎🏻',
+    '👎🏼',
+    '👎🏽',
+    '👎🏾',
+    '👎🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':thumbs-down:',
+  ],
+  animated: true,
+);
+
+/// The 🫶 emoji.
+const heartHands = Emoji(
+  base: '🫶',
+  alternates: [
+    '🫶',
+    '🫶🏻',
+    '🫶🏼',
+    '🫶🏽',
+    '🫶🏾',
+    '🫶🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':heart-hands:',
+  ],
+  animated: false,
+);
+
+/// The 🙌 emoji.
+const raisingHands = Emoji(
+  base: '🙌',
+  alternates: [
+    '🙌',
+    '🙌🏻',
+    '🙌🏼',
+    '🙌🏽',
+    '🙌🏾',
+    '🙌🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':raising-hands:',
+    ':hooray:',
+  ],
+  animated: true,
+);
+
+/// The 👐 emoji.
+const openHands = Emoji(
+  base: '👐',
+  alternates: [
+    '👐',
+    '👐🏻',
+    '👐🏼',
+    '👐🏽',
+    '👐🏾',
+    '👐🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':open-hands:',
+  ],
+  animated: false,
+);
+
+/// The 🤲 emoji.
+const palmsUp = Emoji(
+  base: '🤲',
+  alternates: [
+    '🤲',
+    '🤲🏻',
+    '🤲🏼',
+    '🤲🏽',
+    '🤲🏾',
+    '🤲🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':palms-up:',
+  ],
+  animated: false,
+);
+
+/// The 🤝 emoji.
+const handshake = Emoji(
+  base: '🤝',
+  alternates: [
+    '🤝',
+    '🤝🏻',
+    '🫱🏻‍🫲🏼',
+    '🫱🏻‍🫲🏽',
+    '🫱🏻‍🫲🏾',
+    '🫱🏻‍🫲🏿',
+    '🫱🏼‍🫲🏻',
+    '🤝🏼',
+    '🫱🏼‍🫲🏽',
+    '🫱🏼‍🫲🏾',
+    '🫱🏼‍🫲🏿',
+    '🫱🏽‍🫲🏻',
+    '🫱🏽‍🫲🏼',
+    '🤝🏽',
+    '🫱🏽‍🫲🏾',
+    '🫱🏽‍🫲🏿',
+    '🫱🏾‍🫲🏻',
+    '🫱🏾‍🫲🏼',
+    '🫱🏾‍🫲🏽',
+    '🤝🏾',
+    '🫱🏾‍🫲🏿',
+    '🫱🏿‍🫲🏻',
+    '🫱🏿‍🫲🏼',
+    '🫱🏿‍🫲🏽',
+    '🫱🏿‍🫲🏾',
+    '🤝🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':handshake:',
+  ],
+  animated: false,
+);
+
+/// The 🤜 emoji.
+const fistRightwards = Emoji(
+  base: '🤜',
+  alternates: [
+    '🤜',
+    '🤜🏻',
+    '🤜🏼',
+    '🤜🏽',
+    '🤜🏾',
+    '🤜🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':fist-rightwards:',
+  ],
+  animated: false,
+);
+
+/// The 🤛 emoji.
+const fistLeftwards = Emoji(
+  base: '🤛',
+  alternates: [
+    '🤛',
+    '🤛🏻',
+    '🤛🏼',
+    '🤛🏽',
+    '🤛🏾',
+    '🤛🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':fist-leftwards:',
+  ],
+  animated: false,
+);
+
+/// The ✊ emoji.
+const raisedFist = Emoji(
+  base: '✊',
+  alternates: [
+    '✊',
+    '✊🏻',
+    '✊🏼',
+    '✊🏽',
+    '✊🏾',
+    '✊🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':raised-fist:',
+  ],
+  animated: false,
+);
+
+/// The 👊 emoji.
+const fist = Emoji(
+  base: '👊',
+  alternates: [
+    '👊',
+    '👊🏻',
+    '👊🏼',
+    '👊🏽',
+    '👊🏾',
+    '👊🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':fist:',
+    ':bump:',
+  ],
+  animated: false,
+);
+
+/// The 🫳 emoji.
+const palmDown = Emoji(
+  base: '🫳',
+  alternates: [
+    '🫳',
+    '🫳🏻',
+    '🫳🏼',
+    '🫳🏽',
+    '🫳🏾',
+    '🫳🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':palm-down:',
+    ':drop:',
+  ],
+  animated: false,
+);
+
+/// The 🫴 emoji.
+const palmUp = Emoji(
+  base: '🫴',
+  alternates: [
+    '🫴',
+    '🫴🏻',
+    '🫴🏼',
+    '🫴🏽',
+    '🫴🏾',
+    '🫴🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':palm-up:',
+    ':throw:',
+  ],
+  animated: false,
+);
+
+/// The 🫱 emoji.
+const rightwardsHand = Emoji(
+  base: '🫱',
+  alternates: [
+    '🫱',
+    '🫱🏻',
+    '🫱🏼',
+    '🫱🏽',
+    '🫱🏾',
+    '🫱🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':rightwards-hand:',
+  ],
+  animated: false,
+);
+
+/// The 🫲 emoji.
+const leftwardsHand = Emoji(
+  base: '🫲',
+  alternates: [
+    '🫲',
+    '🫲🏻',
+    '🫲🏼',
+    '🫲🏽',
+    '🫲🏾',
+    '🫲🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':leftwards-hand:',
+  ],
+  animated: false,
+);
+
+/// The 🫸 emoji.
+const pushRightwards = Emoji(
+  base: '🫸',
+  alternates: [
+    '🫸',
+    '🫸🏻',
+    '🫸🏼',
+    '🫸🏽',
+    '🫸🏾',
+    '🫸🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':push-rightwards:',
+  ],
+  animated: false,
+);
+
+/// The 🫷 emoji.
+const pushLeftwards = Emoji(
+  base: '🫷',
+  alternates: [
+    '🫷',
+    '🫷🏻',
+    '🫷🏼',
+    '🫷🏽',
+    '🫷🏾',
+    '🫷🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':push-leftwards:',
+  ],
+  animated: false,
+);
+
+/// The 👋 emoji.
+const wave = Emoji(
+  base: '👋',
+  alternates: [
+    '👋',
+    '👋🏻',
+    '👋🏼',
+    '👋🏽',
+    '👋🏾',
+    '👋🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':wave:',
+  ],
+  animated: true,
+);
+
+/// The 🤚 emoji.
+const backHand = Emoji(
+  base: '🤚',
+  alternates: [
+    '🤚',
+    '🤚🏻',
+    '🤚🏼',
+    '🤚🏽',
+    '🤚🏾',
+    '🤚🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':back-hand:',
+  ],
+  animated: false,
+);
+
+/// The 🖐️ emoji.
+const palm = Emoji(
+  base: '🖐️',
+  alternates: [
+    '🖐️',
+    '🖐🏻',
+    '🖐🏼',
+    '🖐🏽',
+    '🖐🏾',
+    '🖐🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':palm:',
+  ],
+  animated: false,
+);
+
+/// The ✋ emoji.
+const raisedHand = Emoji(
+  base: '✋',
+  alternates: [
+    '✋',
+    '✋🏻',
+    '✋🏼',
+    '✋🏽',
+    '✋🏾',
+    '✋🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':raised-hand:',
+  ],
+  animated: false,
+);
+
+/// The 🖖 emoji.
+const vulcan = Emoji(
+  base: '🖖',
+  alternates: [
+    '🖖',
+    '🖖🏻',
+    '🖖🏼',
+    '🖖🏽',
+    '🖖🏾',
+    '🖖🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':vulcan:',
+    ':prosper:',
+    ':spock:',
+  ],
+  animated: false,
+);
+
+/// The 🤟 emoji.
+const loveYouGesture = Emoji(
+  base: '🤟',
+  alternates: [
+    '🤟',
+    '🤟🏻',
+    '🤟🏼',
+    '🤟🏽',
+    '🤟🏾',
+    '🤟🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':love-you-gesture:',
+  ],
+  animated: false,
+);
+
+/// The 🤘 emoji.
+const metal = Emoji(
+  base: '🤘',
+  alternates: [
+    '🤘',
+    '🤘🏻',
+    '🤘🏼',
+    '🤘🏽',
+    '🤘🏾',
+    '🤘🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':metal:',
+    ':horns:',
+  ],
+  animated: false,
+);
+
+/// The ✌️ emoji.
+const v = Emoji(
+  base: '✌️',
+  alternates: [
+    '✌️',
+    '✌🏻',
+    '✌🏼',
+    '✌🏽',
+    '✌🏾',
+    '✌🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':v:',
+    ':peace-hand:',
+    ':victory:',
+  ],
+  animated: true,
+);
+
+/// The 🤞 emoji.
+const crossedFingers = Emoji(
+  base: '🤞',
+  alternates: [
+    '🤞',
+    '🤞🏻',
+    '🤞🏼',
+    '🤞🏽',
+    '🤞🏾',
+    '🤞🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':crossed-fingers:',
+  ],
+  animated: true,
+);
+
+/// The 🫰 emoji.
+const handWithIndexFingerAndThumbCrossed = Emoji(
+  base: '🫰',
+  alternates: [
+    '🫰',
+    '🫰🏻',
+    '🫰🏼',
+    '🫰🏽',
+    '🫰🏾',
+    '🫰🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':hand-with-index-finger-and-thumb-crossed:',
+    ':snap:',
+    ':finger-heart:',
+  ],
+  animated: false,
+);
+
+/// The 🤙 emoji.
+const callMeHand = Emoji(
+  base: '🤙',
+  alternates: [
+    '🤙',
+    '🤙🏻',
+    '🤙🏼',
+    '🤙🏽',
+    '🤙🏾',
+    '🤙🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':call-me-hand:',
+  ],
+  animated: false,
+);
+
+/// The 🤌 emoji.
+const pinchedFingers = Emoji(
+  base: '🤌',
+  alternates: [
+    '🤌',
+    '🤌🏻',
+    '🤌🏼',
+    '🤌🏽',
+    '🤌🏾',
+    '🤌🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':pinched-fingers:',
+  ],
+  animated: false,
+);
+
+/// The 🤏 emoji.
+const pinch = Emoji(
+  base: '🤏',
+  alternates: [
+    '🤏',
+    '🤏🏻',
+    '🤏🏼',
+    '🤏🏽',
+    '🤏🏾',
+    '🤏🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':pinch:',
+  ],
+  animated: false,
+);
+
+/// The 👌 emoji.
+const ok = Emoji(
+  base: '👌',
+  alternates: [
+    '👌',
+    '👌🏻',
+    '👌🏼',
+    '👌🏽',
+    '👌🏾',
+    '👌🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':ok:',
+  ],
+  animated: false,
+);
+
+/// The 🫵 emoji.
+const pointing = Emoji(
+  base: '🫵',
+  alternates: [
+    '🫵',
+    '🫵🏻',
+    '🫵🏼',
+    '🫵🏽',
+    '🫵🏾',
+    '🫵🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':pointing:',
+  ],
+  animated: false,
+);
+
+/// The 👉 emoji.
+const pointRight = Emoji(
+  base: '👉',
+  alternates: [
+    '👉',
+    '👉🏻',
+    '👉🏼',
+    '👉🏽',
+    '👉🏾',
+    '👉🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':point-right:',
+  ],
+  animated: false,
+);
+
+/// The 👈 emoji.
+const pointLeft = Emoji(
+  base: '👈',
+  alternates: [
+    '👈',
+    '👈🏻',
+    '👈🏼',
+    '👈🏽',
+    '👈🏾',
+    '👈🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':point-left:',
+  ],
+  animated: false,
+);
+
+/// The ☝️ emoji.
+const indexFinger = Emoji(
+  base: '☝️',
+  alternates: [
+    '☝️',
+    '☝🏻',
+    '☝🏼',
+    '☝🏽',
+    '☝🏾',
+    '☝🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':index-finger:',
+  ],
+  animated: true,
+);
+
+/// The 👆 emoji.
+const pointUp = Emoji(
+  base: '👆',
+  alternates: [
+    '👆',
+    '👆🏻',
+    '👆🏼',
+    '👆🏽',
+    '👆🏾',
+    '👆🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':point-up:',
+  ],
+  animated: false,
+);
+
+/// The 👇 emoji.
+const pointDown = Emoji(
+  base: '👇',
+  alternates: [
+    '👇',
+    '👇🏻',
+    '👇🏼',
+    '👇🏽',
+    '👇🏾',
+    '👇🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':point-down:',
+  ],
+  animated: false,
+);
+
+/// The 🖕 emoji.
+const middleFinger = Emoji(
+  base: '🖕',
+  alternates: [
+    '🖕',
+    '🖕🏻',
+    '🖕🏼',
+    '🖕🏽',
+    '🖕🏾',
+    '🖕🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':middle-finger:',
+  ],
+  animated: false,
+);
+
+/// The ✍️ emoji.
+const writingHand = Emoji(
+  base: '✍️',
+  alternates: [
+    '✍️',
+    '✍🏻',
+    '✍🏼',
+    '✍🏽',
+    '✍🏾',
+    '✍🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':writing-hand:',
+  ],
+  animated: false,
+);
+
+/// The 🤳 emoji.
+const selfie = Emoji(
+  base: '🤳',
+  alternates: [
+    '🤳',
+    '🤳🏻',
+    '🤳🏼',
+    '🤳🏽',
+    '🤳🏾',
+    '🤳🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':selfie:',
+  ],
+  animated: false,
+);
+
+/// The 🙏 emoji.
+const foldedHands = Emoji(
+  base: '🙏',
+  alternates: [
+    '🙏',
+    '🙏🏻',
+    '🙏🏼',
+    '🙏🏽',
+    '🙏🏾',
+    '🙏🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':folded-hands:',
+    ':please:',
+    ':pray:',
+    ':hope:',
+    ':wish:',
+    ':thank-you:',
+    ':high-five:',
+  ],
+  animated: true,
+);
+
+/// The 💅 emoji.
+const nailCare = Emoji(
+  base: '💅',
+  alternates: [
+    '💅',
+    '💅🏻',
+    '💅🏼',
+    '💅🏽',
+    '💅🏾',
+    '💅🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':nail-care:',
+  ],
+  animated: false,
+);
+
+/// The 🙇 emoji.
+const bow = Emoji(
+  base: '🙇',
+  alternates: [
+    '🙇',
+    '🙇🏻',
+    '🙇🏼',
+    '🙇🏽',
+    '🙇🏾',
+    '🙇🏿',
+    '🙇‍♀️',
+    '🙇🏻‍♀️',
+    '🙇🏼‍♀️',
+    '🙇🏽‍♀️',
+    '🙇🏾‍♀️',
+    '🙇🏿‍♀️',
+    '🙇‍♂️',
+    '🙇🏻‍♂️',
+    '🙇🏼‍♂️',
+    '🙇🏽‍♂️',
+    '🙇🏾‍♂️',
+    '🙇🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':bow:',
+  ],
+  animated: false,
+);
+
+/// The 🙋 emoji.
+const raisingHand = Emoji(
+  base: '🙋',
+  alternates: [
+    '🙋',
+    '🙋🏻',
+    '🙋🏼',
+    '🙋🏽',
+    '🙋🏾',
+    '🙋🏿',
+    '🙋‍♀️',
+    '🙋🏻‍♀️',
+    '🙋🏼‍♀️',
+    '🙋🏽‍♀️',
+    '🙋🏾‍♀️',
+    '🙋🏿‍♀️',
+    '🙋‍♂️',
+    '🙋🏻‍♂️',
+    '🙋🏼‍♂️',
+    '🙋🏽‍♂️',
+    '🙋🏾‍♂️',
+    '🙋🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':raising-hand:',
+  ],
+  animated: false,
+);
+
+/// The 💁 emoji.
+const tippingHand = Emoji(
+  base: '💁',
+  alternates: [
+    '💁',
+    '💁🏻',
+    '💁🏼',
+    '💁🏽',
+    '💁🏾',
+    '💁🏿',
+    '💁‍♀️',
+    '💁🏻‍♀️',
+    '💁🏼‍♀️',
+    '💁🏽‍♀️',
+    '💁🏾‍♀️',
+    '💁🏿‍♀️',
+    '💁‍♂️',
+    '💁🏻‍♂️',
+    '💁🏼‍♂️',
+    '💁🏽‍♂️',
+    '💁🏾‍♂️',
+    '💁🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':tipping-hand:',
+  ],
+  animated: false,
+);
+
+/// The 🙆 emoji.
+const gestureOk = Emoji(
+  base: '🙆',
+  alternates: [
+    '🙆',
+    '🙆🏻',
+    '🙆🏼',
+    '🙆🏽',
+    '🙆🏾',
+    '🙆🏿',
+    '🙆‍♀️',
+    '🙆🏻‍♀️',
+    '🙆🏼‍♀️',
+    '🙆🏽‍♀️',
+    '🙆🏾‍♀️',
+    '🙆🏿‍♀️',
+    '🙆‍♂️',
+    '🙆🏻‍♂️',
+    '🙆🏼‍♂️',
+    '🙆🏽‍♂️',
+    '🙆🏾‍♂️',
+    '🙆🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':gesture-ok:',
+  ],
+  animated: false,
+);
+
+/// The 🙅 emoji.
+const noGesture = Emoji(
+  base: '🙅',
+  alternates: [
+    '🙅',
+    '🙅🏻',
+    '🙅🏼',
+    '🙅🏽',
+    '🙅🏾',
+    '🙅🏿',
+    '🙅‍♀️',
+    '🙅🏻‍♀️',
+    '🙅🏼‍♀️',
+    '🙅🏽‍♀️',
+    '🙅🏾‍♀️',
+    '🙅🏿‍♀️',
+    '🙅‍♂️',
+    '🙅🏻‍♂️',
+    '🙅🏼‍♂️',
+    '🙅🏽‍♂️',
+    '🙅🏾‍♂️',
+    '🙅🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':no-gesture:',
+    ':no-good:',
+    ':denied:',
+    ':halt:',
+  ],
+  animated: false,
+);
+
+/// The 🤷 emoji.
+const shrug = Emoji(
+  base: '🤷',
+  alternates: [
+    '🤷',
+    '🤷🏻',
+    '🤷🏼',
+    '🤷🏽',
+    '🤷🏾',
+    '🤷🏿',
+    '🤷‍♀️',
+    '🤷🏻‍♀️',
+    '🤷🏼‍♀️',
+    '🤷🏽‍♀️',
+    '🤷🏾‍♀️',
+    '🤷🏿‍♀️',
+    '🤷‍♂️',
+    '🤷🏻‍♂️',
+    '🤷🏼‍♂️',
+    '🤷🏽‍♂️',
+    '🤷🏾‍♂️',
+    '🤷🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':shrug:',
+  ],
+  animated: false,
+);
+
+/// The 🤦 emoji.
+const facepalm = Emoji(
+  base: '🤦',
+  alternates: [
+    '🤦',
+    '🤦🏻',
+    '🤦🏼',
+    '🤦🏽',
+    '🤦🏾',
+    '🤦🏿',
+    '🤦‍♀️',
+    '🤦🏻‍♀️',
+    '🤦🏼‍♀️',
+    '🤦🏽‍♀️',
+    '🤦🏾‍♀️',
+    '🤦🏿‍♀️',
+    '🤦‍♂️',
+    '🤦🏻‍♂️',
+    '🤦🏼‍♂️',
+    '🤦🏽‍♂️',
+    '🤦🏾‍♂️',
+    '🤦🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':facepalm:',
+  ],
+  animated: false,
+);
+
+/// The 🙍 emoji.
+const frowning = Emoji(
+  base: '🙍',
+  alternates: [
+    '🙍',
+    '🙍🏻',
+    '🙍🏼',
+    '🙍🏽',
+    '🙍🏾',
+    '🙍🏿',
+    '🙍‍♀️',
+    '🙍🏻‍♀️',
+    '🙍🏼‍♀️',
+    '🙍🏽‍♀️',
+    '🙍🏾‍♀️',
+    '🙍🏿‍♀️',
+    '🙍‍♂️',
+    '🙍🏻‍♂️',
+    '🙍🏼‍♂️',
+    '🙍🏽‍♂️',
+    '🙍🏾‍♂️',
+    '🙍🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':frowning:',
+  ],
+  animated: false,
+);
+
+/// The 🙎 emoji.
+const pouting = Emoji(
+  base: '🙎',
+  alternates: [
+    '🙎',
+    '🙎🏻',
+    '🙎🏼',
+    '🙎🏽',
+    '🙎🏾',
+    '🙎🏿',
+    '🙎‍♀️',
+    '🙎🏻‍♀️',
+    '🙎🏼‍♀️',
+    '🙎🏽‍♀️',
+    '🙎🏾‍♀️',
+    '🙎🏿‍♀️',
+    '🙎‍♂️',
+    '🙎🏻‍♂️',
+    '🙎🏼‍♂️',
+    '🙎🏽‍♂️',
+    '🙎🏾‍♂️',
+    '🙎🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':pouting:',
+  ],
+  animated: false,
+);
+
+/// The 🧏 emoji.
+const deaf = Emoji(
+  base: '🧏',
+  alternates: [
+    '🧏',
+    '🧏🏻',
+    '🧏🏼',
+    '🧏🏽',
+    '🧏🏾',
+    '🧏🏿',
+    '🧏‍♀️',
+    '🧏🏻‍♀️',
+    '🧏🏼‍♀️',
+    '🧏🏽‍♀️',
+    '🧏🏾‍♀️',
+    '🧏🏿‍♀️',
+    '🧏‍♂️',
+    '🧏🏻‍♂️',
+    '🧏🏼‍♂️',
+    '🧏🏽‍♂️',
+    '🧏🏾‍♂️',
+    '🧏🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':deaf:',
+  ],
+  animated: false,
+);
+
+/// The 💆 emoji.
+const massage = Emoji(
+  base: '💆',
+  alternates: [
+    '💆',
+    '💆🏻',
+    '💆🏼',
+    '💆🏽',
+    '💆🏾',
+    '💆🏿',
+    '💆‍♀️',
+    '💆🏻‍♀️',
+    '💆🏼‍♀️',
+    '💆🏽‍♀️',
+    '💆🏾‍♀️',
+    '💆🏿‍♀️',
+    '💆‍♂️',
+    '💆🏻‍♂️',
+    '💆🏼‍♂️',
+    '💆🏽‍♂️',
+    '💆🏾‍♂️',
+    '💆🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':massage:',
+  ],
+  animated: false,
+);
+
+/// The 💇 emoji.
+const haircut = Emoji(
+  base: '💇',
+  alternates: [
+    '💇',
+    '💇🏻',
+    '💇🏼',
+    '💇🏽',
+    '💇🏾',
+    '💇🏿',
+    '💇‍♀️',
+    '💇🏻‍♀️',
+    '💇🏼‍♀️',
+    '💇🏽‍♀️',
+    '💇🏾‍♀️',
+    '💇🏿‍♀️',
+    '💇‍♂️',
+    '💇🏻‍♂️',
+    '💇🏼‍♂️',
+    '💇🏽‍♂️',
+    '💇🏾‍♂️',
+    '💇🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':haircut:',
+  ],
+  animated: false,
+);
+
+/// The 🧖 emoji.
+const sauna = Emoji(
+  base: '🧖',
+  alternates: [
+    '🧖',
+    '🧖🏻',
+    '🧖🏼',
+    '🧖🏽',
+    '🧖🏾',
+    '🧖🏿',
+    '🧖‍♀️',
+    '🧖🏻‍♀️',
+    '🧖🏼‍♀️',
+    '🧖🏽‍♀️',
+    '🧖🏾‍♀️',
+    '🧖🏿‍♀️',
+    '🧖‍♂️',
+    '🧖🏻‍♂️',
+    '🧖🏼‍♂️',
+    '🧖🏽‍♂️',
+    '🧖🏾‍♂️',
+    '🧖🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':sauna:',
+    ':steamy:',
+  ],
+  animated: false,
+);
+
+/// The 🛀 emoji.
+const bathe = Emoji(
+  base: '🛀',
+  alternates: [
+    '🛀',
+    '🛀🏻',
+    '🛀🏼',
+    '🛀🏽',
+    '🛀🏾',
+    '🛀🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':bathe:',
+  ],
+  animated: false,
+);
+
+/// The 🛌 emoji.
+const inBed = Emoji(
+  base: '🛌',
+  alternates: [
+    '🛌',
+    '🛌🏻',
+    '🛌🏼',
+    '🛌🏽',
+    '🛌🏾',
+    '🛌🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':in-bed:',
+  ],
+  animated: false,
+);
+
+/// The 🧘 emoji.
+const yoga = Emoji(
+  base: '🧘',
+  alternates: [
+    '🧘',
+    '🧘🏻',
+    '🧘🏼',
+    '🧘🏽',
+    '🧘🏾',
+    '🧘🏿',
+    '🧘‍♀️',
+    '🧘🏻‍♀️',
+    '🧘🏼‍♀️',
+    '🧘🏽‍♀️',
+    '🧘🏾‍♀️',
+    '🧘🏿‍♀️',
+    '🧘‍♂️',
+    '🧘🏻‍♂️',
+    '🧘🏼‍♂️',
+    '🧘🏽‍♂️',
+    '🧘🏾‍♂️',
+    '🧘🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':yoga:',
+    ':meditation:',
+    ':lotus-position:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🦯 emoji.
+const walkingWithCane = Emoji(
+  base: '🧑‍🦯',
+  alternates: [
+    '🧑‍🦯',
+    '🧑🏻‍🦯',
+    '🧑🏼‍🦯',
+    '🧑🏽‍🦯',
+    '🧑🏾‍🦯',
+    '🧑🏿‍🦯',
+    '👩‍🦯',
+    '👩🏻‍🦯',
+    '👩🏼‍🦯',
+    '👩🏽‍🦯',
+    '👩🏾‍🦯',
+    '👩🏿‍🦯',
+    '👨‍🦯',
+    '👨🏻‍🦯',
+    '👨🏼‍🦯',
+    '👨🏽‍🦯',
+    '👨🏾‍🦯',
+    '👨🏿‍🦯',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':walking-with-cane:',
+    ':blind:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🦼 emoji.
+const personInMotorizedWheelchair = Emoji(
+  base: '🧑‍🦼',
+  alternates: [
+    '🧑‍🦼',
+    '🧑🏻‍🦼',
+    '🧑🏼‍🦼',
+    '🧑🏽‍🦼',
+    '🧑🏾‍🦼',
+    '🧑🏿‍🦼',
+    '👩‍🦼',
+    '👩🏻‍🦼',
+    '👩🏼‍🦼',
+    '👩🏽‍🦼',
+    '👩🏾‍🦼',
+    '👩🏿‍🦼',
+    '👨‍🦼',
+    '👨🏻‍🦼',
+    '👨🏼‍🦼',
+    '👨🏽‍🦼',
+    '👨🏾‍🦼',
+    '👨🏿‍🦼',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':person-in-motorized-wheelchair:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🦽 emoji.
+const personInManualWheelchair = Emoji(
+  base: '🧑‍🦽',
+  alternates: [
+    '🧑‍🦽',
+    '🧑🏻‍🦽',
+    '🧑🏼‍🦽',
+    '🧑🏽‍🦽',
+    '🧑🏾‍🦽',
+    '🧑🏿‍🦽',
+    '👩‍🦽',
+    '👩🏻‍🦽',
+    '👩🏼‍🦽',
+    '👩🏽‍🦽',
+    '👩🏾‍🦽',
+    '👩🏿‍🦽',
+    '👨‍🦽',
+    '👨🏻‍🦽',
+    '👨🏼‍🦽',
+    '👨🏽‍🦽',
+    '👨🏾‍🦽',
+    '👨🏿‍🦽',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':person-in-manual-wheelchair:',
+  ],
+  animated: false,
+);
+
+/// The 🧎 emoji.
+const kneeling = Emoji(
+  base: '🧎',
+  alternates: [
+    '🧎',
+    '🧎🏻',
+    '🧎🏼',
+    '🧎🏽',
+    '🧎🏾',
+    '🧎🏿',
+    '🧎‍♀️',
+    '🧎🏻‍♀️',
+    '🧎🏼‍♀️',
+    '🧎🏽‍♀️',
+    '🧎🏾‍♀️',
+    '🧎🏿‍♀️',
+    '🧎‍♂️',
+    '🧎🏻‍♂️',
+    '🧎🏼‍♂️',
+    '🧎🏽‍♂️',
+    '🧎🏾‍♂️',
+    '🧎🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':kneeling:',
+  ],
+  animated: false,
+);
+
+/// The 🧍 emoji.
+const standing = Emoji(
+  base: '🧍',
+  alternates: [
+    '🧍',
+    '🧍🏻',
+    '🧍🏼',
+    '🧍🏽',
+    '🧍🏾',
+    '🧍🏿',
+    '🧍‍♀️',
+    '🧍🏻‍♀️',
+    '🧍🏼‍♀️',
+    '🧍🏽‍♀️',
+    '🧍🏾‍♀️',
+    '🧍🏿‍♀️',
+    '🧍‍♂️',
+    '🧍🏻‍♂️',
+    '🧍🏼‍♂️',
+    '🧍🏽‍♂️',
+    '🧍🏾‍♂️',
+    '🧍🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':standing:',
+  ],
+  animated: false,
+);
+
+/// The 🚶 emoji.
+const walking = Emoji(
+  base: '🚶',
+  alternates: [
+    '🚶',
+    '🚶🏻',
+    '🚶🏼',
+    '🚶🏽',
+    '🚶🏾',
+    '🚶🏿',
+    '🚶‍♀️',
+    '🚶🏻‍♀️',
+    '🚶🏼‍♀️',
+    '🚶🏽‍♀️',
+    '🚶🏾‍♀️',
+    '🚶🏿‍♀️',
+    '🚶‍♂️',
+    '🚶🏻‍♂️',
+    '🚶🏼‍♂️',
+    '🚶🏽‍♂️',
+    '🚶🏾‍♂️',
+    '🚶🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':walking:',
+  ],
+  animated: false,
+);
+
+/// The 🏃 emoji.
+const running = Emoji(
+  base: '🏃',
+  alternates: [
+    '🏃',
+    '🏃🏻',
+    '🏃🏼',
+    '🏃🏽',
+    '🏃🏾',
+    '🏃🏿',
+    '🏃‍♀️',
+    '🏃🏻‍♀️',
+    '🏃🏼‍♀️',
+    '🏃🏽‍♀️',
+    '🏃🏾‍♀️',
+    '🏃🏿‍♀️',
+    '🏃‍♂️',
+    '🏃🏻‍♂️',
+    '🏃🏼‍♂️',
+    '🏃🏽‍♂️',
+    '🏃🏾‍♂️',
+    '🏃🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':running:',
+  ],
+  animated: false,
+);
+
+/// The 🤸 emoji.
+const cartwheel = Emoji(
+  base: '🤸',
+  alternates: [
+    '🤸',
+    '🤸🏻',
+    '🤸🏼',
+    '🤸🏽',
+    '🤸🏾',
+    '🤸🏿',
+    '🤸‍♀️',
+    '🤸🏻‍♀️',
+    '🤸🏼‍♀️',
+    '🤸🏽‍♀️',
+    '🤸🏾‍♀️',
+    '🤸🏿‍♀️',
+    '🤸‍♂️',
+    '🤸🏻‍♂️',
+    '🤸🏼‍♂️',
+    '🤸🏽‍♂️',
+    '🤸🏾‍♂️',
+    '🤸🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':cartwheel:',
+  ],
+  animated: false,
+);
+
+/// The 🏋️ emoji.
+const liftingWeights = Emoji(
+  base: '🏋️',
+  alternates: [
+    '🏋️',
+    '🏋🏻',
+    '🏋🏼',
+    '🏋🏽',
+    '🏋🏾',
+    '🏋🏿',
+    '🏋️‍♀️',
+    '🏋🏻‍♀️',
+    '🏋🏼‍♀️',
+    '🏋🏽‍♀️',
+    '🏋🏾‍♀️',
+    '🏋🏿‍♀️',
+    '🏋️‍♂️',
+    '🏋🏻‍♂️',
+    '🏋🏼‍♂️',
+    '🏋🏽‍♂️',
+    '🏋🏾‍♂️',
+    '🏋🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':lifting-weights:',
+  ],
+  animated: false,
+);
+
+/// The ⛹️ emoji.
+const bouncingBall = Emoji(
+  base: '⛹️',
+  alternates: [
+    '⛹️',
+    '⛹🏻',
+    '⛹🏼',
+    '⛹🏽',
+    '⛹🏾',
+    '⛹🏿',
+    '⛹️‍♀️',
+    '⛹🏻‍♀️',
+    '⛹🏼‍♀️',
+    '⛹🏽‍♀️',
+    '⛹🏾‍♀️',
+    '⛹🏿‍♀️',
+    '⛹️‍♂️',
+    '⛹🏻‍♂️',
+    '⛹🏼‍♂️',
+    '⛹🏽‍♂️',
+    '⛹🏾‍♂️',
+    '⛹🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':bouncing-ball:',
+  ],
+  animated: false,
+);
+
+/// The 🤾 emoji.
+const handball = Emoji(
+  base: '🤾',
+  alternates: [
+    '🤾',
+    '🤾🏻',
+    '🤾🏼',
+    '🤾🏽',
+    '🤾🏾',
+    '🤾🏿',
+    '🤾‍♀️',
+    '🤾🏻‍♀️',
+    '🤾🏼‍♀️',
+    '🤾🏽‍♀️',
+    '🤾🏾‍♀️',
+    '🤾🏿‍♀️',
+    '🤾‍♂️',
+    '🤾🏻‍♂️',
+    '🤾🏼‍♂️',
+    '🤾🏽‍♂️',
+    '🤾🏾‍♂️',
+    '🤾🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':handball:',
+  ],
+  animated: false,
+);
+
+/// The 🚴 emoji.
+const biking = Emoji(
+  base: '🚴',
+  alternates: [
+    '🚴',
+    '🚴🏻',
+    '🚴🏼',
+    '🚴🏽',
+    '🚴🏾',
+    '🚴🏿',
+    '🚴‍♀️',
+    '🚴🏻‍♀️',
+    '🚴🏼‍♀️',
+    '🚴🏽‍♀️',
+    '🚴🏾‍♀️',
+    '🚴🏿‍♀️',
+    '🚴‍♂️',
+    '🚴🏻‍♂️',
+    '🚴🏼‍♂️',
+    '🚴🏽‍♂️',
+    '🚴🏾‍♂️',
+    '🚴🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':biking:',
+  ],
+  animated: false,
+);
+
+/// The 🚵 emoji.
+const mountainBiking = Emoji(
+  base: '🚵',
+  alternates: [
+    '🚵',
+    '🚵🏻',
+    '🚵🏼',
+    '🚵🏽',
+    '🚵🏾',
+    '🚵🏿',
+    '🚵‍♀️',
+    '🚵🏻‍♀️',
+    '🚵🏼‍♀️',
+    '🚵🏽‍♀️',
+    '🚵🏾‍♀️',
+    '🚵🏿‍♀️',
+    '🚵‍♂️',
+    '🚵🏻‍♂️',
+    '🚵🏼‍♂️',
+    '🚵🏽‍♂️',
+    '🚵🏾‍♂️',
+    '🚵🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':mountain-biking:',
+  ],
+  animated: false,
+);
+
+/// The 🧗 emoji.
+const climbing = Emoji(
+  base: '🧗',
+  alternates: [
+    '🧗',
+    '🧗🏻',
+    '🧗🏼',
+    '🧗🏽',
+    '🧗🏾',
+    '🧗🏿',
+    '🧗‍♀️',
+    '🧗🏻‍♀️',
+    '🧗🏼‍♀️',
+    '🧗🏽‍♀️',
+    '🧗🏾‍♀️',
+    '🧗🏿‍♀️',
+    '🧗‍♂️',
+    '🧗🏻‍♂️',
+    '🧗🏼‍♂️',
+    '🧗🏽‍♂️',
+    '🧗🏾‍♂️',
+    '🧗🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':climbing:',
+  ],
+  animated: false,
+);
+
+/// The 🤼 emoji.
+const wrestling = Emoji(
+  base: '🤼',
+  alternates: [
+    '🤼',
+    '🤼‍♀️',
+    '🤼‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':wrestling:',
+  ],
+  animated: false,
+);
+
+/// The 🤹 emoji.
+const juggling = Emoji(
+  base: '🤹',
+  alternates: [
+    '🤹',
+    '🤹🏻',
+    '🤹🏼',
+    '🤹🏽',
+    '🤹🏾',
+    '🤹🏿',
+    '🤹‍♀️',
+    '🤹🏻‍♀️',
+    '🤹🏼‍♀️',
+    '🤹🏽‍♀️',
+    '🤹🏾‍♀️',
+    '🤹🏿‍♀️',
+    '🤹‍♂️',
+    '🤹🏻‍♂️',
+    '🤹🏼‍♂️',
+    '🤹🏽‍♂️',
+    '🤹🏾‍♂️',
+    '🤹🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':juggling:',
+  ],
+  animated: false,
+);
+
+/// The 🏌️ emoji.
+const golfing = Emoji(
+  base: '🏌️',
+  alternates: [
+    '🏌️',
+    '🏌🏻',
+    '🏌🏼',
+    '🏌🏽',
+    '🏌🏾',
+    '🏌🏿',
+    '🏌️‍♀️',
+    '🏌🏻‍♀️',
+    '🏌🏼‍♀️',
+    '🏌🏽‍♀️',
+    '🏌🏾‍♀️',
+    '🏌🏿‍♀️',
+    '🏌️‍♂️',
+    '🏌🏻‍♂️',
+    '🏌🏼‍♂️',
+    '🏌🏽‍♂️',
+    '🏌🏾‍♂️',
+    '🏌🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':golfing:',
+  ],
+  animated: false,
+);
+
+/// The 🏇 emoji.
+const horseRacing = Emoji(
+  base: '🏇',
+  alternates: [
+    '🏇',
+    '🏇🏻',
+    '🏇🏼',
+    '🏇🏽',
+    '🏇🏾',
+    '🏇🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':horse-racing:',
+  ],
+  animated: false,
+);
+
+/// The 🤺 emoji.
+const fencing = Emoji(
+  base: '🤺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fencing:',
+  ],
+  animated: false,
+);
+
+/// The ⛷️ emoji.
+const skier = Emoji(
+  base: '⛷️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':skier:',
+  ],
+  animated: false,
+);
+
+/// The 🏂 emoji.
+const snowboarder = Emoji(
+  base: '🏂',
+  alternates: [
+    '🏂',
+    '🏂🏻',
+    '🏂🏼',
+    '🏂🏽',
+    '🏂🏾',
+    '🏂🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':snowboarder:',
+  ],
+  animated: false,
+);
+
+/// The 🪂 emoji.
+const parachute = Emoji(
+  base: '🪂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':parachute:',
+  ],
+  animated: false,
+);
+
+/// The 🏄 emoji.
+const surfing = Emoji(
+  base: '🏄',
+  alternates: [
+    '🏄',
+    '🏄🏻',
+    '🏄🏼',
+    '🏄🏽',
+    '🏄🏾',
+    '🏄🏿',
+    '🏄‍♀️',
+    '🏄🏻‍♀️',
+    '🏄🏼‍♀️',
+    '🏄🏽‍♀️',
+    '🏄🏾‍♀️',
+    '🏄🏿‍♀️',
+    '🏄‍♂️',
+    '🏄🏻‍♂️',
+    '🏄🏼‍♂️',
+    '🏄🏽‍♂️',
+    '🏄🏾‍♂️',
+    '🏄🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':surfing:',
+  ],
+  animated: false,
+);
+
+/// The 🚣 emoji.
+const rowingBoat = Emoji(
+  base: '🚣',
+  alternates: [
+    '🚣',
+    '🚣🏻',
+    '🚣🏼',
+    '🚣🏽',
+    '🚣🏾',
+    '🚣🏿',
+    '🚣‍♀️',
+    '🚣🏻‍♀️',
+    '🚣🏼‍♀️',
+    '🚣🏽‍♀️',
+    '🚣🏾‍♀️',
+    '🚣🏿‍♀️',
+    '🚣‍♂️',
+    '🚣🏻‍♂️',
+    '🚣🏼‍♂️',
+    '🚣🏽‍♂️',
+    '🚣🏾‍♂️',
+    '🚣🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':rowing-boat:',
+  ],
+  animated: false,
+);
+
+/// The 🏊 emoji.
+const swimming = Emoji(
+  base: '🏊',
+  alternates: [
+    '🏊',
+    '🏊🏻',
+    '🏊🏼',
+    '🏊🏽',
+    '🏊🏾',
+    '🏊🏿',
+    '🏊‍♀️',
+    '🏊🏻‍♀️',
+    '🏊🏼‍♀️',
+    '🏊🏽‍♀️',
+    '🏊🏾‍♀️',
+    '🏊🏿‍♀️',
+    '🏊‍♂️',
+    '🏊🏻‍♂️',
+    '🏊🏼‍♂️',
+    '🏊🏽‍♂️',
+    '🏊🏾‍♂️',
+    '🏊🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':swimming:',
+  ],
+  animated: false,
+);
+
+/// The 🤽 emoji.
+const waterPolo = Emoji(
+  base: '🤽',
+  alternates: [
+    '🤽',
+    '🤽🏻',
+    '🤽🏼',
+    '🤽🏽',
+    '🤽🏾',
+    '🤽🏿',
+    '🤽‍♀️',
+    '🤽🏻‍♀️',
+    '🤽🏼‍♀️',
+    '🤽🏽‍♀️',
+    '🤽🏾‍♀️',
+    '🤽🏿‍♀️',
+    '🤽‍♂️',
+    '🤽🏻‍♂️',
+    '🤽🏼‍♂️',
+    '🤽🏽‍♂️',
+    '🤽🏾‍♂️',
+    '🤽🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':water-polo:',
+  ],
+  animated: false,
+);
+
+/// The 🧜 emoji.
+const merperson = Emoji(
+  base: '🧜',
+  alternates: [
+    '🧜',
+    '🧜🏻',
+    '🧜🏼',
+    '🧜🏽',
+    '🧜🏾',
+    '🧜🏿',
+    '🧜‍♀️',
+    '🧜🏻‍♀️',
+    '🧜🏼‍♀️',
+    '🧜🏽‍♀️',
+    '🧜🏾‍♀️',
+    '🧜🏿‍♀️',
+    '🧜‍♂️',
+    '🧜🏻‍♂️',
+    '🧜🏼‍♂️',
+    '🧜🏽‍♂️',
+    '🧜🏾‍♂️',
+    '🧜🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':merperson:',
+  ],
+  animated: false,
+);
+
+/// The 🧚 emoji.
+const fairy = Emoji(
+  base: '🧚',
+  alternates: [
+    '🧚',
+    '🧚🏻',
+    '🧚🏼',
+    '🧚🏽',
+    '🧚🏾',
+    '🧚🏿',
+    '🧚‍♀️',
+    '🧚🏻‍♀️',
+    '🧚🏼‍♀️',
+    '🧚🏽‍♀️',
+    '🧚🏾‍♀️',
+    '🧚🏿‍♀️',
+    '🧚‍♂️',
+    '🧚🏻‍♂️',
+    '🧚🏼‍♂️',
+    '🧚🏽‍♂️',
+    '🧚🏾‍♂️',
+    '🧚🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':fairy:',
+  ],
+  animated: false,
+);
+
+/// The 🧞 emoji.
+const genie = Emoji(
+  base: '🧞',
+  alternates: [
+    '🧞',
+    '🧞‍♀️',
+    '🧞‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':genie:',
+  ],
+  animated: false,
+);
+
+/// The 🧝 emoji.
+const elf = Emoji(
+  base: '🧝',
+  alternates: [
+    '🧝',
+    '🧝🏻',
+    '🧝🏼',
+    '🧝🏽',
+    '🧝🏾',
+    '🧝🏿',
+    '🧝‍♀️',
+    '🧝🏻‍♀️',
+    '🧝🏼‍♀️',
+    '🧝🏽‍♀️',
+    '🧝🏾‍♀️',
+    '🧝🏿‍♀️',
+    '🧝‍♂️',
+    '🧝🏻‍♂️',
+    '🧝🏼‍♂️',
+    '🧝🏽‍♂️',
+    '🧝🏾‍♂️',
+    '🧝🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':elf:',
+  ],
+  animated: false,
+);
+
+/// The 🧙 emoji.
+const mage = Emoji(
+  base: '🧙',
+  alternates: [
+    '🧙',
+    '🧙🏻',
+    '🧙🏼',
+    '🧙🏽',
+    '🧙🏾',
+    '🧙🏿',
+    '🧙‍♀️',
+    '🧙🏻‍♀️',
+    '🧙🏼‍♀️',
+    '🧙🏽‍♀️',
+    '🧙🏾‍♀️',
+    '🧙🏿‍♀️',
+    '🧙‍♂️',
+    '🧙🏻‍♂️',
+    '🧙🏼‍♂️',
+    '🧙🏽‍♂️',
+    '🧙🏾‍♂️',
+    '🧙🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':mage:',
+  ],
+  animated: false,
+);
+
+/// The 🧛 emoji.
+const vampire = Emoji(
+  base: '🧛',
+  alternates: [
+    '🧛',
+    '🧛🏻',
+    '🧛🏼',
+    '🧛🏽',
+    '🧛🏾',
+    '🧛🏿',
+    '🧛‍♀️',
+    '🧛🏻‍♀️',
+    '🧛🏼‍♀️',
+    '🧛🏽‍♀️',
+    '🧛🏾‍♀️',
+    '🧛🏿‍♀️',
+    '🧛‍♂️',
+    '🧛🏻‍♂️',
+    '🧛🏼‍♂️',
+    '🧛🏽‍♂️',
+    '🧛🏾‍♂️',
+    '🧛🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':vampire:',
+  ],
+  animated: false,
+);
+
+/// The 🧟 emoji.
+const zombie = Emoji(
+  base: '🧟',
+  alternates: [
+    '🧟',
+    '🧟‍♀️',
+    '🧟‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':zombie:',
+  ],
+  animated: false,
+);
+
+/// The 🧌 emoji.
+const troll = Emoji(
+  base: '🧌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':troll:',
+  ],
+  animated: false,
+);
+
+/// The 🦸 emoji.
+const superhero = Emoji(
+  base: '🦸',
+  alternates: [
+    '🦸',
+    '🦸🏻',
+    '🦸🏼',
+    '🦸🏽',
+    '🦸🏾',
+    '🦸🏿',
+    '🦸‍♀️',
+    '🦸🏻‍♀️',
+    '🦸🏼‍♀️',
+    '🦸🏽‍♀️',
+    '🦸🏾‍♀️',
+    '🦸🏿‍♀️',
+    '🦸‍♂️',
+    '🦸🏻‍♂️',
+    '🦸🏼‍♂️',
+    '🦸🏽‍♂️',
+    '🦸🏾‍♂️',
+    '🦸🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':superhero:',
+  ],
+  animated: false,
+);
+
+/// The 🦹 emoji.
+const supervillain = Emoji(
+  base: '🦹',
+  alternates: [
+    '🦹',
+    '🦹🏻',
+    '🦹🏼',
+    '🦹🏽',
+    '🦹🏾',
+    '🦹🏿',
+    '🦹‍♀️',
+    '🦹🏻‍♀️',
+    '🦹🏼‍♀️',
+    '🦹🏽‍♀️',
+    '🦹🏾‍♀️',
+    '🦹🏿‍♀️',
+    '🦹‍♂️',
+    '🦹🏻‍♂️',
+    '🦹🏼‍♂️',
+    '🦹🏽‍♂️',
+    '🦹🏾‍♂️',
+    '🦹🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':supervillain:',
+  ],
+  animated: false,
+);
+
+/// The 🥷 emoji.
+const ninja = Emoji(
+  base: '🥷',
+  alternates: [
+    '🥷',
+    '🥷🏻',
+    '🥷🏼',
+    '🥷🏽',
+    '🥷🏾',
+    '🥷🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':ninja:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🎄 emoji.
+const mxClaus = Emoji(
+  base: '🧑‍🎄',
+  alternates: [
+    '🧑‍🎄',
+    '🧑🏻‍🎄',
+    '🧑🏼‍🎄',
+    '🧑🏽‍🎄',
+    '🧑🏾‍🎄',
+    '🧑🏿‍🎄',
+    '🤶',
+    '🤶🏻',
+    '🤶🏼',
+    '🤶🏽',
+    '🤶🏾',
+    '🤶🏿',
+    '🎅',
+    '🎅🏻',
+    '🎅🏼',
+    '🎅🏽',
+    '🎅🏾',
+    '🎅🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':mx-claus:',
+  ],
+  animated: false,
+);
+
+/// The 👼 emoji.
+const angel = Emoji(
+  base: '👼',
+  alternates: [
+    '👼',
+    '👼🏻',
+    '👼🏼',
+    '👼🏽',
+    '👼🏾',
+    '👼🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':angel:',
+  ],
+  animated: false,
+);
+
+/// The 💂 emoji.
+const guard = Emoji(
+  base: '💂',
+  alternates: [
+    '💂',
+    '💂🏻',
+    '💂🏼',
+    '💂🏽',
+    '💂🏾',
+    '💂🏿',
+    '💂‍♀️',
+    '💂🏻‍♀️',
+    '💂🏼‍♀️',
+    '💂🏽‍♀️',
+    '💂🏾‍♀️',
+    '💂🏿‍♀️',
+    '💂‍♂️',
+    '💂🏻‍♂️',
+    '💂🏼‍♂️',
+    '💂🏽‍♂️',
+    '💂🏾‍♂️',
+    '💂🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':guard:',
+  ],
+  animated: false,
+);
+
+/// The 🫅 emoji.
+const royalty = Emoji(
+  base: '🫅',
+  alternates: [
+    '🫅',
+    '🫅🏻',
+    '🫅🏼',
+    '🫅🏽',
+    '🫅🏾',
+    '🫅🏿',
+    '👸',
+    '👸🏻',
+    '👸🏼',
+    '👸🏽',
+    '👸🏾',
+    '👸🏿',
+    '🤴',
+    '🤴🏻',
+    '🤴🏼',
+    '🤴🏽',
+    '🤴🏾',
+    '🤴🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':royalty:',
+  ],
+  animated: false,
+);
+
+/// The 🤵 emoji.
+const tuxedo = Emoji(
+  base: '🤵',
+  alternates: [
+    '🤵',
+    '🤵🏻',
+    '🤵🏼',
+    '🤵🏽',
+    '🤵🏾',
+    '🤵🏿',
+    '🤵‍♀️',
+    '🤵🏻‍♀️',
+    '🤵🏼‍♀️',
+    '🤵🏽‍♀️',
+    '🤵🏾‍♀️',
+    '🤵🏿‍♀️',
+    '🤵‍♂️',
+    '🤵🏻‍♂️',
+    '🤵🏼‍♂️',
+    '🤵🏽‍♂️',
+    '🤵🏾‍♂️',
+    '🤵🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':tuxedo:',
+  ],
+  animated: false,
+);
+
+/// The 👰 emoji.
+const veil = Emoji(
+  base: '👰',
+  alternates: [
+    '👰',
+    '👰🏻',
+    '👰🏼',
+    '👰🏽',
+    '👰🏾',
+    '👰🏿',
+    '👰‍♀️',
+    '👰🏻‍♀️',
+    '👰🏼‍♀️',
+    '👰🏽‍♀️',
+    '👰🏾‍♀️',
+    '👰🏿‍♀️',
+    '👰‍♂️',
+    '👰🏻‍♂️',
+    '👰🏼‍♂️',
+    '👰🏽‍♂️',
+    '👰🏾‍♂️',
+    '👰🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':veil:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🚀 emoji.
+const astronaut = Emoji(
+  base: '🧑‍🚀',
+  alternates: [
+    '🧑‍🚀',
+    '🧑🏻‍🚀',
+    '🧑🏼‍🚀',
+    '🧑🏽‍🚀',
+    '🧑🏾‍🚀',
+    '🧑🏿‍🚀',
+    '👩‍🚀',
+    '👩🏻‍🚀',
+    '👩🏼‍🚀',
+    '👩🏽‍🚀',
+    '👩🏾‍🚀',
+    '👩🏿‍🚀',
+    '👨‍🚀',
+    '👨🏻‍🚀',
+    '👨🏼‍🚀',
+    '👨🏽‍🚀',
+    '👨🏾‍🚀',
+    '👨🏿‍🚀',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':astronaut:',
+  ],
+  animated: false,
+);
+
+/// The 👷 emoji.
+const constructionWorker = Emoji(
+  base: '👷',
+  alternates: [
+    '👷',
+    '👷🏻',
+    '👷🏼',
+    '👷🏽',
+    '👷🏾',
+    '👷🏿',
+    '👷‍♀️',
+    '👷🏻‍♀️',
+    '👷🏼‍♀️',
+    '👷🏽‍♀️',
+    '👷🏾‍♀️',
+    '👷🏿‍♀️',
+    '👷‍♂️',
+    '👷🏻‍♂️',
+    '👷🏼‍♂️',
+    '👷🏽‍♂️',
+    '👷🏾‍♂️',
+    '👷🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':construction-worker:',
+  ],
+  animated: false,
+);
+
+/// The 👮 emoji.
+const police = Emoji(
+  base: '👮',
+  alternates: [
+    '👮',
+    '👮🏻',
+    '👮🏼',
+    '👮🏽',
+    '👮🏾',
+    '👮🏿',
+    '👮‍♀️',
+    '👮🏻‍♀️',
+    '👮🏼‍♀️',
+    '👮🏽‍♀️',
+    '👮🏾‍♀️',
+    '👮🏿‍♀️',
+    '👮‍♂️',
+    '👮🏻‍♂️',
+    '👮🏼‍♂️',
+    '👮🏽‍♂️',
+    '👮🏾‍♂️',
+    '👮🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':police:',
+  ],
+  animated: false,
+);
+
+/// The 🕵️ emoji.
+const detective = Emoji(
+  base: '🕵️',
+  alternates: [
+    '🕵️',
+    '🕵🏻',
+    '🕵🏼',
+    '🕵🏽',
+    '🕵🏾',
+    '🕵🏿',
+    '🕵️‍♀️',
+    '🕵🏻‍♀️',
+    '🕵🏼‍♀️',
+    '🕵🏽‍♀️',
+    '🕵🏾‍♀️',
+    '🕵🏿‍♀️',
+    '🕵️‍♂️',
+    '🕵🏻‍♂️',
+    '🕵🏼‍♂️',
+    '🕵🏽‍♂️',
+    '🕵🏾‍♂️',
+    '🕵🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':detective:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍✈️ emoji.
+const pilot = Emoji(
+  base: '🧑‍✈️',
+  alternates: [
+    '🧑‍✈️',
+    '🧑🏻‍✈️',
+    '🧑🏼‍✈️',
+    '🧑🏽‍✈️',
+    '🧑🏾‍✈️',
+    '🧑🏿‍✈️',
+    '👩‍✈️',
+    '👩🏻‍✈️',
+    '👩🏼‍✈️',
+    '👩🏽‍✈️',
+    '👩🏾‍✈️',
+    '👩🏿‍✈️',
+    '👨‍✈️',
+    '👨🏻‍✈️',
+    '👨🏼‍✈️',
+    '👨🏽‍✈️',
+    '👨🏾‍✈️',
+    '👨🏿‍✈️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':pilot:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🔬 emoji.
+const scientist = Emoji(
+  base: '🧑‍🔬',
+  alternates: [
+    '🧑‍🔬',
+    '🧑🏻‍🔬',
+    '🧑🏼‍🔬',
+    '🧑🏽‍🔬',
+    '🧑🏾‍🔬',
+    '🧑🏿‍🔬',
+    '👩‍🔬',
+    '👩🏻‍🔬',
+    '👩🏼‍🔬',
+    '👩🏽‍🔬',
+    '👩🏾‍🔬',
+    '👩🏿‍🔬',
+    '👨‍🔬',
+    '👨🏻‍🔬',
+    '👨🏼‍🔬',
+    '👨🏽‍🔬',
+    '👨🏾‍🔬',
+    '👨🏿‍🔬',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':scientist:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍⚕️ emoji.
+const healthWorker = Emoji(
+  base: '🧑‍⚕️',
+  alternates: [
+    '🧑‍⚕️',
+    '🧑🏻‍⚕️',
+    '🧑🏼‍⚕️',
+    '🧑🏽‍⚕️',
+    '🧑🏾‍⚕️',
+    '🧑🏿‍⚕️',
+    '👩‍⚕️',
+    '👩🏻‍⚕️',
+    '👩🏼‍⚕️',
+    '👩🏽‍⚕️',
+    '👩🏾‍⚕️',
+    '👩🏿‍⚕️',
+    '👨‍⚕️',
+    '👨🏻‍⚕️',
+    '👨🏼‍⚕️',
+    '👨🏽‍⚕️',
+    '👨🏾‍⚕️',
+    '👨🏿‍⚕️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':health-worker:',
+    ':doctor:',
+    ':nurse:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🔧 emoji.
+const mechanic = Emoji(
+  base: '🧑‍🔧',
+  alternates: [
+    '🧑‍🔧',
+    '🧑🏻‍🔧',
+    '🧑🏼‍🔧',
+    '🧑🏽‍🔧',
+    '🧑🏾‍🔧',
+    '🧑🏿‍🔧',
+    '👩‍🔧',
+    '👩🏻‍🔧',
+    '👩🏼‍🔧',
+    '👩🏽‍🔧',
+    '👩🏾‍🔧',
+    '👩🏿‍🔧',
+    '👨‍🔧',
+    '👨🏻‍🔧',
+    '👨🏼‍🔧',
+    '👨🏽‍🔧',
+    '👨🏾‍🔧',
+    '👨🏿‍🔧',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':mechanic:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🏭 emoji.
+const factoryWorker = Emoji(
+  base: '🧑‍🏭',
+  alternates: [
+    '🧑‍🏭',
+    '🧑🏻‍🏭',
+    '🧑🏼‍🏭',
+    '🧑🏽‍🏭',
+    '🧑🏾‍🏭',
+    '🧑🏿‍🏭',
+    '👩‍🏭',
+    '👩🏻‍🏭',
+    '👩🏼‍🏭',
+    '👩🏽‍🏭',
+    '👩🏾‍🏭',
+    '👩🏿‍🏭',
+    '👨‍🏭',
+    '👨🏻‍🏭',
+    '👨🏼‍🏭',
+    '👨🏽‍🏭',
+    '👨🏾‍🏭',
+    '👨🏿‍🏭',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':factory-worker:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🚒 emoji.
+const firefighter = Emoji(
+  base: '🧑‍🚒',
+  alternates: [
+    '🧑‍🚒',
+    '🧑🏻‍🚒',
+    '🧑🏼‍🚒',
+    '🧑🏽‍🚒',
+    '🧑🏾‍🚒',
+    '🧑🏿‍🚒',
+    '👩‍🚒',
+    '👩🏻‍🚒',
+    '👩🏼‍🚒',
+    '👩🏽‍🚒',
+    '👩🏾‍🚒',
+    '👩🏿‍🚒',
+    '👨‍🚒',
+    '👨🏻‍🚒',
+    '👨🏼‍🚒',
+    '👨🏽‍🚒',
+    '👨🏾‍🚒',
+    '👨🏿‍🚒',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':firefighter:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🌾 emoji.
+const farmer = Emoji(
+  base: '🧑‍🌾',
+  alternates: [
+    '🧑‍🌾',
+    '🧑🏻‍🌾',
+    '🧑🏼‍🌾',
+    '🧑🏽‍🌾',
+    '🧑🏾‍🌾',
+    '🧑🏿‍🌾',
+    '👩‍🌾',
+    '👩🏻‍🌾',
+    '👩🏼‍🌾',
+    '👩🏽‍🌾',
+    '👩🏾‍🌾',
+    '👩🏿‍🌾',
+    '👨‍🌾',
+    '👨🏻‍🌾',
+    '👨🏼‍🌾',
+    '👨🏽‍🌾',
+    '👨🏾‍🌾',
+    '👨🏿‍🌾',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':farmer:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🏫 emoji.
+const teacher = Emoji(
+  base: '🧑‍🏫',
+  alternates: [
+    '🧑‍🏫',
+    '🧑🏻‍🏫',
+    '🧑🏼‍🏫',
+    '🧑🏽‍🏫',
+    '🧑🏾‍🏫',
+    '🧑🏿‍🏫',
+    '👩‍🏫',
+    '👩🏻‍🏫',
+    '👩🏼‍🏫',
+    '👩🏽‍🏫',
+    '👩🏾‍🏫',
+    '👩🏿‍🏫',
+    '👨‍🏫',
+    '👨🏻‍🏫',
+    '👨🏼‍🏫',
+    '👨🏽‍🏫',
+    '👨🏾‍🏫',
+    '👨🏿‍🏫',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':teacher:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🎓 emoji.
+const student = Emoji(
+  base: '🧑‍🎓',
+  alternates: [
+    '🧑‍🎓',
+    '🧑🏻‍🎓',
+    '🧑🏼‍🎓',
+    '🧑🏽‍🎓',
+    '🧑🏾‍🎓',
+    '🧑🏿‍🎓',
+    '👩‍🎓',
+    '👩🏻‍🎓',
+    '👩🏼‍🎓',
+    '👩🏽‍🎓',
+    '👩🏾‍🎓',
+    '👩🏿‍🎓',
+    '👨‍🎓',
+    '👨🏻‍🎓',
+    '👨🏼‍🎓',
+    '👨🏽‍🎓',
+    '👨🏾‍🎓',
+    '👨🏿‍🎓',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':student:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍💼 emoji.
+const officeWorker = Emoji(
+  base: '🧑‍💼',
+  alternates: [
+    '🧑‍💼',
+    '🧑🏻‍💼',
+    '🧑🏼‍💼',
+    '🧑🏽‍💼',
+    '🧑🏾‍💼',
+    '🧑🏿‍💼',
+    '👩‍💼',
+    '👩🏻‍💼',
+    '👩🏼‍💼',
+    '👩🏽‍💼',
+    '👩🏾‍💼',
+    '👩🏿‍💼',
+    '👨‍💼',
+    '👨🏻‍💼',
+    '👨🏼‍💼',
+    '👨🏽‍💼',
+    '👨🏾‍💼',
+    '👨🏿‍💼',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':office-worker:',
+    ':business-person:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍⚖️ emoji.
+const judge = Emoji(
+  base: '🧑‍⚖️',
+  alternates: [
+    '🧑‍⚖️',
+    '🧑🏻‍⚖️',
+    '🧑🏼‍⚖️',
+    '🧑🏽‍⚖️',
+    '🧑🏾‍⚖️',
+    '🧑🏿‍⚖️',
+    '👩‍⚖️',
+    '👩🏻‍⚖️',
+    '👩🏼‍⚖️',
+    '👩🏽‍⚖️',
+    '👩🏾‍⚖️',
+    '👩🏿‍⚖️',
+    '👨‍⚖️',
+    '👨🏻‍⚖️',
+    '👨🏼‍⚖️',
+    '👨🏽‍⚖️',
+    '👨🏾‍⚖️',
+    '👨🏿‍⚖️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':judge:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍💻 emoji.
+const technologist = Emoji(
+  base: '🧑‍💻',
+  alternates: [
+    '🧑‍💻',
+    '🧑🏻‍💻',
+    '🧑🏼‍💻',
+    '🧑🏽‍💻',
+    '🧑🏾‍💻',
+    '🧑🏿‍💻',
+    '👩‍💻',
+    '👩🏻‍💻',
+    '👩🏼‍💻',
+    '👩🏽‍💻',
+    '👩🏾‍💻',
+    '👩🏿‍💻',
+    '👨‍💻',
+    '👨🏻‍💻',
+    '👨🏼‍💻',
+    '👨🏽‍💻',
+    '👨🏾‍💻',
+    '👨🏿‍💻',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':technologist:',
+    ':person-at-computer:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🎤 emoji.
+const singer = Emoji(
+  base: '🧑‍🎤',
+  alternates: [
+    '🧑‍🎤',
+    '🧑🏻‍🎤',
+    '🧑🏼‍🎤',
+    '🧑🏽‍🎤',
+    '🧑🏾‍🎤',
+    '🧑🏿‍🎤',
+    '👩‍🎤',
+    '👩🏻‍🎤',
+    '👩🏼‍🎤',
+    '👩🏽‍🎤',
+    '👩🏾‍🎤',
+    '👩🏿‍🎤',
+    '👨‍🎤',
+    '👨🏻‍🎤',
+    '👨🏼‍🎤',
+    '👨🏽‍🎤',
+    '👨🏾‍🎤',
+    '👨🏿‍🎤',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':singer:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🎨 emoji.
+const artist = Emoji(
+  base: '🧑‍🎨',
+  alternates: [
+    '🧑‍🎨',
+    '🧑🏻‍🎨',
+    '🧑🏼‍🎨',
+    '🧑🏽‍🎨',
+    '🧑🏾‍🎨',
+    '🧑🏿‍🎨',
+    '👩‍🎨',
+    '👩🏻‍🎨',
+    '👩🏼‍🎨',
+    '👩🏽‍🎨',
+    '👩🏾‍🎨',
+    '👩🏿‍🎨',
+    '👨‍🎨',
+    '👨🏻‍🎨',
+    '👨🏼‍🎨',
+    '👨🏽‍🎨',
+    '👨🏾‍🎨',
+    '👨🏿‍🎨',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':artist:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🍳 emoji.
+const cook = Emoji(
+  base: '🧑‍🍳',
+  alternates: [
+    '🧑‍🍳',
+    '🧑🏻‍🍳',
+    '🧑🏼‍🍳',
+    '🧑🏽‍🍳',
+    '🧑🏾‍🍳',
+    '🧑🏿‍🍳',
+    '👩‍🍳',
+    '👩🏻‍🍳',
+    '👩🏼‍🍳',
+    '👩🏽‍🍳',
+    '👩🏾‍🍳',
+    '👩🏿‍🍳',
+    '👨‍🍳',
+    '👨🏻‍🍳',
+    '👨🏼‍🍳',
+    '👨🏽‍🍳',
+    '👨🏾‍🍳',
+    '👨🏿‍🍳',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':cook:',
+  ],
+  animated: false,
+);
+
+/// The 👳 emoji.
+const turban = Emoji(
+  base: '👳',
+  alternates: [
+    '👳',
+    '👳🏻',
+    '👳🏼',
+    '👳🏽',
+    '👳🏾',
+    '👳🏿',
+    '👳‍♀️',
+    '👳🏻‍♀️',
+    '👳🏼‍♀️',
+    '👳🏽‍♀️',
+    '👳🏾‍♀️',
+    '👳🏿‍♀️',
+    '👳‍♂️',
+    '👳🏻‍♂️',
+    '👳🏼‍♂️',
+    '👳🏽‍♂️',
+    '👳🏾‍♂️',
+    '👳🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':turban:',
+  ],
+  animated: false,
+);
+
+/// The 🧕 emoji.
+const headscarf = Emoji(
+  base: '🧕',
+  alternates: [
+    '🧕',
+    '🧕🏻',
+    '🧕🏼',
+    '🧕🏽',
+    '🧕🏾',
+    '🧕🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':headscarf:',
+  ],
+  animated: false,
+);
+
+/// The 👲 emoji.
+const guaPiMao = Emoji(
+  base: '👲',
+  alternates: [
+    '👲',
+    '👲🏻',
+    '👲🏼',
+    '👲🏽',
+    '👲🏾',
+    '👲🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':gua-pi-mao:',
+  ],
+  animated: false,
+);
+
+/// The 👶 emoji.
+const baby = Emoji(
+  base: '👶',
+  alternates: [
+    '👶',
+    '👶🏻',
+    '👶🏼',
+    '👶🏽',
+    '👶🏾',
+    '👶🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':baby:',
+  ],
+  animated: false,
+);
+
+/// The 🧒 emoji.
+const child = Emoji(
+  base: '🧒',
+  alternates: [
+    '🧒',
+    '🧒🏻',
+    '🧒🏼',
+    '🧒🏽',
+    '🧒🏾',
+    '🧒🏿',
+    '👧',
+    '👧🏻',
+    '👧🏼',
+    '👧🏽',
+    '👧🏾',
+    '👧🏿',
+    '👦',
+    '👦🏻',
+    '👦🏼',
+    '👦🏽',
+    '👦🏾',
+    '👦🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':child:',
+  ],
+  animated: false,
+);
+
+/// The 🧑 emoji.
+const adult = Emoji(
+  base: '🧑',
+  alternates: [
+    '🧑',
+    '🧑🏻',
+    '🧑🏼',
+    '🧑🏽',
+    '🧑🏾',
+    '🧑🏿',
+    '👩',
+    '👩🏻',
+    '👩🏼',
+    '👩🏽',
+    '👩🏾',
+    '👩🏿',
+    '👨',
+    '👨🏻',
+    '👨🏼',
+    '👨🏽',
+    '👨🏾',
+    '👨🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':adult:',
+  ],
+  animated: false,
+);
+
+/// The 🧓 emoji.
+const elder = Emoji(
+  base: '🧓',
+  alternates: [
+    '🧓',
+    '🧓🏻',
+    '🧓🏼',
+    '🧓🏽',
+    '🧓🏾',
+    '🧓🏿',
+    '👵',
+    '👵🏻',
+    '👵🏼',
+    '👵🏽',
+    '👵🏾',
+    '👵🏿',
+    '👴',
+    '👴🏻',
+    '👴🏼',
+    '👴🏽',
+    '👴🏾',
+    '👴🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':elder:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🦳 emoji.
+const whiteHair = Emoji(
+  base: '🧑‍🦳',
+  alternates: [
+    '🧑‍🦳',
+    '🧑🏻‍🦳',
+    '🧑🏼‍🦳',
+    '🧑🏽‍🦳',
+    '🧑🏾‍🦳',
+    '🧑🏿‍🦳',
+    '👩‍🦳',
+    '👩🏻‍🦳',
+    '👩🏼‍🦳',
+    '👩🏽‍🦳',
+    '👩🏾‍🦳',
+    '👩🏿‍🦳',
+    '👨‍🦳',
+    '👨🏻‍🦳',
+    '👨🏼‍🦳',
+    '👨🏽‍🦳',
+    '👨🏾‍🦳',
+    '👨🏿‍🦳',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':white-hair:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🦰 emoji.
+const redHair = Emoji(
+  base: '🧑‍🦰',
+  alternates: [
+    '🧑‍🦰',
+    '🧑🏻‍🦰',
+    '🧑🏼‍🦰',
+    '🧑🏽‍🦰',
+    '🧑🏾‍🦰',
+    '🧑🏿‍🦰',
+    '👩‍🦰',
+    '👩🏻‍🦰',
+    '👩🏼‍🦰',
+    '👩🏽‍🦰',
+    '👩🏾‍🦰',
+    '👩🏿‍🦰',
+    '👨‍🦰',
+    '👨🏻‍🦰',
+    '👨🏼‍🦰',
+    '👨🏽‍🦰',
+    '👨🏾‍🦰',
+    '👨🏿‍🦰',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':red-hair:',
+  ],
+  animated: false,
+);
+
+/// The 👱 emoji.
+const blondHair = Emoji(
+  base: '👱',
+  alternates: [
+    '👱',
+    '👱🏻',
+    '👱🏼',
+    '👱🏽',
+    '👱🏾',
+    '👱🏿',
+    '👱‍♀️',
+    '👱🏻‍♀️',
+    '👱🏼‍♀️',
+    '👱🏽‍♀️',
+    '👱🏾‍♀️',
+    '👱🏿‍♀️',
+    '👱‍♂️',
+    '👱🏻‍♂️',
+    '👱🏼‍♂️',
+    '👱🏽‍♂️',
+    '👱🏾‍♂️',
+    '👱🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':blond-hair:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🦱 emoji.
+const curlyHair = Emoji(
+  base: '🧑‍🦱',
+  alternates: [
+    '🧑‍🦱',
+    '🧑🏻‍🦱',
+    '🧑🏼‍🦱',
+    '🧑🏽‍🦱',
+    '🧑🏾‍🦱',
+    '🧑🏿‍🦱',
+    '👩‍🦱',
+    '👩🏻‍🦱',
+    '👩🏼‍🦱',
+    '👩🏽‍🦱',
+    '👩🏾‍🦱',
+    '👩🏿‍🦱',
+    '👨‍🦱',
+    '👨🏻‍🦱',
+    '👨🏼‍🦱',
+    '👨🏽‍🦱',
+    '👨🏾‍🦱',
+    '👨🏿‍🦱',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':curly-hair:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🦲 emoji.
+const bald = Emoji(
+  base: '🧑‍🦲',
+  alternates: [
+    '🧑‍🦲',
+    '🧑🏻‍🦲',
+    '🧑🏼‍🦲',
+    '🧑🏽‍🦲',
+    '🧑🏾‍🦲',
+    '🧑🏿‍🦲',
+    '👩‍🦲',
+    '👩🏻‍🦲',
+    '👩🏼‍🦲',
+    '👩🏽‍🦲',
+    '👩🏾‍🦲',
+    '👩🏿‍🦲',
+    '👨‍🦲',
+    '👨🏻‍🦲',
+    '👨🏼‍🦲',
+    '👨🏽‍🦲',
+    '👨🏾‍🦲',
+    '👨🏿‍🦲',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':bald:',
+  ],
+  animated: false,
+);
+
+/// The 🧔 emoji.
+const beard = Emoji(
+  base: '🧔',
+  alternates: [
+    '🧔',
+    '🧔🏻',
+    '🧔🏼',
+    '🧔🏽',
+    '🧔🏾',
+    '🧔🏿',
+    '🧔‍♀️',
+    '🧔🏻‍♀️',
+    '🧔🏼‍♀️',
+    '🧔🏽‍♀️',
+    '🧔🏾‍♀️',
+    '🧔🏿‍♀️',
+    '🧔‍♂️',
+    '🧔🏻‍♂️',
+    '🧔🏼‍♂️',
+    '🧔🏽‍♂️',
+    '🧔🏾‍♂️',
+    '🧔🏿‍♂️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':beard:',
+  ],
+  animated: false,
+);
+
+/// The 🕴️ emoji.
+const levitatingSuit = Emoji(
+  base: '🕴️',
+  alternates: [
+    '🕴️',
+    '🕴🏻',
+    '🕴🏼',
+    '🕴🏽',
+    '🕴🏾',
+    '🕴🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':levitating-suit:',
+  ],
+  animated: false,
+);
+
+/// The 💃 emoji.
+const dancerWoman = Emoji(
+  base: '💃',
+  alternates: [
+    '💃',
+    '💃🏻',
+    '💃🏼',
+    '💃🏽',
+    '💃🏾',
+    '💃🏿',
+  ],
+  emoticons: [
+    '♪┏(･o･)┛♪',
+  ],
+  shortcodes: [
+    ':dancer-woman:',
+  ],
+  animated: true,
+);
+
+/// The 🕺 emoji.
+const dancerMan = Emoji(
+  base: '🕺',
+  alternates: [
+    '🕺',
+    '🕺🏻',
+    '🕺🏼',
+    '🕺🏽',
+    '🕺🏾',
+    '🕺🏿',
+  ],
+  emoticons: [
+    '♪┗(･o･)┓♪',
+  ],
+  shortcodes: [
+    ':dancer-man:',
+  ],
+  animated: false,
+);
+
+/// The 👯 emoji.
+const bunnyEars = Emoji(
+  base: '👯',
+  alternates: [
+    '👯',
+    '👯‍♂️',
+    '👯‍♀️',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':bunny-ears:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🤝‍🧑 emoji.
+const holdingHands = Emoji(
+  base: '🧑‍🤝‍🧑',
+  alternates: [
+    '🧑‍🤝‍🧑',
+    '🧑🏻‍🤝‍🧑🏻',
+    '🧑🏻‍🤝‍🧑🏼',
+    '🧑🏻‍🤝‍🧑🏽',
+    '🧑🏻‍🤝‍🧑🏾',
+    '🧑🏻‍🤝‍🧑🏿',
+    '🧑🏼‍🤝‍🧑🏻',
+    '🧑🏼‍🤝‍🧑🏼',
+    '🧑🏼‍🤝‍🧑🏽',
+    '🧑🏼‍🤝‍🧑🏾',
+    '🧑🏼‍🤝‍🧑🏿',
+    '🧑🏽‍🤝‍🧑🏻',
+    '🧑🏽‍🤝‍🧑🏼',
+    '🧑🏽‍🤝‍🧑🏽',
+    '🧑🏽‍🤝‍🧑🏾',
+    '🧑🏽‍🤝‍🧑🏿',
+    '🧑🏾‍🤝‍🧑🏻',
+    '🧑🏾‍🤝‍🧑🏼',
+    '🧑🏾‍🤝‍🧑🏽',
+    '🧑🏾‍🤝‍🧑🏾',
+    '🧑🏾‍🤝‍🧑🏿',
+    '🧑🏿‍🤝‍🧑🏻',
+    '🧑🏿‍🤝‍🧑🏼',
+    '🧑🏿‍🤝‍🧑🏽',
+    '🧑🏿‍🤝‍🧑🏾',
+    '🧑🏿‍🤝‍🧑🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':holding-hands:',
+  ],
+  animated: false,
+);
+
+/// The 👭 emoji.
+const holdingHandsWomen = Emoji(
+  base: '👭',
+  alternates: [
+    '👭',
+    '👭🏻',
+    '👩🏻‍🤝‍👩🏼',
+    '👩🏻‍🤝‍👩🏽',
+    '👩🏻‍🤝‍👩🏾',
+    '👩🏻‍🤝‍👩🏿',
+    '👩🏼‍🤝‍👩🏻',
+    '👭🏼',
+    '👩🏼‍🤝‍👩🏽',
+    '👩🏼‍🤝‍👩🏾',
+    '👩🏼‍🤝‍👩🏿',
+    '👩🏽‍🤝‍👩🏻',
+    '👩🏽‍🤝‍👩🏼',
+    '👭🏽',
+    '👩🏽‍🤝‍👩🏾',
+    '👩🏽‍🤝‍👩🏿',
+    '👩🏾‍🤝‍👩🏻',
+    '👩🏾‍🤝‍👩🏼',
+    '👩🏾‍🤝‍👩🏽',
+    '👭🏾',
+    '👩🏾‍🤝‍👩🏿',
+    '👩🏿‍🤝‍👩🏻',
+    '👩🏿‍🤝‍👩🏼',
+    '👩🏿‍🤝‍👩🏽',
+    '👩🏿‍🤝‍👩🏾',
+    '👭🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':holding-hands-women:',
+  ],
+  animated: false,
+);
+
+/// The 👬 emoji.
+const holdingHandsMen = Emoji(
+  base: '👬',
+  alternates: [
+    '👬',
+    '👬🏻',
+    '👨🏻‍🤝‍👨🏼',
+    '👨🏻‍🤝‍👨🏽',
+    '👨🏻‍🤝‍👨🏾',
+    '👨🏻‍🤝‍👨🏿',
+    '👨🏼‍🤝‍👨🏻',
+    '👬🏼',
+    '👨🏼‍🤝‍👨🏽',
+    '👨🏼‍🤝‍👨🏾',
+    '👨🏼‍🤝‍👨🏿',
+    '👨🏽‍🤝‍👨🏻',
+    '👨🏽‍🤝‍👨🏼',
+    '👬🏽',
+    '👨🏽‍🤝‍👨🏾',
+    '👨🏽‍🤝‍👨🏿',
+    '👨🏾‍🤝‍👨🏻',
+    '👨🏾‍🤝‍👨🏼',
+    '👨🏾‍🤝‍👨🏽',
+    '👬🏾',
+    '👨🏾‍🤝‍👨🏿',
+    '👨🏿‍🤝‍👨🏻',
+    '👨🏿‍🤝‍👨🏼',
+    '👨🏿‍🤝‍👨🏽',
+    '👨🏿‍🤝‍👨🏾',
+    '👬🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':holding-hands-men:',
+  ],
+  animated: false,
+);
+
+/// The 👫 emoji.
+const holdingHandsWomanAndMan = Emoji(
+  base: '👫',
+  alternates: [
+    '👫',
+    '👫🏻',
+    '👩🏻‍🤝‍👨🏼',
+    '👩🏻‍🤝‍👨🏽',
+    '👩🏻‍🤝‍👨🏾',
+    '👩🏻‍🤝‍👨🏿',
+    '👩🏼‍🤝‍👨🏻',
+    '👫🏼',
+    '👩🏼‍🤝‍👨🏽',
+    '👩🏼‍🤝‍👨🏾',
+    '👩🏼‍🤝‍👨🏿',
+    '👩🏽‍🤝‍👨🏻',
+    '👩🏽‍🤝‍👨🏼',
+    '👫🏽',
+    '👩🏽‍🤝‍👨🏾',
+    '👩🏽‍🤝‍👨🏿',
+    '👩🏾‍🤝‍👨🏻',
+    '👩🏾‍🤝‍👨🏼',
+    '👩🏾‍🤝‍👨🏽',
+    '👫🏾',
+    '👩🏾‍🤝‍👨🏿',
+    '👩🏿‍🤝‍👨🏻',
+    '👩🏿‍🤝‍👨🏼',
+    '👩🏿‍🤝‍👨🏽',
+    '👩🏿‍🤝‍👨🏾',
+    '👫🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':holding-hands-woman-and-man:',
+  ],
+  animated: false,
+);
+
+/// The 💏 emoji.
+const kissPeople = Emoji(
+  base: '💏',
+  alternates: [
+    '💏',
+    '💏🏻',
+    '🧑🏻‍❤️‍💋‍🧑🏼',
+    '🧑🏻‍❤️‍💋‍🧑🏽',
+    '🧑🏻‍❤️‍💋‍🧑🏾',
+    '🧑🏻‍❤️‍💋‍🧑🏿',
+    '🧑🏼‍❤️‍💋‍🧑🏻',
+    '💏🏼',
+    '🧑🏼‍❤️‍💋‍🧑🏽',
+    '🧑🏼‍❤️‍💋‍🧑🏾',
+    '🧑🏼‍❤️‍💋‍🧑🏿',
+    '🧑🏽‍❤️‍💋‍🧑🏻',
+    '🧑🏽‍❤️‍💋‍🧑🏼',
+    '💏🏽',
+    '🧑🏽‍❤️‍💋‍🧑🏾',
+    '🧑🏽‍❤️‍💋‍🧑🏿',
+    '🧑🏾‍❤️‍💋‍🧑🏻',
+    '🧑🏾‍❤️‍💋‍🧑🏼',
+    '🧑🏾‍❤️‍💋‍🧑🏽',
+    '💏🏾',
+    '🧑🏾‍❤️‍💋‍🧑🏿',
+    '🧑🏿‍❤️‍💋‍🧑🏻',
+    '🧑🏿‍❤️‍💋‍🧑🏼',
+    '🧑🏿‍❤️‍💋‍🧑🏽',
+    '🧑🏿‍❤️‍💋‍🧑🏾',
+    '💏🏿',
+  ],
+  emoticons: [
+    '(-}{-)',
+  ],
+  shortcodes: [
+    ':kiss-people:',
+  ],
+  animated: false,
+);
+
+/// The 👩‍❤️‍💋‍👨 emoji.
+const kissWomanAndMan = Emoji(
+  base: '👩‍❤️‍💋‍👨',
+  alternates: [
+    '👩‍❤️‍💋‍👨',
+    '👩🏻‍❤️‍💋‍👨🏻',
+    '👩🏻‍❤️‍💋‍👨🏼',
+    '👩🏻‍❤️‍💋‍👨🏽',
+    '👩🏻‍❤️‍💋‍👨🏾',
+    '👩🏻‍❤️‍💋‍👨🏿',
+    '👩🏼‍❤️‍💋‍👨🏻',
+    '👩🏼‍❤️‍💋‍👨🏼',
+    '👩🏼‍❤️‍💋‍👨🏽',
+    '👩🏼‍❤️‍💋‍👨🏾',
+    '👩🏼‍❤️‍💋‍👨🏿',
+    '👩🏽‍❤️‍💋‍👨🏻',
+    '👩🏽‍❤️‍💋‍👨🏼',
+    '👩🏽‍❤️‍💋‍👨🏽',
+    '👩🏽‍❤️‍💋‍👨🏾',
+    '👩🏽‍❤️‍💋‍👨🏿',
+    '👩🏾‍❤️‍💋‍👨🏻',
+    '👩🏾‍❤️‍💋‍👨🏼',
+    '👩🏾‍❤️‍💋‍👨🏽',
+    '👩🏾‍❤️‍💋‍👨🏾',
+    '👩🏾‍❤️‍💋‍👨🏿',
+    '👩🏿‍❤️‍💋‍👨🏻',
+    '👩🏿‍❤️‍💋‍👨🏼',
+    '👩🏿‍❤️‍💋‍👨🏽',
+    '👩🏿‍❤️‍💋‍👨🏾',
+    '👩🏿‍❤️‍💋‍👨🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':kiss-woman-and-man:',
+  ],
+  animated: false,
+);
+
+/// The 👨‍❤️‍💋‍👨 emoji.
+const kissManAndMan = Emoji(
+  base: '👨‍❤️‍💋‍👨',
+  alternates: [
+    '👨‍❤️‍💋‍👨',
+    '👨🏻‍❤️‍💋‍👨🏻',
+    '👨🏻‍❤️‍💋‍👨🏼',
+    '👨🏻‍❤️‍💋‍👨🏽',
+    '👨🏻‍❤️‍💋‍👨🏾',
+    '👨🏻‍❤️‍💋‍👨🏿',
+    '👨🏼‍❤️‍💋‍👨🏻',
+    '👨🏼‍❤️‍💋‍👨🏼',
+    '👨🏼‍❤️‍💋‍👨🏽',
+    '👨🏼‍❤️‍💋‍👨🏾',
+    '👨🏼‍❤️‍💋‍👨🏿',
+    '👨🏽‍❤️‍💋‍👨🏻',
+    '👨🏽‍❤️‍💋‍👨🏼',
+    '👨🏽‍❤️‍💋‍👨🏽',
+    '👨🏽‍❤️‍💋‍👨🏾',
+    '👨🏽‍❤️‍💋‍👨🏿',
+    '👨🏾‍❤️‍💋‍👨🏻',
+    '👨🏾‍❤️‍💋‍👨🏼',
+    '👨🏾‍❤️‍💋‍👨🏽',
+    '👨🏾‍❤️‍💋‍👨🏾',
+    '👨🏾‍❤️‍💋‍👨🏿',
+    '👨🏿‍❤️‍💋‍👨🏻',
+    '👨🏿‍❤️‍💋‍👨🏼',
+    '👨🏿‍❤️‍💋‍👨🏽',
+    '👨🏿‍❤️‍💋‍👨🏾',
+    '👨🏿‍❤️‍💋‍👨🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':kiss-man-and-man:',
+  ],
+  animated: false,
+);
+
+/// The 👩‍❤️‍💋‍👩 emoji.
+const kissWomanAndWoman = Emoji(
+  base: '👩‍❤️‍💋‍👩',
+  alternates: [
+    '👩‍❤️‍💋‍👩',
+    '👩🏻‍❤️‍💋‍👩🏻',
+    '👩🏻‍❤️‍💋‍👩🏼',
+    '👩🏻‍❤️‍💋‍👩🏽',
+    '👩🏻‍❤️‍💋‍👩🏾',
+    '👩🏻‍❤️‍💋‍👩🏿',
+    '👩🏼‍❤️‍💋‍👩🏻',
+    '👩🏼‍❤️‍💋‍👩🏼',
+    '👩🏼‍❤️‍💋‍👩🏽',
+    '👩🏼‍❤️‍💋‍👩🏾',
+    '👩🏼‍❤️‍💋‍👩🏿',
+    '👩🏽‍❤️‍💋‍👩🏻',
+    '👩🏽‍❤️‍💋‍👩🏼',
+    '👩🏽‍❤️‍💋‍👩🏽',
+    '👩🏽‍❤️‍💋‍👩🏾',
+    '👩🏽‍❤️‍💋‍👩🏿',
+    '👩🏾‍❤️‍💋‍👩🏻',
+    '👩🏾‍❤️‍💋‍👩🏼',
+    '👩🏾‍❤️‍💋‍👩🏽',
+    '👩🏾‍❤️‍💋‍👩🏾',
+    '👩🏾‍❤️‍💋‍👩🏿',
+    '👩🏿‍❤️‍💋‍👩🏻',
+    '👩🏿‍❤️‍💋‍👩🏼',
+    '👩🏿‍❤️‍💋‍👩🏽',
+    '👩🏿‍❤️‍💋‍👩🏾',
+    '👩🏿‍❤️‍💋‍👩🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':kiss-woman-and-woman:',
+  ],
+  animated: false,
+);
+
+/// The 💑 emoji.
+const peopleWithHeart = Emoji(
+  base: '💑',
+  alternates: [
+    '💑',
+    '💑🏻',
+    '🧑🏻‍❤️‍🧑🏼',
+    '🧑🏻‍❤️‍🧑🏽',
+    '🧑🏻‍❤️‍🧑🏾',
+    '🧑🏻‍❤️‍🧑🏿',
+    '🧑🏼‍❤️‍🧑🏻',
+    '💑🏼',
+    '🧑🏼‍❤️‍🧑🏽',
+    '🧑🏼‍❤️‍🧑🏾',
+    '🧑🏼‍❤️‍🧑🏿',
+    '🧑🏽‍❤️‍🧑🏻',
+    '🧑🏽‍❤️‍🧑🏼',
+    '💑🏽',
+    '🧑🏽‍❤️‍🧑🏾',
+    '🧑🏽‍❤️‍🧑🏿',
+    '🧑🏾‍❤️‍🧑🏻',
+    '🧑🏾‍❤️‍🧑🏼',
+    '🧑🏾‍❤️‍🧑🏽',
+    '💑🏾',
+    '🧑🏾‍❤️‍🧑🏿',
+    '🧑🏿‍❤️‍🧑🏻',
+    '🧑🏿‍❤️‍🧑🏼',
+    '🧑🏿‍❤️‍🧑🏽',
+    '🧑🏿‍❤️‍🧑🏾',
+    '💑🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':people-with-heart:',
+  ],
+  animated: false,
+);
+
+/// The 👩‍❤️‍👨 emoji.
+const heartWithWomanAndMan = Emoji(
+  base: '👩‍❤️‍👨',
+  alternates: [
+    '👩‍❤️‍👨',
+    '👩🏻‍❤️‍👨🏻',
+    '👩🏻‍❤️‍👨🏼',
+    '👩🏻‍❤️‍👨🏽',
+    '👩🏻‍❤️‍👨🏾',
+    '👩🏻‍❤️‍👨🏿',
+    '👩🏼‍❤️‍👨🏻',
+    '👩🏼‍❤️‍👨🏼',
+    '👩🏼‍❤️‍👨🏽',
+    '👩🏼‍❤️‍👨🏾',
+    '👩🏼‍❤️‍👨🏿',
+    '👩🏽‍❤️‍👨🏻',
+    '👩🏽‍❤️‍👨🏼',
+    '👩🏽‍❤️‍👨🏽',
+    '👩🏽‍❤️‍👨🏾',
+    '👩🏽‍❤️‍👨🏿',
+    '👩🏾‍❤️‍👨🏻',
+    '👩🏾‍❤️‍👨🏼',
+    '👩🏾‍❤️‍👨🏽',
+    '👩🏾‍❤️‍👨🏾',
+    '👩🏾‍❤️‍👨🏿',
+    '👩🏿‍❤️‍👨🏻',
+    '👩🏿‍❤️‍👨🏼',
+    '👩🏿‍❤️‍👨🏽',
+    '👩🏿‍❤️‍👨🏾',
+    '👩🏿‍❤️‍👨🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':heart-with-woman-and-man:',
+  ],
+  animated: false,
+);
+
+/// The 👨‍❤️‍👨 emoji.
+const heartWithManAndMan = Emoji(
+  base: '👨‍❤️‍👨',
+  alternates: [
+    '👨‍❤️‍👨',
+    '👨🏻‍❤️‍👨🏻',
+    '👨🏻‍❤️‍👨🏼',
+    '👨🏻‍❤️‍👨🏽',
+    '👨🏻‍❤️‍👨🏾',
+    '👨🏻‍❤️‍👨🏿',
+    '👨🏼‍❤️‍👨🏻',
+    '👨🏼‍❤️‍👨🏼',
+    '👨🏼‍❤️‍👨🏽',
+    '👨🏼‍❤️‍👨🏾',
+    '👨🏼‍❤️‍👨🏿',
+    '👨🏽‍❤️‍👨🏻',
+    '👨🏽‍❤️‍👨🏼',
+    '👨🏽‍❤️‍👨🏽',
+    '👨🏽‍❤️‍👨🏾',
+    '👨🏽‍❤️‍👨🏿',
+    '👨🏾‍❤️‍👨🏻',
+    '👨🏾‍❤️‍👨🏼',
+    '👨🏾‍❤️‍👨🏽',
+    '👨🏾‍❤️‍👨🏾',
+    '👨🏾‍❤️‍👨🏿',
+    '👨🏿‍❤️‍👨🏻',
+    '👨🏿‍❤️‍👨🏼',
+    '👨🏿‍❤️‍👨🏽',
+    '👨🏿‍❤️‍👨🏾',
+    '👨🏿‍❤️‍👨🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':heart-with-man-and-man:',
+  ],
+  animated: false,
+);
+
+/// The 👩‍❤️‍👩 emoji.
+const heartWithWomanAndWoman = Emoji(
+  base: '👩‍❤️‍👩',
+  alternates: [
+    '👩‍❤️‍👩',
+    '👩🏻‍❤️‍👩🏻',
+    '👩🏻‍❤️‍👩🏼',
+    '👩🏻‍❤️‍👩🏽',
+    '👩🏻‍❤️‍👩🏾',
+    '👩🏻‍❤️‍👩🏿',
+    '👩🏼‍❤️‍👩🏻',
+    '👩🏼‍❤️‍👩🏼',
+    '👩🏼‍❤️‍👩🏽',
+    '👩🏼‍❤️‍👩🏾',
+    '👩🏼‍❤️‍👩🏿',
+    '👩🏽‍❤️‍👩🏻',
+    '👩🏽‍❤️‍👩🏼',
+    '👩🏽‍❤️‍👩🏽',
+    '👩🏽‍❤️‍👩🏾',
+    '👩🏽‍❤️‍👩🏿',
+    '👩🏾‍❤️‍👩🏻',
+    '👩🏾‍❤️‍👩🏼',
+    '👩🏾‍❤️‍👩🏽',
+    '👩🏾‍❤️‍👩🏾',
+    '👩🏾‍❤️‍👩🏿',
+    '👩🏿‍❤️‍👩🏻',
+    '👩🏿‍❤️‍👩🏼',
+    '👩🏿‍❤️‍👩🏽',
+    '👩🏿‍❤️‍👩🏾',
+    '👩🏿‍❤️‍👩🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':heart-with-woman-and-woman:',
+  ],
+  animated: false,
+);
+
+/// The 🫄 emoji.
+const pregnant = Emoji(
+  base: '🫄',
+  alternates: [
+    '🫄',
+    '🫄🏻',
+    '🫄🏼',
+    '🫄🏽',
+    '🫄🏾',
+    '🫄🏿',
+    '🤰',
+    '🤰🏻',
+    '🤰🏼',
+    '🤰🏽',
+    '🤰🏾',
+    '🤰🏿',
+    '🫃',
+    '🫃🏻',
+    '🫃🏼',
+    '🫃🏽',
+    '🫃🏾',
+    '🫃🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':pregnant:',
+  ],
+  animated: false,
+);
+
+/// The 🤱 emoji.
+const breastFeeding = Emoji(
+  base: '🤱',
+  alternates: [
+    '🤱',
+    '🤱🏻',
+    '🤱🏼',
+    '🤱🏽',
+    '🤱🏾',
+    '🤱🏿',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':breast-feeding:',
+  ],
+  animated: false,
+);
+
+/// The 🧑‍🍼 emoji.
+const personFeedingBaby = Emoji(
+  base: '🧑‍🍼',
+  alternates: [
+    '🧑‍🍼',
+    '🧑🏻‍🍼',
+    '🧑🏼‍🍼',
+    '🧑🏽‍🍼',
+    '🧑🏾‍🍼',
+    '🧑🏿‍🍼',
+    '👩‍🍼',
+    '👩🏻‍🍼',
+    '👩🏼‍🍼',
+    '👩🏽‍🍼',
+    '👩🏾‍🍼',
+    '👩🏿‍🍼',
+    '👨‍🍼',
+    '👨🏻‍🍼',
+    '👨🏼‍🍼',
+    '👨🏽‍🍼',
+    '👨🏾‍🍼',
+    '👨🏿‍🍼',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':person-feeding-baby:',
+  ],
+  animated: false,
+);
+
+/// The 👪 emoji.
+const family = Emoji(
+  base: '👪',
+  alternates: [
+    '👪',
+    '👨‍👩‍👦',
+    '👨‍👩‍👧',
+    '👨‍👩‍👧‍👦',
+    '👨‍👩‍👦‍👦',
+    '👨‍👩‍👧‍👧',
+    '👨‍👨‍👦',
+    '👨‍👨‍👧',
+    '👨‍👨‍👧‍👦',
+    '👨‍👨‍👦‍👦',
+    '👨‍👨‍👧‍👧',
+    '👨‍👦',
+    '👨‍👧',
+    '👨‍👧‍👦',
+    '👨‍👦‍👦',
+    '👨‍👧‍👧',
+    '👩‍👩‍👦',
+    '👩‍👩‍👧',
+    '👩‍👩‍👧‍👦',
+    '👩‍👩‍👦‍👦',
+    '👩‍👩‍👧‍👧',
+    '👩‍👦',
+    '👩‍👧',
+    '👩‍👧‍👦',
+    '👩‍👦‍👦',
+    '👩‍👧‍👧',
+  ],
+  emoticons: [],
+  shortcodes: [
+    ':family:',
+  ],
+  animated: false,
+);
+
+/// The 💐 emoji.
+const bouquet = Emoji(
+  base: '💐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bouquet:',
+    ':flowers:',
+  ],
+  animated: false,
+);
+
+/// The 🌹 emoji.
+const rose = Emoji(
+  base: '🌹',
+  alternates: [],
+  emoticons: [
+    "@-,-'-,-",
+  ],
+  shortcodes: [
+    ':rose:',
+  ],
+  animated: true,
+);
+
+/// The 🥀 emoji.
+const wiltedFlower = Emoji(
+  base: '🥀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wilted-flower:',
+  ],
+  animated: true,
+);
+
+/// The 🌺 emoji.
+const hibiscus = Emoji(
+  base: '🌺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hibiscus:',
+  ],
+  animated: false,
+);
+
+/// The 🌷 emoji.
+const tulip = Emoji(
+  base: '🌷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tulip:',
+  ],
+  animated: false,
+);
+
+/// The 🪷 emoji.
+const lotus = Emoji(
+  base: '🪷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lotus:',
+  ],
+  animated: false,
+);
+
+/// The 🌸 emoji.
+const cherryBlossom = Emoji(
+  base: '🌸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cherry-blossom:',
+  ],
+  animated: false,
+);
+
+/// The 💮 emoji.
+const whiteFlower = Emoji(
+  base: '💮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':white-flower:',
+  ],
+  animated: false,
+);
+
+/// The 🏵️ emoji.
+const rosette = Emoji(
+  base: '🏵️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rosette:',
+  ],
+  animated: false,
+);
+
+/// The 🪻 emoji.
+const hyacinth = Emoji(
+  base: '🪻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hyacinth:',
+  ],
+  animated: false,
+);
+
+/// The 🌻 emoji.
+const sunflower = Emoji(
+  base: '🌻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sunflower:',
+  ],
+  animated: false,
+);
+
+/// The 🌼 emoji.
+const blossom = Emoji(
+  base: '🌼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':blossom:',
+  ],
+  animated: false,
+);
+
+/// The 🍂 emoji.
+const fallenLeaf = Emoji(
+  base: '🍂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fallen-leaf:',
+  ],
+  animated: true,
+);
+
+/// The 🍁 emoji.
+const mapleLeaf = Emoji(
+  base: '🍁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':maple-leaf:',
+  ],
+  animated: false,
+);
+
+/// The 🍄 emoji.
+const mushroom = Emoji(
+  base: '🍄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mushroom:',
+  ],
+  animated: false,
+);
+
+/// The 🌾 emoji.
+const earOfRice = Emoji(
+  base: '🌾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ear-of-rice:',
+  ],
+  animated: false,
+);
+
+/// The 🌱 emoji.
+const plant = Emoji(
+  base: '🌱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':plant:',
+    ':seed:',
+  ],
+  animated: true,
+);
+
+/// The 🌿 emoji.
+const herb = Emoji(
+  base: '🌿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':herb:',
+  ],
+  animated: false,
+);
+
+/// The 🍃 emoji.
+const leaves = Emoji(
+  base: '🍃',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':leaves:',
+  ],
+  animated: false,
+);
+
+/// The ☘️ emoji.
+const shamrock = Emoji(
+  base: '☘️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shamrock:',
+  ],
+  animated: false,
+);
+
+/// The 🍀 emoji.
+const luck = Emoji(
+  base: '🍀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':luck:',
+    ':four-leaf-clover:',
+  ],
+  animated: true,
+);
+
+/// The 🪴 emoji.
+const pottedPlant = Emoji(
+  base: '🪴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':potted-plant:',
+  ],
+  animated: false,
+);
+
+/// The 🌵 emoji.
+const cactus = Emoji(
+  base: '🌵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cactus:',
+  ],
+  animated: false,
+);
+
+/// The 🌴 emoji.
+const palmTree = Emoji(
+  base: '🌴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':palm-tree:',
+  ],
+  animated: false,
+);
+
+/// The 🌳 emoji.
+const deciduousTree = Emoji(
+  base: '🌳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':deciduous-tree:',
+  ],
+  animated: false,
+);
+
+/// The 🌲 emoji.
+const evergreenTree = Emoji(
+  base: '🌲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':evergreen-tree:',
+  ],
+  animated: false,
+);
+
+/// The 🪵 emoji.
+const wood = Emoji(
+  base: '🪵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wood:',
+  ],
+  animated: false,
+);
+
+/// The 🪹 emoji.
+const nest = Emoji(
+  base: '🪹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':nest:',
+  ],
+  animated: false,
+);
+
+/// The 🪺 emoji.
+const nestWithEggs = Emoji(
+  base: '🪺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':nest-with-eggs:',
+  ],
+  animated: false,
+);
+
+/// The 🪨 emoji.
+const rock = Emoji(
+  base: '🪨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rock:',
+  ],
+  animated: false,
+);
+
+/// The ⛰️ emoji.
+const mountain = Emoji(
+  base: '⛰️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mountain:',
+  ],
+  animated: false,
+);
+
+/// The 🏔️ emoji.
+const snowMountain = Emoji(
+  base: '🏔️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':snow-mountain:',
+  ],
+  animated: false,
+);
+
+/// The ❄️ emoji.
+const snowflake = Emoji(
+  base: '❄️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':snowflake:',
+    ':winter:',
+    ':cold:',
+  ],
+  animated: true,
+);
+
+/// The ☃️ emoji.
+const snowmanWithSnow = Emoji(
+  base: '☃️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':snowman-with-snow:',
+  ],
+  animated: false,
+);
+
+/// The ⛄ emoji.
+const snowman = Emoji(
+  base: '⛄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':snowman:',
+  ],
+  animated: false,
+);
+
+/// The 🌫️ emoji.
+const fog = Emoji(
+  base: '🌫️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fog:',
+  ],
+  animated: false,
+);
+
+/// The 🌡️ emoji.
+const thermometer = Emoji(
+  base: '🌡️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':thermometer:',
+  ],
+  animated: false,
+);
+
+/// The 🌋 emoji.
+const volcano = Emoji(
+  base: '🌋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':volcano:',
+  ],
+  animated: true,
+);
+
+/// The 🏜️ emoji.
+const desert = Emoji(
+  base: '🏜️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':desert:',
+  ],
+  animated: false,
+);
+
+/// The 🏞️ emoji.
+const nationalPark = Emoji(
+  base: '🏞️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':national-park:',
+  ],
+  animated: false,
+);
+
+/// The 🏝️ emoji.
+const desertIsland = Emoji(
+  base: '🏝️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':desert-island:',
+  ],
+  animated: false,
+);
+
+/// The 🏖️ emoji.
+const beach = Emoji(
+  base: '🏖️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':beach:',
+  ],
+  animated: false,
+);
+
+/// The 🌅 emoji.
+const sunrise = Emoji(
+  base: '🌅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sunrise:',
+  ],
+  animated: true,
+);
+
+/// The 🌄 emoji.
+const sunriseOverMountains = Emoji(
+  base: '🌄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sunrise-over-mountains:',
+  ],
+  animated: true,
+);
+
+/// The 🌈 emoji.
+const rainbow = Emoji(
+  base: '🌈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rainbow:',
+  ],
+  animated: true,
+);
+
+/// The 🫧 emoji.
+const bubbles = Emoji(
+  base: '🫧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bubbles:',
+  ],
+  animated: false,
+);
+
+/// The 🌊 emoji.
+const ocean = Emoji(
+  base: '🌊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ocean:',
+  ],
+  animated: false,
+);
+
+/// The 🌬️ emoji.
+const windFace = Emoji(
+  base: '🌬️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wind-face:',
+  ],
+  animated: true,
+);
+
+/// The 🌀 emoji.
+const cyclone = Emoji(
+  base: '🌀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cyclone:',
+  ],
+  animated: false,
+);
+
+/// The 🌪️ emoji.
+const tornado = Emoji(
+  base: '🌪️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tornado:',
+  ],
+  animated: false,
+);
+
+/// The ⚡ emoji.
+const electricity = Emoji(
+  base: '⚡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':electricity:',
+    ':zap:',
+    ':lightning:',
+  ],
+  animated: true,
+);
+
+/// The ☔ emoji.
+const umbrellaInRain = Emoji(
+  base: '☔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':umbrella-in-rain:',
+  ],
+  animated: false,
+);
+
+/// The 💧 emoji.
+const droplet = Emoji(
+  base: '💧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':droplet:',
+  ],
+  animated: false,
+);
+
+/// The 🌧️ emoji.
+const rainCloud = Emoji(
+  base: '🌧️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rain-cloud:',
+  ],
+  animated: false,
+);
+
+/// The 🌩️ emoji.
+const cloudWithLightning = Emoji(
+  base: '🌩️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cloud-with-lightning:',
+  ],
+  animated: false,
+);
+
+/// The ⛈️ emoji.
+const cloudWithLightningAndRain = Emoji(
+  base: '⛈️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cloud-with-lightning-and-rain:',
+  ],
+  animated: false,
+);
+
+/// The 🌨️ emoji.
+const cloudWithSnow = Emoji(
+  base: '🌨️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cloud-with-snow:',
+  ],
+  animated: false,
+);
+
+/// The ☁️ emoji.
+const cloud = Emoji(
+  base: '☁️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cloud:',
+  ],
+  animated: false,
+);
+
+/// The 🌦️ emoji.
+const sunBehindRainCloud = Emoji(
+  base: '🌦️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sun-behind-rain-cloud:',
+  ],
+  animated: false,
+);
+
+/// The 🌥️ emoji.
+const sunBehindLargeCloud = Emoji(
+  base: '🌥️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sun-behind-large-cloud:',
+  ],
+  animated: false,
+);
+
+/// The ⛅ emoji.
+const partlySunny = Emoji(
+  base: '⛅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':partly-sunny:',
+  ],
+  animated: false,
+);
+
+/// The 🌤️ emoji.
+const sunBehindSmallCloud = Emoji(
+  base: '🌤️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sun-behind-small-cloud:',
+  ],
+  animated: false,
+);
+
+/// The ☀️ emoji.
+const sunny = Emoji(
+  base: '☀️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sunny:',
+  ],
+  animated: false,
+);
+
+/// The 🌙 emoji.
+const crescentMoon = Emoji(
+  base: '🌙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':crescent-moon:',
+  ],
+  animated: false,
+);
+
+/// The ☄️ emoji.
+const comet = Emoji(
+  base: '☄️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':comet:',
+  ],
+  animated: true,
+);
+
+/// The 🌠 emoji.
+const shootingStar = Emoji(
+  base: '🌠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shooting-star:',
+  ],
+  animated: false,
+);
+
+/// The 🌌 emoji.
+const milkyWay = Emoji(
+  base: '🌌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':milky-way:',
+  ],
+  animated: false,
+);
+
+/// The 🌍 emoji.
+const globeShowingEuropeAfrica = Emoji(
+  base: '🌍',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':globe-showing-Europe-Africa:',
+  ],
+  animated: true,
+);
+
+/// The 🌎 emoji.
+const globeShowingAmericas = Emoji(
+  base: '🌎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':globe-showing-Americas:',
+  ],
+  animated: false,
+);
+
+/// The 🌏 emoji.
+const globeShowingAsiaAustralia = Emoji(
+  base: '🌏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':globe-showing-Asia-Australia:',
+  ],
+  animated: false,
+);
+
+/// The 🪐 emoji.
+const ringedPlanet = Emoji(
+  base: '🪐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ringed-planet:',
+  ],
+  animated: false,
+);
+
+/// The 🌑 emoji.
+const newMoon = Emoji(
+  base: '🌑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':new-moon:',
+  ],
+  animated: false,
+);
+
+/// The 🌒 emoji.
+const waxingCrescentMoon = Emoji(
+  base: '🌒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':waxing-crescent-moon:',
+  ],
+  animated: false,
+);
+
+/// The 🌓 emoji.
+const firstQuarterMoon = Emoji(
+  base: '🌓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':first-quarter-moon:',
+  ],
+  animated: false,
+);
+
+/// The 🌔 emoji.
+const waxingGibbousMoon = Emoji(
+  base: '🌔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':waxing-gibbous-moon:',
+  ],
+  animated: false,
+);
+
+/// The 🌕 emoji.
+const fullMoon = Emoji(
+  base: '🌕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':full-moon:',
+  ],
+  animated: false,
+);
+
+/// The 🌖 emoji.
+const waningGibbousMoon = Emoji(
+  base: '🌖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':waning-gibbous-moon:',
+  ],
+  animated: false,
+);
+
+/// The 🌗 emoji.
+const lastQuarterMoon = Emoji(
+  base: '🌗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':last-quarter-moon:',
+  ],
+  animated: false,
+);
+
+/// The 🌘 emoji.
+const waningCrescentMoon = Emoji(
+  base: '🌘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':waning-crescent-moon:',
+  ],
+  animated: false,
+);
+
+/// The 🐵 emoji.
+const monkeyFace = Emoji(
+  base: '🐵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':monkey-face:',
+  ],
+  animated: false,
+);
+
+/// The 🦁 emoji.
+const lionFace = Emoji(
+  base: '🦁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lion-face:',
+  ],
+  animated: false,
+);
+
+/// The 🐯 emoji.
+const tigerFace = Emoji(
+  base: '🐯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tiger-face:',
+  ],
+  animated: false,
+);
+
+/// The 🐱 emoji.
+const catFace = Emoji(
+  base: '🐱',
+  alternates: [],
+  emoticons: [
+    '=^.^=',
+  ],
+  shortcodes: [
+    ':cat-face:',
+  ],
+  animated: false,
+);
+
+/// The 🐶 emoji.
+const dogFace = Emoji(
+  base: '🐶',
+  alternates: [],
+  emoticons: [
+    '▼・ᴥ・▼',
+  ],
+  shortcodes: [
+    ':dog-face:',
+  ],
+  animated: false,
+);
+
+/// The 🐺 emoji.
+const wolf = Emoji(
+  base: '🐺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wolf:',
+  ],
+  animated: false,
+);
+
+/// The 🐻 emoji.
+const bearFace = Emoji(
+  base: '🐻',
+  alternates: [],
+  emoticons: [
+    'ʕ·ᴥ·ʔ',
+  ],
+  shortcodes: [
+    ':bear-face:',
+  ],
+  animated: false,
+);
+
+/// The 🐻‍❄️ emoji.
+const polarBear = Emoji(
+  base: '🐻‍❄️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':polar-bear:',
+  ],
+  animated: false,
+);
+
+/// The 🐨 emoji.
+const koala = Emoji(
+  base: '🐨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':koala:',
+  ],
+  animated: false,
+);
+
+/// The 🐼 emoji.
+const panda = Emoji(
+  base: '🐼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':panda:',
+  ],
+  animated: false,
+);
+
+/// The 🐹 emoji.
+const hamster = Emoji(
+  base: '🐹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hamster:',
+  ],
+  animated: false,
+);
+
+/// The 🐭 emoji.
+const mouseFace = Emoji(
+  base: '🐭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mouse-face:',
+  ],
+  animated: false,
+);
+
+/// The 🐰 emoji.
+const rabbitFace = Emoji(
+  base: '🐰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rabbit-face:',
+  ],
+  animated: false,
+);
+
+/// The 🦊 emoji.
+const foxFace = Emoji(
+  base: '🦊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fox-face:',
+  ],
+  animated: false,
+);
+
+/// The 🦝 emoji.
+const raccoon = Emoji(
+  base: '🦝',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':raccoon:',
+  ],
+  animated: false,
+);
+
+/// The 🐮 emoji.
+const cowFace = Emoji(
+  base: '🐮',
+  alternates: [],
+  emoticons: [
+    '3:O',
+  ],
+  shortcodes: [
+    ':cow-face:',
+  ],
+  animated: false,
+);
+
+/// The 🐷 emoji.
+const pigFace = Emoji(
+  base: '🐷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pig-face:',
+  ],
+  animated: false,
+);
+
+/// The 🐽 emoji.
+const snout = Emoji(
+  base: '🐽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':snout:',
+  ],
+  animated: false,
+);
+
+/// The 🐗 emoji.
+const boar = Emoji(
+  base: '🐗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':boar:',
+  ],
+  animated: false,
+);
+
+/// The 🦓 emoji.
+const zebra = Emoji(
+  base: '🦓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':zebra:',
+  ],
+  animated: false,
+);
+
+/// The 🦄 emoji.
+const unicorn = Emoji(
+  base: '🦄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':unicorn:',
+  ],
+  animated: true,
+);
+
+/// The 🐴 emoji.
+const horseFace = Emoji(
+  base: '🐴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':horse-face:',
+  ],
+  animated: false,
+);
+
+/// The 🫎 emoji.
+const moose = Emoji(
+  base: '🫎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':moose:',
+  ],
+  animated: false,
+);
+
+/// The 🐲 emoji.
+const dragonFace = Emoji(
+  base: '🐲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dragon-face:',
+  ],
+  animated: false,
+);
+
+/// The 🦎 emoji.
+const lizard = Emoji(
+  base: '🦎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lizard:',
+  ],
+  animated: true,
+);
+
+/// The 🐉 emoji.
+const dragon = Emoji(
+  base: '🐉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dragon:',
+  ],
+  animated: true,
+);
+
+/// The 🦖 emoji.
+const tRex = Emoji(
+  base: '🦖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':t-rex:',
+  ],
+  animated: true,
+);
+
+/// The 🦕 emoji.
+const dinosaur = Emoji(
+  base: '🦕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dinosaur:',
+  ],
+  animated: false,
+);
+
+/// The 🐢 emoji.
+const turtle = Emoji(
+  base: '🐢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':turtle:',
+  ],
+  animated: true,
+);
+
+/// The 🐊 emoji.
+const crocodile = Emoji(
+  base: '🐊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':crocodile:',
+  ],
+  animated: false,
+);
+
+/// The 🐍 emoji.
+const snake = Emoji(
+  base: '🐍',
+  alternates: [],
+  emoticons: [
+    '～>゜）～～～～',
+  ],
+  shortcodes: [
+    ':snake:',
+  ],
+  animated: true,
+);
+
+/// The 🐸 emoji.
+const frog = Emoji(
+  base: '🐸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':frog:',
+  ],
+  animated: true,
+);
+
+/// The 🐇 emoji.
+const rabbit = Emoji(
+  base: '🐇',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rabbit:',
+  ],
+  animated: true,
+);
+
+/// The 🐁 emoji.
+const mouse = Emoji(
+  base: '🐁',
+  alternates: [],
+  emoticons: [
+    '<:3)~',
+  ],
+  shortcodes: [
+    ':mouse:',
+  ],
+  animated: false,
+);
+
+/// The 🐀 emoji.
+const rat = Emoji(
+  base: '🐀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rat:',
+  ],
+  animated: true,
+);
+
+/// The 🐈 emoji.
+const cat = Emoji(
+  base: '🐈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cat:',
+  ],
+  animated: false,
+);
+
+/// The 🐈‍⬛ emoji.
+const blackCat = Emoji(
+  base: '🐈‍⬛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':black-cat:',
+  ],
+  animated: false,
+);
+
+/// The 🐩 emoji.
+const poodle = Emoji(
+  base: '🐩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':poodle:',
+  ],
+  animated: false,
+);
+
+/// The 🐕 emoji.
+const dog = Emoji(
+  base: '🐕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dog:',
+  ],
+  animated: true,
+);
+
+/// The 🦮 emoji.
+const guideDog = Emoji(
+  base: '🦮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':guide-dog:',
+  ],
+  animated: false,
+);
+
+/// The 🐕‍🦺 emoji.
+const serviceDog = Emoji(
+  base: '🐕‍🦺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':service-dog:',
+  ],
+  animated: false,
+);
+
+/// The 🐖 emoji.
+const pig = Emoji(
+  base: '🐖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pig:',
+  ],
+  animated: true,
+);
+
+/// The 🐎 emoji.
+const racehorse = Emoji(
+  base: '🐎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':racehorse:',
+  ],
+  animated: true,
+);
+
+/// The 🫏 emoji.
+const donkey = Emoji(
+  base: '🫏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':donkey:',
+  ],
+  animated: true,
+);
+
+/// The 🐄 emoji.
+const cow = Emoji(
+  base: '🐄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cow:',
+  ],
+  animated: false,
+);
+
+/// The 🐂 emoji.
+const ox = Emoji(
+  base: '🐂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ox:',
+  ],
+  animated: true,
+);
+
+/// The 🐃 emoji.
+const waterBuffalo = Emoji(
+  base: '🐃',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':water-buffalo:',
+  ],
+  animated: false,
+);
+
+/// The 🦬 emoji.
+const bison = Emoji(
+  base: '🦬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bison:',
+  ],
+  animated: false,
+);
+
+/// The 🐏 emoji.
+const ram = Emoji(
+  base: '🐏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ram:',
+  ],
+  animated: false,
+);
+
+/// The 🐑 emoji.
+const sheep = Emoji(
+  base: '🐑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sheep:',
+    ':ewe:',
+  ],
+  animated: false,
+);
+
+/// The 🐐 emoji.
+const goat = Emoji(
+  base: '🐐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':goat:',
+  ],
+  animated: true,
+);
+
+/// The 🦌 emoji.
+const deer = Emoji(
+  base: '🦌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':deer:',
+  ],
+  animated: false,
+);
+
+/// The 🦙 emoji.
+const llama = Emoji(
+  base: '🦙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':llama:',
+  ],
+  animated: false,
+);
+
+/// The 🦥 emoji.
+const sloth = Emoji(
+  base: '🦥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sloth:',
+  ],
+  animated: false,
+);
+
+/// The 🦘 emoji.
+const kangaroo = Emoji(
+  base: '🦘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':kangaroo:',
+  ],
+  animated: true,
+);
+
+/// The 🐘 emoji.
+const elephant = Emoji(
+  base: '🐘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':elephant:',
+  ],
+  animated: false,
+);
+
+/// The 🦣 emoji.
+const mammoth = Emoji(
+  base: '🦣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mammoth:',
+  ],
+  animated: false,
+);
+
+/// The 🦏 emoji.
+const rhino = Emoji(
+  base: '🦏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rhino:',
+    ':rhinoceros:',
+  ],
+  animated: false,
+);
+
+/// The 🦛 emoji.
+const hippo = Emoji(
+  base: '🦛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hippo:',
+  ],
+  animated: false,
+);
+
+/// The 🦒 emoji.
+const giraffe = Emoji(
+  base: '🦒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':giraffe:',
+  ],
+  animated: false,
+);
+
+/// The 🐆 emoji.
+const leopard = Emoji(
+  base: '🐆',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':leopard:',
+  ],
+  animated: false,
+);
+
+/// The 🐅 emoji.
+const tiger = Emoji(
+  base: '🐅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tiger:',
+  ],
+  animated: true,
+);
+
+/// The 🐒 emoji.
+const monkey = Emoji(
+  base: '🐒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':monkey:',
+  ],
+  animated: true,
+);
+
+/// The 🦍 emoji.
+const gorilla = Emoji(
+  base: '🦍',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':gorilla:',
+  ],
+  animated: false,
+);
+
+/// The 🦧 emoji.
+const orangutan = Emoji(
+  base: '🦧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':orangutan:',
+  ],
+  animated: false,
+);
+
+/// The 🐪 emoji.
+const camel = Emoji(
+  base: '🐪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':camel:',
+  ],
+  animated: false,
+);
+
+/// The 🐫 emoji.
+const bactrianCamel = Emoji(
+  base: '🐫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bactrian-camel:',
+  ],
+  animated: false,
+);
+
+/// The 🐿️ emoji.
+const chipmunk = Emoji(
+  base: '🐿️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':chipmunk:',
+  ],
+  animated: true,
+);
+
+/// The 🦫 emoji.
+const beaver = Emoji(
+  base: '🦫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':beaver:',
+  ],
+  animated: false,
+);
+
+/// The 🦨 emoji.
+const skunk = Emoji(
+  base: '🦨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':skunk:',
+  ],
+  animated: false,
+);
+
+/// The 🦡 emoji.
+const badger = Emoji(
+  base: '🦡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':badger:',
+  ],
+  animated: false,
+);
+
+/// The 🦔 emoji.
+const hedgehog = Emoji(
+  base: '🦔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hedgehog:',
+  ],
+  animated: false,
+);
+
+/// The 🦦 emoji.
+const otter = Emoji(
+  base: '🦦',
+  alternates: [],
+  emoticons: [
+    '(:3ꇤ⁐ꃳ',
+  ],
+  shortcodes: [
+    ':otter:',
+  ],
+  animated: true,
+);
+
+/// The 🦇 emoji.
+const bat = Emoji(
+  base: '🦇',
+  alternates: [],
+  emoticons: [
+    '⎛⎝(•ⱅ•)⎠⎞',
+  ],
+  shortcodes: [
+    ':bat:',
+  ],
+  animated: true,
+);
+
+/// The 🪽 emoji.
+const wingfly = Emoji(
+  base: '🪽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wing:; :fly:',
+  ],
+  animated: false,
+);
+
+/// The 🪶 emoji.
+const feather = Emoji(
+  base: '🪶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':feather:',
+  ],
+  animated: false,
+);
+
+/// The 🐦 emoji.
+const bird = Emoji(
+  base: '🐦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bird:',
+  ],
+  animated: false,
+);
+
+/// The 🐦‍⬛ emoji.
+const blackBird = Emoji(
+  base: '🐦‍⬛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':black-bird:',
+  ],
+  animated: false,
+);
+
+/// The 🐓 emoji.
+const rooster = Emoji(
+  base: '🐓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rooster:',
+  ],
+  animated: true,
+);
+
+/// The 🐔 emoji.
+const chicken = Emoji(
+  base: '🐔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':chicken:',
+  ],
+  animated: false,
+);
+
+/// The 🐣 emoji.
+const hatchingChick = Emoji(
+  base: '🐣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hatching-chick:',
+  ],
+  animated: true,
+);
+
+/// The 🐤 emoji.
+const babyChick = Emoji(
+  base: '🐤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':baby-chick:',
+  ],
+  animated: true,
+);
+
+/// The 🐥 emoji.
+const hatchedChick = Emoji(
+  base: '🐥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hatched-chick:',
+  ],
+  animated: true,
+);
+
+/// The 🦅 emoji.
+const eagle = Emoji(
+  base: '🦅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eagle:',
+  ],
+  animated: true,
+);
+
+/// The 🦉 emoji.
+const owl = Emoji(
+  base: '🦉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':owl:',
+  ],
+  animated: false,
+);
+
+/// The 🦜 emoji.
+const parrot = Emoji(
+  base: '🦜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':parrot:',
+  ],
+  animated: false,
+);
+
+/// The 🕊️ emoji.
+const peace = Emoji(
+  base: '🕊️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':peace:',
+    ':dove:',
+  ],
+  animated: true,
+);
+
+/// The 🦤 emoji.
+const dodo = Emoji(
+  base: '🦤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dodo:',
+  ],
+  animated: false,
+);
+
+/// The 🦢 emoji.
+const swan = Emoji(
+  base: '🦢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':swan:',
+  ],
+  animated: false,
+);
+
+/// The 🦆 emoji.
+const duck = Emoji(
+  base: '🦆',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':duck:',
+  ],
+  animated: false,
+);
+
+/// The 🪿 emoji.
+const goose = Emoji(
+  base: '🪿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':goose:',
+  ],
+  animated: true,
+);
+
+/// The 🦩 emoji.
+const flamingo = Emoji(
+  base: '🦩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':flamingo:',
+  ],
+  animated: false,
+);
+
+/// The 🦚 emoji.
+const peacock = Emoji(
+  base: '🦚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':peacock:',
+  ],
+  animated: true,
+);
+
+/// The 🦃 emoji.
+const turkey = Emoji(
+  base: '🦃',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':turkey:',
+  ],
+  animated: false,
+);
+
+/// The 🐧 emoji.
+const penguin = Emoji(
+  base: '🐧',
+  alternates: [],
+  emoticons: [
+    '<(")',
+  ],
+  shortcodes: [
+    ':penguin:',
+  ],
+  animated: false,
+);
+
+/// The 🦭 emoji.
+const seal = Emoji(
+  base: '🦭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':seal:',
+  ],
+  animated: true,
+);
+
+/// The 🦈 emoji.
+const shark = Emoji(
+  base: '🦈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shark:',
+  ],
+  animated: false,
+);
+
+/// The 🐬 emoji.
+const dolphin = Emoji(
+  base: '🐬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dolphin:',
+  ],
+  animated: true,
+);
+
+/// The 🐋 emoji.
+const humpbackWhale = Emoji(
+  base: '🐋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':humpback-whale:',
+  ],
+  animated: false,
+);
+
+/// The 🐳 emoji.
+const whale = Emoji(
+  base: '🐳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':whale:',
+  ],
+  animated: true,
+);
+
+/// The 🐟 emoji.
+const fish = Emoji(
+  base: '🐟',
+  alternates: [],
+  emoticons: [
+    '<><',
+  ],
+  shortcodes: [
+    ':fish:',
+  ],
+  animated: false,
+);
+
+/// The 🐠 emoji.
+const tropicalFish = Emoji(
+  base: '🐠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tropical-fish:',
+  ],
+  animated: false,
+);
+
+/// The 🐡 emoji.
+const blowfish = Emoji(
+  base: '🐡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':blowfish:',
+  ],
+  animated: true,
+);
+
+/// The 🦐 emoji.
+const shrimp = Emoji(
+  base: '🦐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shrimp:',
+  ],
+  animated: false,
+);
+
+/// The 🦞 emoji.
+const lobster = Emoji(
+  base: '🦞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lobster:',
+  ],
+  animated: false,
+);
+
+/// The 🦀 emoji.
+const crab = Emoji(
+  base: '🦀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':crab:',
+  ],
+  animated: true,
+);
+
+/// The 🦑 emoji.
+const squid = Emoji(
+  base: '🦑',
+  alternates: [],
+  emoticons: [
+    'くコ:彡',
+  ],
+  shortcodes: [
+    ':squid:',
+  ],
+  animated: false,
+);
+
+/// The 🐙 emoji.
+const octopus = Emoji(
+  base: '🐙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':octopus:',
+  ],
+  animated: true,
+);
+
+/// The 🪼 emoji.
+const jellyfish = Emoji(
+  base: '🪼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':jellyfish:',
+  ],
+  animated: true,
+);
+
+/// The 🦪 emoji.
+const oyster = Emoji(
+  base: '🦪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':oyster:',
+  ],
+  animated: false,
+);
+
+/// The 🪸 emoji.
+const coral = Emoji(
+  base: '🪸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':coral:',
+  ],
+  animated: false,
+);
+
+/// The 🦂 emoji.
+const scorpion = Emoji(
+  base: '🦂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':scorpion:',
+  ],
+  animated: false,
+);
+
+/// The 🕷️ emoji.
+const spider = Emoji(
+  base: '🕷️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':spider:',
+  ],
+  animated: false,
+);
+
+/// The 🕸️ emoji.
+const spiderWeb = Emoji(
+  base: '🕸️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':spider-web:',
+  ],
+  animated: false,
+);
+
+/// The 🐚 emoji.
+const shell = Emoji(
+  base: '🐚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shell:',
+  ],
+  animated: false,
+);
+
+/// The 🐌 emoji.
+const snail = Emoji(
+  base: '🐌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':snail:',
+  ],
+  animated: true,
+);
+
+/// The 🐜 emoji.
+const ant = Emoji(
+  base: '🐜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ant:',
+  ],
+  animated: true,
+);
+
+/// The 🦗 emoji.
+const cricket = Emoji(
+  base: '🦗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cricket:',
+  ],
+  animated: false,
+);
+
+/// The 🪲 emoji.
+const beetle = Emoji(
+  base: '🪲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':beetle:',
+  ],
+  animated: false,
+);
+
+/// The 🦟 emoji.
+const mosquito = Emoji(
+  base: '🦟',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mosquito:',
+  ],
+  animated: true,
+);
+
+/// The 🪳 emoji.
+const cockroach = Emoji(
+  base: '🪳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cockroach:',
+  ],
+  animated: false,
+);
+
+/// The 🪰 emoji.
+const fly = Emoji(
+  base: '🪰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fly:',
+  ],
+  animated: false,
+);
+
+/// The 🐝 emoji.
+const bee = Emoji(
+  base: '🐝',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bee:',
+  ],
+  animated: true,
+);
+
+/// The 🐞 emoji.
+const ladyBug = Emoji(
+  base: '🐞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lady-bug:',
+  ],
+  animated: false,
+);
+
+/// The 🦋 emoji.
+const butterfly = Emoji(
+  base: '🦋',
+  alternates: [],
+  emoticons: [
+    'εїз',
+  ],
+  shortcodes: [
+    ':butterfly:',
+  ],
+  animated: true,
+);
+
+/// The 🐛 emoji.
+const bug = Emoji(
+  base: '🐛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bug:',
+  ],
+  animated: false,
+);
+
+/// The 🪱 emoji.
+const worm = Emoji(
+  base: '🪱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':worm:',
+  ],
+  animated: false,
+);
+
+/// The 🐾 emoji.
+const pawprints = Emoji(
+  base: '🐾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':paw prints:',
+  ],
+  animated: true,
+);
+
+/// The 🍓 emoji.
+const strawberry = Emoji(
+  base: '🍓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':strawberry:',
+  ],
+  animated: false,
+);
+
+/// The 🍒 emoji.
+const cherries = Emoji(
+  base: '🍒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cherries:',
+  ],
+  animated: false,
+);
+
+/// The 🍎 emoji.
+const redApple = Emoji(
+  base: '🍎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':red-apple:',
+  ],
+  animated: false,
+);
+
+/// The 🍉 emoji.
+const watermelon = Emoji(
+  base: '🍉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':watermelon:',
+  ],
+  animated: false,
+);
+
+/// The 🍑 emoji.
+const peach = Emoji(
+  base: '🍑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':peach:',
+  ],
+  animated: false,
+);
+
+/// The 🍊 emoji.
+const tangerine = Emoji(
+  base: '🍊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tangerine:',
+    ':orange:',
+    ':mandarin:',
+  ],
+  animated: false,
+);
+
+/// The 🥭 emoji.
+const mango = Emoji(
+  base: '🥭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mango:',
+  ],
+  animated: false,
+);
+
+/// The 🍍 emoji.
+const pineapple = Emoji(
+  base: '🍍',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pineapple:',
+  ],
+  animated: false,
+);
+
+/// The 🍌 emoji.
+const banana = Emoji(
+  base: '🍌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':banana:',
+  ],
+  animated: false,
+);
+
+/// The 🍋 emoji.
+const lemon = Emoji(
+  base: '🍋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lemon:',
+  ],
+  animated: false,
+);
+
+/// The 🍈 emoji.
+const melon = Emoji(
+  base: '🍈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':melon:',
+  ],
+  animated: false,
+);
+
+/// The 🍏 emoji.
+const greenApple = Emoji(
+  base: '🍏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':green-apple:',
+  ],
+  animated: false,
+);
+
+/// The 🍐 emoji.
+const pear = Emoji(
+  base: '🍐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pear:',
+  ],
+  animated: false,
+);
+
+/// The 🥝 emoji.
+const kiwiFruit = Emoji(
+  base: '🥝',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':kiwi-fruit:',
+  ],
+  animated: false,
+);
+
+/// The 🫒 emoji.
+const olive = Emoji(
+  base: '🫒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':olive:',
+  ],
+  animated: false,
+);
+
+/// The 🫐 emoji.
+const blueberries = Emoji(
+  base: '🫐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':blueberries:',
+  ],
+  animated: false,
+);
+
+/// The 🍇 emoji.
+const grapes = Emoji(
+  base: '🍇',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':grapes:',
+  ],
+  animated: false,
+);
+
+/// The 🥥 emoji.
+const coconut = Emoji(
+  base: '🥥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':coconut:',
+  ],
+  animated: false,
+);
+
+/// The 🍅 emoji.
+const tomato = Emoji(
+  base: '🍅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tomato:',
+  ],
+  animated: true,
+);
+
+/// The 🌶️ emoji.
+const hotPepper = Emoji(
+  base: '🌶️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hot-pepper:',
+  ],
+  animated: false,
+);
+
+/// The 🫚 emoji.
+const ginger = Emoji(
+  base: '🫚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ginger:',
+  ],
+  animated: false,
+);
+
+/// The 🥕 emoji.
+const carrot = Emoji(
+  base: '🥕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':carrot:',
+  ],
+  animated: false,
+);
+
+/// The 🍠 emoji.
+const roastedSweetPotato = Emoji(
+  base: '🍠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':roasted-sweet-potato:',
+  ],
+  animated: false,
+);
+
+/// The 🧅 emoji.
+const onion = Emoji(
+  base: '🧅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':onion:',
+  ],
+  animated: false,
+);
+
+/// The 🌽 emoji.
+const earOfCorn = Emoji(
+  base: '🌽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ear-of-corn:',
+  ],
+  animated: false,
+);
+
+/// The 🥦 emoji.
+const broccoli = Emoji(
+  base: '🥦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':broccoli:',
+  ],
+  animated: false,
+);
+
+/// The 🥒 emoji.
+const cucumber = Emoji(
+  base: '🥒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cucumber:',
+  ],
+  animated: false,
+);
+
+/// The 🥬 emoji.
+const leafyGreen = Emoji(
+  base: '🥬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':leafy-green:',
+  ],
+  animated: false,
+);
+
+/// The 🫛 emoji.
+const peaPod = Emoji(
+  base: '🫛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pea-pod:',
+  ],
+  animated: false,
+);
+
+/// The 🫑 emoji.
+const bellPepper = Emoji(
+  base: '🫑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bell-pepper:',
+  ],
+  animated: false,
+);
+
+/// The 🥑 emoji.
+const avocado = Emoji(
+  base: '🥑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':avocado:',
+  ],
+  animated: false,
+);
+
+/// The 🍆 emoji.
+const eggplant = Emoji(
+  base: '🍆',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eggplant:',
+  ],
+  animated: false,
+);
+
+/// The 🧄 emoji.
+const garlic = Emoji(
+  base: '🧄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':garlic:',
+  ],
+  animated: false,
+);
+
+/// The 🥔 emoji.
+const potato = Emoji(
+  base: '🥔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':potato:',
+  ],
+  animated: false,
+);
+
+/// The 🫘 emoji.
+const beans = Emoji(
+  base: '🫘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':beans:',
+  ],
+  animated: false,
+);
+
+/// The 🌰 emoji.
+const chestnut = Emoji(
+  base: '🌰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':chestnut:',
+  ],
+  animated: false,
+);
+
+/// The 🥜 emoji.
+const peanuts = Emoji(
+  base: '🥜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':peanuts:',
+  ],
+  animated: false,
+);
+
+/// The 🍞 emoji.
+const bread = Emoji(
+  base: '🍞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bread:',
+  ],
+  animated: false,
+);
+
+/// The 🫓 emoji.
+const flatbread = Emoji(
+  base: '🫓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':flatbread:',
+  ],
+  animated: false,
+);
+
+/// The 🥐 emoji.
+const croissant = Emoji(
+  base: '🥐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':croissant:',
+  ],
+  animated: false,
+);
+
+/// The 🥖 emoji.
+const baguetteBread = Emoji(
+  base: '🥖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':baguette-bread:',
+  ],
+  animated: false,
+);
+
+/// The 🥯 emoji.
+const bagel = Emoji(
+  base: '🥯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bagel:',
+  ],
+  animated: false,
+);
+
+/// The 🧇 emoji.
+const waffle = Emoji(
+  base: '🧇',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':waffle:',
+  ],
+  animated: false,
+);
+
+/// The 🥞 emoji.
+const pancakes = Emoji(
+  base: '🥞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pancakes:',
+  ],
+  animated: false,
+);
+
+/// The 🍳 emoji.
+const cooking = Emoji(
+  base: '🍳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cooking:',
+  ],
+  animated: false,
+);
+
+/// The 🥚 emoji.
+const egg = Emoji(
+  base: '🥚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':egg:',
+  ],
+  animated: false,
+);
+
+/// The 🧀 emoji.
+const cheeseWedge = Emoji(
+  base: '🧀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cheese-wedge:',
+  ],
+  animated: false,
+);
+
+/// The 🥓 emoji.
+const bacon = Emoji(
+  base: '🥓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bacon:',
+  ],
+  animated: false,
+);
+
+/// The 🥩 emoji.
+const cutOfMeat = Emoji(
+  base: '🥩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cut-of-meat:',
+  ],
+  animated: false,
+);
+
+/// The 🍗 emoji.
+const poultryLeg = Emoji(
+  base: '🍗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':poultry-leg:',
+  ],
+  animated: false,
+);
+
+/// The 🍖 emoji.
+const meatOnBone = Emoji(
+  base: '🍖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':meat-on-bone:',
+  ],
+  animated: false,
+);
+
+/// The 🍔 emoji.
+const hamburger = Emoji(
+  base: '🍔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hamburger:',
+  ],
+  animated: false,
+);
+
+/// The 🌭 emoji.
+const hotDog = Emoji(
+  base: '🌭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hot-dog:',
+  ],
+  animated: false,
+);
+
+/// The 🥪 emoji.
+const sandwich = Emoji(
+  base: '🥪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sandwich:',
+  ],
+  animated: false,
+);
+
+/// The 🥨 emoji.
+const pretzel = Emoji(
+  base: '🥨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pretzel:',
+  ],
+  animated: false,
+);
+
+/// The 🍟 emoji.
+const frenchFries = Emoji(
+  base: '🍟',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':french-fries:',
+  ],
+  animated: false,
+);
+
+/// The 🍕 emoji.
+const pizza = Emoji(
+  base: '🍕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pizza:',
+  ],
+  animated: false,
+);
+
+/// The 🫔 emoji.
+const tamale = Emoji(
+  base: '🫔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tamale:',
+  ],
+  animated: false,
+);
+
+/// The 🌮 emoji.
+const taco = Emoji(
+  base: '🌮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':taco:',
+  ],
+  animated: false,
+);
+
+/// The 🌯 emoji.
+const burrito = Emoji(
+  base: '🌯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':burrito:',
+  ],
+  animated: false,
+);
+
+/// The 🥙 emoji.
+const stuffedFlatbread = Emoji(
+  base: '🥙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':stuffed-flatbread:',
+  ],
+  animated: false,
+);
+
+/// The 🧆 emoji.
+const falafel = Emoji(
+  base: '🧆',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':falafel:',
+  ],
+  animated: false,
+);
+
+/// The 🥘 emoji.
+const shallowPanOfFood = Emoji(
+  base: '🥘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shallow-pan-of-food:',
+  ],
+  animated: false,
+);
+
+/// The 🍝 emoji.
+const spaghetti = Emoji(
+  base: '🍝',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':spaghetti:',
+  ],
+  animated: false,
+);
+
+/// The 🥫 emoji.
+const cannedFood = Emoji(
+  base: '🥫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':canned-food:',
+  ],
+  animated: false,
+);
+
+/// The 🫕 emoji.
+const fondue = Emoji(
+  base: '🫕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fondue:',
+  ],
+  animated: false,
+);
+
+/// The 🥣 emoji.
+const bowlWithSpoon = Emoji(
+  base: '🥣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bowl-with-spoon:',
+  ],
+  animated: false,
+);
+
+/// The 🥗 emoji.
+const greenSalad = Emoji(
+  base: '🥗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':green-salad:',
+  ],
+  animated: false,
+);
+
+/// The 🍲 emoji.
+const potOfFood = Emoji(
+  base: '🍲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pot-of-food:',
+  ],
+  animated: false,
+);
+
+/// The 🍛 emoji.
+const curryRice = Emoji(
+  base: '🍛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':curry-rice:',
+  ],
+  animated: false,
+);
+
+/// The 🍜 emoji.
+const steamingBowl = Emoji(
+  base: '🍜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':steaming-bowl:',
+  ],
+  animated: false,
+);
+
+/// The 🍣 emoji.
+const sushi = Emoji(
+  base: '🍣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sushi:',
+  ],
+  animated: false,
+);
+
+/// The 🍤 emoji.
+const friedShrimp = Emoji(
+  base: '🍤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fried-shrimp:',
+  ],
+  animated: false,
+);
+
+/// The 🥡 emoji.
+const takeoutBox = Emoji(
+  base: '🥡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':takeout-box:',
+  ],
+  animated: false,
+);
+
+/// The 🍚 emoji.
+const cookedRice = Emoji(
+  base: '🍚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cooked-rice:',
+  ],
+  animated: false,
+);
+
+/// The 🍱 emoji.
+const bentoBox = Emoji(
+  base: '🍱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bento-box:',
+  ],
+  animated: false,
+);
+
+/// The 🥟 emoji.
+const dumpling = Emoji(
+  base: '🥟',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dumpling:',
+  ],
+  animated: false,
+);
+
+/// The 🍢 emoji.
+const oden = Emoji(
+  base: '🍢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':oden:',
+  ],
+  animated: false,
+);
+
+/// The 🍙 emoji.
+const riceBall = Emoji(
+  base: '🍙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rice-ball:',
+  ],
+  animated: false,
+);
+
+/// The 🍘 emoji.
+const riceCracker = Emoji(
+  base: '🍘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rice-cracker:',
+  ],
+  animated: false,
+);
+
+/// The 🍥 emoji.
+const fishCakeWithSwirl = Emoji(
+  base: '🍥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fish-cake-with-swirl:',
+  ],
+  animated: false,
+);
+
+/// The 🍡 emoji.
+const dango = Emoji(
+  base: '🍡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dango:',
+  ],
+  animated: false,
+);
+
+/// The 🥠 emoji.
+const fortuneCookie = Emoji(
+  base: '🥠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fortune-cookie:',
+  ],
+  animated: false,
+);
+
+/// The 🥮 emoji.
+const moonCake = Emoji(
+  base: '🥮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':moon-cake:',
+  ],
+  animated: false,
+);
+
+/// The 🍧 emoji.
+const shavedIce = Emoji(
+  base: '🍧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shaved-ice:',
+  ],
+  animated: false,
+);
+
+/// The 🍨 emoji.
+const iceCream = Emoji(
+  base: '🍨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ice-cream:',
+  ],
+  animated: false,
+);
+
+/// The 🍦 emoji.
+const softIceCream = Emoji(
+  base: '🍦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':soft-ice-cream:',
+  ],
+  animated: false,
+);
+
+/// The 🥧 emoji.
+const pie = Emoji(
+  base: '🥧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pie:',
+  ],
+  animated: false,
+);
+
+/// The 🍰 emoji.
+const shortcake = Emoji(
+  base: '🍰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shortcake:',
+  ],
+  animated: false,
+);
+
+/// The 🍮 emoji.
+const custard = Emoji(
+  base: '🍮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':custard:',
+  ],
+  animated: false,
+);
+
+/// The 🎂 emoji.
+const birthdayCake = Emoji(
+  base: '🎂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':birthday-cake:',
+  ],
+  animated: false,
+);
+
+/// The 🧁 emoji.
+const cupcake = Emoji(
+  base: '🧁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cupcake:',
+  ],
+  animated: false,
+);
+
+/// The 🍭 emoji.
+const lollipop = Emoji(
+  base: '🍭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lollipop:',
+  ],
+  animated: false,
+);
+
+/// The 🍬 emoji.
+const candy = Emoji(
+  base: '🍬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':candy:',
+  ],
+  animated: false,
+);
+
+/// The 🍫 emoji.
+const chocolateBar = Emoji(
+  base: '🍫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':chocolate-bar:',
+  ],
+  animated: false,
+);
+
+/// The 🍩 emoji.
+const doughnut = Emoji(
+  base: '🍩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':doughnut:',
+  ],
+  animated: false,
+);
+
+/// The 🍪 emoji.
+const cookie = Emoji(
+  base: '🍪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cookie:',
+  ],
+  animated: false,
+);
+
+/// The 🍯 emoji.
+const honeyPot = Emoji(
+  base: '🍯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':honey-pot:',
+  ],
+  animated: false,
+);
+
+/// The 🧂 emoji.
+const salt = Emoji(
+  base: '🧂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':salt:',
+  ],
+  animated: false,
+);
+
+/// The 🧈 emoji.
+const butter = Emoji(
+  base: '🧈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':butter:',
+  ],
+  animated: false,
+);
+
+/// The 🍿 emoji.
+const popcorn = Emoji(
+  base: '🍿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':popcorn:',
+  ],
+  animated: true,
+);
+
+/// The 🧊 emoji.
+const iceCube = Emoji(
+  base: '🧊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ice-cube:',
+  ],
+  animated: false,
+);
+
+/// The 🫙 emoji.
+const jar = Emoji(
+  base: '🫙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':jar:',
+  ],
+  animated: false,
+);
+
+/// The 🥤 emoji.
+const cupWithStraw = Emoji(
+  base: '🥤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cup-with-straw:',
+  ],
+  animated: false,
+);
+
+/// The 🧋 emoji.
+const bubbleTea = Emoji(
+  base: '🧋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bubble-tea:',
+    ':milk-tea:',
+  ],
+  animated: false,
+);
+
+/// The 🧃 emoji.
+const beverageBox = Emoji(
+  base: '🧃',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':beverage-box:',
+  ],
+  animated: false,
+);
+
+/// The 🥛 emoji.
+const glassOfMilk = Emoji(
+  base: '🥛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':glass-of-milk:',
+  ],
+  animated: false,
+);
+
+/// The 🍼 emoji.
+const babyBottle = Emoji(
+  base: '🍼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':baby-bottle:',
+  ],
+  animated: false,
+);
+
+/// The 🍵 emoji.
+const teacupWithoutHandle = Emoji(
+  base: '🍵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':teacup-without-handle:',
+  ],
+  animated: false,
+);
+
+/// The ☕ emoji.
+const hotBeverage = Emoji(
+  base: '☕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hot-beverage:',
+  ],
+  animated: true,
+);
+
+/// The 🫖 emoji.
+const teapot = Emoji(
+  base: '🫖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':teapot:',
+  ],
+  animated: false,
+);
+
+/// The 🧉 emoji.
+const mate = Emoji(
+  base: '🧉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mate:',
+  ],
+  animated: false,
+);
+
+/// The 🍺 emoji.
+const beerMug = Emoji(
+  base: '🍺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':beer-mug:',
+  ],
+  animated: false,
+);
+
+/// The 🍻 emoji.
+const clinkingBeerMugs = Emoji(
+  base: '🍻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':clinking-beer-mugs:',
+  ],
+  animated: true,
+);
+
+/// The 🥂 emoji.
+const clinkingGlasses = Emoji(
+  base: '🥂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':clinking-glasses:',
+  ],
+  animated: true,
+);
+
+/// The 🍾 emoji.
+const bottleWithPoppingCork = Emoji(
+  base: '🍾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bottle-with-popping-cork:',
+  ],
+  animated: true,
+);
+
+/// The 🍷 emoji.
+const wineGlass = Emoji(
+  base: '🍷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wine-glass:',
+  ],
+  animated: true,
+);
+
+/// The 🥃 emoji.
+const tumblerGlass = Emoji(
+  base: '🥃',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tumbler-glass:',
+  ],
+  animated: false,
+);
+
+/// The 🫗 emoji.
+const pour = Emoji(
+  base: '🫗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pour:',
+  ],
+  animated: false,
+);
+
+/// The 🍸 emoji.
+const cocktailGlass = Emoji(
+  base: '🍸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cocktail-glass:',
+  ],
+  animated: false,
+);
+
+/// The 🍹 emoji.
+const tropicalDrink = Emoji(
+  base: '🍹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tropical-drink:',
+  ],
+  animated: true,
+);
+
+/// The 🍶 emoji.
+const sake = Emoji(
+  base: '🍶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sake:',
+  ],
+  animated: false,
+);
+
+/// The 🥢 emoji.
+const chopsticks = Emoji(
+  base: '🥢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':chopsticks:',
+  ],
+  animated: false,
+);
+
+/// The 🍴 emoji.
+const forkAndKnife = Emoji(
+  base: '🍴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fork-and-knife:',
+  ],
+  animated: false,
+);
+
+/// The 🥄 emoji.
+const spoon = Emoji(
+  base: '🥄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':spoon:',
+  ],
+  animated: false,
+);
+
+/// The 🔪 emoji.
+const kitchenKnife = Emoji(
+  base: '🔪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':kitchen-knife:',
+  ],
+  animated: false,
+);
+
+/// The 🍽️ emoji.
+const forkAndKnifeWithPlate = Emoji(
+  base: '🍽️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fork-and-knife-with-plate:',
+  ],
+  animated: false,
+);
+
+/// The 🛑 emoji.
+const stopSign = Emoji(
+  base: '🛑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':stop-sign:',
+  ],
+  animated: false,
+);
+
+/// The 🚧 emoji.
+const construction = Emoji(
+  base: '🚧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':construction:',
+  ],
+  animated: false,
+);
+
+/// The 🚨 emoji.
+const policeCarLight = Emoji(
+  base: '🚨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':police-car-light:',
+  ],
+  animated: true,
+);
+
+/// The ⛽ emoji.
+const fuelPump = Emoji(
+  base: '⛽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fuel-pump:',
+  ],
+  animated: false,
+);
+
+/// The 🛢️ emoji.
+const oilDrum = Emoji(
+  base: '🛢️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':oil-drum:',
+  ],
+  animated: false,
+);
+
+/// The 🧭 emoji.
+const compass = Emoji(
+  base: '🧭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':compass:',
+  ],
+  animated: false,
+);
+
+/// The 🛞 emoji.
+const wheel = Emoji(
+  base: '🛞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wheel:',
+  ],
+  animated: false,
+);
+
+/// The 🛟 emoji.
+const ringBuoy = Emoji(
+  base: '🛟',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ring-buoy:',
+  ],
+  animated: false,
+);
+
+/// The ⚓ emoji.
+const anchor = Emoji(
+  base: '⚓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':anchor:',
+  ],
+  animated: false,
+);
+
+/// The 🚏 emoji.
+const busStop = Emoji(
+  base: '🚏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bus-stop:',
+  ],
+  animated: false,
+);
+
+/// The 🚇 emoji.
+const metro = Emoji(
+  base: '🚇',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':metro:',
+  ],
+  animated: false,
+);
+
+/// The 🚥 emoji.
+const horizontalTrafficLight = Emoji(
+  base: '🚥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':horizontal-traffic-light:',
+  ],
+  animated: false,
+);
+
+/// The 🚦 emoji.
+const verticalTrafficLight = Emoji(
+  base: '🚦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':vertical-traffic-light:',
+  ],
+  animated: false,
+);
+
+/// The 🛴 emoji.
+const kickScooter = Emoji(
+  base: '🛴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':kick-scooter:',
+  ],
+  animated: false,
+);
+
+/// The 🦽 emoji.
+const manualWheelchair = Emoji(
+  base: '🦽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':manual-wheelchair:',
+  ],
+  animated: false,
+);
+
+/// The 🦼 emoji.
+const motorizedWheelchair = Emoji(
+  base: '🦼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':motorized-wheelchair:',
+  ],
+  animated: false,
+);
+
+/// The 🩼 emoji.
+const crutch = Emoji(
+  base: '🩼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':crutch:',
+  ],
+  animated: false,
+);
+
+/// The 🚲 emoji.
+const bicycle = Emoji(
+  base: '🚲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bicycle:',
+  ],
+  animated: false,
+);
+
+/// The 🛵 emoji.
+const motorScooter = Emoji(
+  base: '🛵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':motor-scooter:',
+  ],
+  animated: false,
+);
+
+/// The 🏍️ emoji.
+const motorcycle = Emoji(
+  base: '🏍️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':motorcycle:',
+  ],
+  animated: false,
+);
+
+/// The 🚙 emoji.
+const sportUtilityVehicle = Emoji(
+  base: '🚙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sport-utility-vehicle:',
+  ],
+  animated: false,
+);
+
+/// The 🚗 emoji.
+const automobile = Emoji(
+  base: '🚗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':automobile:',
+  ],
+  animated: false,
+);
+
+/// The 🛻 emoji.
+const pickupTruck = Emoji(
+  base: '🛻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pickup-truck:',
+  ],
+  animated: false,
+);
+
+/// The 🚐 emoji.
+const minibus = Emoji(
+  base: '🚐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':minibus:',
+  ],
+  animated: false,
+);
+
+/// The 🚚 emoji.
+const deliveryTruck = Emoji(
+  base: '🚚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':delivery-truck:',
+  ],
+  animated: false,
+);
+
+/// The 🚛 emoji.
+const articulatedLorry = Emoji(
+  base: '🚛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':articulated-lorry:',
+  ],
+  animated: false,
+);
+
+/// The 🚜 emoji.
+const tractor = Emoji(
+  base: '🚜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tractor:',
+  ],
+  animated: false,
+);
+
+/// The 🏎️ emoji.
+const racingCar = Emoji(
+  base: '🏎️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':racing-car:',
+  ],
+  animated: false,
+);
+
+/// The 🚒 emoji.
+const fireEngine = Emoji(
+  base: '🚒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fire-engine:',
+  ],
+  animated: false,
+);
+
+/// The 🚑 emoji.
+const ambulance = Emoji(
+  base: '🚑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ambulance:',
+  ],
+  animated: false,
+);
+
+/// The 🚓 emoji.
+const policeCar = Emoji(
+  base: '🚓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':police-car:',
+  ],
+  animated: false,
+);
+
+/// The 🚕 emoji.
+const taxi = Emoji(
+  base: '🚕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':taxi:',
+  ],
+  animated: false,
+);
+
+/// The 🛺 emoji.
+const autoRickshaw = Emoji(
+  base: '🛺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':auto-rickshaw:',
+  ],
+  animated: false,
+);
+
+/// The 🚌 emoji.
+const bus = Emoji(
+  base: '🚌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bus:',
+  ],
+  animated: false,
+);
+
+/// The 🚈 emoji.
+const lightRail = Emoji(
+  base: '🚈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':light-rail:',
+  ],
+  animated: false,
+);
+
+/// The 🚝 emoji.
+const monorail = Emoji(
+  base: '🚝',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':monorail:',
+  ],
+  animated: false,
+);
+
+/// The 🚅 emoji.
+const bulletTrain = Emoji(
+  base: '🚅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bullet-train:',
+  ],
+  animated: false,
+);
+
+/// The 🚄 emoji.
+const highSpeedTrain = Emoji(
+  base: '🚄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':high-speed-train:',
+  ],
+  animated: false,
+);
+
+/// The 🚂 emoji.
+const locomotive = Emoji(
+  base: '🚂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':locomotive:',
+  ],
+  animated: false,
+);
+
+/// The 🚃 emoji.
+const railwayCar = Emoji(
+  base: '🚃',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':railway-car:',
+  ],
+  animated: false,
+);
+
+/// The 🚋 emoji.
+const tramCar = Emoji(
+  base: '🚋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tram-car:',
+  ],
+  animated: false,
+);
+
+/// The 🚎 emoji.
+const trolleybus = Emoji(
+  base: '🚎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':trolleybus:',
+  ],
+  animated: false,
+);
+
+/// The 🚞 emoji.
+const mountainRailway = Emoji(
+  base: '🚞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mountain-railway:',
+  ],
+  animated: false,
+);
+
+/// The 🚊 emoji.
+const tram = Emoji(
+  base: '🚊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tram:',
+  ],
+  animated: false,
+);
+
+/// The 🚉 emoji.
+const station = Emoji(
+  base: '🚉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':station:',
+  ],
+  animated: false,
+);
+
+/// The 🚍 emoji.
+const busFront = Emoji(
+  base: '🚍',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bus-front:',
+  ],
+  animated: false,
+);
+
+/// The 🚔 emoji.
+const policeCarFront = Emoji(
+  base: '🚔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':police-car-front:',
+  ],
+  animated: false,
+);
+
+/// The 🚘 emoji.
+const automobileFront = Emoji(
+  base: '🚘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':automobile-front:',
+  ],
+  animated: false,
+);
+
+/// The 🚖 emoji.
+const taxiFront = Emoji(
+  base: '🚖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':taxi-front:',
+  ],
+  animated: false,
+);
+
+/// The 🚆 emoji.
+const train = Emoji(
+  base: '🚆',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':train:',
+  ],
+  animated: false,
+);
+
+/// The 🚢 emoji.
+const ship = Emoji(
+  base: '🚢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ship:',
+  ],
+  animated: false,
+);
+
+/// The 🛳️ emoji.
+const passengerShip = Emoji(
+  base: '🛳️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':passenger-ship:',
+  ],
+  animated: false,
+);
+
+/// The 🛥️ emoji.
+const motorBoat = Emoji(
+  base: '🛥️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':motor-boat:',
+  ],
+  animated: false,
+);
+
+/// The 🚤 emoji.
+const speedboat = Emoji(
+  base: '🚤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':speedboat:',
+  ],
+  animated: false,
+);
+
+/// The ⛴️ emoji.
+const ferry = Emoji(
+  base: '⛴️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ferry:',
+  ],
+  animated: false,
+);
+
+/// The ⛵ emoji.
+const sailboat = Emoji(
+  base: '⛵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sailboat:',
+  ],
+  animated: false,
+);
+
+/// The 🛶 emoji.
+const canoe = Emoji(
+  base: '🛶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':canoe:',
+  ],
+  animated: false,
+);
+
+/// The 🚟 emoji.
+const suspensionRailway = Emoji(
+  base: '🚟',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':suspension-railway:',
+  ],
+  animated: false,
+);
+
+/// The 🚠 emoji.
+const mountainCableway = Emoji(
+  base: '🚠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mountain-cableway:',
+  ],
+  animated: false,
+);
+
+/// The 🚡 emoji.
+const aerialTramway = Emoji(
+  base: '🚡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':aerial-tramway:',
+  ],
+  animated: false,
+);
+
+/// The 🚁 emoji.
+const helicopter = Emoji(
+  base: '🚁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':helicopter:',
+  ],
+  animated: false,
+);
+
+/// The 🛸 emoji.
+const flyingSaucer = Emoji(
+  base: '🛸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':flying-saucer:',
+  ],
+  animated: true,
+);
+
+/// The 🚀 emoji.
+const rocket = Emoji(
+  base: '🚀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rocket:',
+  ],
+  animated: true,
+);
+
+/// The ✈️ emoji.
+const airplane = Emoji(
+  base: '✈️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':airplane:',
+  ],
+  animated: false,
+);
+
+/// The 🛫 emoji.
+const airplaneDeparture = Emoji(
+  base: '🛫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':airplane-departure:',
+  ],
+  animated: true,
+);
+
+/// The 🛬 emoji.
+const airplaneArrival = Emoji(
+  base: '🛬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':airplane-arrival:',
+  ],
+  animated: true,
+);
+
+/// The 🛩️ emoji.
+const smallAirplane = Emoji(
+  base: '🛩️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':small-airplane:',
+  ],
+  animated: false,
+);
+
+/// The 🛝 emoji.
+const slide = Emoji(
+  base: '🛝',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':slide:',
+    ':playground:',
+  ],
+  animated: false,
+);
+
+/// The 🎢 emoji.
+const rollerCoaster = Emoji(
+  base: '🎢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':roller-coaster:',
+  ],
+  animated: true,
+);
+
+/// The 🎡 emoji.
+const ferrisWheel = Emoji(
+  base: '🎡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ferris-wheel:',
+  ],
+  animated: false,
+);
+
+/// The 🎠 emoji.
+const carouselHorse = Emoji(
+  base: '🎠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':carousel-horse:',
+  ],
+  animated: false,
+);
+
+/// The 🎪 emoji.
+const circusTent = Emoji(
+  base: '🎪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':circus-tent:',
+  ],
+  animated: false,
+);
+
+/// The 🗼 emoji.
+const tokyoTower = Emoji(
+  base: '🗼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tokyo-tower:',
+  ],
+  animated: false,
+);
+
+/// The 🗽 emoji.
+const statueOfLiberty = Emoji(
+  base: '🗽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':statue-of-Liberty:',
+  ],
+  animated: false,
+);
+
+/// The 🗿 emoji.
+const moai = Emoji(
+  base: '🗿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':moai:',
+  ],
+  animated: false,
+);
+
+/// The 🗻 emoji.
+const mountFuji = Emoji(
+  base: '🗻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mount-fuji:',
+  ],
+  animated: false,
+);
+
+/// The 🏛️ emoji.
+const classicalBuilding = Emoji(
+  base: '🏛️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':classical-building:',
+  ],
+  animated: false,
+);
+
+/// The 💈 emoji.
+const barberPole = Emoji(
+  base: '💈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':barber-pole:',
+  ],
+  animated: false,
+);
+
+/// The ⛲ emoji.
+const fountain = Emoji(
+  base: '⛲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fountain:',
+  ],
+  animated: false,
+);
+
+/// The ⛩️ emoji.
+const shintoShrine = Emoji(
+  base: '⛩️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shinto-shrine:',
+  ],
+  animated: false,
+);
+
+/// The 🕍 emoji.
+const synagogue = Emoji(
+  base: '🕍',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':synagogue:',
+  ],
+  animated: false,
+);
+
+/// The 🕌 emoji.
+const mosque = Emoji(
+  base: '🕌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mosque:',
+  ],
+  animated: false,
+);
+
+/// The 🕋 emoji.
+const kaaba = Emoji(
+  base: '🕋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':kaaba:',
+  ],
+  animated: false,
+);
+
+/// The 🛕 emoji.
+const hinduTemple = Emoji(
+  base: '🛕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hindu-temple:',
+  ],
+  animated: false,
+);
+
+/// The ⛪ emoji.
+const church = Emoji(
+  base: '⛪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':church:',
+  ],
+  animated: false,
+);
+
+/// The 💒 emoji.
+const wedding = Emoji(
+  base: '💒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wedding:',
+  ],
+  animated: false,
+);
+
+/// The 🏩 emoji.
+const loveHotel = Emoji(
+  base: '🏩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':love-hotel:',
+  ],
+  animated: false,
+);
+
+/// The 🏯 emoji.
+const japaneseCastle = Emoji(
+  base: '🏯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Japanese-castle:',
+  ],
+  animated: false,
+);
+
+/// The 🏰 emoji.
+const castle = Emoji(
+  base: '🏰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':castle:',
+  ],
+  animated: false,
+);
+
+/// The 🏗️ emoji.
+const constructionBuilding = Emoji(
+  base: '🏗️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':construction-building:',
+  ],
+  animated: false,
+);
+
+/// The 🏢 emoji.
+const officeBuilding = Emoji(
+  base: '🏢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':office-building:',
+  ],
+  animated: false,
+);
+
+/// The 🏭 emoji.
+const factory = Emoji(
+  base: '🏭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':factory:',
+  ],
+  animated: false,
+);
+
+/// The 🏬 emoji.
+const departmentStore = Emoji(
+  base: '🏬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':department-store:',
+  ],
+  animated: false,
+);
+
+/// The 🏪 emoji.
+const convenienceStore = Emoji(
+  base: '🏪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':convenience-store:',
+  ],
+  animated: false,
+);
+
+/// The 🏟️ emoji.
+const stadium = Emoji(
+  base: '🏟️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':stadium:',
+  ],
+  animated: false,
+);
+
+/// The 🏦 emoji.
+const bank = Emoji(
+  base: '🏦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bank:',
+  ],
+  animated: false,
+);
+
+/// The 🏫 emoji.
+const school = Emoji(
+  base: '🏫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':school:',
+  ],
+  animated: false,
+);
+
+/// The 🏨 emoji.
+const hotel = Emoji(
+  base: '🏨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hotel:',
+  ],
+  animated: false,
+);
+
+/// The 🏣 emoji.
+const japanesePostOffice = Emoji(
+  base: '🏣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Japanese-post-office:',
+  ],
+  animated: false,
+);
+
+/// The 🏤 emoji.
+const postOffice = Emoji(
+  base: '🏤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':post-office:',
+  ],
+  animated: false,
+);
+
+/// The 🏥 emoji.
+const hospital = Emoji(
+  base: '🏥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hospital:',
+  ],
+  animated: false,
+);
+
+/// The 🏚️ emoji.
+const derelictHouse = Emoji(
+  base: '🏚️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':derelict-house:',
+  ],
+  animated: false,
+);
+
+/// The 🏠 emoji.
+const house = Emoji(
+  base: '🏠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':house:',
+  ],
+  animated: false,
+);
+
+/// The 🏡 emoji.
+const houseWithGarden = Emoji(
+  base: '🏡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':house-with-garden:',
+  ],
+  animated: false,
+);
+
+/// The 🏘️ emoji.
+const houses = Emoji(
+  base: '🏘️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':houses:',
+  ],
+  animated: false,
+);
+
+/// The 🛖 emoji.
+const hut = Emoji(
+  base: '🛖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hut:',
+  ],
+  animated: false,
+);
+
+/// The ⛺ emoji.
+const tent = Emoji(
+  base: '⛺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tent:',
+  ],
+  animated: false,
+);
+
+/// The 🏕️ emoji.
+const camping = Emoji(
+  base: '🏕️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':camping:',
+  ],
+  animated: false,
+);
+
+/// The ⛱️ emoji.
+const umbrellaOnGround = Emoji(
+  base: '⛱️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':umbrella-on-ground:',
+  ],
+  animated: false,
+);
+
+/// The 🏙️ emoji.
+const cityscape = Emoji(
+  base: '🏙️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cityscape:',
+  ],
+  animated: false,
+);
+
+/// The 🌆 emoji.
+const sunsetCityscape = Emoji(
+  base: '🌆',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sunset-cityscape:',
+  ],
+  animated: false,
+);
+
+/// The 🌇 emoji.
+const sunset = Emoji(
+  base: '🌇',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sunset:',
+  ],
+  animated: false,
+);
+
+/// The 🌃 emoji.
+const nightWithStars = Emoji(
+  base: '🌃',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':night-with-stars:',
+  ],
+  animated: false,
+);
+
+/// The 🌉 emoji.
+const bridgeAtNight = Emoji(
+  base: '🌉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bridge-at-night:',
+  ],
+  animated: false,
+);
+
+/// The 🌁 emoji.
+const foggy = Emoji(
+  base: '🌁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':foggy:',
+  ],
+  animated: false,
+);
+
+/// The 🛤️ emoji.
+const railwayTrack = Emoji(
+  base: '🛤️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':railway-track:',
+  ],
+  animated: false,
+);
+
+/// The 🛣️ emoji.
+const motorway = Emoji(
+  base: '🛣️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':motorway:',
+  ],
+  animated: false,
+);
+
+/// The 🗾 emoji.
+const mapOfJapan = Emoji(
+  base: '🗾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':map-of-Japan:',
+  ],
+  animated: false,
+);
+
+/// The 🗺️ emoji.
+const worldMap = Emoji(
+  base: '🗺️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':world-map:',
+  ],
+  animated: false,
+);
+
+/// The 🌐 emoji.
+const globeWithMeridians = Emoji(
+  base: '🌐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':globe-with-meridians:',
+  ],
+  animated: false,
+);
+
+/// The 💺 emoji.
+const seat = Emoji(
+  base: '💺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':seat:',
+  ],
+  animated: false,
+);
+
+/// The 🧳 emoji.
+const luggage = Emoji(
+  base: '🧳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':luggage:',
+  ],
+  animated: false,
+);
+
+/// The 🎊 emoji.
+const confettiBall = Emoji(
+  base: '🎊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':confetti-ball:',
+  ],
+  animated: true,
+);
+
+/// The 🎈 emoji.
+const balloon = Emoji(
+  base: '🎈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':balloon:',
+  ],
+  animated: true,
+);
+
+/// The 🎀 emoji.
+const ribbon = Emoji(
+  base: '🎀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ribbon:',
+  ],
+  animated: false,
+);
+
+/// The 🎁 emoji.
+const wrappedGift = Emoji(
+  base: '🎁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wrapped-gift:',
+  ],
+  animated: false,
+);
+
+/// The 🎇 emoji.
+const sparkler = Emoji(
+  base: '🎇',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sparkler:',
+  ],
+  animated: false,
+);
+
+/// The 🎆 emoji.
+const fireworks = Emoji(
+  base: '🎆',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fireworks:',
+  ],
+  animated: true,
+);
+
+/// The 🧨 emoji.
+const firecracker = Emoji(
+  base: '🧨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':firecracker:',
+  ],
+  animated: false,
+);
+
+/// The 🧧 emoji.
+const redEnvelope = Emoji(
+  base: '🧧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':red-envelope:',
+  ],
+  animated: false,
+);
+
+/// The 🪔 emoji.
+const diyaLamp = Emoji(
+  base: '🪔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':diya-lamp:',
+  ],
+  animated: false,
+);
+
+/// The 🪅 emoji.
+const pinata = Emoji(
+  base: '🪅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':piñata:',
+  ],
+  animated: false,
+);
+
+/// The 🪩 emoji.
+const mirrorBall = Emoji(
+  base: '🪩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mirror-ball:',
+    ':disco-ball:',
+  ],
+  animated: true,
+);
+
+/// The 🎐 emoji.
+const windChime = Emoji(
+  base: '🎐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wind-chime:',
+  ],
+  animated: false,
+);
+
+/// The 🎏 emoji.
+const carpStreamer = Emoji(
+  base: '🎏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':carp-streamer:',
+  ],
+  animated: false,
+);
+
+/// The 🎎 emoji.
+const japaneseDolls = Emoji(
+  base: '🎎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Japanese-dolls:',
+  ],
+  animated: false,
+);
+
+/// The 🎑 emoji.
+const moonViewingCeremony = Emoji(
+  base: '🎑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':moon-viewing-ceremony:',
+  ],
+  animated: false,
+);
+
+/// The 🎍 emoji.
+const pineDecoration = Emoji(
+  base: '🎍',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pine-decoration:',
+  ],
+  animated: false,
+);
+
+/// The 🎋 emoji.
+const tanabataTree = Emoji(
+  base: '🎋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tanabata-tree:',
+  ],
+  animated: false,
+);
+
+/// The 🎄 emoji.
+const christmasTree = Emoji(
+  base: '🎄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Christmas-tree:',
+  ],
+  animated: false,
+);
+
+/// The 🎗️ emoji.
+const reminderRibbon = Emoji(
+  base: '🎗️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':reminder-ribbon:',
+  ],
+  animated: false,
+);
+
+/// The 🥇 emoji.
+const goldMedal = Emoji(
+  base: '🥇',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':gold-medal:',
+    ':1st-place-medal:',
+  ],
+  animated: false,
+);
+
+/// The 🥈 emoji.
+const silverMedal = Emoji(
+  base: '🥈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':silver-medal:',
+    ':2nd-place-medal:',
+  ],
+  animated: false,
+);
+
+/// The 🥉 emoji.
+const bronzeMedal = Emoji(
+  base: '🥉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bronze-medal:',
+    ':3rd-place-medal:',
+  ],
+  animated: false,
+);
+
+/// The 🏅 emoji.
+const medal = Emoji(
+  base: '🏅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':medal:',
+  ],
+  animated: false,
+);
+
+/// The 🎖️ emoji.
+const militaryMedal = Emoji(
+  base: '🎖️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':military-medal:',
+  ],
+  animated: false,
+);
+
+/// The 🏆 emoji.
+const trophy = Emoji(
+  base: '🏆',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':trophy:',
+  ],
+  animated: false,
+);
+
+/// The 📢 emoji.
+const loudspeaker = Emoji(
+  base: '📢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':loudspeaker:',
+  ],
+  animated: false,
+);
+
+/// The ⚽ emoji.
+const soccerBall = Emoji(
+  base: '⚽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':soccer-ball:',
+  ],
+  animated: true,
+);
+
+/// The ⚾ emoji.
+const baseball = Emoji(
+  base: '⚾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':baseball:',
+  ],
+  animated: false,
+);
+
+/// The 🥎 emoji.
+const softball = Emoji(
+  base: '🥎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':softball:',
+  ],
+  animated: false,
+);
+
+/// The 🏀 emoji.
+const basketball = Emoji(
+  base: '🏀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':basketball:',
+  ],
+  animated: false,
+);
+
+/// The 🏐 emoji.
+const volleyball = Emoji(
+  base: '🏐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':volleyball:',
+  ],
+  animated: false,
+);
+
+/// The 🏈 emoji.
+const americanFootball = Emoji(
+  base: '🏈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':american-football:',
+  ],
+  animated: false,
+);
+
+/// The 🏉 emoji.
+const rugbyFootball = Emoji(
+  base: '🏉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rugby-football:',
+  ],
+  animated: false,
+);
+
+/// The 🥅 emoji.
+const goalNet = Emoji(
+  base: '🥅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':goal-net:',
+  ],
+  animated: false,
+);
+
+/// The 🎾 emoji.
+const tennis = Emoji(
+  base: '🎾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tennis:',
+  ],
+  animated: false,
+);
+
+/// The 🏸 emoji.
+const badminton = Emoji(
+  base: '🏸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':badminton:',
+  ],
+  animated: false,
+);
+
+/// The 🥍 emoji.
+const lacrosse = Emoji(
+  base: '🥍',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lacrosse:',
+  ],
+  animated: false,
+);
+
+/// The 🏏 emoji.
+const cricketGame = Emoji(
+  base: '🏏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cricket-game:',
+  ],
+  animated: false,
+);
+
+/// The 🏑 emoji.
+const fieldHockey = Emoji(
+  base: '🏑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':field-hockey:',
+  ],
+  animated: false,
+);
+
+/// The 🏒 emoji.
+const iceHockey = Emoji(
+  base: '🏒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ice-hockey:',
+  ],
+  animated: false,
+);
+
+/// The 🥌 emoji.
+const curlingStone = Emoji(
+  base: '🥌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':curling-stone:',
+  ],
+  animated: false,
+);
+
+/// The 🛷 emoji.
+const sled = Emoji(
+  base: '🛷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sled:',
+  ],
+  animated: false,
+);
+
+/// The 🎿 emoji.
+const skis = Emoji(
+  base: '🎿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':skis:',
+  ],
+  animated: false,
+);
+
+/// The ⛸️ emoji.
+const iceSkate = Emoji(
+  base: '⛸️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ice-skate:',
+  ],
+  animated: false,
+);
+
+/// The 🛼 emoji.
+const rollerSkates = Emoji(
+  base: '🛼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':roller-skates:',
+  ],
+  animated: false,
+);
+
+/// The 🩰 emoji.
+const balletShoes = Emoji(
+  base: '🩰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ballet-shoes:',
+  ],
+  animated: false,
+);
+
+/// The 🛹 emoji.
+const skateboard = Emoji(
+  base: '🛹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':skateboard:',
+  ],
+  animated: false,
+);
+
+/// The ⛳ emoji.
+const flagInHole = Emoji(
+  base: '⛳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':flag-in-hole:',
+  ],
+  animated: false,
+);
+
+/// The 🎯 emoji.
+const directHit = Emoji(
+  base: '🎯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':direct-hit:',
+    ':target:',
+  ],
+  animated: true,
+);
+
+/// The 🏹 emoji.
+const bowAndArrow = Emoji(
+  base: '🏹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bow-and-arrow:',
+  ],
+  animated: false,
+);
+
+/// The 🥏 emoji.
+const flyingDisc = Emoji(
+  base: '🥏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':flying-disc:',
+  ],
+  animated: false,
+);
+
+/// The 🪃 emoji.
+const boomerang = Emoji(
+  base: '🪃',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':boomerang:',
+  ],
+  animated: false,
+);
+
+/// The 🪁 emoji.
+const kite = Emoji(
+  base: '🪁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':kite:',
+  ],
+  animated: false,
+);
+
+/// The 🎣 emoji.
+const fishingPole = Emoji(
+  base: '🎣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fishing-pole:',
+  ],
+  animated: false,
+);
+
+/// The 🤿 emoji.
+const divingMask = Emoji(
+  base: '🤿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':diving-mask:',
+  ],
+  animated: false,
+);
+
+/// The 🩱 emoji.
+const onePieceSwimsuit = Emoji(
+  base: '🩱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':one-piece-swimsuit:',
+  ],
+  animated: false,
+);
+
+/// The 🎽 emoji.
+const runningShirt = Emoji(
+  base: '🎽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':running-shirt:',
+  ],
+  animated: false,
+);
+
+/// The 🥋 emoji.
+const martialArtsUniform = Emoji(
+  base: '🥋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':martial-arts-uniform:',
+  ],
+  animated: false,
+);
+
+/// The 🥊 emoji.
+const boxingGlove = Emoji(
+  base: '🥊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':boxing-glove:',
+  ],
+  animated: false,
+);
+
+/// The 🎱 emoji.
+const eightBall = Emoji(
+  base: '🎱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':8-ball:',
+  ],
+  animated: false,
+);
+
+/// The 🏓 emoji.
+const pingPong = Emoji(
+  base: '🏓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ping-pong:',
+  ],
+  animated: false,
+);
+
+/// The 🎳 emoji.
+const bowling = Emoji(
+  base: '🎳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bowling:',
+  ],
+  animated: false,
+);
+
+/// The ♟️ emoji.
+const chessPawn = Emoji(
+  base: '♟️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':chess-pawn:',
+  ],
+  animated: false,
+);
+
+/// The 🪀 emoji.
+const yoYo = Emoji(
+  base: '🪀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':yo-yo:',
+  ],
+  animated: false,
+);
+
+/// The 🧩 emoji.
+const jigsaw = Emoji(
+  base: '🧩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':jigsaw:',
+  ],
+  animated: false,
+);
+
+/// The 🎮 emoji.
+const videoGame = Emoji(
+  base: '🎮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':video-game:',
+  ],
+  animated: false,
+);
+
+/// The 🕹️ emoji.
+const joystick = Emoji(
+  base: '🕹️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':joystick:',
+  ],
+  animated: false,
+);
+
+/// The 🔫 emoji.
+const pistol = Emoji(
+  base: '🔫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pistol:',
+  ],
+  animated: false,
+);
+
+/// The 🎲 emoji.
+const die = Emoji(
+  base: '🎲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':die:',
+  ],
+  animated: false,
+);
+
+/// The 🎰 emoji.
+const slotMachine = Emoji(
+  base: '🎰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':slot-machine:',
+  ],
+  animated: false,
+);
+
+/// The 🎴 emoji.
+const flowerPlayingCards = Emoji(
+  base: '🎴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':flower-playing-cards:',
+  ],
+  animated: false,
+);
+
+/// The 🀄 emoji.
+const mahjongRedDragon = Emoji(
+  base: '🀄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mahjong-red-dragon:',
+  ],
+  animated: false,
+);
+
+/// The 🃏 emoji.
+const joker = Emoji(
+  base: '🃏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':joker:',
+  ],
+  animated: false,
+);
+
+/// The 🪄 emoji.
+const wand = Emoji(
+  base: '🪄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wand:',
+  ],
+  animated: false,
+);
+
+/// The 🎩 emoji.
+const gameDie = Emoji(
+  base: '🎩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':game-die:',
+  ],
+  animated: false,
+);
+
+/// The 📷 emoji.
+const camera = Emoji(
+  base: '📷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':camera:',
+  ],
+  animated: false,
+);
+
+/// The 📸 emoji.
+const cameraFlash = Emoji(
+  base: '📸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':camera-flash:',
+  ],
+  animated: false,
+);
+
+/// The 🖼️ emoji.
+const framedPicture = Emoji(
+  base: '🖼️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':framed-picture:',
+  ],
+  animated: false,
+);
+
+/// The 🎨 emoji.
+const artistPalette = Emoji(
+  base: '🎨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':artist-palette:',
+  ],
+  animated: false,
+);
+
+/// The 🖌️ emoji.
+const paintbrush = Emoji(
+  base: '🖌️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':paintbrush:',
+  ],
+  animated: false,
+);
+
+/// The 🖍️ emoji.
+const crayon = Emoji(
+  base: '🖍️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':crayon:',
+  ],
+  animated: false,
+);
+
+/// The 🪡 emoji.
+const needle = Emoji(
+  base: '🪡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':needle:',
+  ],
+  animated: false,
+);
+
+/// The 🧵 emoji.
+const thread = Emoji(
+  base: '🧵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':thread:',
+  ],
+  animated: false,
+);
+
+/// The 🧶 emoji.
+const yarn = Emoji(
+  base: '🧶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':yarn:',
+  ],
+  animated: false,
+);
+
+/// The 🎹 emoji.
+const piano = Emoji(
+  base: '🎹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':piano:',
+    ':musical-keyboard:',
+  ],
+  animated: false,
+);
+
+/// The 🎷 emoji.
+const saxophone = Emoji(
+  base: '🎷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':saxophone:',
+  ],
+  animated: false,
+);
+
+/// The 🎺 emoji.
+const trumpet = Emoji(
+  base: '🎺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':trumpet:',
+  ],
+  animated: false,
+);
+
+/// The 🎸 emoji.
+const guitar = Emoji(
+  base: '🎸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':guitar:',
+  ],
+  animated: false,
+);
+
+/// The 🪕 emoji.
+const banjo = Emoji(
+  base: '🪕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':banjo:',
+  ],
+  animated: false,
+);
+
+/// The 🎻 emoji.
+const violin = Emoji(
+  base: '🎻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':violin:',
+  ],
+  animated: true,
+);
+
+/// The 🪘 emoji.
+const longDrum = Emoji(
+  base: '🪘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':long-drum:',
+  ],
+  animated: false,
+);
+
+/// The 🥁 emoji.
+const drum = Emoji(
+  base: '🥁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':drum:',
+  ],
+  animated: true,
+);
+
+/// The 🪇 emoji.
+const maracas = Emoji(
+  base: '🪇',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':maracas:',
+  ],
+  animated: true,
+);
+
+/// The 🪈 emoji.
+const flute = Emoji(
+  base: '🪈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':flute:',
+  ],
+  animated: false,
+);
+
+/// The 🪗 emoji.
+const accordion = Emoji(
+  base: '🪗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':accordion:',
+  ],
+  animated: false,
+);
+
+/// The 🎤 emoji.
+const microphone = Emoji(
+  base: '🎤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':microphone:',
+  ],
+  animated: false,
+);
+
+/// The 🎧 emoji.
+const headphone = Emoji(
+  base: '🎧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':headphone:',
+  ],
+  animated: false,
+);
+
+/// The 🎚️ emoji.
+const levelSlider = Emoji(
+  base: '🎚️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':level-slider:',
+  ],
+  animated: false,
+);
+
+/// The 🎛️ emoji.
+const controlKnobs = Emoji(
+  base: '🎛️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':control-knobs:',
+  ],
+  animated: false,
+);
+
+/// The 🎙️ emoji.
+const studioMicrophone = Emoji(
+  base: '🎙️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':studio-microphone:',
+  ],
+  animated: false,
+);
+
+/// The 📻 emoji.
+const radio = Emoji(
+  base: '📻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':radio:',
+  ],
+  animated: false,
+);
+
+/// The 📺 emoji.
+const television = Emoji(
+  base: '📺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':television:',
+  ],
+  animated: false,
+);
+
+/// The 📼 emoji.
+const videocassette = Emoji(
+  base: '📼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':videocassette:',
+  ],
+  animated: false,
+);
+
+/// The 📹 emoji.
+const videoCamera = Emoji(
+  base: '📹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':video-camera:',
+  ],
+  animated: false,
+);
+
+/// The 📽️ emoji.
+const filmProjector = Emoji(
+  base: '📽️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':film-projector:',
+  ],
+  animated: false,
+);
+
+/// The 🎥 emoji.
+const movieCamera = Emoji(
+  base: '🎥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':movie-camera:',
+  ],
+  animated: false,
+);
+
+/// The 🎞️ emoji.
+const film = Emoji(
+  base: '🎞️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':film:',
+  ],
+  animated: false,
+);
+
+/// The 🎬 emoji.
+const clapper = Emoji(
+  base: '🎬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':clapper:',
+  ],
+  animated: false,
+);
+
+/// The 🎭 emoji.
+const performingArts = Emoji(
+  base: '🎭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':performing-arts:',
+  ],
+  animated: false,
+);
+
+/// The 🎫 emoji.
+const ticket = Emoji(
+  base: '🎫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ticket:',
+  ],
+  animated: false,
+);
+
+/// The 🎟️ emoji.
+const admissionTickets = Emoji(
+  base: '🎟️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':admission-tickets:',
+  ],
+  animated: false,
+);
+
+/// The 📱 emoji.
+const mobilePhone = Emoji(
+  base: '📱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mobile-phone:',
+  ],
+  animated: false,
+);
+
+/// The ☎️ emoji.
+const telephone = Emoji(
+  base: '☎️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':telephone:',
+  ],
+  animated: false,
+);
+
+/// The 📞 emoji.
+const telephoneReceiver = Emoji(
+  base: '📞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':telephone-receiver:',
+  ],
+  animated: false,
+);
+
+/// The 📟 emoji.
+const pager = Emoji(
+  base: '📟',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pager:',
+  ],
+  animated: false,
+);
+
+/// The 📠 emoji.
+const faxMachine = Emoji(
+  base: '📠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fax-machine:',
+  ],
+  animated: false,
+);
+
+/// The 🔌 emoji.
+const electricPlug = Emoji(
+  base: '🔌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':electric-plug:',
+  ],
+  animated: false,
+);
+
+/// The 🔋 emoji.
+const batteryFull = Emoji(
+  base: '🔋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':battery-full:',
+  ],
+  animated: true,
+);
+
+/// The 🪫 emoji.
+const batteryLow = Emoji(
+  base: '🪫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':battery-low:',
+  ],
+  animated: true,
+);
+
+/// The 🖲️ emoji.
+const trackball = Emoji(
+  base: '🖲️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':trackball:',
+  ],
+  animated: false,
+);
+
+/// The 💽 emoji.
+const computerDisk = Emoji(
+  base: '💽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':computer-disk:',
+  ],
+  animated: false,
+);
+
+/// The 💾 emoji.
+const floppyDisk = Emoji(
+  base: '💾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':floppy-disk:',
+  ],
+  animated: false,
+);
+
+/// The 💿 emoji.
+const opticalDisk = Emoji(
+  base: '💿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':optical-disk:',
+  ],
+  animated: false,
+);
+
+/// The 📀 emoji.
+const dvd = Emoji(
+  base: '📀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dvd:',
+  ],
+  animated: false,
+);
+
+/// The 🖥️ emoji.
+const desktopComputer = Emoji(
+  base: '🖥️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':desktop-computer:',
+  ],
+  animated: false,
+);
+
+/// The 💻 emoji.
+const laptopComputer = Emoji(
+  base: '💻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':laptop-computer:',
+  ],
+  animated: false,
+);
+
+/// The ⌨️ emoji.
+const keyboard = Emoji(
+  base: '⌨️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':keyboard:',
+  ],
+  animated: false,
+);
+
+/// The 🖨️ emoji.
+const printer = Emoji(
+  base: '🖨️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':printer:',
+  ],
+  animated: false,
+);
+
+/// The 🖱️ emoji.
+const computerMouse = Emoji(
+  base: '🖱️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':computer-mouse:',
+  ],
+  animated: false,
+);
+
+/// The 🪙 emoji.
+const coin = Emoji(
+  base: '🪙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':coin:',
+  ],
+  animated: false,
+);
+
+/// The 💸 emoji.
+const moneyWithWings = Emoji(
+  base: '💸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':money-with-wings:',
+  ],
+  animated: true,
+);
+
+/// The 💵 emoji.
+const dollar = Emoji(
+  base: '💵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dollar:',
+  ],
+  animated: false,
+);
+
+/// The 💴 emoji.
+const yen = Emoji(
+  base: '💴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':yen:',
+  ],
+  animated: false,
+);
+
+/// The 💶 emoji.
+const euro = Emoji(
+  base: '💶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':euro:',
+  ],
+  animated: false,
+);
+
+/// The 💷 emoji.
+const pound = Emoji(
+  base: '💷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pound:',
+  ],
+  animated: false,
+);
+
+/// The 💳 emoji.
+const creditCard = Emoji(
+  base: '💳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':credit-card:',
+  ],
+  animated: false,
+);
+
+/// The 💰 emoji.
+const moneyBag = Emoji(
+  base: '💰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':money-bag:',
+  ],
+  animated: false,
+);
+
+/// The 🧾 emoji.
+const receipt = Emoji(
+  base: '🧾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':receipt:',
+  ],
+  animated: false,
+);
+
+/// The 🧮 emoji.
+const abacus = Emoji(
+  base: '🧮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':abacus:',
+  ],
+  animated: false,
+);
+
+/// The ⚖️ emoji.
+const balanceScale = Emoji(
+  base: '⚖️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':balance-scale:',
+  ],
+  animated: false,
+);
+
+/// The 🛒 emoji.
+const shoppingCart = Emoji(
+  base: '🛒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shopping-cart:',
+  ],
+  animated: false,
+);
+
+/// The 🛍️ emoji.
+const shoppingBags = Emoji(
+  base: '🛍️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shopping-bags:',
+  ],
+  animated: false,
+);
+
+/// The 🕯️ emoji.
+const candle = Emoji(
+  base: '🕯️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':candle:',
+  ],
+  animated: false,
+);
+
+/// The 💡 emoji.
+const lightBulb = Emoji(
+  base: '💡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':light-bulb:',
+  ],
+  animated: true,
+);
+
+/// The 🔦 emoji.
+const flashlight = Emoji(
+  base: '🔦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':flashlight:',
+  ],
+  animated: false,
+);
+
+/// The 🏮 emoji.
+const redPaperLantern = Emoji(
+  base: '🏮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':red-paper-lantern:',
+  ],
+  animated: false,
+);
+
+/// The 🧱 emoji.
+const bricks = Emoji(
+  base: '🧱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bricks:',
+  ],
+  animated: false,
+);
+
+/// The 🪟 emoji.
+const window = Emoji(
+  base: '🪟',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':window:',
+  ],
+  animated: false,
+);
+
+/// The 🪞 emoji.
+const mirror = Emoji(
+  base: '🪞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mirror:',
+  ],
+  animated: false,
+);
+
+/// The 🚪 emoji.
+const door = Emoji(
+  base: '🚪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':door:',
+  ],
+  animated: false,
+);
+
+/// The 🪑 emoji.
+const chair = Emoji(
+  base: '🪑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':chair:',
+  ],
+  animated: false,
+);
+
+/// The 🛏️ emoji.
+const bed = Emoji(
+  base: '🛏️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bed:',
+  ],
+  animated: false,
+);
+
+/// The 🛋️ emoji.
+const couchAndLamp = Emoji(
+  base: '🛋️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':couch-and-lamp:',
+  ],
+  animated: false,
+);
+
+/// The 🚿 emoji.
+const shower = Emoji(
+  base: '🚿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shower:',
+  ],
+  animated: false,
+);
+
+/// The 🛁 emoji.
+const bathtub = Emoji(
+  base: '🛁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bathtub:',
+  ],
+  animated: false,
+);
+
+/// The 🚽 emoji.
+const toilet = Emoji(
+  base: '🚽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':toilet:',
+  ],
+  animated: false,
+);
+
+/// The 🧻 emoji.
+const rollOfPaper = Emoji(
+  base: '🧻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':roll-of-paper:',
+  ],
+  animated: false,
+);
+
+/// The 🪠 emoji.
+const plunger = Emoji(
+  base: '🪠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':plunger:',
+  ],
+  animated: false,
+);
+
+/// The 🧸 emoji.
+const teddyBear = Emoji(
+  base: '🧸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':teddy-bear:',
+  ],
+  animated: false,
+);
+
+/// The 🪆 emoji.
+const nestingDoll = Emoji(
+  base: '🪆',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':nesting-doll:',
+  ],
+  animated: false,
+);
+
+/// The 🧷 emoji.
+const safetyPin = Emoji(
+  base: '🧷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':safety-pin:',
+  ],
+  animated: false,
+);
+
+/// The 🪢 emoji.
+const knot = Emoji(
+  base: '🪢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':knot:',
+  ],
+  animated: false,
+);
+
+/// The 🧹 emoji.
+const broom = Emoji(
+  base: '🧹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':broom:',
+  ],
+  animated: false,
+);
+
+/// The 🧴 emoji.
+const lotionBottle = Emoji(
+  base: '🧴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lotion-bottle:',
+  ],
+  animated: false,
+);
+
+/// The 🧽 emoji.
+const sponge = Emoji(
+  base: '🧽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sponge:',
+  ],
+  animated: false,
+);
+
+/// The 🧼 emoji.
+const soap = Emoji(
+  base: '🧼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':soap:',
+  ],
+  animated: false,
+);
+
+/// The 🪥 emoji.
+const toothbrush = Emoji(
+  base: '🪥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':toothbrush:',
+  ],
+  animated: false,
+);
+
+/// The 🪒 emoji.
+const razor = Emoji(
+  base: '🪒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':razor:',
+  ],
+  animated: false,
+);
+
+/// The 🪮 emoji.
+const hairPick = Emoji(
+  base: '🪮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hair-pick:',
+  ],
+  animated: false,
+);
+
+/// The 🧺 emoji.
+const basket = Emoji(
+  base: '🧺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':basket:',
+  ],
+  animated: false,
+);
+
+/// The 🧦 emoji.
+const socks = Emoji(
+  base: '🧦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':socks:',
+  ],
+  animated: false,
+);
+
+/// The 🧤 emoji.
+const gloves = Emoji(
+  base: '🧤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':gloves:',
+  ],
+  animated: false,
+);
+
+/// The 🧣 emoji.
+const scarf = Emoji(
+  base: '🧣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':scarf:',
+  ],
+  animated: false,
+);
+
+/// The 👖 emoji.
+const jeans = Emoji(
+  base: '👖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':jeans:',
+  ],
+  animated: false,
+);
+
+/// The 👕 emoji.
+const tShirt = Emoji(
+  base: '👕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':t-shirt:',
+  ],
+  animated: false,
+);
+
+/// The 👚 emoji.
+const womansClothes = Emoji(
+  base: '👚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':woman’s-clothes:',
+  ],
+  animated: false,
+);
+
+/// The 👔 emoji.
+const necktie = Emoji(
+  base: '👔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':necktie:',
+  ],
+  animated: false,
+);
+
+/// The 👗 emoji.
+const dress = Emoji(
+  base: '👗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dress:',
+  ],
+  animated: false,
+);
+
+/// The 👘 emoji.
+const kimono = Emoji(
+  base: '👘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':kimono:',
+  ],
+  animated: false,
+);
+
+/// The 🥻 emoji.
+const sari = Emoji(
+  base: '🥻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sari:',
+  ],
+  animated: false,
+);
+
+/// The 👙 emoji.
+const bikini = Emoji(
+  base: '👙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bikini:',
+  ],
+  animated: false,
+);
+
+/// The 🩳 emoji.
+const shorts = Emoji(
+  base: '🩳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shorts:',
+  ],
+  animated: false,
+);
+
+/// The 🩲 emoji.
+const swimBrief = Emoji(
+  base: '🩲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':swim-brief:',
+  ],
+  animated: false,
+);
+
+/// The 🧥 emoji.
+const coat = Emoji(
+  base: '🧥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':coat:',
+  ],
+  animated: false,
+);
+
+/// The 🥼 emoji.
+const labCoat = Emoji(
+  base: '🥼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lab-coat:',
+  ],
+  animated: false,
+);
+
+/// The 🦺 emoji.
+const safetyVest = Emoji(
+  base: '🦺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':safety-vest:',
+  ],
+  animated: false,
+);
+
+/// The ⛑️ emoji.
+const rescueWorkersHelmet = Emoji(
+  base: '⛑️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rescue-worker’s-helmet:',
+  ],
+  animated: false,
+);
+
+/// The 🪖 emoji.
+const militaryHelmet = Emoji(
+  base: '🪖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':military-helmet:',
+  ],
+  animated: false,
+);
+
+/// The 🎓 emoji.
+const graduationCap = Emoji(
+  base: '🎓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':graduation-cap:',
+  ],
+  animated: true,
+);
+
+/// The 🎩 emoji.
+const topHat = Emoji(
+  base: '🎩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':top-hat:',
+  ],
+  animated: false,
+);
+
+/// The 👒 emoji.
+const womansHat = Emoji(
+  base: '👒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':woman’s-hat:',
+  ],
+  animated: false,
+);
+
+/// The 🧢 emoji.
+const billedCap = Emoji(
+  base: '🧢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':billed-cap:',
+  ],
+  animated: false,
+);
+
+/// The 👑 emoji.
+const crown = Emoji(
+  base: '👑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':crown:',
+  ],
+  animated: false,
+);
+
+/// The 🪭 emoji.
+const fan = Emoji(
+  base: '🪭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fan:',
+  ],
+  animated: false,
+);
+
+/// The 🎒 emoji.
+const schoolBackpack = Emoji(
+  base: '🎒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':school-backpack:',
+  ],
+  animated: false,
+);
+
+/// The 👝 emoji.
+const clutchBag = Emoji(
+  base: '👝',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':clutch-bag:',
+  ],
+  animated: false,
+);
+
+/// The 👛 emoji.
+const purse = Emoji(
+  base: '👛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':purse:',
+  ],
+  animated: false,
+);
+
+/// The 👜 emoji.
+const handbag = Emoji(
+  base: '👜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':handbag:',
+  ],
+  animated: false,
+);
+
+/// The 💼 emoji.
+const briefcase = Emoji(
+  base: '💼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':briefcase:',
+  ],
+  animated: false,
+);
+
+/// The ☂️ emoji.
+const umbrella = Emoji(
+  base: '☂️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':umbrella:',
+  ],
+  animated: true,
+);
+
+/// The 🌂 emoji.
+const closedUmbrella = Emoji(
+  base: '🌂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':closed-umbrella:',
+  ],
+  animated: false,
+);
+
+/// The 💍 emoji.
+const ring = Emoji(
+  base: '💍',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ring:',
+  ],
+  animated: false,
+);
+
+/// The 💎 emoji.
+const gemStone = Emoji(
+  base: '💎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':gem-stone:',
+  ],
+  animated: true,
+);
+
+/// The 💄 emoji.
+const lipstick = Emoji(
+  base: '💄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lipstick:',
+  ],
+  animated: false,
+);
+
+/// The 👠 emoji.
+const highHeeledShoe = Emoji(
+  base: '👠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':high-heeled-shoe:',
+  ],
+  animated: false,
+);
+
+/// The 👟 emoji.
+const runningShoe = Emoji(
+  base: '👟',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':running-shoe:',
+  ],
+  animated: false,
+);
+
+/// The 👞 emoji.
+const mansShoe = Emoji(
+  base: '👞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':man’s-shoe:',
+  ],
+  animated: false,
+);
+
+/// The 🥿 emoji.
+const flatShoe = Emoji(
+  base: '🥿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':flat-shoe:',
+  ],
+  animated: false,
+);
+
+/// The 🩴 emoji.
+const flipFlop = Emoji(
+  base: '🩴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':flip-flop:',
+    ':thong-sandal:',
+  ],
+  animated: false,
+);
+
+/// The 👡 emoji.
+const sandal = Emoji(
+  base: '👡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sandal:',
+  ],
+  animated: false,
+);
+
+/// The 👢 emoji.
+const boot = Emoji(
+  base: '👢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':boot:',
+  ],
+  animated: false,
+);
+
+/// The 🥾 emoji.
+const hikingBoot = Emoji(
+  base: '🥾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hiking-boot:',
+  ],
+  animated: false,
+);
+
+/// The 🦯 emoji.
+const probingCane = Emoji(
+  base: '🦯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':probing-cane:',
+  ],
+  animated: false,
+);
+
+/// The 🕶️ emoji.
+const sunglasses = Emoji(
+  base: '🕶️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sunglasses:',
+  ],
+  animated: false,
+);
+
+/// The 👓 emoji.
+const glasses = Emoji(
+  base: '👓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':glasses:',
+  ],
+  animated: false,
+);
+
+/// The 🥽 emoji.
+const goggles = Emoji(
+  base: '🥽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':goggles:',
+  ],
+  animated: false,
+);
+
+/// The ⚗️ emoji.
+const alembic = Emoji(
+  base: '⚗️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':alembic:',
+  ],
+  animated: false,
+);
+
+/// The 🧫 emoji.
+const petriDish = Emoji(
+  base: '🧫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':petri-dish:',
+  ],
+  animated: false,
+);
+
+/// The 🧪 emoji.
+const testTube = Emoji(
+  base: '🧪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':test-tube:',
+  ],
+  animated: false,
+);
+
+/// The 💉 emoji.
+const syringe = Emoji(
+  base: '💉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':syringe:',
+  ],
+  animated: false,
+);
+
+/// The 💊 emoji.
+const pill = Emoji(
+  base: '💊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pill:',
+  ],
+  animated: false,
+);
+
+/// The 🩹 emoji.
+const adhesiveBandage = Emoji(
+  base: '🩹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':adhesive-bandage:',
+  ],
+  animated: false,
+);
+
+/// The 🩺 emoji.
+const stethoscope = Emoji(
+  base: '🩺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':stethoscope:',
+  ],
+  animated: false,
+);
+
+/// The 🩻 emoji.
+const xRay = Emoji(
+  base: '🩻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':x-ray:',
+  ],
+  animated: false,
+);
+
+/// The 🧬 emoji.
+const dna = Emoji(
+  base: '🧬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dna:',
+  ],
+  animated: false,
+);
+
+/// The 🔭 emoji.
+const telescope = Emoji(
+  base: '🔭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':telescope:',
+  ],
+  animated: false,
+);
+
+/// The 🔬 emoji.
+const microscope = Emoji(
+  base: '🔬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':microscope:',
+  ],
+  animated: false,
+);
+
+/// The 📡 emoji.
+const satelliteAntenna = Emoji(
+  base: '📡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':satellite-antenna:',
+  ],
+  animated: false,
+);
+
+/// The 🛰️ emoji.
+const satellite = Emoji(
+  base: '🛰️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':satellite:',
+  ],
+  animated: false,
+);
+
+/// The 🧯 emoji.
+const fireExtinguisher = Emoji(
+  base: '🧯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fire-extinguisher:',
+  ],
+  animated: false,
+);
+
+/// The 🪓 emoji.
+const axe = Emoji(
+  base: '🪓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':axe:',
+  ],
+  animated: false,
+);
+
+/// The 🪜 emoji.
+const ladder = Emoji(
+  base: '🪜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ladder:',
+  ],
+  animated: false,
+);
+
+/// The 🪣 emoji.
+const bucket = Emoji(
+  base: '🪣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bucket:',
+  ],
+  animated: false,
+);
+
+/// The 🪝 emoji.
+const hook = Emoji(
+  base: '🪝',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hook:',
+  ],
+  animated: false,
+);
+
+/// The 🧲 emoji.
+const magnet = Emoji(
+  base: '🧲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':magnet:',
+  ],
+  animated: false,
+);
+
+/// The 🧰 emoji.
+const toolbox = Emoji(
+  base: '🧰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':toolbox:',
+  ],
+  animated: false,
+);
+
+/// The 🗜️ emoji.
+const clamp = Emoji(
+  base: '🗜️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':clamp:',
+  ],
+  animated: false,
+);
+
+/// The 🔩 emoji.
+const nutAndBolt = Emoji(
+  base: '🔩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':nut-and-bolt:',
+  ],
+  animated: false,
+);
+
+/// The 🪛 emoji.
+const screwdriver = Emoji(
+  base: '🪛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':screwdriver:',
+  ],
+  animated: false,
+);
+
+/// The 🪚 emoji.
+const saw = Emoji(
+  base: '🪚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':saw:',
+  ],
+  animated: false,
+);
+
+/// The 🔧 emoji.
+const wrench = Emoji(
+  base: '🔧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wrench:',
+  ],
+  animated: false,
+);
+
+/// The 🔨 emoji.
+const hammer = Emoji(
+  base: '🔨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hammer:',
+  ],
+  animated: false,
+);
+
+/// The ⚒️ emoji.
+const hammerAndPick = Emoji(
+  base: '⚒️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hammer-and-pick:',
+  ],
+  animated: false,
+);
+
+/// The 🛠️ emoji.
+const hammerAndWrench = Emoji(
+  base: '🛠️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hammer-and-wrench:',
+  ],
+  animated: false,
+);
+
+/// The ⛏️ emoji.
+const pick = Emoji(
+  base: '⛏️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pick:',
+  ],
+  animated: false,
+);
+
+/// The ⚙️ emoji.
+const gear = Emoji(
+  base: '⚙️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':gear:',
+  ],
+  animated: false,
+);
+
+/// The 🔗 emoji.
+const link = Emoji(
+  base: '🔗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':link:',
+  ],
+  animated: false,
+);
+
+/// The ⛓️ emoji.
+const chains = Emoji(
+  base: '⛓️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':chains:',
+  ],
+  animated: false,
+);
+
+/// The 📎 emoji.
+const paperclip = Emoji(
+  base: '📎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':paperclip:',
+  ],
+  animated: false,
+);
+
+/// The 🖇️ emoji.
+const linkedPaperclips = Emoji(
+  base: '🖇️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':linked-paperclips:',
+  ],
+  animated: false,
+);
+
+/// The 📏 emoji.
+const straightRuler = Emoji(
+  base: '📏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':straight-ruler:',
+  ],
+  animated: false,
+);
+
+/// The 📐 emoji.
+const triangularRuler = Emoji(
+  base: '📐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':triangular-ruler:',
+  ],
+  animated: false,
+);
+
+/// The 🖊️ emoji.
+const pen = Emoji(
+  base: '🖊️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pen:',
+  ],
+  animated: false,
+);
+
+/// The 🖋️ emoji.
+const fountainPen = Emoji(
+  base: '🖋️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fountain-pen:',
+  ],
+  animated: false,
+);
+
+/// The ✒️ emoji.
+const blackNib = Emoji(
+  base: '✒️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':black-nib:',
+  ],
+  animated: false,
+);
+
+/// The ✏️ emoji.
+const pencil = Emoji(
+  base: '✏️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pencil:',
+  ],
+  animated: false,
+);
+
+/// The 📝 emoji.
+const memo = Emoji(
+  base: '📝',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':memo:',
+  ],
+  animated: false,
+);
+
+/// The 📖 emoji.
+const openBook = Emoji(
+  base: '📖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':open-book:',
+  ],
+  animated: false,
+);
+
+/// The 📚 emoji.
+const books = Emoji(
+  base: '📚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':books:',
+  ],
+  animated: false,
+);
+
+/// The 📒 emoji.
+const ledger = Emoji(
+  base: '📒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ledger:',
+  ],
+  animated: false,
+);
+
+/// The 📔 emoji.
+const notebookWithDecorativeCover = Emoji(
+  base: '📔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':notebook-with-decorative-cover:',
+  ],
+  animated: false,
+);
+
+/// The 📕 emoji.
+const closedBook = Emoji(
+  base: '📕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':closed-book:',
+  ],
+  animated: false,
+);
+
+/// The 📓 emoji.
+const notebook = Emoji(
+  base: '📓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':notebook:',
+  ],
+  animated: false,
+);
+
+/// The 📗 emoji.
+const greenBook = Emoji(
+  base: '📗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':green-book:',
+  ],
+  animated: false,
+);
+
+/// The 📘 emoji.
+const blueBook = Emoji(
+  base: '📘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':blue-book:',
+  ],
+  animated: false,
+);
+
+/// The 📙 emoji.
+const orangeBook = Emoji(
+  base: '📙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':orange-book:',
+  ],
+  animated: false,
+);
+
+/// The 🔖 emoji.
+const bookmark = Emoji(
+  base: '🔖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bookmark:',
+  ],
+  animated: false,
+);
+
+/// The 🗒️ emoji.
+const spiralNotepad = Emoji(
+  base: '🗒️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':spiral-notepad:',
+  ],
+  animated: false,
+);
+
+/// The 📄 emoji.
+const pageFacingUp = Emoji(
+  base: '📄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':page-facing-up:',
+  ],
+  animated: false,
+);
+
+/// The 📃 emoji.
+const pageWithCurl = Emoji(
+  base: '📃',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':page-with-curl:',
+  ],
+  animated: false,
+);
+
+/// The 📋 emoji.
+const clipboard = Emoji(
+  base: '📋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':clipboard:',
+  ],
+  animated: false,
+);
+
+/// The 📑 emoji.
+const bookmarkTabs = Emoji(
+  base: '📑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bookmark-tabs:',
+  ],
+  animated: false,
+);
+
+/// The 📂 emoji.
+const openFileFolder = Emoji(
+  base: '📂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':open-file-folder:',
+  ],
+  animated: false,
+);
+
+/// The 📁 emoji.
+const fileFolder = Emoji(
+  base: '📁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':file-folder:',
+  ],
+  animated: false,
+);
+
+/// The 🗂️ emoji.
+const cardIndexDividers = Emoji(
+  base: '🗂️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':card-index-dividers:',
+  ],
+  animated: false,
+);
+
+/// The 🗃️ emoji.
+const cardFileBox = Emoji(
+  base: '🗃️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':card-file-box:',
+  ],
+  animated: false,
+);
+
+/// The 🗄️ emoji.
+const fileCabinet = Emoji(
+  base: '🗄️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':file-cabinet:',
+  ],
+  animated: false,
+);
+
+/// The 📊 emoji.
+const barChart = Emoji(
+  base: '📊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bar-chart:',
+  ],
+  animated: false,
+);
+
+/// The 📈 emoji.
+const chartIncreasing = Emoji(
+  base: '📈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':chart-increasing:',
+  ],
+  animated: false,
+);
+
+/// The 📉 emoji.
+const chartDecreasing = Emoji(
+  base: '📉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':chart-decreasing:',
+  ],
+  animated: false,
+);
+
+/// The 📇 emoji.
+const cardIndex = Emoji(
+  base: '📇',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':card-index:',
+  ],
+  animated: false,
+);
+
+/// The 🪪 emoji.
+const id = Emoji(
+  base: '🪪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':id:',
+  ],
+  animated: false,
+);
+
+/// The 📌 emoji.
+const pushpin = Emoji(
+  base: '📌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pushpin:',
+  ],
+  animated: false,
+);
+
+/// The 📍 emoji.
+const roundPushpin = Emoji(
+  base: '📍',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':round-pushpin:',
+  ],
+  animated: false,
+);
+
+/// The ✂️ emoji.
+const scissors = Emoji(
+  base: '✂️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':scissors:',
+  ],
+  animated: false,
+);
+
+/// The 🗑️ emoji.
+const wastebasket = Emoji(
+  base: '🗑️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wastebasket:',
+  ],
+  animated: false,
+);
+
+/// The 📰 emoji.
+const newspaper = Emoji(
+  base: '📰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':newspaper:',
+  ],
+  animated: false,
+);
+
+/// The 🗞️ emoji.
+const rolledUpNewspaper = Emoji(
+  base: '🗞️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rolled-up-newspaper:',
+  ],
+  animated: false,
+);
+
+/// The 🏷️ emoji.
+const label = Emoji(
+  base: '🏷️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':label:',
+  ],
+  animated: false,
+);
+
+/// The 📦 emoji.
+const package = Emoji(
+  base: '📦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':package:',
+  ],
+  animated: false,
+);
+
+/// The 📫 emoji.
+const closedMailboxWithRaised = Emoji(
+  base: '📫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':closed-mailbox-with-raised:',
+  ],
+  animated: false,
+);
+
+/// The 📪 emoji.
+const closedMailboxWithLowered = Emoji(
+  base: '📪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':closed-mailbox-with-lowered:',
+  ],
+  animated: false,
+);
+
+/// The 📬 emoji.
+const openMailboxWithRaised = Emoji(
+  base: '📬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':open-mailbox-with-raised:',
+  ],
+  animated: false,
+);
+
+/// The 📭 emoji.
+const openMailboxWithLowered = Emoji(
+  base: '📭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':open-mailbox-with-lowered:',
+  ],
+  animated: false,
+);
+
+/// The 📮 emoji.
+const postbox = Emoji(
+  base: '📮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':postbox:',
+  ],
+  animated: false,
+);
+
+/// The ✉️ emoji.
+const envelope = Emoji(
+  base: '✉️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':envelope:',
+  ],
+  animated: false,
+);
+
+/// The 📧 emoji.
+const eMail = Emoji(
+  base: '📧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':e-mail:',
+  ],
+  animated: false,
+);
+
+/// The 📩 emoji.
+const envelopeWithArrow = Emoji(
+  base: '📩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':envelope-with-arrow:',
+  ],
+  animated: false,
+);
+
+/// The 📨 emoji.
+const incomingEnvelope = Emoji(
+  base: '📨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':incoming-envelope:',
+  ],
+  animated: false,
+);
+
+/// The 📤 emoji.
+const outboxTray = Emoji(
+  base: '📤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':outbox-tray:',
+  ],
+  animated: false,
+);
+
+/// The 📥 emoji.
+const inboxTray = Emoji(
+  base: '📥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':inbox-tray:',
+  ],
+  animated: false,
+);
+
+/// The 🗳️ emoji.
+const ballotBox = Emoji(
+  base: '🗳️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ballot-box:',
+  ],
+  animated: false,
+);
+
+/// The 🕛 emoji.
+const twelveOClock = Emoji(
+  base: '🕛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':twelve-o-clock:',
+  ],
+  animated: false,
+);
+
+/// The 🕧 emoji.
+const twelveThirty = Emoji(
+  base: '🕧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':twelve-thirty:',
+  ],
+  animated: false,
+);
+
+/// The 🕐 emoji.
+const oneOClock = Emoji(
+  base: '🕐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':one-o-clock:',
+  ],
+  animated: false,
+);
+
+/// The 🕜 emoji.
+const oneThirty = Emoji(
+  base: '🕜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':one-thirty:',
+  ],
+  animated: false,
+);
+
+/// The 🕑 emoji.
+const twoOClock = Emoji(
+  base: '🕑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':two-o-clock:',
+  ],
+  animated: false,
+);
+
+/// The 🕝 emoji.
+const twoThirty = Emoji(
+  base: '🕝',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':two-thirty:',
+  ],
+  animated: false,
+);
+
+/// The 🕒 emoji.
+const threeOClock = Emoji(
+  base: '🕒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':three-o-clock:',
+  ],
+  animated: false,
+);
+
+/// The 🕞 emoji.
+const threeThirty = Emoji(
+  base: '🕞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':three-thirty:',
+  ],
+  animated: false,
+);
+
+/// The 🕓 emoji.
+const fourOClock = Emoji(
+  base: '🕓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':four-o-clock:',
+  ],
+  animated: false,
+);
+
+/// The 🕟 emoji.
+const fourThirty = Emoji(
+  base: '🕟',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':four-thirty:',
+  ],
+  animated: false,
+);
+
+/// The 🕔 emoji.
+const fiveOClock = Emoji(
+  base: '🕔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':five-o-clock:',
+  ],
+  animated: false,
+);
+
+/// The 🕠 emoji.
+const fiveThirty = Emoji(
+  base: '🕠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':five-thirty:',
+  ],
+  animated: false,
+);
+
+/// The 🕕 emoji.
+const sixOClock = Emoji(
+  base: '🕕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':six-o-clock:',
+  ],
+  animated: false,
+);
+
+/// The 🕡 emoji.
+const sixThirty = Emoji(
+  base: '🕡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':six-thirty:',
+  ],
+  animated: false,
+);
+
+/// The 🕖 emoji.
+const sevenOClock = Emoji(
+  base: '🕖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':seven-o-clock:',
+  ],
+  animated: false,
+);
+
+/// The 🕢 emoji.
+const sevenThirty = Emoji(
+  base: '🕢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':seven-thirty:',
+  ],
+  animated: false,
+);
+
+/// The 🕗 emoji.
+const eightOClock = Emoji(
+  base: '🕗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eight-o-clock:',
+  ],
+  animated: false,
+);
+
+/// The 🕣 emoji.
+const eightThirty = Emoji(
+  base: '🕣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eight-thirty:',
+  ],
+  animated: false,
+);
+
+/// The 🕘 emoji.
+const nineOClock = Emoji(
+  base: '🕘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':nine-o-clock:',
+  ],
+  animated: false,
+);
+
+/// The 🕤 emoji.
+const nineThirty = Emoji(
+  base: '🕤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':nine-thirty:',
+  ],
+  animated: false,
+);
+
+/// The 🕙 emoji.
+const tenOClock = Emoji(
+  base: '🕙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ten-o-clock:',
+  ],
+  animated: false,
+);
+
+/// The 🕥 emoji.
+const tenThirty = Emoji(
+  base: '🕥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ten-thirty:',
+  ],
+  animated: false,
+);
+
+/// The 🕚 emoji.
+const elevenOClock = Emoji(
+  base: '🕚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eleven-o-clock:',
+  ],
+  animated: false,
+);
+
+/// The 🕦 emoji.
+const elevenThirty = Emoji(
+  base: '🕦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eleven-thirty:',
+  ],
+  animated: false,
+);
+
+/// The ⏱️ emoji.
+const stopwatch = Emoji(
+  base: '⏱️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':stopwatch:',
+  ],
+  animated: false,
+);
+
+/// The ⌚ emoji.
+const watch = Emoji(
+  base: '⌚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':watch:',
+  ],
+  animated: false,
+);
+
+/// The 🕰️ emoji.
+const mantelpieceClock = Emoji(
+  base: '🕰️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mantelpiece-clock:',
+  ],
+  animated: false,
+);
+
+/// The ⌛ emoji.
+const hourglassDone = Emoji(
+  base: '⌛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hourglass-done:',
+  ],
+  animated: false,
+);
+
+/// The ⏳ emoji.
+const hourglassNotDone = Emoji(
+  base: '⏳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hourglass-not-done:',
+  ],
+  animated: false,
+);
+
+/// The ⏲️ emoji.
+const timerClock = Emoji(
+  base: '⏲️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':timer-clock:',
+  ],
+  animated: false,
+);
+
+/// The ⏰ emoji.
+const alarmClock = Emoji(
+  base: '⏰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':alarm-clock:',
+  ],
+  animated: true,
+);
+
+/// The 📅 emoji.
+const calendar = Emoji(
+  base: '📅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':calendar:',
+  ],
+  animated: false,
+);
+
+/// The 📆 emoji.
+const tearOffCalendar = Emoji(
+  base: '📆',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':tear-off-calendar:',
+  ],
+  animated: false,
+);
+
+/// The 🗓️ emoji.
+const spiralCalendar = Emoji(
+  base: '🗓️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':spiral-calendar:',
+  ],
+  animated: false,
+);
+
+/// The 🪧 emoji.
+const placard = Emoji(
+  base: '🪧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':placard:',
+  ],
+  animated: false,
+);
+
+/// The 🛎️ emoji.
+const bellhopBell = Emoji(
+  base: '🛎️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bellhop-bell:',
+  ],
+  animated: true,
+);
+
+/// The 🔔 emoji.
+const bell = Emoji(
+  base: '🔔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bell:',
+  ],
+  animated: true,
+);
+
+/// The 📯 emoji.
+const postalHorn = Emoji(
+  base: '📯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':postal-horn:',
+  ],
+  animated: false,
+);
+
+/// The 📣 emoji.
+const megaphone = Emoji(
+  base: '📣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':megaphone:',
+  ],
+  animated: false,
+);
+
+/// The 🔍 emoji.
+const magnifyingGlassTiltedLeft = Emoji(
+  base: '🔍',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':magnifying-glass-tilted-left:',
+  ],
+  animated: false,
+);
+
+/// The 🔎 emoji.
+const magnifyingGlassTiltedRight = Emoji(
+  base: '🔎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':magnifying-glass-tilted-right:',
+  ],
+  animated: false,
+);
+
+/// The 🔮 emoji.
+const crystalBall = Emoji(
+  base: '🔮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':crystal-ball:',
+  ],
+  animated: false,
+);
+
+/// The 🧿 emoji.
+const evilEye = Emoji(
+  base: '🧿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':evil-eye:',
+    ':nazar-amulet:',
+  ],
+  animated: false,
+);
+
+/// The 🪬 emoji.
+const hamsa = Emoji(
+  base: '🪬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hamsa:',
+  ],
+  animated: false,
+);
+
+/// The 📿 emoji.
+const prayerBeads = Emoji(
+  base: '📿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':prayer-beads:',
+  ],
+  animated: false,
+);
+
+/// The 🏺 emoji.
+const amphora = Emoji(
+  base: '🏺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':amphora:',
+  ],
+  animated: false,
+);
+
+/// The ⚱️ emoji.
+const urn = Emoji(
+  base: '⚱️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':urn:',
+  ],
+  animated: false,
+);
+
+/// The ⚰️ emoji.
+const coffin = Emoji(
+  base: '⚰️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':coffin:',
+  ],
+  animated: false,
+);
+
+/// The 🪦 emoji.
+const headstone = Emoji(
+  base: '🪦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':headstone:',
+  ],
+  animated: false,
+);
+
+/// The 🚬 emoji.
+const cigarette = Emoji(
+  base: '🚬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cigarette:',
+  ],
+  animated: false,
+);
+
+/// The 💣 emoji.
+const bomb = Emoji(
+  base: '💣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bomb:',
+  ],
+  animated: false,
+);
+
+/// The 🪤 emoji.
+const mouseTrap = Emoji(
+  base: '🪤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mouse-trap:',
+  ],
+  animated: false,
+);
+
+/// The 📜 emoji.
+const scroll = Emoji(
+  base: '📜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':scroll:',
+  ],
+  animated: false,
+);
+
+/// The ⚔️ emoji.
+const crossedSwords = Emoji(
+  base: '⚔️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':crossed-swords:',
+  ],
+  animated: false,
+);
+
+/// The 🗡️ emoji.
+const dagger = Emoji(
+  base: '🗡️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dagger:',
+  ],
+  animated: false,
+);
+
+/// The 🛡️ emoji.
+const shield = Emoji(
+  base: '🛡️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shield:',
+  ],
+  animated: false,
+);
+
+/// The 🗝️ emoji.
+const oldKey = Emoji(
+  base: '🗝️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':old-key:',
+  ],
+  animated: false,
+);
+
+/// The 🔑 emoji.
+const key = Emoji(
+  base: '🔑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':key:',
+  ],
+  animated: false,
+);
+
+/// The 🔐 emoji.
+const lockWithKey = Emoji(
+  base: '🔐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lock-with-key:',
+  ],
+  animated: false,
+);
+
+/// The 🔏 emoji.
+const lockWithPen = Emoji(
+  base: '🔏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lock-with-pen:',
+  ],
+  animated: false,
+);
+
+/// The 🔒 emoji.
+const locked = Emoji(
+  base: '🔒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':locked:',
+  ],
+  animated: false,
+);
+
+/// The 🔓 emoji.
+const unlocked = Emoji(
+  base: '🔓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':unlocked:',
+  ],
+  animated: false,
+);
+
+/// The 🔴 emoji.
+const redCircle = Emoji(
+  base: '🔴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':red-circle:',
+  ],
+  animated: false,
+);
+
+/// The 🟠 emoji.
+const orangeCircle = Emoji(
+  base: '🟠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':orange-circle:',
+  ],
+  animated: false,
+);
+
+/// The 🟡 emoji.
+const yellowCircle = Emoji(
+  base: '🟡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':yellow-circle:',
+  ],
+  animated: false,
+);
+
+/// The 🟢 emoji.
+const greenCircle = Emoji(
+  base: '🟢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':green-circle:',
+  ],
+  animated: false,
+);
+
+/// The 🔵 emoji.
+const blueCircle = Emoji(
+  base: '🔵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':blue-circle:',
+  ],
+  animated: false,
+);
+
+/// The 🟣 emoji.
+const purpleCircle = Emoji(
+  base: '🟣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':purple-circle:',
+  ],
+  animated: false,
+);
+
+/// The 🟤 emoji.
+const brownCircle = Emoji(
+  base: '🟤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':brown-circle:',
+  ],
+  animated: false,
+);
+
+/// The ⚫ emoji.
+const blackCircle = Emoji(
+  base: '⚫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':black-circle:',
+  ],
+  animated: false,
+);
+
+/// The ⚪ emoji.
+const whiteCircle = Emoji(
+  base: '⚪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':white-circle:',
+  ],
+  animated: false,
+);
+
+/// The 🟥 emoji.
+const redSquare = Emoji(
+  base: '🟥',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':red-square:',
+  ],
+  animated: false,
+);
+
+/// The 🟧 emoji.
+const orangeSquare = Emoji(
+  base: '🟧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':orange-square:',
+  ],
+  animated: false,
+);
+
+/// The 🟨 emoji.
+const yellowSquare = Emoji(
+  base: '🟨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':yellow-square:',
+  ],
+  animated: false,
+);
+
+/// The 🟩 emoji.
+const greenSquare = Emoji(
+  base: '🟩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':green-square:',
+  ],
+  animated: false,
+);
+
+/// The 🟦 emoji.
+const blueSquare = Emoji(
+  base: '🟦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':blue-square:',
+  ],
+  animated: false,
+);
+
+/// The 🟪 emoji.
+const purpleSquare = Emoji(
+  base: '🟪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':purple-square:',
+  ],
+  animated: false,
+);
+
+/// The 🟫 emoji.
+const brownSquare = Emoji(
+  base: '🟫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':brown-square:',
+  ],
+  animated: false,
+);
+
+/// The ⬛ emoji.
+const blackSquare = Emoji(
+  base: '⬛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':black-square:',
+  ],
+  animated: false,
+);
+
+/// The ⬜ emoji.
+const whiteSquare = Emoji(
+  base: '⬜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':white-square:',
+  ],
+  animated: false,
+);
+
+/// The 🩶 emoji.
+const grayHeart = Emoji(
+  base: '🩶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':gray-heart:',
+  ],
+  animated: true,
+);
+
+/// The ♦️ emoji.
+const diamond = Emoji(
+  base: '♦️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':diamond:',
+  ],
+  animated: false,
+);
+
+/// The ♣️ emoji.
+const club = Emoji(
+  base: '♣️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':club:',
+  ],
+  animated: false,
+);
+
+/// The ♠️ emoji.
+const spade = Emoji(
+  base: '♠️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':spade:',
+  ],
+  animated: false,
+);
+
+/// The ♈ emoji.
+const aries = Emoji(
+  base: '♈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Aries:',
+  ],
+  animated: true,
+);
+
+/// The ♉ emoji.
+const taurus = Emoji(
+  base: '♉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Taurus:',
+  ],
+  animated: true,
+);
+
+/// The ♊ emoji.
+const gemini = Emoji(
+  base: '♊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Gemini:',
+  ],
+  animated: true,
+);
+
+/// The ♋ emoji.
+const cancer = Emoji(
+  base: '♋',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Cancer:',
+  ],
+  animated: true,
+);
+
+/// The ♌ emoji.
+const leo = Emoji(
+  base: '♌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Leo:',
+  ],
+  animated: true,
+);
+
+/// The ♍ emoji.
+const virgo = Emoji(
+  base: '♍',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Virgo:',
+  ],
+  animated: true,
+);
+
+/// The ♎ emoji.
+const libra = Emoji(
+  base: '♎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Libra:',
+  ],
+  animated: true,
+);
+
+/// The ♏ emoji.
+const scorpio = Emoji(
+  base: '♏',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Scorpio:',
+  ],
+  animated: true,
+);
+
+/// The ♐ emoji.
+const sagittarius = Emoji(
+  base: '♐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Sagittarius:',
+  ],
+  animated: true,
+);
+
+/// The ♑ emoji.
+const capricorn = Emoji(
+  base: '♑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Capricorn:',
+  ],
+  animated: true,
+);
+
+/// The ♒ emoji.
+const aquarius = Emoji(
+  base: '♒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Aquarius:',
+  ],
+  animated: true,
+);
+
+/// The ♓ emoji.
+const pisces = Emoji(
+  base: '♓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Pisces:',
+  ],
+  animated: true,
+);
+
+/// The ⛎ emoji.
+const ophiuchus = Emoji(
+  base: '⛎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Ophiuchus:',
+  ],
+  animated: true,
+);
+
+/// The ♀️ emoji.
+const femaleSign = Emoji(
+  base: '♀️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':female-sign:',
+  ],
+  animated: false,
+);
+
+/// The ♂️ emoji.
+const maleSign = Emoji(
+  base: '♂️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':male-sign:',
+  ],
+  animated: false,
+);
+
+/// The ⚧️ emoji.
+const transSign = Emoji(
+  base: '⚧️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':trans-sign:',
+  ],
+  animated: false,
+);
+
+/// The 💭 emoji.
+const thoughtBubble = Emoji(
+  base: '💭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':thought-bubble:',
+    ':thought-balloon:',
+  ],
+  animated: false,
+);
+
+/// The 🗯️ emoji.
+const angerBubble = Emoji(
+  base: '🗯️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':anger-bubble:',
+  ],
+  animated: false,
+);
+
+/// The 💬 emoji.
+const speechBubble = Emoji(
+  base: '💬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':speech-bubble:',
+  ],
+  animated: false,
+);
+
+/// The 🗨️ emoji.
+const speechBubbleLeftwards = Emoji(
+  base: '🗨️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':speech-bubble-leftwards:',
+  ],
+  animated: false,
+);
+
+/// The ❕ emoji.
+const exclamationMarkWhite = Emoji(
+  base: '❕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':exclamation-mark-white:',
+  ],
+  animated: false,
+);
+
+/// The ❗ emoji.
+const exclamation = Emoji(
+  base: '❗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':exclamation:',
+    ':exclamation-mark:',
+  ],
+  animated: false,
+);
+
+/// The ❔ emoji.
+const questionMarkWhite = Emoji(
+  base: '❔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':question-mark-white:',
+  ],
+  animated: false,
+);
+
+/// The ❓ emoji.
+const question = Emoji(
+  base: '❓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':question:',
+    ':question-mark:',
+    ':?:',
+  ],
+  animated: false,
+);
+
+/// The ⁉️ emoji.
+const exclamationQuestionMark = Emoji(
+  base: '⁉️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':exclamation-question-mark:',
+    ':!?:',
+  ],
+  animated: false,
+);
+
+/// The ‼️ emoji.
+const exclamationDouble = Emoji(
+  base: '‼️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':exclamation-double:',
+    ':!!:',
+  ],
+  animated: true,
+);
+
+/// The ⭕ emoji.
+const largeCircle = Emoji(
+  base: '⭕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':large-circle:',
+  ],
+  animated: false,
+);
+
+/// The ❌ emoji.
+const x = Emoji(
+  base: '❌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':x:',
+    ':cross-mark:',
+  ],
+  animated: true,
+);
+
+/// The 🚫 emoji.
+const prohibited = Emoji(
+  base: '🚫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':prohibited:',
+  ],
+  animated: false,
+);
+
+/// The 🚳 emoji.
+const noBicycles = Emoji(
+  base: '🚳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':no-bicycles:',
+  ],
+  animated: false,
+);
+
+/// The 🚭 emoji.
+const noSmoking = Emoji(
+  base: '🚭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':no-smoking:',
+  ],
+  animated: false,
+);
+
+/// The 🚯 emoji.
+const noLittering = Emoji(
+  base: '🚯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':no-littering:',
+  ],
+  animated: false,
+);
+
+/// The 🚱 emoji.
+const nonPotableWater = Emoji(
+  base: '🚱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':non-potable-water:',
+  ],
+  animated: false,
+);
+
+/// The 🚷 emoji.
+const noPedestrians = Emoji(
+  base: '🚷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':no-pedestrians:',
+  ],
+  animated: false,
+);
+
+/// The 📵 emoji.
+const noMobilePhones = Emoji(
+  base: '📵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':no-mobile-phones:',
+  ],
+  animated: false,
+);
+
+/// The 🔞 emoji.
+const noUnderEighteen = Emoji(
+  base: '🔞',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':no-under-eighteen:',
+  ],
+  animated: false,
+);
+
+/// The 🔕 emoji.
+const noSound = Emoji(
+  base: '🔕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':no-sound:',
+    ':no-bell:',
+  ],
+  animated: false,
+);
+
+/// The 🔇 emoji.
+const mute = Emoji(
+  base: '🔇',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mute:',
+  ],
+  animated: false,
+);
+
+/// The 🅰️ emoji.
+const aButton = Emoji(
+  base: '🅰️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':a-button:',
+    ':blood-type-a:',
+  ],
+  animated: false,
+);
+
+/// The 🆎 emoji.
+const abButton = Emoji(
+  base: '🆎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ab-button:',
+    ':blood-type-ab:',
+  ],
+  animated: false,
+);
+
+/// The 🅱️ emoji.
+const bButton = Emoji(
+  base: '🅱️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':b-button:',
+    ':blood-type-b:',
+  ],
+  animated: false,
+);
+
+/// The 🅾️ emoji.
+const oButton = Emoji(
+  base: '🅾️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':o-button:',
+    ':blood-type-o:',
+  ],
+  animated: false,
+);
+
+/// The 🆑 emoji.
+const clButton = Emoji(
+  base: '🆑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cl-button:',
+  ],
+  animated: false,
+);
+
+/// The 🆘 emoji.
+const sos = Emoji(
+  base: '🆘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sos:',
+  ],
+  animated: false,
+);
+
+/// The 🛑 emoji.
+const stop = Emoji(
+  base: '🛑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':stop:',
+  ],
+  animated: false,
+);
+
+/// The ⛔ emoji.
+const noEntry = Emoji(
+  base: '⛔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':no-entry:',
+  ],
+  animated: false,
+);
+
+/// The 📛 emoji.
+const nameBadge = Emoji(
+  base: '📛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':name-badge:',
+  ],
+  animated: false,
+);
+
+/// The ♨️ emoji.
+const hotSprings = Emoji(
+  base: '♨️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':hot-springs:',
+  ],
+  animated: false,
+);
+
+/// The 💢 emoji.
+const anger = Emoji(
+  base: '💢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':anger:',
+  ],
+  animated: false,
+);
+
+/// The 🔻 emoji.
+const trianglePointedDown = Emoji(
+  base: '🔻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':triangle-pointed-down:',
+  ],
+  animated: false,
+);
+
+/// The 🔺 emoji.
+const trianglePointedUp = Emoji(
+  base: '🔺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':triangle-pointed-up:',
+  ],
+  animated: false,
+);
+
+/// The 🉐 emoji.
+const bargain = Emoji(
+  base: '🉐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bargain:',
+  ],
+  animated: false,
+);
+
+/// The ㊙️ emoji.
+const secret = Emoji(
+  base: '㊙️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':secret:',
+  ],
+  animated: false,
+);
+
+/// The ㊗️ emoji.
+const congratulations = Emoji(
+  base: '㊗️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':congratulations:',
+  ],
+  animated: false,
+);
+
+/// The 🈴 emoji.
+const passingGrade = Emoji(
+  base: '🈴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':passing-grade:',
+  ],
+  animated: false,
+);
+
+/// The 🈵 emoji.
+const noVacancy = Emoji(
+  base: '🈵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':no-vacancy:',
+  ],
+  animated: false,
+);
+
+/// The 🈹 emoji.
+const discount = Emoji(
+  base: '🈹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':discount:',
+  ],
+  animated: false,
+);
+
+/// The 🈲 emoji.
+const prohibitedButton = Emoji(
+  base: '🈲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':prohibited-button:',
+  ],
+  animated: false,
+);
+
+/// The 🉑 emoji.
+const accept = Emoji(
+  base: '🉑',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':accept:',
+  ],
+  animated: false,
+);
+
+/// The 🈶 emoji.
+const notFreeOfCharge = Emoji(
+  base: '🈶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':not-free-of-charge:',
+  ],
+  animated: false,
+);
+
+/// The 🈚 emoji.
+const freeOfCharge = Emoji(
+  base: '🈚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':free-of-charge:',
+  ],
+  animated: false,
+);
+
+/// The 🈸 emoji.
+const application = Emoji(
+  base: '🈸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':application:',
+  ],
+  animated: false,
+);
+
+/// The 🈺 emoji.
+const openForBusiness = Emoji(
+  base: '🈺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':open-for-business:',
+  ],
+  animated: false,
+);
+
+/// The 🈷️ emoji.
+const monthlyAmount = Emoji(
+  base: '🈷️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':monthly-amount:',
+  ],
+  animated: false,
+);
+
+/// The ✴️ emoji.
+const eightPointedStar = Emoji(
+  base: '✴️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eight-pointed-star:',
+  ],
+  animated: false,
+);
+
+/// The 🔶 emoji.
+const diamondOrangeLarge = Emoji(
+  base: '🔶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':diamond-orange-large:',
+  ],
+  animated: false,
+);
+
+/// The 🔸 emoji.
+const diamondOrangeSmall = Emoji(
+  base: '🔸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':diamond-orange-small:',
+  ],
+  animated: false,
+);
+
+/// The 🔆 emoji.
+const bright = Emoji(
+  base: '🔆',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':bright:',
+    ':brightness:',
+  ],
+  animated: false,
+);
+
+/// The 🔅 emoji.
+const dim = Emoji(
+  base: '🔅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dim:',
+    ':dimness:',
+  ],
+  animated: false,
+);
+
+/// The 🆚 emoji.
+const vs = Emoji(
+  base: '🆚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':vs:',
+  ],
+  animated: false,
+);
+
+/// The 🎦 emoji.
+const cinema = Emoji(
+  base: '🎦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cinema:',
+  ],
+  animated: false,
+);
+
+/// The 📶 emoji.
+const signalStrength = Emoji(
+  base: '📶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':signal-strength:',
+  ],
+  animated: false,
+);
+
+/// The 🔁 emoji.
+const repeat = Emoji(
+  base: '🔁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':repeat:',
+  ],
+  animated: false,
+);
+
+/// The 🔂 emoji.
+const repeatOne = Emoji(
+  base: '🔂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':repeat-one:',
+  ],
+  animated: false,
+);
+
+/// The 🔀 emoji.
+const shuffle = Emoji(
+  base: '🔀',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':shuffle:',
+    ':twisted-rightwards-arrows:',
+  ],
+  animated: false,
+);
+
+/// The ▶️ emoji.
+const arrowForward = Emoji(
+  base: '▶️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':arrow-forward:',
+    ':play-button:',
+  ],
+  animated: false,
+);
+
+/// The ⏩ emoji.
+const fastForward = Emoji(
+  base: '⏩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fast-forward:',
+  ],
+  animated: false,
+);
+
+/// The ⏭️ emoji.
+const nextTrack = Emoji(
+  base: '⏭️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':next-track:',
+    ':play-next:',
+    ':next:',
+    ':right-pointing-double-triangle-with-vertical-bar:',
+  ],
+  animated: false,
+);
+
+/// The ⏯️ emoji.
+const playOrPause = Emoji(
+  base: '⏯️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':play-or-pause:',
+    ':right-pointing-triangle-with-double-vertical-bar:',
+  ],
+  animated: false,
+);
+
+/// The ◀️ emoji.
+const reverse = Emoji(
+  base: '◀️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':reverse:',
+    ':leftwards-triangle:',
+    ':arrow-backward:',
+  ],
+  animated: false,
+);
+
+/// The ⏪ emoji.
+const rewind = Emoji(
+  base: '⏪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rewind:',
+    ':leftwards-double-triangles:',
+  ],
+  animated: false,
+);
+
+/// The ⏮️ emoji.
+const previous = Emoji(
+  base: '⏮️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':previous:',
+    ':left-pointing-double-triangle-with-vertical-bar:',
+  ],
+  animated: false,
+);
+
+/// The 🔼 emoji.
+const upwards = Emoji(
+  base: '🔼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':upwards:',
+    ':arrow-up:',
+    ':triangle-up:',
+  ],
+  animated: false,
+);
+
+/// The ⏫ emoji.
+const fastUp = Emoji(
+  base: '⏫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fast-up:',
+    ':double-triangle-up:',
+  ],
+  animated: false,
+);
+
+/// The 🔽 emoji.
+const downwards = Emoji(
+  base: '🔽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':downwards:',
+    ':arrow-down:',
+    ':triangle-down:',
+  ],
+  animated: false,
+);
+
+/// The ⏬ emoji.
+const fastDown = Emoji(
+  base: '⏬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fast-down:',
+    ':double-triangle-down:',
+  ],
+  animated: false,
+);
+
+/// The ⏸️ emoji.
+const pause = Emoji(
+  base: '⏸️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pause:',
+    ':double-vertical-bar:',
+  ],
+  animated: false,
+);
+
+/// The ⏹️ emoji.
+const stopButton = Emoji(
+  base: '⏹️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':stop-button:',
+    ':square-button:',
+  ],
+  animated: false,
+);
+
+/// The ⏺️ emoji.
+const record = Emoji(
+  base: '⏺️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':record:',
+  ],
+  animated: false,
+);
+
+/// The ⏏️ emoji.
+const eject = Emoji(
+  base: '⏏️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eject:',
+    ':triangle-up-with-horizontal-bar:',
+  ],
+  animated: false,
+);
+
+/// The 📴 emoji.
+const phoneOff = Emoji(
+  base: '📴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':phone-off:',
+  ],
+  animated: false,
+);
+
+/// The 🛜 emoji.
+const wireless = Emoji(
+  base: '🛜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wireless:',
+  ],
+  animated: false,
+);
+
+/// The 📳 emoji.
+const vibration = Emoji(
+  base: '📳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':vibration:',
+    ':vibration-mode:',
+  ],
+  animated: false,
+);
+
+/// The 📲 emoji.
+const phoneWithArrow = Emoji(
+  base: '📲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':phone-with-arrow:',
+  ],
+  animated: false,
+);
+
+/// The 🔈 emoji.
+const lowVolume = Emoji(
+  base: '🔈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':low-volume:',
+    ':speaker-low-volume:',
+  ],
+  animated: false,
+);
+
+/// The 🔉 emoji.
+const mediumVolume = Emoji(
+  base: '🔉',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':medium-volume:',
+    ':speaker-medium-volume:',
+  ],
+  animated: false,
+);
+
+/// The 🔊 emoji.
+const highVolume = Emoji(
+  base: '🔊',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':high-volume:',
+    ':speaker-high-volume:',
+  ],
+  animated: false,
+);
+
+/// The 🎼 emoji.
+const musicalScore = Emoji(
+  base: '🎼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':musical-score:',
+    ':treble-clef:',
+  ],
+  animated: false,
+);
+
+/// The 🎵 emoji.
+const musicalNote = Emoji(
+  base: '🎵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':musical-note:',
+  ],
+  animated: false,
+);
+
+/// The 🎶 emoji.
+const musicalNotes = Emoji(
+  base: '🎶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':musical-notes:',
+  ],
+  animated: true,
+);
+
+/// The ☢️ emoji.
+const radioactive = Emoji(
+  base: '☢️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':radioactive:',
+  ],
+  animated: false,
+);
+
+/// The ☣️ emoji.
+const biohazard = Emoji(
+  base: '☣️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':biohazard:',
+  ],
+  animated: false,
+);
+
+/// The ⚠️ emoji.
+const warning = Emoji(
+  base: '⚠️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':warning:',
+  ],
+  animated: false,
+);
+
+/// The 🚸 emoji.
+const childrenCrossing = Emoji(
+  base: '🚸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':children-crossing:',
+  ],
+  animated: false,
+);
+
+/// The ⚜️ emoji.
+const fleurDeLis = Emoji(
+  base: '⚜️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':fleur-de-lis:',
+  ],
+  animated: false,
+);
+
+/// The 🔱 emoji.
+const tridentEmblem = Emoji(
+  base: '🔱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':trident-emblem:',
+  ],
+  animated: false,
+);
+
+/// The 〽️ emoji.
+const partAlternationMark = Emoji(
+  base: '〽️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':part-alternation-mark:',
+  ],
+  animated: false,
+);
+
+/// The 🔰 emoji.
+const japaneseSymbolForBeginner = Emoji(
+  base: '🔰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Japanese-symbol-for-beginner:',
+    ':beginner:',
+  ],
+  animated: false,
+);
+
+/// The ✳️ emoji.
+const eightSpokedAsterisk = Emoji(
+  base: '✳️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eight-spoked-asterisk:',
+  ],
+  animated: false,
+);
+
+/// The ❇️ emoji.
+const sparkle = Emoji(
+  base: '❇️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':sparkle:',
+  ],
+  animated: false,
+);
+
+/// The ♻️ emoji.
+const recyclingSymbol = Emoji(
+  base: '♻️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':recycling-symbol:',
+  ],
+  animated: false,
+);
+
+/// The 💱 emoji.
+const currencyExchange = Emoji(
+  base: '💱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':currency-exchange:',
+  ],
+  animated: false,
+);
+
+/// The 💲 emoji.
+const dollarSign = Emoji(
+  base: '💲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':dollar-sign:',
+  ],
+  animated: false,
+);
+
+/// The 💹 emoji.
+const chartIncreasingWithYen = Emoji(
+  base: '💹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':chart-increasing-with-yen:',
+  ],
+  animated: false,
+);
+
+/// The 🈯 emoji.
+const reserved = Emoji(
+  base: '🈯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':reserved:',
+  ],
+  animated: false,
+);
+
+/// The ❎ emoji.
+const xMark = Emoji(
+  base: '❎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':x-mark:',
+    ':cross mark button:',
+    ':no-mark:',
+  ],
+  animated: false,
+);
+
+/// The ✅ emoji.
+const checkMark = Emoji(
+  base: '✅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':check-mark:',
+    ':check-mark-green:',
+  ],
+  animated: true,
+);
+
+/// The ✔️ emoji.
+const checkMarkBlack = Emoji(
+  base: '✔️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':check-mark-black:',
+  ],
+  animated: false,
+);
+
+/// The ☑️ emoji.
+const checkMarkButton = Emoji(
+  base: '☑️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':check-mark-button:',
+    ':vote:',
+  ],
+  animated: false,
+);
+
+/// The ⬆️ emoji.
+const upArrow = Emoji(
+  base: '⬆️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':up-arrow:',
+  ],
+  animated: false,
+);
+
+/// The ↗️ emoji.
+const upRightArrow = Emoji(
+  base: '↗️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':up-right-arrow:',
+  ],
+  animated: false,
+);
+
+/// The ➡️ emoji.
+const rightArrow = Emoji(
+  base: '➡️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':right-arrow:',
+  ],
+  animated: false,
+);
+
+/// The ↘️ emoji.
+const downRightArrow = Emoji(
+  base: '↘️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':down-right-arrow:',
+  ],
+  animated: false,
+);
+
+/// The ⬇️ emoji.
+const downArrow = Emoji(
+  base: '⬇️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':down-arrow:',
+  ],
+  animated: false,
+);
+
+/// The ↙️ emoji.
+const downLeftArrow = Emoji(
+  base: '↙️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':down-left-arrow:',
+  ],
+  animated: false,
+);
+
+/// The ⬅️ emoji.
+const leftArrow = Emoji(
+  base: '⬅️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':left-arrow:',
+  ],
+  animated: false,
+);
+
+/// The ↖️ emoji.
+const upLeftArrow = Emoji(
+  base: '↖️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':up-left-arrow:',
+  ],
+  animated: false,
+);
+
+/// The ↕️ emoji.
+const upDownArrow = Emoji(
+  base: '↕️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':up-down-arrow:',
+  ],
+  animated: false,
+);
+
+/// The ↔️ emoji.
+const leftRightArrow = Emoji(
+  base: '↔️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':left-right-arrow:',
+  ],
+  animated: false,
+);
+
+/// The ↩️ emoji.
+const rightArrowCurvingLeft = Emoji(
+  base: '↩️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':right-arrow-curving-left:',
+  ],
+  animated: false,
+);
+
+/// The ↪️ emoji.
+const leftArrowCurvingRight = Emoji(
+  base: '↪️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':left-arrow-curving-right:',
+  ],
+  animated: false,
+);
+
+/// The ⤴️ emoji.
+const rightArrowCurvingUp = Emoji(
+  base: '⤴️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':right-arrow-curving-up:',
+  ],
+  animated: false,
+);
+
+/// The ⤵️ emoji.
+const rightArrowCurvingDown = Emoji(
+  base: '⤵️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':right-arrow-curving-down:',
+  ],
+  animated: false,
+);
+
+/// The 🔃 emoji.
+const clockwiseArrows = Emoji(
+  base: '🔃',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':clockwise-arrows:',
+  ],
+  animated: false,
+);
+
+/// The 🔄 emoji.
+const counterclockwiseArrows = Emoji(
+  base: '🔄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':counterclockwise-arrows:',
+  ],
+  animated: false,
+);
+
+/// The 🔙 emoji.
+const back = Emoji(
+  base: '🔙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':back:',
+    ':arrow-back:',
+  ],
+  animated: false,
+);
+
+/// The 🔛 emoji.
+const on = Emoji(
+  base: '🔛',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':on:',
+    ':arrow-on:',
+  ],
+  animated: false,
+);
+
+/// The 🔝 emoji.
+const top = Emoji(
+  base: '🔝',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':top:',
+    ':arrow-top:',
+  ],
+  animated: false,
+);
+
+/// The 🔚 emoji.
+const end = Emoji(
+  base: '🔚',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':end:',
+    ':arrow-end:',
+  ],
+  animated: false,
+);
+
+/// The 🔜 emoji.
+const soon = Emoji(
+  base: '🔜',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':soon:',
+    ':arrow-soon:',
+  ],
+  animated: false,
+);
+
+/// The 🆕 emoji.
+const $new = Emoji(
+  base: '🆕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':new:',
+  ],
+  animated: false,
+);
+
+/// The 🆓 emoji.
+const free = Emoji(
+  base: '🆓',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':free:',
+  ],
+  animated: false,
+);
+
+/// The 🆙 emoji.
+const up = Emoji(
+  base: '🆙',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':up!:',
+  ],
+  animated: false,
+);
+
+/// The 🆗 emoji.
+const okButton = Emoji(
+  base: '🆗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ok-button:',
+  ],
+  animated: false,
+);
+
+/// The 🆒 emoji.
+const cool = Emoji(
+  base: '🆒',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':cool:',
+  ],
+  animated: true,
+);
+
+/// The 🆖 emoji.
+const ng = Emoji(
+  base: '🆖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ng:',
+  ],
+  animated: false,
+);
+
+/// The ℹ️ emoji.
+const information = Emoji(
+  base: 'ℹ️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':information:',
+  ],
+  animated: false,
+);
+
+/// The 🅿️ emoji.
+const parking = Emoji(
+  base: '🅿️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Parking:',
+  ],
+  animated: false,
+);
+
+/// The 🈁 emoji.
+const here = Emoji(
+  base: '🈁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':here:',
+  ],
+  animated: false,
+);
+
+/// The 🈂️ emoji.
+const serviceCharge = Emoji(
+  base: '🈂️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':service-charge:',
+  ],
+  animated: false,
+);
+
+/// The 🈳 emoji.
+const vacancy = Emoji(
+  base: '🈳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':vacancy:',
+  ],
+  animated: false,
+);
+
+/// The 🔣 emoji.
+const symbols = Emoji(
+  base: '🔣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':symbols:',
+  ],
+  animated: false,
+);
+
+/// The 🔤 emoji.
+const letters = Emoji(
+  base: '🔤',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':letters:',
+    ':abc:',
+  ],
+  animated: false,
+);
+
+/// The 🔠 emoji.
+const uppercaseLetters = Emoji(
+  base: '🔠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':uppercase-letters:',
+  ],
+  animated: false,
+);
+
+/// The 🔡 emoji.
+const lowercaseLetters = Emoji(
+  base: '🔡',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':lowercase-letters:',
+  ],
+  animated: false,
+);
+
+/// The 🔢 emoji.
+const numbers = Emoji(
+  base: '🔢',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':numbers:',
+  ],
+  animated: false,
+);
+
+/// The #️⃣ emoji.
+const numberSign = Emoji(
+  base: '#️⃣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':#:',
+    ':number-sign:',
+  ],
+  animated: false,
+);
+
+/// The *️⃣ emoji.
+const asterisk = Emoji(
+  base: '*️⃣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':asterisk:',
+    ':keycap-asterisk:',
+  ],
+  animated: false,
+);
+
+/// The 0️⃣ emoji.
+const zero = Emoji(
+  base: '0️⃣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':zero:',
+    ':keycap-zero:',
+  ],
+  animated: false,
+);
+
+/// The 1️⃣ emoji.
+const one = Emoji(
+  base: '1️⃣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':one:',
+    ':keycap-one:',
+  ],
+  animated: false,
+);
+
+/// The 2️⃣ emoji.
+const two = Emoji(
+  base: '2️⃣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':two:',
+    ':keycap-two:',
+  ],
+  animated: false,
+);
+
+/// The 3️⃣ emoji.
+const three = Emoji(
+  base: '3️⃣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':three:',
+    ':keycap-three:',
+  ],
+  animated: false,
+);
+
+/// The 4️⃣ emoji.
+const four = Emoji(
+  base: '4️⃣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':four:',
+    ':keycap-four:',
+  ],
+  animated: false,
+);
+
+/// The 5️⃣ emoji.
+const five = Emoji(
+  base: '5️⃣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':five:',
+    ':keycap-five:',
+  ],
+  animated: false,
+);
+
+/// The 6️⃣ emoji.
+const six = Emoji(
+  base: '6️⃣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':six:',
+    ':keycap-six:',
+  ],
+  animated: false,
+);
+
+/// The 7️⃣ emoji.
+const seven = Emoji(
+  base: '7️⃣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':seven:',
+    ':keycap-seven:',
+  ],
+  animated: false,
+);
+
+/// The 8️⃣ emoji.
+const eight = Emoji(
+  base: '8️⃣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eight:',
+    ':keycap-eight:',
+  ],
+  animated: false,
+);
+
+/// The 9️⃣ emoji.
+const nine = Emoji(
+  base: '9️⃣',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':nine:',
+    ':keycap-nine:',
+  ],
+  animated: false,
+);
+
+/// The 🔟 emoji.
+const ten = Emoji(
+  base: '🔟',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ten:',
+    ':keycap-ten:',
+  ],
+  animated: false,
+);
+
+/// The 💠 emoji.
+const diamondJewel = Emoji(
+  base: '💠',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':diamond-jewel:',
+  ],
+  animated: false,
+);
+
+/// The 🔷 emoji.
+const blueDiamondLarge = Emoji(
+  base: '🔷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':blue-diamond-large:',
+  ],
+  animated: false,
+);
+
+/// The 🔹 emoji.
+const blueDiamondSmall = Emoji(
+  base: '🔹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':blue-diamond-small:',
+  ],
+  animated: false,
+);
+
+/// The 🌐 emoji.
+const globe = Emoji(
+  base: '🌐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':globe:',
+  ],
+  animated: false,
+);
+
+/// The 🏧 emoji.
+const atm = Emoji(
+  base: '🏧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':ATM:',
+  ],
+  animated: false,
+);
+
+/// The Ⓜ️ emoji.
+const metroSign = Emoji(
+  base: 'Ⓜ️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':metro-sign:',
+    ':circled-m:',
+  ],
+  animated: false,
+);
+
+/// The 🚾 emoji.
+const waterCloset = Emoji(
+  base: '🚾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':water-closet:',
+  ],
+  animated: false,
+);
+
+/// The 🚻 emoji.
+const restroom = Emoji(
+  base: '🚻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':restroom:',
+  ],
+  animated: false,
+);
+
+/// The 🚹 emoji.
+const mensRoom = Emoji(
+  base: '🚹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':mens-room:',
+  ],
+  animated: false,
+);
+
+/// The 🚺 emoji.
+const womensRoom = Emoji(
+  base: '🚺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':womens-room:',
+  ],
+  animated: false,
+);
+
+/// The ♿ emoji.
+const wheelchairSymbol = Emoji(
+  base: '♿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wheelchair-symbol:',
+  ],
+  animated: false,
+);
+
+/// The 🚼 emoji.
+const babySymbol = Emoji(
+  base: '🚼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':baby-symbol:',
+  ],
+  animated: false,
+);
+
+/// The 🛗 emoji.
+const elevator = Emoji(
+  base: '🛗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':elevator:',
+  ],
+  animated: false,
+);
+
+/// The 🚮 emoji.
+const litter = Emoji(
+  base: '🚮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':litter:',
+  ],
+  animated: false,
+);
+
+/// The 🚰 emoji.
+const waterFaucet = Emoji(
+  base: '🚰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':water-faucet:',
+  ],
+  animated: false,
+);
+
+/// The 🛂 emoji.
+const passportControl = Emoji(
+  base: '🛂',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':passport-control:',
+  ],
+  animated: false,
+);
+
+/// The 🛃 emoji.
+const customs = Emoji(
+  base: '🛃',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':customs:',
+  ],
+  animated: false,
+);
+
+/// The 🛄 emoji.
+const baggageClaim = Emoji(
+  base: '🛄',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':baggage-claim:',
+  ],
+  animated: false,
+);
+
+/// The 🛅 emoji.
+const leftLuggage = Emoji(
+  base: '🛅',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':left-luggage:',
+  ],
+  animated: false,
+);
+
+/// The ⚛️ emoji.
+const atomSymbol = Emoji(
+  base: '⚛️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':atom-symbol:',
+  ],
+  animated: false,
+);
+
+/// The 🛐 emoji.
+const placeOfWorship = Emoji(
+  base: '🛐',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':place-of-worship:',
+  ],
+  animated: false,
+);
+
+/// The 🕉️ emoji.
+const om = Emoji(
+  base: '🕉️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':om:',
+  ],
+  animated: false,
+);
+
+/// The ☸️ emoji.
+const wheelOfDharma = Emoji(
+  base: '☸️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wheel-of-dharma:',
+  ],
+  animated: false,
+);
+
+/// The ☮️ emoji.
+const peaceSymbol = Emoji(
+  base: '☮️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':peace-symbol:',
+  ],
+  animated: false,
+);
+
+/// The ☯️ emoji.
+const yinYang = Emoji(
+  base: '☯️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':yin-yang:',
+  ],
+  animated: false,
+);
+
+/// The ☪️ emoji.
+const starAndCrescent = Emoji(
+  base: '☪️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':star-and-crescent:',
+  ],
+  animated: false,
+);
+
+/// The 🪯 emoji.
+const khanda = Emoji(
+  base: '🪯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':khanda:',
+  ],
+  animated: false,
+);
+
+/// The ✝️ emoji.
+const latinCross = Emoji(
+  base: '✝️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':latin-cross:',
+  ],
+  animated: false,
+);
+
+/// The ☦️ emoji.
+const orthodoxCross = Emoji(
+  base: '☦️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':orthodox-cross:',
+  ],
+  animated: false,
+);
+
+/// The ✡️ emoji.
+const starOfDavid = Emoji(
+  base: '✡️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':star-of-David:',
+  ],
+  animated: false,
+);
+
+/// The 🔯 emoji.
+const starOfDavidWithDot = Emoji(
+  base: '🔯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':star-of-david-with-dot:',
+  ],
+  animated: false,
+);
+
+/// The 🕎 emoji.
+const menorah = Emoji(
+  base: '🕎',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':menorah:',
+  ],
+  animated: false,
+);
+
+/// The ♾️ emoji.
+const infinity = Emoji(
+  base: '♾️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':infinity:',
+  ],
+  animated: false,
+);
+
+/// The 🆔 emoji.
+const idButton = Emoji(
+  base: '🆔',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':id-button:',
+  ],
+  animated: false,
+);
+
+/// The ⚕️ emoji.
+const medicalSymbol = Emoji(
+  base: '⚕️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':medical-symbol:',
+  ],
+  animated: false,
+);
+
+/// The ✖️ emoji.
+const multiplicationX = Emoji(
+  base: '✖️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':multiplication-x:',
+  ],
+  animated: false,
+);
+
+/// The ➕ emoji.
+const plusSign = Emoji(
+  base: '➕',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':plus-sign:',
+    ':+:',
+  ],
+  animated: true,
+);
+
+/// The ➖ emoji.
+const minusSign = Emoji(
+  base: '➖',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':minus-sign:',
+    ':-:',
+  ],
+  animated: false,
+);
+
+/// The ➗ emoji.
+const divisionSign = Emoji(
+  base: '➗',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':division-sign:',
+  ],
+  animated: false,
+);
+
+/// The 🟰 emoji.
+const equalsSign = Emoji(
+  base: '🟰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':equals-sign:',
+    ':=:',
+  ],
+  animated: false,
+);
+
+/// The ➰ emoji.
+const curlyLoop = Emoji(
+  base: '➰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':curly-loop:',
+  ],
+  animated: false,
+);
+
+/// The ➿ emoji.
+const curlyLoopDouble = Emoji(
+  base: '➿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':curly-loop-double:',
+  ],
+  animated: false,
+);
+
+/// The 〰️ emoji.
+const wavyDash = Emoji(
+  base: '〰️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':wavy-dash:',
+  ],
+  animated: false,
+);
+
+/// The ©️ emoji.
+const copyright = Emoji(
+  base: '©️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':copyright:',
+  ],
+  animated: false,
+);
+
+/// The ®️ emoji.
+const registered = Emoji(
+  base: '®️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':registered:',
+  ],
+  animated: false,
+);
+
+/// The ™️ emoji.
+const tradeMark = Emoji(
+  base: '™️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':trade-mark:',
+  ],
+  animated: false,
+);
+
+/// The 🔘 emoji.
+const radioButton = Emoji(
+  base: '🔘',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':radio-button:',
+  ],
+  animated: false,
+);
+
+/// The 🔳 emoji.
+const whiteSquareButton = Emoji(
+  base: '🔳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':white-square-button:',
+  ],
+  animated: false,
+);
+
+/// The ◼️ emoji.
+const blackSquareMedium = Emoji(
+  base: '◼️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':black-square-medium:',
+  ],
+  animated: false,
+);
+
+/// The ◾ emoji.
+const blackSquareMediumSmall = Emoji(
+  base: '◾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':black-square-medium-small:',
+  ],
+  animated: false,
+);
+
+/// The ▪️ emoji.
+const blackSquareSmall = Emoji(
+  base: '▪️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':black-square-small:',
+  ],
+  animated: false,
+);
+
+/// The 🔲 emoji.
+const buttonBlackSquare = Emoji(
+  base: '🔲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':button-black-square:',
+  ],
+  animated: false,
+);
+
+/// The ◻️ emoji.
+const whiteSquareMedium = Emoji(
+  base: '◻️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':white-square-medium:',
+  ],
+  animated: false,
+);
+
+/// The ◽ emoji.
+const whiteSquareMediumSmall = Emoji(
+  base: '◽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':white-square-medium-small:',
+  ],
+  animated: false,
+);
+
+/// The ▫️ emoji.
+const whiteSquareSmall = Emoji(
+  base: '▫️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':white-square-small:',
+  ],
+  animated: false,
+);
+
+/// The 👁️‍🗨️ emoji.
+const eyeBubble = Emoji(
+  base: '👁️‍🗨️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':eye-bubble:',
+  ],
+  animated: false,
+);
+
+/// The 🏁 emoji.
+const chequeredFlag = Emoji(
+  base: '🏁',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':chequered-flag:',
+  ],
+  animated: true,
+);
+
+/// The 🚩 emoji.
+const triangularFlag = Emoji(
+  base: '🚩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':triangular-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🎌 emoji.
+const crossedFlags = Emoji(
+  base: '🎌',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':crossed-flags:',
+  ],
+  animated: false,
+);
+
+/// The 🏴 emoji.
+const blackFlag = Emoji(
+  base: '🏴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':black-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🏳️ emoji.
+const whiteFlag = Emoji(
+  base: '🏳️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':white-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🏳️‍🌈 emoji.
+const rainbowFlag = Emoji(
+  base: '🏳️‍🌈',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':rainbow-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🏳️‍⚧️ emoji.
+const transFlag = Emoji(
+  base: '🏳️‍⚧️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':trans-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🏴‍☠️ emoji.
+const pirateFlag = Emoji(
+  base: '🏴‍☠️',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':pirate-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇨 emoji.
+const ascensionIslandFlag = Emoji(
+  base: '🇦🇨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Ascension-Island-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇩 emoji.
+const andorraFlag = Emoji(
+  base: '🇦🇩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Andorra-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇪 emoji.
+const unitedArabEmiratesFlag = Emoji(
+  base: '🇦🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':United-Arab-Emirates-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇫 emoji.
+const afghanistanFlag = Emoji(
+  base: '🇦🇫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Afghanistan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇬 emoji.
+const antiguaBarbudaFlag = Emoji(
+  base: '🇦🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Antigua-Barbuda-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇮 emoji.
+const anguillaFlag = Emoji(
+  base: '🇦🇮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Anguilla-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇱 emoji.
+const albaniaFlag = Emoji(
+  base: '🇦🇱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Albania-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇲 emoji.
+const armeniaFlag = Emoji(
+  base: '🇦🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Armenia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇴 emoji.
+const angolaFlag = Emoji(
+  base: '🇦🇴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Angola-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇶 emoji.
+const antarcticaFlag = Emoji(
+  base: '🇦🇶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Antarctica-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇷 emoji.
+const argentinaFlag = Emoji(
+  base: '🇦🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Argentina-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇸 emoji.
+const americanSamoaFlag = Emoji(
+  base: '🇦🇸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':American-Samoa-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇹 emoji.
+const austriaFlag = Emoji(
+  base: '🇦🇹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Austria-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇺 emoji.
+const australiaFlag = Emoji(
+  base: '🇦🇺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Australia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇼 emoji.
+const arubaFlag = Emoji(
+  base: '🇦🇼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Aruba-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇽 emoji.
+const alandIslandsFlag = Emoji(
+  base: '🇦🇽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Åland-Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇦🇿 emoji.
+const azerbaijanFlag = Emoji(
+  base: '🇦🇿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Azerbaijan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇦 emoji.
+const bosniaHerzegovinaFlag = Emoji(
+  base: '🇧🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Bosnia-Herzegovina-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇧 emoji.
+const barbadosFlag = Emoji(
+  base: '🇧🇧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Barbados-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇩 emoji.
+const bangladeshFlag = Emoji(
+  base: '🇧🇩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Bangladesh-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇪 emoji.
+const belgiumFlag = Emoji(
+  base: '🇧🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Belgium-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇫 emoji.
+const burkinaFasoFlag = Emoji(
+  base: '🇧🇫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Burkina-Faso-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇬 emoji.
+const bulgariaFlag = Emoji(
+  base: '🇧🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Bulgaria-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇭 emoji.
+const bahrainFlag = Emoji(
+  base: '🇧🇭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Bahrain-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇮 emoji.
+const burundiFlag = Emoji(
+  base: '🇧🇮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Burundi-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇯 emoji.
+const beninFlag = Emoji(
+  base: '🇧🇯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Benin-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇱 emoji.
+const stBarthelemyFlag = Emoji(
+  base: '🇧🇱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':St-Barthélemy-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇲 emoji.
+const bermudaFlag = Emoji(
+  base: '🇧🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Bermuda-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇳 emoji.
+const bruneiFlag = Emoji(
+  base: '🇧🇳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Brunei-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇴 emoji.
+const boliviaFlag = Emoji(
+  base: '🇧🇴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Bolivia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇶 emoji.
+const caribbeanNetherlandsFlag = Emoji(
+  base: '🇧🇶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Caribbean-Netherlands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇷 emoji.
+const brazilFlag = Emoji(
+  base: '🇧🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Brazil-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇸 emoji.
+const bahamasFlag = Emoji(
+  base: '🇧🇸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Bahamas-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇹 emoji.
+const bhutanFlag = Emoji(
+  base: '🇧🇹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Bhutan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇻 emoji.
+const bouvetIslandFlag = Emoji(
+  base: '🇧🇻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Bouvet-Island-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇼 emoji.
+const botswanaFlag = Emoji(
+  base: '🇧🇼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Botswana-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇾 emoji.
+const belarusFlag = Emoji(
+  base: '🇧🇾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Belarus-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇧🇿 emoji.
+const belizeFlag = Emoji(
+  base: '🇧🇿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Belize-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇦 emoji.
+const canadaFlag = Emoji(
+  base: '🇨🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Canada-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇨 emoji.
+const cocosIslandsFlag = Emoji(
+  base: '🇨🇨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Cocos-Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇩 emoji.
+const congoKinshasaFlag = Emoji(
+  base: '🇨🇩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Congo-Kinshasa-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇫 emoji.
+const centralAfricanRepublicFlag = Emoji(
+  base: '🇨🇫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Central-African-Republic-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇬 emoji.
+const congoBrazzavilleFlag = Emoji(
+  base: '🇨🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Congo-Brazzaville-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇭 emoji.
+const switzerlandFlag = Emoji(
+  base: '🇨🇭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Switzerland-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇮 emoji.
+const coteDivoireFlag = Emoji(
+  base: '🇨🇮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Côte-d’Ivoire-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇰 emoji.
+const cookIslandsFlag = Emoji(
+  base: '🇨🇰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Cook-Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇱 emoji.
+const chileFlag = Emoji(
+  base: '🇨🇱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Chile-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇲 emoji.
+const cameroonFlag = Emoji(
+  base: '🇨🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Cameroon-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇳 emoji.
+const chinaFlag = Emoji(
+  base: '🇨🇳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':China-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇴 emoji.
+const colombiaFlag = Emoji(
+  base: '🇨🇴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Colombia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇵 emoji.
+const clippertonIslandFlag = Emoji(
+  base: '🇨🇵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Clipperton-Island-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇷 emoji.
+const costaRicaFlag = Emoji(
+  base: '🇨🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Costa-Rica-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇺 emoji.
+const cubaFlag = Emoji(
+  base: '🇨🇺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Cuba-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇻 emoji.
+const capeVerdeFlag = Emoji(
+  base: '🇨🇻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Cape-Verde-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇼 emoji.
+const curacaoFlag = Emoji(
+  base: '🇨🇼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Curaçao-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇽 emoji.
+const christmasIslandFlag = Emoji(
+  base: '🇨🇽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Christmas-Island-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇾 emoji.
+const cyprusFlag = Emoji(
+  base: '🇨🇾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Cyprus-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇨🇿 emoji.
+const czechiaFlag = Emoji(
+  base: '🇨🇿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Czechia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇩🇪 emoji.
+const germanyFlag = Emoji(
+  base: '🇩🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Germany-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇩🇬 emoji.
+const diegoGarciaFlag = Emoji(
+  base: '🇩🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Diego-Garcia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇩🇯 emoji.
+const djiboutiFlag = Emoji(
+  base: '🇩🇯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Djibouti-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇩🇰 emoji.
+const denmarkFlag = Emoji(
+  base: '🇩🇰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Denmark-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇩🇲 emoji.
+const dominicaFlag = Emoji(
+  base: '🇩🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Dominica-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇩🇴 emoji.
+const dominicanrepublicFlag = Emoji(
+  base: '🇩🇴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Dominican Republic-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇩🇿 emoji.
+const algeriaFlag = Emoji(
+  base: '🇩🇿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Algeria-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇪🇦 emoji.
+const ceutaMelillaFlag = Emoji(
+  base: '🇪🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Ceuta-Melilla-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇪🇨 emoji.
+const ecuadorFlag = Emoji(
+  base: '🇪🇨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Ecuador-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇪🇪 emoji.
+const estoniaFlag = Emoji(
+  base: '🇪🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Estonia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇪🇬 emoji.
+const egyptFlag = Emoji(
+  base: '🇪🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Egypt-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇪🇭 emoji.
+const westernSaharaFlag = Emoji(
+  base: '🇪🇭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Western-Sahara-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇪🇷 emoji.
+const eritreaFlag = Emoji(
+  base: '🇪🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Eritrea-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇪🇸 emoji.
+const spainFlag = Emoji(
+  base: '🇪🇸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Spain-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇪🇹 emoji.
+const ethiopiaFlag = Emoji(
+  base: '🇪🇹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Ethiopia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇪🇺 emoji.
+const europeanUnionFlag = Emoji(
+  base: '🇪🇺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':European-Union-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇫🇮 emoji.
+const finlandFlag = Emoji(
+  base: '🇫🇮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Finland-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇫🇯 emoji.
+const fijiFlag = Emoji(
+  base: '🇫🇯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Fiji-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇫🇰 emoji.
+const falklandIslandsFlag = Emoji(
+  base: '🇫🇰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Falkland-Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇫🇲 emoji.
+const micronesiaFlag = Emoji(
+  base: '🇫🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Micronesia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇫🇴 emoji.
+const faroeIslandsFlag = Emoji(
+  base: '🇫🇴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Faroe-Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇫🇷 emoji.
+const franceFlag = Emoji(
+  base: '🇫🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':France-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇦 emoji.
+const gabonFlag = Emoji(
+  base: '🇬🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Gabon-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇧 emoji.
+const unitedKingdomFlag = Emoji(
+  base: '🇬🇧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':United-Kingdom-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇩 emoji.
+const grenadaFlag = Emoji(
+  base: '🇬🇩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Grenada-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇪 emoji.
+const georgiaFlag = Emoji(
+  base: '🇬🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Georgia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇫 emoji.
+const frenchguianaFlag = Emoji(
+  base: '🇬🇫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':French Guiana-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇬 emoji.
+const guernseyFlag = Emoji(
+  base: '🇬🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Guernsey-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇭 emoji.
+const ghanaFlag = Emoji(
+  base: '🇬🇭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Ghana-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇮 emoji.
+const gibraltarFlag = Emoji(
+  base: '🇬🇮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Gibraltar-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇱 emoji.
+const greenlandFlag = Emoji(
+  base: '🇬🇱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Greenland-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇲 emoji.
+const gambiaFlag = Emoji(
+  base: '🇬🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Gambia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇳 emoji.
+const guineaFlag = Emoji(
+  base: '🇬🇳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Guinea-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇵 emoji.
+const guadeloupeFlag = Emoji(
+  base: '🇬🇵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Guadeloupe-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇶 emoji.
+const equatorialGuineaFlag = Emoji(
+  base: '🇬🇶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Equatorial-Guinea-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇷 emoji.
+const greeceFlag = Emoji(
+  base: '🇬🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Greece-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇸 emoji.
+const southGeorgiaSouthFlag = Emoji(
+  base: '🇬🇸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':South-Georgia-South-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇹 emoji.
+const guatemalaFlag = Emoji(
+  base: '🇬🇹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Guatemala-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇺 emoji.
+const guamFlag = Emoji(
+  base: '🇬🇺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Guam-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇼 emoji.
+const guineaBissauFlag = Emoji(
+  base: '🇬🇼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Guinea-Bissau-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇬🇾 emoji.
+const guyanaFlag = Emoji(
+  base: '🇬🇾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Guyana-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇭🇰 emoji.
+const hongKongSarChinaFlag = Emoji(
+  base: '🇭🇰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Hong-Kong-SAR-China-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇭🇲 emoji.
+const heardMcdonaldislandsFlag = Emoji(
+  base: '🇭🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Heard-McDonald Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇭🇳 emoji.
+const hondurasFlag = Emoji(
+  base: '🇭🇳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Honduras-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇭🇷 emoji.
+const croatiaFlag = Emoji(
+  base: '🇭🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Croatia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇭🇹 emoji.
+const haitiFlag = Emoji(
+  base: '🇭🇹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Haiti-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇭🇺 emoji.
+const hungaryFlag = Emoji(
+  base: '🇭🇺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Hungary-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇮🇨 emoji.
+const canaryIslandsFlag = Emoji(
+  base: '🇮🇨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Canary-Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇮🇩 emoji.
+const indonesiaFlag = Emoji(
+  base: '🇮🇩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Indonesia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇮🇪 emoji.
+const irelandFlag = Emoji(
+  base: '🇮🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Ireland-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇮🇱 emoji.
+const israelFlag = Emoji(
+  base: '🇮🇱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Israel-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇮🇲 emoji.
+const isleOfManFlag = Emoji(
+  base: '🇮🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Isle-of-Man-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇮🇳 emoji.
+const indiaFlag = Emoji(
+  base: '🇮🇳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':India-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇮🇴 emoji.
+const britishIndianOceanTerritoryFlag = Emoji(
+  base: '🇮🇴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':British-Indian-Ocean-Territory-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇮🇶 emoji.
+const iraqFlag = Emoji(
+  base: '🇮🇶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Iraq-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇮🇷 emoji.
+const iranFlag = Emoji(
+  base: '🇮🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Iran-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇮🇸 emoji.
+const icelandFlag = Emoji(
+  base: '🇮🇸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Iceland-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇮🇹 emoji.
+const italyFlag = Emoji(
+  base: '🇮🇹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Italy-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇯🇪 emoji.
+const jerseyFlag = Emoji(
+  base: '🇯🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Jersey-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇯🇲 emoji.
+const jamaicaFlag = Emoji(
+  base: '🇯🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Jamaica-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇯🇴 emoji.
+const jordanFlag = Emoji(
+  base: '🇯🇴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Jordan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇯🇵 emoji.
+const japanFlag = Emoji(
+  base: '🇯🇵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Japan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇰🇪 emoji.
+const kenyaFlag = Emoji(
+  base: '🇰🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Kenya-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇰🇬 emoji.
+const kyrgyzstanFlag = Emoji(
+  base: '🇰🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Kyrgyzstan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇰🇭 emoji.
+const cambodiaFlag = Emoji(
+  base: '🇰🇭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Cambodia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇰🇮 emoji.
+const kiribatiFlag = Emoji(
+  base: '🇰🇮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Kiribati-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇰🇲 emoji.
+const comorosFlag = Emoji(
+  base: '🇰🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Comoros-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇰🇳 emoji.
+const stkittsnevisFlag = Emoji(
+  base: '🇰🇳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':St. Kitts & Nevis-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇰🇵 emoji.
+const northkoreaFlag = Emoji(
+  base: '🇰🇵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':North Korea-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇰🇷 emoji.
+const southkoreaFlag = Emoji(
+  base: '🇰🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':South Korea-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇰🇼 emoji.
+const kuwaitFlag = Emoji(
+  base: '🇰🇼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Kuwait-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇰🇾 emoji.
+const caymanislandsFlag = Emoji(
+  base: '🇰🇾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Cayman Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇰🇿 emoji.
+const kazakhstanFlag = Emoji(
+  base: '🇰🇿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Kazakhstan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇱🇦 emoji.
+const laosFlag = Emoji(
+  base: '🇱🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Laos-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇱🇧 emoji.
+const lebanonFlag = Emoji(
+  base: '🇱🇧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Lebanon-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇱🇨 emoji.
+const stluciaFlag = Emoji(
+  base: '🇱🇨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':St. Lucia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇱🇮 emoji.
+const liechtensteinFlag = Emoji(
+  base: '🇱🇮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Liechtenstein-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇱🇰 emoji.
+const srilankaFlag = Emoji(
+  base: '🇱🇰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Sri Lanka-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇱🇷 emoji.
+const liberiaFlag = Emoji(
+  base: '🇱🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Liberia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇱🇸 emoji.
+const lesothoFlag = Emoji(
+  base: '🇱🇸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Lesotho-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇱🇹 emoji.
+const lithuaniaFlag = Emoji(
+  base: '🇱🇹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Lithuania-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇱🇺 emoji.
+const luxembourgFlag = Emoji(
+  base: '🇱🇺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Luxembourg-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇱🇻 emoji.
+const latviaFlag = Emoji(
+  base: '🇱🇻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Latvia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇱🇾 emoji.
+const libyaFlag = Emoji(
+  base: '🇱🇾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Libya-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇦 emoji.
+const moroccoFlag = Emoji(
+  base: '🇲🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Morocco-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇨 emoji.
+const monacoFlag = Emoji(
+  base: '🇲🇨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Monaco-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇩 emoji.
+const moldovaFlag = Emoji(
+  base: '🇲🇩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Moldova-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇪 emoji.
+const montenegroFlag = Emoji(
+  base: '🇲🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Montenegro-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇫 emoji.
+const stMartinFlag = Emoji(
+  base: '🇲🇫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':St-Martin-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇬 emoji.
+const madagascarFlag = Emoji(
+  base: '🇲🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Madagascar-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇭 emoji.
+const marshallIslandsFlag = Emoji(
+  base: '🇲🇭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Marshall-Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇰 emoji.
+const macedoniaFlag = Emoji(
+  base: '🇲🇰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Macedonia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇱 emoji.
+const maliFlag = Emoji(
+  base: '🇲🇱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Mali-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇲 emoji.
+const myanmarFlag = Emoji(
+  base: '🇲🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Myanmar-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇳 emoji.
+const mongoliaFlag = Emoji(
+  base: '🇲🇳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Mongolia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇴 emoji.
+const macauSarChinaFlag = Emoji(
+  base: '🇲🇴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Macau-SAR-China-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇵 emoji.
+const northernMarianaIslandsFlag = Emoji(
+  base: '🇲🇵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Northern-Mariana-Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇶 emoji.
+const martiniqueFlag = Emoji(
+  base: '🇲🇶',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Martinique-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇷 emoji.
+const mauritaniaFlag = Emoji(
+  base: '🇲🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Mauritania-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇸 emoji.
+const montserratFlag = Emoji(
+  base: '🇲🇸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Montserrat-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇹 emoji.
+const maltaFlag = Emoji(
+  base: '🇲🇹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Malta-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇺 emoji.
+const mauritiusFlag = Emoji(
+  base: '🇲🇺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Mauritius-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇻 emoji.
+const maldivesFlag = Emoji(
+  base: '🇲🇻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Maldives-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇼 emoji.
+const malawiFlag = Emoji(
+  base: '🇲🇼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Malawi-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇽 emoji.
+const mexicoFlag = Emoji(
+  base: '🇲🇽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Mexico-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇾 emoji.
+const malaysiaFlag = Emoji(
+  base: '🇲🇾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Malaysia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇲🇿 emoji.
+const mozambiqueFlag = Emoji(
+  base: '🇲🇿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Mozambique-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇳🇦 emoji.
+const namibiaFlag = Emoji(
+  base: '🇳🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Namibia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇳🇨 emoji.
+const newCaledoniaFlag = Emoji(
+  base: '🇳🇨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':New-Caledonia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇳🇪 emoji.
+const nigerFlag = Emoji(
+  base: '🇳🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Niger-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇳🇫 emoji.
+const norfolkIslandFlag = Emoji(
+  base: '🇳🇫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Norfolk-Island-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇳🇬 emoji.
+const nigeriaFlag = Emoji(
+  base: '🇳🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Nigeria-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇳🇮 emoji.
+const nicaraguaFlag = Emoji(
+  base: '🇳🇮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Nicaragua-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇳🇱 emoji.
+const netherlandsFlag = Emoji(
+  base: '🇳🇱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Netherlands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇳🇴 emoji.
+const norwayFlag = Emoji(
+  base: '🇳🇴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Norway-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇳🇵 emoji.
+const nepalFlag = Emoji(
+  base: '🇳🇵',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Nepal-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇳🇷 emoji.
+const nauruFlag = Emoji(
+  base: '🇳🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Nauru-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇳🇺 emoji.
+const niueFlag = Emoji(
+  base: '🇳🇺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Niue-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇳🇿 emoji.
+const newZealandFlag = Emoji(
+  base: '🇳🇿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':New-Zealand-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇴🇲 emoji.
+const omanFlag = Emoji(
+  base: '🇴🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Oman-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇦 emoji.
+const panamaFlag = Emoji(
+  base: '🇵🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Panama-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇪 emoji.
+const peruFlag = Emoji(
+  base: '🇵🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Peru-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇫 emoji.
+const frenchPolynesiaFlag = Emoji(
+  base: '🇵🇫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':French-Polynesia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇬 emoji.
+const papuaNewGuineaFlag = Emoji(
+  base: '🇵🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Papua-New-Guinea-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇭 emoji.
+const philippinesFlag = Emoji(
+  base: '🇵🇭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Philippines-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇰 emoji.
+const pakistanFlag = Emoji(
+  base: '🇵🇰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Pakistan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇱 emoji.
+const polandFlag = Emoji(
+  base: '🇵🇱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Poland-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇲 emoji.
+const stPierreMiquelonFlag = Emoji(
+  base: '🇵🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':St-Pierre-Miquelon-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇳 emoji.
+const pitcairnIslandsFlag = Emoji(
+  base: '🇵🇳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Pitcairn-Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇷 emoji.
+const puertoRicoFlag = Emoji(
+  base: '🇵🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Puerto-Rico-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇸 emoji.
+const palestinianTerritoriesFlag = Emoji(
+  base: '🇵🇸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Palestinian-Territories-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇹 emoji.
+const portugalFlag = Emoji(
+  base: '🇵🇹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Portugal-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇼 emoji.
+const palauFlag = Emoji(
+  base: '🇵🇼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Palau-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇵🇾 emoji.
+const paraguayFlag = Emoji(
+  base: '🇵🇾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Paraguay-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇶🇦 emoji.
+const qatarFlag = Emoji(
+  base: '🇶🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Qatar-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇷🇪 emoji.
+const reunionFlag = Emoji(
+  base: '🇷🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Réunion-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇷🇴 emoji.
+const romaniaFlag = Emoji(
+  base: '🇷🇴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Romania-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇷🇸 emoji.
+const serbiaFlag = Emoji(
+  base: '🇷🇸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Serbia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇷🇺 emoji.
+const russiaFlag = Emoji(
+  base: '🇷🇺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Russia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇷🇼 emoji.
+const rwandaFlag = Emoji(
+  base: '🇷🇼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Rwanda-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇦 emoji.
+const saudiArabiaFlag = Emoji(
+  base: '🇸🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Saudi-Arabia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇧 emoji.
+const solomonIslandsFlag = Emoji(
+  base: '🇸🇧',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Solomon-Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇨 emoji.
+const seychellesFlag = Emoji(
+  base: '🇸🇨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Seychelles-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇩 emoji.
+const sudanFlag = Emoji(
+  base: '🇸🇩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Sudan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇪 emoji.
+const swedenFlag = Emoji(
+  base: '🇸🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Sweden-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇬 emoji.
+const singaporeFlag = Emoji(
+  base: '🇸🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Singapore-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇭 emoji.
+const stHelenaFlag = Emoji(
+  base: '🇸🇭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':St-Helena-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇮 emoji.
+const sloveniaFlag = Emoji(
+  base: '🇸🇮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Slovenia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇯 emoji.
+const svalbardJanmayenFlag = Emoji(
+  base: '🇸🇯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Svalbard-Jan Mayen-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇰 emoji.
+const slovakiaFlag = Emoji(
+  base: '🇸🇰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Slovakia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇱 emoji.
+const sierraLeoneFlag = Emoji(
+  base: '🇸🇱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Sierra-Leone-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇲 emoji.
+const sanMarinoFlag = Emoji(
+  base: '🇸🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':San-Marino-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇳 emoji.
+const senegalFlag = Emoji(
+  base: '🇸🇳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Senegal-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇴 emoji.
+const somaliaFlag = Emoji(
+  base: '🇸🇴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Somalia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇷 emoji.
+const surinameFlag = Emoji(
+  base: '🇸🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Suriname-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇸 emoji.
+const southSudanFlag = Emoji(
+  base: '🇸🇸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':South-Sudan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇹 emoji.
+const saoTomePrincipeFlag = Emoji(
+  base: '🇸🇹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':São-Tomé-Príncipe-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇻 emoji.
+const elSalvadorFlag = Emoji(
+  base: '🇸🇻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':El-Salvador-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇽 emoji.
+const sintMaartenFlag = Emoji(
+  base: '🇸🇽',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Sint-Maarten-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇾 emoji.
+const syriaFlag = Emoji(
+  base: '🇸🇾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Syria-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇸🇿 emoji.
+const swazilandFlag = Emoji(
+  base: '🇸🇿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Swaziland-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇦 emoji.
+const tristanDaCunhaFlag = Emoji(
+  base: '🇹🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Tristan-da-Cunha-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇨 emoji.
+const turksCaicosislandsFlag = Emoji(
+  base: '🇹🇨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Turks-Caicos Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇩 emoji.
+const chadFlag = Emoji(
+  base: '🇹🇩',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Chad-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇫 emoji.
+const frenchSouthernTerritoriesFlag = Emoji(
+  base: '🇹🇫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':French-Southern-Territories-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇬 emoji.
+const togoFlag = Emoji(
+  base: '🇹🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Togo-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇭 emoji.
+const thailandFlag = Emoji(
+  base: '🇹🇭',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Thailand-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇯 emoji.
+const tajikistanFlag = Emoji(
+  base: '🇹🇯',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Tajikistan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇰 emoji.
+const tokelauFlag = Emoji(
+  base: '🇹🇰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Tokelau-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇱 emoji.
+const timorLesteFlag = Emoji(
+  base: '🇹🇱',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Timor-Leste-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇲 emoji.
+const turkmenistanFlag = Emoji(
+  base: '🇹🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Turkmenistan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇳 emoji.
+const tunisiaFlag = Emoji(
+  base: '🇹🇳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Tunisia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇴 emoji.
+const tongaFlag = Emoji(
+  base: '🇹🇴',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Tonga-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇷 emoji.
+const turkeyFlag = Emoji(
+  base: '🇹🇷',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Turkey-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇹 emoji.
+const trinidadTobagoFlag = Emoji(
+  base: '🇹🇹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Trinidad-Tobago-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇻 emoji.
+const tuvaluFlag = Emoji(
+  base: '🇹🇻',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Tuvalu-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇼 emoji.
+const taiwanFlag = Emoji(
+  base: '🇹🇼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Taiwan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇹🇿 emoji.
+const tanzaniaFlag = Emoji(
+  base: '🇹🇿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Tanzania-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇺🇦 emoji.
+const ukraineFlag = Emoji(
+  base: '🇺🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Ukraine-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇺🇬 emoji.
+const ugandaFlag = Emoji(
+  base: '🇺🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Uganda-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇺🇲 emoji.
+const usOutlyingislandsFlag = Emoji(
+  base: '🇺🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':US-Outlying Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇺🇳 emoji.
+const unitedNationsFlag = Emoji(
+  base: '🇺🇳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':United-Nations-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇺🇸 emoji.
+const unitedStatesFlag = Emoji(
+  base: '🇺🇸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':United-States-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇺🇾 emoji.
+const uruguayFlag = Emoji(
+  base: '🇺🇾',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Uruguay-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇺🇿 emoji.
+const uzbekistanFlag = Emoji(
+  base: '🇺🇿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Uzbekistan-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇻🇦 emoji.
+const vaticancityFlag = Emoji(
+  base: '🇻🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Vatican City-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇻🇨 emoji.
+const stVincentGrenadinesFlag = Emoji(
+  base: '🇻🇨',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':St-Vincent-Grenadines-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇻🇪 emoji.
+const venezuelaFlag = Emoji(
+  base: '🇻🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Venezuela-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇻🇬 emoji.
+const britishVirginislandsFlag = Emoji(
+  base: '🇻🇬',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':British-Virgin Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇻🇮 emoji.
+const usVirginIslandsFlag = Emoji(
+  base: '🇻🇮',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':US-Virgin-Islands-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇻🇳 emoji.
+const vietnamFlag = Emoji(
+  base: '🇻🇳',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Vietnam-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇻🇺 emoji.
+const vanuatuFlag = Emoji(
+  base: '🇻🇺',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Vanuatu-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇼🇫 emoji.
+const wallisFutunaFlag = Emoji(
+  base: '🇼🇫',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Wallis-Futuna-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇼🇸 emoji.
+const samoaFlag = Emoji(
+  base: '🇼🇸',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Samoa-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇽🇰 emoji.
+const kosovoFlag = Emoji(
+  base: '🇽🇰',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Kosovo-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇾🇪 emoji.
+const yemenFlag = Emoji(
+  base: '🇾🇪',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Yemen-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇾🇹 emoji.
+const mayotteFlag = Emoji(
+  base: '🇾🇹',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Mayotte-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇿🇦 emoji.
+const southAfricaFlag = Emoji(
+  base: '🇿🇦',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':South-Africa-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇿🇲 emoji.
+const zambiaFlag = Emoji(
+  base: '🇿🇲',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Zambia-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🇿🇼 emoji.
+const zimbabweFlag = Emoji(
+  base: '🇿🇼',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Zimbabwe-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🏴󠁧󠁢󠁥󠁮󠁧󠁿 emoji.
+const englandFlag = Emoji(
+  base: '🏴󠁧󠁢󠁥󠁮󠁧󠁿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':England-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🏴󠁧󠁢󠁳󠁣󠁴󠁿 emoji.
+const scotlandFlag = Emoji(
+  base: '🏴󠁧󠁢󠁳󠁣󠁴󠁿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Scotland-flag:',
+  ],
+  animated: false,
+);
+
+/// The 🏴󠁧󠁢󠁷󠁬󠁳󠁿 emoji.
+const walesFlag = Emoji(
+  base: '🏴󠁧󠁢󠁷󠁬󠁳󠁿',
+  alternates: [],
+  emoticons: [],
+  shortcodes: [
+    ':Wales-flag:',
+  ],
+  animated: false,
+);
+
+/// The "Smileys and emotions" emojis.
+const smileysAndEmotionsGroup = [
+  smile,
+  smileWithBigEyes,
+  grin,
+  grinning,
+  laughing,
+  grinSweat,
+  joy,
+  rofl,
+  loudlyCrying,
+  wink,
+  kissing,
+  kissingSmilingEyes,
+  kissingClosedEyes,
+  kissingHeart,
+  heartFace,
+  heartEyes,
+  starStruck,
+  partyingFace,
+  melting,
+  upsideDownFace,
+  slightlyHappy,
+  happyCry,
+  holdingBackTears,
+  blush,
+  warmSmile,
+  relieved,
+  smirk,
+  sleep,
+  sleepy,
+  drool,
+  yum,
+  stuckOutTongue,
+  squintingTongue,
+  winkyTongue,
+  zanyFace,
+  woozy,
+  pensive,
+  pleading,
+  grimacing,
+  expressionless,
+  neutralFace,
+  mouthNone,
+  faceInClouds,
+  dottedLineFace,
+  zipperFace,
+  salute,
+  thinkingFace,
+  shushingFace,
+  handOverMouth,
+  smilingEyesWithHandOverMouth,
+  yawn,
+  hugFace,
+  peeking,
+  screaming,
+  raisedEyebrow,
+  monocle,
+  unamused,
+  rollingEyes,
+  exhale,
+  triumph,
+  angry,
+  rage,
+  cursing,
+  sad,
+  sweat,
+  worried,
+  concerned,
+  cry,
+  bigFrown,
+  frown,
+  diagonalMouth,
+  slightlyFrowning,
+  anxiousWithSweat,
+  scared,
+  anguished,
+  gasp,
+  mouthOpen,
+  surprised,
+  astonished,
+  flushed,
+  mindBlown,
+  scrunchedMouth,
+  scrunchedEyes,
+  weary,
+  distraught,
+  xEyes,
+  dizzyFace,
+  shakingFace,
+  coldFace,
+  hotFace,
+  sick,
+  vomit,
+  sneeze,
+  thermometerFace,
+  bandageFace,
+  mask,
+  liar,
+  halo,
+  cowboy,
+  moneyFace,
+  nerdFace,
+  sunglassesFace,
+  disguise,
+  clown,
+  impSmile,
+  impFrown,
+  ghost,
+  jackOLantern,
+  poop,
+  robot,
+  alien,
+  alienMonster,
+  moonFaceFirstQuarter,
+  moonFaceLastQuarter,
+  moonFaceNew,
+  moonFaceFull,
+  sunWithFace,
+  skullAndCrossbones,
+  ogre,
+  goblin,
+  fire,
+  oneHundred,
+  dizzy,
+  star,
+  glowingStar,
+  sparkles,
+  collision,
+  dash,
+  sweatDroplets,
+  zzz,
+  hole,
+  partyPopper,
+  seeNoEvilMonkey,
+  hearNoEvilMonkey,
+  speakNoEvilMonkey,
+  smileyCat,
+  smileCat,
+  joyCat,
+  heartEyesCat,
+  smirkCat,
+  kissingCat,
+  screamCat,
+  cryingCatFace,
+  poutingCat,
+  redHeart,
+  orangeHeart,
+  yellowHeart,
+  greenHeart,
+  lightBlueHeart,
+  blueHeart,
+  purpleHeart,
+  brownHeart,
+  blackHeart,
+  greyHeart,
+  whiteHeart,
+  pinkHeart,
+  cupid,
+  giftHeart,
+  sparklingHeart,
+  heartGrow,
+  beatingHeart,
+  revolvingHearts,
+  twoHearts,
+  loveLetter,
+  heartBox,
+  heart,
+  heartExclamationPoint,
+  bandagedHeart,
+  brokenHeart,
+  fireHeart,
+  kiss,
+  hugging,
+  bustsInSilhouette,
+  bustInSilhouette,
+  speakingHead,
+  footprints,
+  brain,
+  anatomicalHeart,
+  lungs,
+  blood,
+  microbe,
+  tooth,
+  bone,
+  skull,
+  eyes,
+  eye,
+  mouth,
+  bitingLip,
+  tongue,
+  nose,
+  ear,
+  hearingAid,
+  foot,
+  leg,
+  legMechanical,
+  armMechanical,
+  muscle,
+  clap,
+  thumbsUp,
+  thumbsDown,
+  heartHands,
+  raisingHands,
+  openHands,
+  palmsUp,
+  handshake,
+  fistRightwards,
+  fistLeftwards,
+  raisedFist,
+  fist,
+  palmDown,
+  palmUp,
+  rightwardsHand,
+  leftwardsHand,
+  pushRightwards,
+  pushLeftwards,
+  wave,
+  backHand,
+  palm,
+  raisedHand,
+  vulcan,
+  loveYouGesture,
+  metal,
+  v,
+  crossedFingers,
+  handWithIndexFingerAndThumbCrossed,
+  callMeHand,
+  pinchedFingers,
+  pinch,
+  ok,
+  pointing,
+  pointRight,
+  pointLeft,
+  indexFinger,
+  pointUp,
+  pointDown,
+  middleFinger,
+  writingHand,
+  selfie,
+  foldedHands,
+  nailCare,
+];
+
+/// The "People" emojis.
+const peopleGroup = [
+  bow,
+  raisingHand,
+  tippingHand,
+  gestureOk,
+  noGesture,
+  shrug,
+  facepalm,
+  frowning,
+  pouting,
+  deaf,
+  massage,
+  haircut,
+  sauna,
+  bathe,
+  inBed,
+  yoga,
+  walkingWithCane,
+  personInMotorizedWheelchair,
+  personInManualWheelchair,
+  kneeling,
+  standing,
+  walking,
+  running,
+  cartwheel,
+  liftingWeights,
+  bouncingBall,
+  handball,
+  biking,
+  mountainBiking,
+  climbing,
+  wrestling,
+  juggling,
+  golfing,
+  horseRacing,
+  fencing,
+  skier,
+  snowboarder,
+  parachute,
+  surfing,
+  rowingBoat,
+  swimming,
+  waterPolo,
+  merperson,
+  fairy,
+  genie,
+  elf,
+  mage,
+  vampire,
+  zombie,
+  troll,
+  superhero,
+  supervillain,
+  ninja,
+  mxClaus,
+  angel,
+  guard,
+  royalty,
+  tuxedo,
+  veil,
+  astronaut,
+  constructionWorker,
+  police,
+  detective,
+  pilot,
+  scientist,
+  healthWorker,
+  mechanic,
+  factoryWorker,
+  firefighter,
+  farmer,
+  teacher,
+  student,
+  officeWorker,
+  judge,
+  technologist,
+  singer,
+  artist,
+  cook,
+  turban,
+  headscarf,
+  guaPiMao,
+  baby,
+  child,
+  adult,
+  elder,
+  whiteHair,
+  redHair,
+  blondHair,
+  curlyHair,
+  bald,
+  beard,
+  levitatingSuit,
+  dancerWoman,
+  dancerMan,
+  bunnyEars,
+  holdingHands,
+  holdingHandsWomen,
+  holdingHandsMen,
+  holdingHandsWomanAndMan,
+  kissPeople,
+  kissWomanAndMan,
+  kissManAndMan,
+  kissWomanAndWoman,
+  peopleWithHeart,
+  heartWithWomanAndMan,
+  heartWithManAndMan,
+  heartWithWomanAndWoman,
+  pregnant,
+  breastFeeding,
+  personFeedingBaby,
+  family,
+];
+
+/// The "Animals and nature" emojis.
+const animalsAndNatureGroup = [
+  bouquet,
+  rose,
+  wiltedFlower,
+  hibiscus,
+  tulip,
+  lotus,
+  cherryBlossom,
+  whiteFlower,
+  rosette,
+  hyacinth,
+  sunflower,
+  blossom,
+  fallenLeaf,
+  mapleLeaf,
+  mushroom,
+  earOfRice,
+  plant,
+  herb,
+  leaves,
+  shamrock,
+  luck,
+  pottedPlant,
+  cactus,
+  palmTree,
+  deciduousTree,
+  evergreenTree,
+  wood,
+  nest,
+  nestWithEggs,
+  rock,
+  mountain,
+  snowMountain,
+  snowflake,
+  snowmanWithSnow,
+  snowman,
+  fog,
+  thermometer,
+  fire,
+  volcano,
+  desert,
+  nationalPark,
+  desertIsland,
+  beach,
+  sunrise,
+  sunriseOverMountains,
+  rainbow,
+  bubbles,
+  ocean,
+  windFace,
+  cyclone,
+  tornado,
+  electricity,
+  umbrellaInRain,
+  droplet,
+  rainCloud,
+  cloudWithLightning,
+  cloudWithLightningAndRain,
+  cloudWithSnow,
+  cloud,
+  sunBehindRainCloud,
+  sunBehindLargeCloud,
+  partlySunny,
+  sunBehindSmallCloud,
+  sunny,
+  sunWithFace,
+  moonFaceFull,
+  moonFaceNew,
+  moonFaceLastQuarter,
+  moonFaceFirstQuarter,
+  star,
+  glowingStar,
+  sparkles,
+  dizzy,
+  crescentMoon,
+  comet,
+  hole,
+  shootingStar,
+  milkyWay,
+  globeShowingEuropeAfrica,
+  globeShowingAmericas,
+  globeShowingAsiaAustralia,
+  ringedPlanet,
+  newMoon,
+  waxingCrescentMoon,
+  firstQuarterMoon,
+  waxingGibbousMoon,
+  fullMoon,
+  waningGibbousMoon,
+  lastQuarterMoon,
+  waningCrescentMoon,
+  seeNoEvilMonkey,
+  hearNoEvilMonkey,
+  speakNoEvilMonkey,
+  monkeyFace,
+  lionFace,
+  tigerFace,
+  catFace,
+  dogFace,
+  wolf,
+  bearFace,
+  polarBear,
+  koala,
+  panda,
+  hamster,
+  mouseFace,
+  rabbitFace,
+  foxFace,
+  raccoon,
+  cowFace,
+  pigFace,
+  snout,
+  boar,
+  zebra,
+  unicorn,
+  horseFace,
+  moose,
+  dragonFace,
+  lizard,
+  dragon,
+  tRex,
+  dinosaur,
+  turtle,
+  crocodile,
+  snake,
+  frog,
+  rabbit,
+  mouse,
+  rat,
+  cat,
+  blackCat,
+  poodle,
+  dog,
+  guideDog,
+  serviceDog,
+  pig,
+  racehorse,
+  donkey,
+  cow,
+  ox,
+  waterBuffalo,
+  bison,
+  ram,
+  sheep,
+  goat,
+  deer,
+  llama,
+  sloth,
+  kangaroo,
+  elephant,
+  mammoth,
+  rhino,
+  hippo,
+  giraffe,
+  leopard,
+  tiger,
+  monkey,
+  gorilla,
+  orangutan,
+  camel,
+  bactrianCamel,
+  chipmunk,
+  beaver,
+  skunk,
+  badger,
+  hedgehog,
+  otter,
+  bat,
+  wingfly,
+  feather,
+  bird,
+  blackBird,
+  rooster,
+  chicken,
+  hatchingChick,
+  babyChick,
+  hatchedChick,
+  eagle,
+  owl,
+  parrot,
+  peace,
+  dodo,
+  swan,
+  duck,
+  goose,
+  flamingo,
+  peacock,
+  turkey,
+  penguin,
+  seal,
+  shark,
+  dolphin,
+  humpbackWhale,
+  whale,
+  fish,
+  tropicalFish,
+  blowfish,
+  shrimp,
+  lobster,
+  crab,
+  squid,
+  octopus,
+  jellyfish,
+  oyster,
+  coral,
+  scorpion,
+  spider,
+  spiderWeb,
+  shell,
+  snail,
+  ant,
+  cricket,
+  beetle,
+  mosquito,
+  cockroach,
+  fly,
+  bee,
+  ladyBug,
+  butterfly,
+  bug,
+  worm,
+  microbe,
+  pawprints,
+];
+
+/// The "Food and drink" emojis.
+const foodAndDrinkGroup = [
+  strawberry,
+  cherries,
+  redApple,
+  watermelon,
+  peach,
+  tangerine,
+  mango,
+  pineapple,
+  banana,
+  lemon,
+  melon,
+  greenApple,
+  pear,
+  kiwiFruit,
+  olive,
+  blueberries,
+  grapes,
+  coconut,
+  tomato,
+  hotPepper,
+  ginger,
+  carrot,
+  roastedSweetPotato,
+  onion,
+  earOfCorn,
+  broccoli,
+  cucumber,
+  leafyGreen,
+  peaPod,
+  bellPepper,
+  avocado,
+  eggplant,
+  garlic,
+  potato,
+  beans,
+  chestnut,
+  peanuts,
+  bread,
+  flatbread,
+  croissant,
+  baguetteBread,
+  bagel,
+  waffle,
+  pancakes,
+  cooking,
+  egg,
+  cheeseWedge,
+  bacon,
+  cutOfMeat,
+  poultryLeg,
+  meatOnBone,
+  hamburger,
+  hotDog,
+  sandwich,
+  pretzel,
+  frenchFries,
+  pizza,
+  tamale,
+  taco,
+  burrito,
+  stuffedFlatbread,
+  falafel,
+  shallowPanOfFood,
+  spaghetti,
+  cannedFood,
+  fondue,
+  bowlWithSpoon,
+  greenSalad,
+  potOfFood,
+  curryRice,
+  steamingBowl,
+  oyster,
+  lobster,
+  sushi,
+  friedShrimp,
+  takeoutBox,
+  cookedRice,
+  bentoBox,
+  dumpling,
+  oden,
+  riceBall,
+  riceCracker,
+  fishCakeWithSwirl,
+  dango,
+  fortuneCookie,
+  moonCake,
+  shavedIce,
+  iceCream,
+  softIceCream,
+  pie,
+  shortcake,
+  custard,
+  birthdayCake,
+  cupcake,
+  lollipop,
+  candy,
+  chocolateBar,
+  doughnut,
+  cookie,
+  honeyPot,
+  salt,
+  butter,
+  popcorn,
+  iceCube,
+  jar,
+  cupWithStraw,
+  bubbleTea,
+  beverageBox,
+  glassOfMilk,
+  babyBottle,
+  teacupWithoutHandle,
+  hotBeverage,
+  teapot,
+  mate,
+  beerMug,
+  clinkingBeerMugs,
+  clinkingGlasses,
+  bottleWithPoppingCork,
+  wineGlass,
+  tumblerGlass,
+  pour,
+  cocktailGlass,
+  tropicalDrink,
+  sake,
+  chopsticks,
+  forkAndKnife,
+  spoon,
+  kitchenKnife,
+  forkAndKnifeWithPlate,
+];
+
+/// The "Travel and places" emojis.
+const travelAndPlacesGroup = [
+  stopSign,
+  construction,
+  policeCarLight,
+  fuelPump,
+  oilDrum,
+  compass,
+  wheel,
+  ringBuoy,
+  anchor,
+  busStop,
+  metro,
+  horizontalTrafficLight,
+  verticalTrafficLight,
+  kickScooter,
+  manualWheelchair,
+  motorizedWheelchair,
+  crutch,
+  bicycle,
+  motorScooter,
+  motorcycle,
+  sportUtilityVehicle,
+  automobile,
+  pickupTruck,
+  minibus,
+  deliveryTruck,
+  articulatedLorry,
+  tractor,
+  racingCar,
+  fireEngine,
+  ambulance,
+  policeCar,
+  taxi,
+  autoRickshaw,
+  bus,
+  lightRail,
+  monorail,
+  bulletTrain,
+  highSpeedTrain,
+  locomotive,
+  railwayCar,
+  tramCar,
+  trolleybus,
+  mountainRailway,
+  tram,
+  station,
+  busFront,
+  policeCarFront,
+  automobileFront,
+  taxiFront,
+  train,
+  ship,
+  passengerShip,
+  motorBoat,
+  speedboat,
+  ferry,
+  sailboat,
+  canoe,
+  suspensionRailway,
+  mountainCableway,
+  aerialTramway,
+  helicopter,
+  flyingSaucer,
+  rocket,
+  airplane,
+  airplaneDeparture,
+  airplaneArrival,
+  smallAirplane,
+  slide,
+  rollerCoaster,
+  ferrisWheel,
+  carouselHorse,
+  circusTent,
+  tokyoTower,
+  statueOfLiberty,
+  moai,
+  mountFuji,
+  classicalBuilding,
+  barberPole,
+  fountain,
+  shintoShrine,
+  synagogue,
+  mosque,
+  kaaba,
+  hinduTemple,
+  church,
+  wedding,
+  loveHotel,
+  japaneseCastle,
+  castle,
+  constructionBuilding,
+  officeBuilding,
+  factory,
+  departmentStore,
+  convenienceStore,
+  stadium,
+  bank,
+  school,
+  hotel,
+  japanesePostOffice,
+  postOffice,
+  hospital,
+  derelictHouse,
+  house,
+  houseWithGarden,
+  houses,
+  hut,
+  tent,
+  camping,
+  umbrellaOnGround,
+  cityscape,
+  sunsetCityscape,
+  sunset,
+  nightWithStars,
+  bridgeAtNight,
+  foggy,
+  railwayTrack,
+  motorway,
+  mapOfJapan,
+  worldMap,
+  globeWithMeridians,
+  seat,
+  luggage,
+];
+
+/// The "Activities and events" emojis.
+const activitiesAndEventsGroup = [
+  partyPopper,
+  confettiBall,
+  balloon,
+  birthdayCake,
+  ribbon,
+  wrappedGift,
+  sparkler,
+  fireworks,
+  firecracker,
+  redEnvelope,
+  diyaLamp,
+  pinata,
+  mirrorBall,
+  windChime,
+  carpStreamer,
+  japaneseDolls,
+  moonViewingCeremony,
+  pineDecoration,
+  tanabataTree,
+  christmasTree,
+  jackOLantern,
+  reminderRibbon,
+  goldMedal,
+  silverMedal,
+  bronzeMedal,
+  medal,
+  militaryMedal,
+  trophy,
+  loudspeaker,
+  soccerBall,
+  baseball,
+  softball,
+  basketball,
+  volleyball,
+  americanFootball,
+  rugbyFootball,
+  goalNet,
+  tennis,
+  badminton,
+  lacrosse,
+  cricketGame,
+  fieldHockey,
+  iceHockey,
+  curlingStone,
+  sled,
+  skis,
+  iceSkate,
+  rollerSkates,
+  balletShoes,
+  skateboard,
+  flagInHole,
+  directHit,
+  bowAndArrow,
+  flyingDisc,
+  boomerang,
+  kite,
+  fishingPole,
+  divingMask,
+  onePieceSwimsuit,
+  runningShirt,
+  martialArtsUniform,
+  boxingGlove,
+  eightBall,
+  pingPong,
+  bowling,
+  chessPawn,
+  yoYo,
+  jigsaw,
+  videoGame,
+  joystick,
+  alienMonster,
+  pistol,
+  die,
+  slotMachine,
+  flowerPlayingCards,
+  mahjongRedDragon,
+  joker,
+  wand,
+  gameDie,
+  camera,
+  cameraFlash,
+  framedPicture,
+  artistPalette,
+  paintbrush,
+  crayon,
+  needle,
+  thread,
+  yarn,
+  piano,
+  saxophone,
+  trumpet,
+  guitar,
+  banjo,
+  violin,
+  longDrum,
+  drum,
+  maracas,
+  flute,
+  accordion,
+  microphone,
+  headphone,
+  levelSlider,
+  controlKnobs,
+  studioMicrophone,
+  radio,
+  television,
+  videocassette,
+  videoCamera,
+  filmProjector,
+  movieCamera,
+  film,
+  clapper,
+  performingArts,
+  ticket,
+  admissionTickets,
+];
+
+/// The "Objects" emojis.
+const objectsGroup = [
+  mobilePhone,
+  telephone,
+  telephoneReceiver,
+  pager,
+  faxMachine,
+  electricPlug,
+  batteryFull,
+  batteryLow,
+  trackball,
+  computerDisk,
+  floppyDisk,
+  opticalDisk,
+  dvd,
+  desktopComputer,
+  laptopComputer,
+  keyboard,
+  printer,
+  computerMouse,
+  coin,
+  moneyWithWings,
+  dollar,
+  yen,
+  euro,
+  pound,
+  creditCard,
+  moneyBag,
+  receipt,
+  abacus,
+  balanceScale,
+  shoppingCart,
+  shoppingBags,
+  candle,
+  lightBulb,
+  flashlight,
+  redPaperLantern,
+  bricks,
+  window,
+  mirror,
+  door,
+  chair,
+  bed,
+  couchAndLamp,
+  shower,
+  bathtub,
+  toilet,
+  rollOfPaper,
+  plunger,
+  teddyBear,
+  nestingDoll,
+  safetyPin,
+  knot,
+  broom,
+  lotionBottle,
+  sponge,
+  soap,
+  toothbrush,
+  razor,
+  hairPick,
+  basket,
+  socks,
+  gloves,
+  scarf,
+  jeans,
+  tShirt,
+  runningShirt,
+  womansClothes,
+  necktie,
+  dress,
+  kimono,
+  sari,
+  onePieceSwimsuit,
+  bikini,
+  shorts,
+  swimBrief,
+  coat,
+  labCoat,
+  safetyVest,
+  rescueWorkersHelmet,
+  militaryHelmet,
+  graduationCap,
+  topHat,
+  womansHat,
+  billedCap,
+  crown,
+  fan,
+  schoolBackpack,
+  clutchBag,
+  purse,
+  handbag,
+  briefcase,
+  luggage,
+  umbrella,
+  closedUmbrella,
+  ring,
+  gemStone,
+  lipstick,
+  highHeeledShoe,
+  runningShoe,
+  mansShoe,
+  flatShoe,
+  flipFlop,
+  sandal,
+  boot,
+  hikingBoot,
+  probingCane,
+  sunglasses,
+  glasses,
+  goggles,
+  alembic,
+  petriDish,
+  testTube,
+  thermometer,
+  syringe,
+  pill,
+  adhesiveBandage,
+  stethoscope,
+  xRay,
+  dna,
+  telescope,
+  microscope,
+  satelliteAntenna,
+  satellite,
+  fireExtinguisher,
+  axe,
+  ladder,
+  bucket,
+  hook,
+  magnet,
+  toolbox,
+  clamp,
+  nutAndBolt,
+  screwdriver,
+  saw,
+  wrench,
+  hammer,
+  hammerAndPick,
+  hammerAndWrench,
+  pick,
+  gear,
+  link,
+  chains,
+  paperclip,
+  linkedPaperclips,
+  straightRuler,
+  triangularRuler,
+  paintbrush,
+  crayon,
+  pen,
+  fountainPen,
+  blackNib,
+  pencil,
+  memo,
+  openBook,
+  books,
+  ledger,
+  notebookWithDecorativeCover,
+  closedBook,
+  notebook,
+  greenBook,
+  blueBook,
+  orangeBook,
+  bookmark,
+  spiralNotepad,
+  pageFacingUp,
+  pageWithCurl,
+  clipboard,
+  bookmarkTabs,
+  openFileFolder,
+  fileFolder,
+  cardIndexDividers,
+  cardFileBox,
+  fileCabinet,
+  barChart,
+  chartIncreasing,
+  chartDecreasing,
+  cardIndex,
+  id,
+  pushpin,
+  roundPushpin,
+  scissors,
+  wastebasket,
+  newspaper,
+  rolledUpNewspaper,
+  label,
+  package,
+  closedMailboxWithRaised,
+  closedMailboxWithLowered,
+  openMailboxWithRaised,
+  openMailboxWithLowered,
+  postbox,
+  envelope,
+  eMail,
+  envelopeWithArrow,
+  incomingEnvelope,
+  loveLetter,
+  outboxTray,
+  inboxTray,
+  ballotBox,
+  twelveOClock,
+  twelveThirty,
+  oneOClock,
+  oneThirty,
+  twoOClock,
+  twoThirty,
+  threeOClock,
+  threeThirty,
+  fourOClock,
+  fourThirty,
+  fiveOClock,
+  fiveThirty,
+  sixOClock,
+  sixThirty,
+  sevenOClock,
+  sevenThirty,
+  eightOClock,
+  eightThirty,
+  nineOClock,
+  nineThirty,
+  tenOClock,
+  tenThirty,
+  elevenOClock,
+  elevenThirty,
+  stopwatch,
+  watch,
+  mantelpieceClock,
+  hourglassDone,
+  hourglassNotDone,
+  timerClock,
+  alarmClock,
+  calendar,
+  tearOffCalendar,
+  spiralCalendar,
+  placard,
+  bellhopBell,
+  bell,
+  postalHorn,
+  loudspeaker,
+  megaphone,
+  magnifyingGlassTiltedLeft,
+  magnifyingGlassTiltedRight,
+  crystalBall,
+  evilEye,
+  hamsa,
+  prayerBeads,
+  amphora,
+  urn,
+  coffin,
+  headstone,
+  cigarette,
+  bomb,
+  mouseTrap,
+  scroll,
+  crossedSwords,
+  dagger,
+  shield,
+  oldKey,
+  key,
+  lockWithKey,
+  lockWithPen,
+  locked,
+  unlocked,
+];
+
+/// The "Symbols" emojis.
+const symbolsGroup = [
+  redCircle,
+  orangeCircle,
+  yellowCircle,
+  greenCircle,
+  blueCircle,
+  purpleCircle,
+  brownCircle,
+  blackCircle,
+  whiteCircle,
+  redSquare,
+  orangeSquare,
+  yellowSquare,
+  greenSquare,
+  blueSquare,
+  purpleSquare,
+  brownSquare,
+  blackSquare,
+  whiteSquare,
+  redHeart,
+  orangeHeart,
+  yellowHeart,
+  greenHeart,
+  blueHeart,
+  purpleHeart,
+  brownHeart,
+  blackHeart,
+  whiteHeart,
+  pinkHeart,
+  lightBlueHeart,
+  grayHeart,
+  heart,
+  diamond,
+  club,
+  spade,
+  aries,
+  taurus,
+  gemini,
+  cancer,
+  leo,
+  virgo,
+  libra,
+  scorpio,
+  sagittarius,
+  capricorn,
+  aquarius,
+  pisces,
+  ophiuchus,
+  femaleSign,
+  maleSign,
+  transSign,
+  thoughtBubble,
+  angerBubble,
+  speechBubble,
+  speechBubbleLeftwards,
+  exclamationMarkWhite,
+  exclamation,
+  questionMarkWhite,
+  question,
+  exclamationQuestionMark,
+  exclamationDouble,
+  largeCircle,
+  x,
+  prohibited,
+  noBicycles,
+  noSmoking,
+  noLittering,
+  nonPotableWater,
+  noPedestrians,
+  noMobilePhones,
+  noUnderEighteen,
+  noSound,
+  mute,
+  aButton,
+  abButton,
+  bButton,
+  oButton,
+  clButton,
+  sos,
+  stop,
+  noEntry,
+  nameBadge,
+  hotSprings,
+  anger,
+  trianglePointedDown,
+  trianglePointedUp,
+  bargain,
+  secret,
+  congratulations,
+  passingGrade,
+  noVacancy,
+  discount,
+  prohibitedButton,
+  accept,
+  notFreeOfCharge,
+  freeOfCharge,
+  application,
+  openForBusiness,
+  monthlyAmount,
+  eightPointedStar,
+  diamondOrangeLarge,
+  diamondOrangeSmall,
+  bright,
+  dim,
+  vs,
+  cinema,
+  signalStrength,
+  repeat,
+  repeatOne,
+  shuffle,
+  arrowForward,
+  fastForward,
+  nextTrack,
+  playOrPause,
+  reverse,
+  rewind,
+  previous,
+  upwards,
+  fastUp,
+  downwards,
+  fastDown,
+  pause,
+  stopButton,
+  record,
+  eject,
+  phoneOff,
+  wireless,
+  vibration,
+  phoneWithArrow,
+  lowVolume,
+  mediumVolume,
+  highVolume,
+  musicalScore,
+  musicalNote,
+  musicalNotes,
+  radioactive,
+  biohazard,
+  warning,
+  childrenCrossing,
+  fleurDeLis,
+  tridentEmblem,
+  partAlternationMark,
+  japaneseSymbolForBeginner,
+  eightSpokedAsterisk,
+  sparkle,
+  recyclingSymbol,
+  currencyExchange,
+  dollarSign,
+  chartIncreasingWithYen,
+  reserved,
+  xMark,
+  checkMark,
+  checkMarkBlack,
+  checkMarkButton,
+  upArrow,
+  upRightArrow,
+  rightArrow,
+  downRightArrow,
+  downArrow,
+  downLeftArrow,
+  leftArrow,
+  upLeftArrow,
+  upDownArrow,
+  leftRightArrow,
+  rightArrowCurvingLeft,
+  leftArrowCurvingRight,
+  rightArrowCurvingUp,
+  rightArrowCurvingDown,
+  clockwiseArrows,
+  counterclockwiseArrows,
+  back,
+  on,
+  top,
+  end,
+  soon,
+  $new,
+  free,
+  up,
+  okButton,
+  cool,
+  ng,
+  information,
+  parking,
+  here,
+  serviceCharge,
+  vacancy,
+  symbols,
+  letters,
+  uppercaseLetters,
+  lowercaseLetters,
+  numbers,
+  numberSign,
+  asterisk,
+  zero,
+  one,
+  two,
+  three,
+  four,
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+  diamondJewel,
+  blueDiamondLarge,
+  blueDiamondSmall,
+  globe,
+  atm,
+  metroSign,
+  waterCloset,
+  restroom,
+  mensRoom,
+  womensRoom,
+  wheelchairSymbol,
+  babySymbol,
+  elevator,
+  litter,
+  waterFaucet,
+  passportControl,
+  customs,
+  baggageClaim,
+  leftLuggage,
+  heartBox,
+  atomSymbol,
+  placeOfWorship,
+  om,
+  wheelOfDharma,
+  peaceSymbol,
+  yinYang,
+  starAndCrescent,
+  khanda,
+  latinCross,
+  orthodoxCross,
+  starOfDavid,
+  starOfDavidWithDot,
+  menorah,
+  infinity,
+  idButton,
+  medicalSymbol,
+  multiplicationX,
+  plusSign,
+  minusSign,
+  divisionSign,
+  equalsSign,
+  curlyLoop,
+  curlyLoopDouble,
+  wavyDash,
+  copyright,
+  registered,
+  tradeMark,
+  radioButton,
+  whiteSquareButton,
+  blackSquareMedium,
+  blackSquareMediumSmall,
+  blackSquareSmall,
+  buttonBlackSquare,
+  whiteSquareMedium,
+  whiteSquareMediumSmall,
+  whiteSquareSmall,
+  eyeBubble,
+];
+
+/// The "Flags" emojis.
+const flagsGroup = [
+  chequeredFlag,
+  triangularFlag,
+  crossedFlags,
+  blackFlag,
+  whiteFlag,
+  rainbowFlag,
+  transFlag,
+  pirateFlag,
+  ascensionIslandFlag,
+  andorraFlag,
+  unitedArabEmiratesFlag,
+  afghanistanFlag,
+  antiguaBarbudaFlag,
+  anguillaFlag,
+  albaniaFlag,
+  armeniaFlag,
+  angolaFlag,
+  antarcticaFlag,
+  argentinaFlag,
+  americanSamoaFlag,
+  austriaFlag,
+  australiaFlag,
+  arubaFlag,
+  alandIslandsFlag,
+  azerbaijanFlag,
+  bosniaHerzegovinaFlag,
+  barbadosFlag,
+  bangladeshFlag,
+  belgiumFlag,
+  burkinaFasoFlag,
+  bulgariaFlag,
+  bahrainFlag,
+  burundiFlag,
+  beninFlag,
+  stBarthelemyFlag,
+  bermudaFlag,
+  bruneiFlag,
+  boliviaFlag,
+  caribbeanNetherlandsFlag,
+  brazilFlag,
+  bahamasFlag,
+  bhutanFlag,
+  bouvetIslandFlag,
+  botswanaFlag,
+  belarusFlag,
+  belizeFlag,
+  canadaFlag,
+  cocosIslandsFlag,
+  congoKinshasaFlag,
+  centralAfricanRepublicFlag,
+  congoBrazzavilleFlag,
+  switzerlandFlag,
+  coteDivoireFlag,
+  cookIslandsFlag,
+  chileFlag,
+  cameroonFlag,
+  chinaFlag,
+  colombiaFlag,
+  clippertonIslandFlag,
+  costaRicaFlag,
+  cubaFlag,
+  capeVerdeFlag,
+  curacaoFlag,
+  christmasIslandFlag,
+  cyprusFlag,
+  czechiaFlag,
+  germanyFlag,
+  diegoGarciaFlag,
+  djiboutiFlag,
+  denmarkFlag,
+  dominicaFlag,
+  dominicanrepublicFlag,
+  algeriaFlag,
+  ceutaMelillaFlag,
+  ecuadorFlag,
+  estoniaFlag,
+  egyptFlag,
+  westernSaharaFlag,
+  eritreaFlag,
+  spainFlag,
+  ethiopiaFlag,
+  europeanUnionFlag,
+  finlandFlag,
+  fijiFlag,
+  falklandIslandsFlag,
+  micronesiaFlag,
+  faroeIslandsFlag,
+  franceFlag,
+  gabonFlag,
+  unitedKingdomFlag,
+  grenadaFlag,
+  georgiaFlag,
+  frenchguianaFlag,
+  guernseyFlag,
+  ghanaFlag,
+  gibraltarFlag,
+  greenlandFlag,
+  gambiaFlag,
+  guineaFlag,
+  guadeloupeFlag,
+  equatorialGuineaFlag,
+  greeceFlag,
+  southGeorgiaSouthFlag,
+  guatemalaFlag,
+  guamFlag,
+  guineaBissauFlag,
+  guyanaFlag,
+  hongKongSarChinaFlag,
+  heardMcdonaldislandsFlag,
+  hondurasFlag,
+  croatiaFlag,
+  haitiFlag,
+  hungaryFlag,
+  canaryIslandsFlag,
+  indonesiaFlag,
+  irelandFlag,
+  israelFlag,
+  isleOfManFlag,
+  indiaFlag,
+  britishIndianOceanTerritoryFlag,
+  iraqFlag,
+  iranFlag,
+  icelandFlag,
+  italyFlag,
+  jerseyFlag,
+  jamaicaFlag,
+  jordanFlag,
+  japanFlag,
+  kenyaFlag,
+  kyrgyzstanFlag,
+  cambodiaFlag,
+  kiribatiFlag,
+  comorosFlag,
+  stkittsnevisFlag,
+  northkoreaFlag,
+  southkoreaFlag,
+  kuwaitFlag,
+  caymanislandsFlag,
+  kazakhstanFlag,
+  laosFlag,
+  lebanonFlag,
+  stluciaFlag,
+  liechtensteinFlag,
+  srilankaFlag,
+  liberiaFlag,
+  lesothoFlag,
+  lithuaniaFlag,
+  luxembourgFlag,
+  latviaFlag,
+  libyaFlag,
+  moroccoFlag,
+  monacoFlag,
+  moldovaFlag,
+  montenegroFlag,
+  stMartinFlag,
+  madagascarFlag,
+  marshallIslandsFlag,
+  macedoniaFlag,
+  maliFlag,
+  myanmarFlag,
+  mongoliaFlag,
+  macauSarChinaFlag,
+  northernMarianaIslandsFlag,
+  martiniqueFlag,
+  mauritaniaFlag,
+  montserratFlag,
+  maltaFlag,
+  mauritiusFlag,
+  maldivesFlag,
+  malawiFlag,
+  mexicoFlag,
+  malaysiaFlag,
+  mozambiqueFlag,
+  namibiaFlag,
+  newCaledoniaFlag,
+  nigerFlag,
+  norfolkIslandFlag,
+  nigeriaFlag,
+  nicaraguaFlag,
+  netherlandsFlag,
+  norwayFlag,
+  nepalFlag,
+  nauruFlag,
+  niueFlag,
+  newZealandFlag,
+  omanFlag,
+  panamaFlag,
+  peruFlag,
+  frenchPolynesiaFlag,
+  papuaNewGuineaFlag,
+  philippinesFlag,
+  pakistanFlag,
+  polandFlag,
+  stPierreMiquelonFlag,
+  pitcairnIslandsFlag,
+  puertoRicoFlag,
+  palestinianTerritoriesFlag,
+  portugalFlag,
+  palauFlag,
+  paraguayFlag,
+  qatarFlag,
+  reunionFlag,
+  romaniaFlag,
+  serbiaFlag,
+  russiaFlag,
+  rwandaFlag,
+  saudiArabiaFlag,
+  solomonIslandsFlag,
+  seychellesFlag,
+  sudanFlag,
+  swedenFlag,
+  singaporeFlag,
+  stHelenaFlag,
+  sloveniaFlag,
+  svalbardJanmayenFlag,
+  slovakiaFlag,
+  sierraLeoneFlag,
+  sanMarinoFlag,
+  senegalFlag,
+  somaliaFlag,
+  surinameFlag,
+  southSudanFlag,
+  saoTomePrincipeFlag,
+  elSalvadorFlag,
+  sintMaartenFlag,
+  syriaFlag,
+  swazilandFlag,
+  tristanDaCunhaFlag,
+  turksCaicosislandsFlag,
+  chadFlag,
+  frenchSouthernTerritoriesFlag,
+  togoFlag,
+  thailandFlag,
+  tajikistanFlag,
+  tokelauFlag,
+  timorLesteFlag,
+  turkmenistanFlag,
+  tunisiaFlag,
+  tongaFlag,
+  turkeyFlag,
+  trinidadTobagoFlag,
+  tuvaluFlag,
+  taiwanFlag,
+  tanzaniaFlag,
+  ukraineFlag,
+  ugandaFlag,
+  usOutlyingislandsFlag,
+  unitedNationsFlag,
+  unitedStatesFlag,
+  uruguayFlag,
+  uzbekistanFlag,
+  vaticancityFlag,
+  stVincentGrenadinesFlag,
+  venezuelaFlag,
+  britishVirginislandsFlag,
+  usVirginIslandsFlag,
+  vietnamFlag,
+  vanuatuFlag,
+  wallisFutunaFlag,
+  samoaFlag,
+  kosovoFlag,
+  yemenFlag,
+  mayotteFlag,
+  southAfricaFlag,
+  zambiaFlag,
+  zimbabweFlag,
+  englandFlag,
+  scotlandFlag,
+  walesFlag,
+];
+
+/// All emojis.
+const all = [
+  smile,
+  smileWithBigEyes,
+  grin,
+  grinning,
+  laughing,
+  grinSweat,
+  joy,
+  rofl,
+  loudlyCrying,
+  wink,
+  kissing,
+  kissingSmilingEyes,
+  kissingClosedEyes,
+  kissingHeart,
+  heartFace,
+  heartEyes,
+  starStruck,
+  partyingFace,
+  melting,
+  upsideDownFace,
+  slightlyHappy,
+  happyCry,
+  holdingBackTears,
+  blush,
+  warmSmile,
+  relieved,
+  smirk,
+  sleep,
+  sleepy,
+  drool,
+  yum,
+  stuckOutTongue,
+  squintingTongue,
+  winkyTongue,
+  zanyFace,
+  woozy,
+  pensive,
+  pleading,
+  grimacing,
+  expressionless,
+  neutralFace,
+  mouthNone,
+  faceInClouds,
+  dottedLineFace,
+  zipperFace,
+  salute,
+  thinkingFace,
+  shushingFace,
+  handOverMouth,
+  smilingEyesWithHandOverMouth,
+  yawn,
+  hugFace,
+  peeking,
+  screaming,
+  raisedEyebrow,
+  monocle,
+  unamused,
+  rollingEyes,
+  exhale,
+  triumph,
+  angry,
+  rage,
+  cursing,
+  sad,
+  sweat,
+  worried,
+  concerned,
+  cry,
+  bigFrown,
+  frown,
+  diagonalMouth,
+  slightlyFrowning,
+  anxiousWithSweat,
+  scared,
+  anguished,
+  gasp,
+  mouthOpen,
+  surprised,
+  astonished,
+  flushed,
+  mindBlown,
+  scrunchedMouth,
+  scrunchedEyes,
+  weary,
+  distraught,
+  xEyes,
+  dizzyFace,
+  shakingFace,
+  coldFace,
+  hotFace,
+  sick,
+  vomit,
+  sneeze,
+  thermometerFace,
+  bandageFace,
+  mask,
+  liar,
+  halo,
+  cowboy,
+  moneyFace,
+  nerdFace,
+  sunglassesFace,
+  disguise,
+  clown,
+  impSmile,
+  impFrown,
+  ghost,
+  jackOLantern,
+  poop,
+  robot,
+  alien,
+  alienMonster,
+  moonFaceFirstQuarter,
+  moonFaceLastQuarter,
+  moonFaceNew,
+  moonFaceFull,
+  sunWithFace,
+  skullAndCrossbones,
+  ogre,
+  goblin,
+  fire,
+  oneHundred,
+  dizzy,
+  star,
+  glowingStar,
+  sparkles,
+  collision,
+  dash,
+  sweatDroplets,
+  zzz,
+  hole,
+  partyPopper,
+  seeNoEvilMonkey,
+  hearNoEvilMonkey,
+  speakNoEvilMonkey,
+  smileyCat,
+  smileCat,
+  joyCat,
+  heartEyesCat,
+  smirkCat,
+  kissingCat,
+  screamCat,
+  cryingCatFace,
+  poutingCat,
+  redHeart,
+  orangeHeart,
+  yellowHeart,
+  greenHeart,
+  lightBlueHeart,
+  blueHeart,
+  purpleHeart,
+  brownHeart,
+  blackHeart,
+  greyHeart,
+  whiteHeart,
+  pinkHeart,
+  cupid,
+  giftHeart,
+  sparklingHeart,
+  heartGrow,
+  beatingHeart,
+  revolvingHearts,
+  twoHearts,
+  loveLetter,
+  heartBox,
+  heart,
+  heartExclamationPoint,
+  bandagedHeart,
+  brokenHeart,
+  fireHeart,
+  kiss,
+  hugging,
+  bustsInSilhouette,
+  bustInSilhouette,
+  speakingHead,
+  footprints,
+  brain,
+  anatomicalHeart,
+  lungs,
+  blood,
+  microbe,
+  tooth,
+  bone,
+  skull,
+  eyes,
+  eye,
+  mouth,
+  bitingLip,
+  tongue,
+  nose,
+  ear,
+  hearingAid,
+  foot,
+  leg,
+  legMechanical,
+  armMechanical,
+  muscle,
+  clap,
+  thumbsUp,
+  thumbsDown,
+  heartHands,
+  raisingHands,
+  openHands,
+  palmsUp,
+  handshake,
+  fistRightwards,
+  fistLeftwards,
+  raisedFist,
+  fist,
+  palmDown,
+  palmUp,
+  rightwardsHand,
+  leftwardsHand,
+  pushRightwards,
+  pushLeftwards,
+  wave,
+  backHand,
+  palm,
+  raisedHand,
+  vulcan,
+  loveYouGesture,
+  metal,
+  v,
+  crossedFingers,
+  handWithIndexFingerAndThumbCrossed,
+  callMeHand,
+  pinchedFingers,
+  pinch,
+  ok,
+  pointing,
+  pointRight,
+  pointLeft,
+  indexFinger,
+  pointUp,
+  pointDown,
+  middleFinger,
+  writingHand,
+  selfie,
+  foldedHands,
+  nailCare,
+  bow,
+  raisingHand,
+  tippingHand,
+  gestureOk,
+  noGesture,
+  shrug,
+  facepalm,
+  frowning,
+  pouting,
+  deaf,
+  massage,
+  haircut,
+  sauna,
+  bathe,
+  inBed,
+  yoga,
+  walkingWithCane,
+  personInMotorizedWheelchair,
+  personInManualWheelchair,
+  kneeling,
+  standing,
+  walking,
+  running,
+  cartwheel,
+  liftingWeights,
+  bouncingBall,
+  handball,
+  biking,
+  mountainBiking,
+  climbing,
+  wrestling,
+  juggling,
+  golfing,
+  horseRacing,
+  fencing,
+  skier,
+  snowboarder,
+  parachute,
+  surfing,
+  rowingBoat,
+  swimming,
+  waterPolo,
+  merperson,
+  fairy,
+  genie,
+  elf,
+  mage,
+  vampire,
+  zombie,
+  troll,
+  superhero,
+  supervillain,
+  ninja,
+  mxClaus,
+  angel,
+  guard,
+  royalty,
+  tuxedo,
+  veil,
+  astronaut,
+  constructionWorker,
+  police,
+  detective,
+  pilot,
+  scientist,
+  healthWorker,
+  mechanic,
+  factoryWorker,
+  firefighter,
+  farmer,
+  teacher,
+  student,
+  officeWorker,
+  judge,
+  technologist,
+  singer,
+  artist,
+  cook,
+  turban,
+  headscarf,
+  guaPiMao,
+  baby,
+  child,
+  adult,
+  elder,
+  whiteHair,
+  redHair,
+  blondHair,
+  curlyHair,
+  bald,
+  beard,
+  levitatingSuit,
+  dancerWoman,
+  dancerMan,
+  bunnyEars,
+  holdingHands,
+  holdingHandsWomen,
+  holdingHandsMen,
+  holdingHandsWomanAndMan,
+  kissPeople,
+  kissWomanAndMan,
+  kissManAndMan,
+  kissWomanAndWoman,
+  peopleWithHeart,
+  heartWithWomanAndMan,
+  heartWithManAndMan,
+  heartWithWomanAndWoman,
+  pregnant,
+  breastFeeding,
+  personFeedingBaby,
+  family,
+  bouquet,
+  rose,
+  wiltedFlower,
+  hibiscus,
+  tulip,
+  lotus,
+  cherryBlossom,
+  whiteFlower,
+  rosette,
+  hyacinth,
+  sunflower,
+  blossom,
+  fallenLeaf,
+  mapleLeaf,
+  mushroom,
+  earOfRice,
+  plant,
+  herb,
+  leaves,
+  shamrock,
+  luck,
+  pottedPlant,
+  cactus,
+  palmTree,
+  deciduousTree,
+  evergreenTree,
+  wood,
+  nest,
+  nestWithEggs,
+  rock,
+  mountain,
+  snowMountain,
+  snowflake,
+  snowmanWithSnow,
+  snowman,
+  fog,
+  thermometer,
+  fire,
+  volcano,
+  desert,
+  nationalPark,
+  desertIsland,
+  beach,
+  sunrise,
+  sunriseOverMountains,
+  rainbow,
+  bubbles,
+  ocean,
+  windFace,
+  cyclone,
+  tornado,
+  electricity,
+  umbrellaInRain,
+  droplet,
+  rainCloud,
+  cloudWithLightning,
+  cloudWithLightningAndRain,
+  cloudWithSnow,
+  cloud,
+  sunBehindRainCloud,
+  sunBehindLargeCloud,
+  partlySunny,
+  sunBehindSmallCloud,
+  sunny,
+  sunWithFace,
+  moonFaceFull,
+  moonFaceNew,
+  moonFaceLastQuarter,
+  moonFaceFirstQuarter,
+  star,
+  glowingStar,
+  sparkles,
+  dizzy,
+  crescentMoon,
+  comet,
+  hole,
+  shootingStar,
+  milkyWay,
+  globeShowingEuropeAfrica,
+  globeShowingAmericas,
+  globeShowingAsiaAustralia,
+  ringedPlanet,
+  newMoon,
+  waxingCrescentMoon,
+  firstQuarterMoon,
+  waxingGibbousMoon,
+  fullMoon,
+  waningGibbousMoon,
+  lastQuarterMoon,
+  waningCrescentMoon,
+  seeNoEvilMonkey,
+  hearNoEvilMonkey,
+  speakNoEvilMonkey,
+  monkeyFace,
+  lionFace,
+  tigerFace,
+  catFace,
+  dogFace,
+  wolf,
+  bearFace,
+  polarBear,
+  koala,
+  panda,
+  hamster,
+  mouseFace,
+  rabbitFace,
+  foxFace,
+  raccoon,
+  cowFace,
+  pigFace,
+  snout,
+  boar,
+  zebra,
+  unicorn,
+  horseFace,
+  moose,
+  dragonFace,
+  lizard,
+  dragon,
+  tRex,
+  dinosaur,
+  turtle,
+  crocodile,
+  snake,
+  frog,
+  rabbit,
+  mouse,
+  rat,
+  cat,
+  blackCat,
+  poodle,
+  dog,
+  guideDog,
+  serviceDog,
+  pig,
+  racehorse,
+  donkey,
+  cow,
+  ox,
+  waterBuffalo,
+  bison,
+  ram,
+  sheep,
+  goat,
+  deer,
+  llama,
+  sloth,
+  kangaroo,
+  elephant,
+  mammoth,
+  rhino,
+  hippo,
+  giraffe,
+  leopard,
+  tiger,
+  monkey,
+  gorilla,
+  orangutan,
+  camel,
+  bactrianCamel,
+  chipmunk,
+  beaver,
+  skunk,
+  badger,
+  hedgehog,
+  otter,
+  bat,
+  wingfly,
+  feather,
+  bird,
+  blackBird,
+  rooster,
+  chicken,
+  hatchingChick,
+  babyChick,
+  hatchedChick,
+  eagle,
+  owl,
+  parrot,
+  peace,
+  dodo,
+  swan,
+  duck,
+  goose,
+  flamingo,
+  peacock,
+  turkey,
+  penguin,
+  seal,
+  shark,
+  dolphin,
+  humpbackWhale,
+  whale,
+  fish,
+  tropicalFish,
+  blowfish,
+  shrimp,
+  lobster,
+  crab,
+  squid,
+  octopus,
+  jellyfish,
+  oyster,
+  coral,
+  scorpion,
+  spider,
+  spiderWeb,
+  shell,
+  snail,
+  ant,
+  cricket,
+  beetle,
+  mosquito,
+  cockroach,
+  fly,
+  bee,
+  ladyBug,
+  butterfly,
+  bug,
+  worm,
+  microbe,
+  pawprints,
+  strawberry,
+  cherries,
+  redApple,
+  watermelon,
+  peach,
+  tangerine,
+  mango,
+  pineapple,
+  banana,
+  lemon,
+  melon,
+  greenApple,
+  pear,
+  kiwiFruit,
+  olive,
+  blueberries,
+  grapes,
+  coconut,
+  tomato,
+  hotPepper,
+  ginger,
+  carrot,
+  roastedSweetPotato,
+  onion,
+  earOfCorn,
+  broccoli,
+  cucumber,
+  leafyGreen,
+  peaPod,
+  bellPepper,
+  avocado,
+  eggplant,
+  garlic,
+  potato,
+  beans,
+  chestnut,
+  peanuts,
+  bread,
+  flatbread,
+  croissant,
+  baguetteBread,
+  bagel,
+  waffle,
+  pancakes,
+  cooking,
+  egg,
+  cheeseWedge,
+  bacon,
+  cutOfMeat,
+  poultryLeg,
+  meatOnBone,
+  hamburger,
+  hotDog,
+  sandwich,
+  pretzel,
+  frenchFries,
+  pizza,
+  tamale,
+  taco,
+  burrito,
+  stuffedFlatbread,
+  falafel,
+  shallowPanOfFood,
+  spaghetti,
+  cannedFood,
+  fondue,
+  bowlWithSpoon,
+  greenSalad,
+  potOfFood,
+  curryRice,
+  steamingBowl,
+  oyster,
+  lobster,
+  sushi,
+  friedShrimp,
+  takeoutBox,
+  cookedRice,
+  bentoBox,
+  dumpling,
+  oden,
+  riceBall,
+  riceCracker,
+  fishCakeWithSwirl,
+  dango,
+  fortuneCookie,
+  moonCake,
+  shavedIce,
+  iceCream,
+  softIceCream,
+  pie,
+  shortcake,
+  custard,
+  birthdayCake,
+  cupcake,
+  lollipop,
+  candy,
+  chocolateBar,
+  doughnut,
+  cookie,
+  honeyPot,
+  salt,
+  butter,
+  popcorn,
+  iceCube,
+  jar,
+  cupWithStraw,
+  bubbleTea,
+  beverageBox,
+  glassOfMilk,
+  babyBottle,
+  teacupWithoutHandle,
+  hotBeverage,
+  teapot,
+  mate,
+  beerMug,
+  clinkingBeerMugs,
+  clinkingGlasses,
+  bottleWithPoppingCork,
+  wineGlass,
+  tumblerGlass,
+  pour,
+  cocktailGlass,
+  tropicalDrink,
+  sake,
+  chopsticks,
+  forkAndKnife,
+  spoon,
+  kitchenKnife,
+  forkAndKnifeWithPlate,
+  stopSign,
+  construction,
+  policeCarLight,
+  fuelPump,
+  oilDrum,
+  compass,
+  wheel,
+  ringBuoy,
+  anchor,
+  busStop,
+  metro,
+  horizontalTrafficLight,
+  verticalTrafficLight,
+  kickScooter,
+  manualWheelchair,
+  motorizedWheelchair,
+  crutch,
+  bicycle,
+  motorScooter,
+  motorcycle,
+  sportUtilityVehicle,
+  automobile,
+  pickupTruck,
+  minibus,
+  deliveryTruck,
+  articulatedLorry,
+  tractor,
+  racingCar,
+  fireEngine,
+  ambulance,
+  policeCar,
+  taxi,
+  autoRickshaw,
+  bus,
+  lightRail,
+  monorail,
+  bulletTrain,
+  highSpeedTrain,
+  locomotive,
+  railwayCar,
+  tramCar,
+  trolleybus,
+  mountainRailway,
+  tram,
+  station,
+  busFront,
+  policeCarFront,
+  automobileFront,
+  taxiFront,
+  train,
+  ship,
+  passengerShip,
+  motorBoat,
+  speedboat,
+  ferry,
+  sailboat,
+  canoe,
+  suspensionRailway,
+  mountainCableway,
+  aerialTramway,
+  helicopter,
+  flyingSaucer,
+  rocket,
+  airplane,
+  airplaneDeparture,
+  airplaneArrival,
+  smallAirplane,
+  slide,
+  rollerCoaster,
+  ferrisWheel,
+  carouselHorse,
+  circusTent,
+  tokyoTower,
+  statueOfLiberty,
+  moai,
+  mountFuji,
+  classicalBuilding,
+  barberPole,
+  fountain,
+  shintoShrine,
+  synagogue,
+  mosque,
+  kaaba,
+  hinduTemple,
+  church,
+  wedding,
+  loveHotel,
+  japaneseCastle,
+  castle,
+  constructionBuilding,
+  officeBuilding,
+  factory,
+  departmentStore,
+  convenienceStore,
+  stadium,
+  bank,
+  school,
+  hotel,
+  japanesePostOffice,
+  postOffice,
+  hospital,
+  derelictHouse,
+  house,
+  houseWithGarden,
+  houses,
+  hut,
+  tent,
+  camping,
+  umbrellaOnGround,
+  cityscape,
+  sunsetCityscape,
+  sunset,
+  nightWithStars,
+  bridgeAtNight,
+  foggy,
+  railwayTrack,
+  motorway,
+  mapOfJapan,
+  worldMap,
+  globeWithMeridians,
+  seat,
+  luggage,
+  partyPopper,
+  confettiBall,
+  balloon,
+  birthdayCake,
+  ribbon,
+  wrappedGift,
+  sparkler,
+  fireworks,
+  firecracker,
+  redEnvelope,
+  diyaLamp,
+  pinata,
+  mirrorBall,
+  windChime,
+  carpStreamer,
+  japaneseDolls,
+  moonViewingCeremony,
+  pineDecoration,
+  tanabataTree,
+  christmasTree,
+  jackOLantern,
+  reminderRibbon,
+  goldMedal,
+  silverMedal,
+  bronzeMedal,
+  medal,
+  militaryMedal,
+  trophy,
+  loudspeaker,
+  soccerBall,
+  baseball,
+  softball,
+  basketball,
+  volleyball,
+  americanFootball,
+  rugbyFootball,
+  goalNet,
+  tennis,
+  badminton,
+  lacrosse,
+  cricketGame,
+  fieldHockey,
+  iceHockey,
+  curlingStone,
+  sled,
+  skis,
+  iceSkate,
+  rollerSkates,
+  balletShoes,
+  skateboard,
+  flagInHole,
+  directHit,
+  bowAndArrow,
+  flyingDisc,
+  boomerang,
+  kite,
+  fishingPole,
+  divingMask,
+  onePieceSwimsuit,
+  runningShirt,
+  martialArtsUniform,
+  boxingGlove,
+  eightBall,
+  pingPong,
+  bowling,
+  chessPawn,
+  yoYo,
+  jigsaw,
+  videoGame,
+  joystick,
+  alienMonster,
+  pistol,
+  die,
+  slotMachine,
+  flowerPlayingCards,
+  mahjongRedDragon,
+  joker,
+  wand,
+  gameDie,
+  camera,
+  cameraFlash,
+  framedPicture,
+  artistPalette,
+  paintbrush,
+  crayon,
+  needle,
+  thread,
+  yarn,
+  piano,
+  saxophone,
+  trumpet,
+  guitar,
+  banjo,
+  violin,
+  longDrum,
+  drum,
+  maracas,
+  flute,
+  accordion,
+  microphone,
+  headphone,
+  levelSlider,
+  controlKnobs,
+  studioMicrophone,
+  radio,
+  television,
+  videocassette,
+  videoCamera,
+  filmProjector,
+  movieCamera,
+  film,
+  clapper,
+  performingArts,
+  ticket,
+  admissionTickets,
+  mobilePhone,
+  telephone,
+  telephoneReceiver,
+  pager,
+  faxMachine,
+  electricPlug,
+  batteryFull,
+  batteryLow,
+  trackball,
+  computerDisk,
+  floppyDisk,
+  opticalDisk,
+  dvd,
+  desktopComputer,
+  laptopComputer,
+  keyboard,
+  printer,
+  computerMouse,
+  coin,
+  moneyWithWings,
+  dollar,
+  yen,
+  euro,
+  pound,
+  creditCard,
+  moneyBag,
+  receipt,
+  abacus,
+  balanceScale,
+  shoppingCart,
+  shoppingBags,
+  candle,
+  lightBulb,
+  flashlight,
+  redPaperLantern,
+  bricks,
+  window,
+  mirror,
+  door,
+  chair,
+  bed,
+  couchAndLamp,
+  shower,
+  bathtub,
+  toilet,
+  rollOfPaper,
+  plunger,
+  teddyBear,
+  nestingDoll,
+  safetyPin,
+  knot,
+  broom,
+  lotionBottle,
+  sponge,
+  soap,
+  toothbrush,
+  razor,
+  hairPick,
+  basket,
+  socks,
+  gloves,
+  scarf,
+  jeans,
+  tShirt,
+  runningShirt,
+  womansClothes,
+  necktie,
+  dress,
+  kimono,
+  sari,
+  onePieceSwimsuit,
+  bikini,
+  shorts,
+  swimBrief,
+  coat,
+  labCoat,
+  safetyVest,
+  rescueWorkersHelmet,
+  militaryHelmet,
+  graduationCap,
+  topHat,
+  womansHat,
+  billedCap,
+  crown,
+  fan,
+  schoolBackpack,
+  clutchBag,
+  purse,
+  handbag,
+  briefcase,
+  luggage,
+  umbrella,
+  closedUmbrella,
+  ring,
+  gemStone,
+  lipstick,
+  highHeeledShoe,
+  runningShoe,
+  mansShoe,
+  flatShoe,
+  flipFlop,
+  sandal,
+  boot,
+  hikingBoot,
+  probingCane,
+  sunglasses,
+  glasses,
+  goggles,
+  alembic,
+  petriDish,
+  testTube,
+  thermometer,
+  syringe,
+  pill,
+  adhesiveBandage,
+  stethoscope,
+  xRay,
+  dna,
+  telescope,
+  microscope,
+  satelliteAntenna,
+  satellite,
+  fireExtinguisher,
+  axe,
+  ladder,
+  bucket,
+  hook,
+  magnet,
+  toolbox,
+  clamp,
+  nutAndBolt,
+  screwdriver,
+  saw,
+  wrench,
+  hammer,
+  hammerAndPick,
+  hammerAndWrench,
+  pick,
+  gear,
+  link,
+  chains,
+  paperclip,
+  linkedPaperclips,
+  straightRuler,
+  triangularRuler,
+  paintbrush,
+  crayon,
+  pen,
+  fountainPen,
+  blackNib,
+  pencil,
+  memo,
+  openBook,
+  books,
+  ledger,
+  notebookWithDecorativeCover,
+  closedBook,
+  notebook,
+  greenBook,
+  blueBook,
+  orangeBook,
+  bookmark,
+  spiralNotepad,
+  pageFacingUp,
+  pageWithCurl,
+  clipboard,
+  bookmarkTabs,
+  openFileFolder,
+  fileFolder,
+  cardIndexDividers,
+  cardFileBox,
+  fileCabinet,
+  barChart,
+  chartIncreasing,
+  chartDecreasing,
+  cardIndex,
+  id,
+  pushpin,
+  roundPushpin,
+  scissors,
+  wastebasket,
+  newspaper,
+  rolledUpNewspaper,
+  label,
+  package,
+  closedMailboxWithRaised,
+  closedMailboxWithLowered,
+  openMailboxWithRaised,
+  openMailboxWithLowered,
+  postbox,
+  envelope,
+  eMail,
+  envelopeWithArrow,
+  incomingEnvelope,
+  loveLetter,
+  outboxTray,
+  inboxTray,
+  ballotBox,
+  twelveOClock,
+  twelveThirty,
+  oneOClock,
+  oneThirty,
+  twoOClock,
+  twoThirty,
+  threeOClock,
+  threeThirty,
+  fourOClock,
+  fourThirty,
+  fiveOClock,
+  fiveThirty,
+  sixOClock,
+  sixThirty,
+  sevenOClock,
+  sevenThirty,
+  eightOClock,
+  eightThirty,
+  nineOClock,
+  nineThirty,
+  tenOClock,
+  tenThirty,
+  elevenOClock,
+  elevenThirty,
+  stopwatch,
+  watch,
+  mantelpieceClock,
+  hourglassDone,
+  hourglassNotDone,
+  timerClock,
+  alarmClock,
+  calendar,
+  tearOffCalendar,
+  spiralCalendar,
+  placard,
+  bellhopBell,
+  bell,
+  postalHorn,
+  loudspeaker,
+  megaphone,
+  magnifyingGlassTiltedLeft,
+  magnifyingGlassTiltedRight,
+  crystalBall,
+  evilEye,
+  hamsa,
+  prayerBeads,
+  amphora,
+  urn,
+  coffin,
+  headstone,
+  cigarette,
+  bomb,
+  mouseTrap,
+  scroll,
+  crossedSwords,
+  dagger,
+  shield,
+  oldKey,
+  key,
+  lockWithKey,
+  lockWithPen,
+  locked,
+  unlocked,
+  redCircle,
+  orangeCircle,
+  yellowCircle,
+  greenCircle,
+  blueCircle,
+  purpleCircle,
+  brownCircle,
+  blackCircle,
+  whiteCircle,
+  redSquare,
+  orangeSquare,
+  yellowSquare,
+  greenSquare,
+  blueSquare,
+  purpleSquare,
+  brownSquare,
+  blackSquare,
+  whiteSquare,
+  redHeart,
+  orangeHeart,
+  yellowHeart,
+  greenHeart,
+  blueHeart,
+  purpleHeart,
+  brownHeart,
+  blackHeart,
+  whiteHeart,
+  pinkHeart,
+  lightBlueHeart,
+  grayHeart,
+  heart,
+  diamond,
+  club,
+  spade,
+  aries,
+  taurus,
+  gemini,
+  cancer,
+  leo,
+  virgo,
+  libra,
+  scorpio,
+  sagittarius,
+  capricorn,
+  aquarius,
+  pisces,
+  ophiuchus,
+  femaleSign,
+  maleSign,
+  transSign,
+  thoughtBubble,
+  angerBubble,
+  speechBubble,
+  speechBubbleLeftwards,
+  exclamationMarkWhite,
+  exclamation,
+  questionMarkWhite,
+  question,
+  exclamationQuestionMark,
+  exclamationDouble,
+  largeCircle,
+  x,
+  prohibited,
+  noBicycles,
+  noSmoking,
+  noLittering,
+  nonPotableWater,
+  noPedestrians,
+  noMobilePhones,
+  noUnderEighteen,
+  noSound,
+  mute,
+  aButton,
+  abButton,
+  bButton,
+  oButton,
+  clButton,
+  sos,
+  stop,
+  noEntry,
+  nameBadge,
+  hotSprings,
+  anger,
+  trianglePointedDown,
+  trianglePointedUp,
+  bargain,
+  secret,
+  congratulations,
+  passingGrade,
+  noVacancy,
+  discount,
+  prohibitedButton,
+  accept,
+  notFreeOfCharge,
+  freeOfCharge,
+  application,
+  openForBusiness,
+  monthlyAmount,
+  eightPointedStar,
+  diamondOrangeLarge,
+  diamondOrangeSmall,
+  bright,
+  dim,
+  vs,
+  cinema,
+  signalStrength,
+  repeat,
+  repeatOne,
+  shuffle,
+  arrowForward,
+  fastForward,
+  nextTrack,
+  playOrPause,
+  reverse,
+  rewind,
+  previous,
+  upwards,
+  fastUp,
+  downwards,
+  fastDown,
+  pause,
+  stopButton,
+  record,
+  eject,
+  phoneOff,
+  wireless,
+  vibration,
+  phoneWithArrow,
+  lowVolume,
+  mediumVolume,
+  highVolume,
+  musicalScore,
+  musicalNote,
+  musicalNotes,
+  radioactive,
+  biohazard,
+  warning,
+  childrenCrossing,
+  fleurDeLis,
+  tridentEmblem,
+  partAlternationMark,
+  japaneseSymbolForBeginner,
+  eightSpokedAsterisk,
+  sparkle,
+  recyclingSymbol,
+  currencyExchange,
+  dollarSign,
+  chartIncreasingWithYen,
+  reserved,
+  xMark,
+  checkMark,
+  checkMarkBlack,
+  checkMarkButton,
+  upArrow,
+  upRightArrow,
+  rightArrow,
+  downRightArrow,
+  downArrow,
+  downLeftArrow,
+  leftArrow,
+  upLeftArrow,
+  upDownArrow,
+  leftRightArrow,
+  rightArrowCurvingLeft,
+  leftArrowCurvingRight,
+  rightArrowCurvingUp,
+  rightArrowCurvingDown,
+  clockwiseArrows,
+  counterclockwiseArrows,
+  back,
+  on,
+  top,
+  end,
+  soon,
+  $new,
+  free,
+  up,
+  okButton,
+  cool,
+  ng,
+  information,
+  parking,
+  here,
+  serviceCharge,
+  vacancy,
+  symbols,
+  letters,
+  uppercaseLetters,
+  lowercaseLetters,
+  numbers,
+  numberSign,
+  asterisk,
+  zero,
+  one,
+  two,
+  three,
+  four,
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+  diamondJewel,
+  blueDiamondLarge,
+  blueDiamondSmall,
+  globe,
+  atm,
+  metroSign,
+  waterCloset,
+  restroom,
+  mensRoom,
+  womensRoom,
+  wheelchairSymbol,
+  babySymbol,
+  elevator,
+  litter,
+  waterFaucet,
+  passportControl,
+  customs,
+  baggageClaim,
+  leftLuggage,
+  heartBox,
+  atomSymbol,
+  placeOfWorship,
+  om,
+  wheelOfDharma,
+  peaceSymbol,
+  yinYang,
+  starAndCrescent,
+  khanda,
+  latinCross,
+  orthodoxCross,
+  starOfDavid,
+  starOfDavidWithDot,
+  menorah,
+  infinity,
+  idButton,
+  medicalSymbol,
+  multiplicationX,
+  plusSign,
+  minusSign,
+  divisionSign,
+  equalsSign,
+  curlyLoop,
+  curlyLoopDouble,
+  wavyDash,
+  copyright,
+  registered,
+  tradeMark,
+  radioButton,
+  whiteSquareButton,
+  blackSquareMedium,
+  blackSquareMediumSmall,
+  blackSquareSmall,
+  buttonBlackSquare,
+  whiteSquareMedium,
+  whiteSquareMediumSmall,
+  whiteSquareSmall,
+  eyeBubble,
+  chequeredFlag,
+  triangularFlag,
+  crossedFlags,
+  blackFlag,
+  whiteFlag,
+  rainbowFlag,
+  transFlag,
+  pirateFlag,
+  ascensionIslandFlag,
+  andorraFlag,
+  unitedArabEmiratesFlag,
+  afghanistanFlag,
+  antiguaBarbudaFlag,
+  anguillaFlag,
+  albaniaFlag,
+  armeniaFlag,
+  angolaFlag,
+  antarcticaFlag,
+  argentinaFlag,
+  americanSamoaFlag,
+  austriaFlag,
+  australiaFlag,
+  arubaFlag,
+  alandIslandsFlag,
+  azerbaijanFlag,
+  bosniaHerzegovinaFlag,
+  barbadosFlag,
+  bangladeshFlag,
+  belgiumFlag,
+  burkinaFasoFlag,
+  bulgariaFlag,
+  bahrainFlag,
+  burundiFlag,
+  beninFlag,
+  stBarthelemyFlag,
+  bermudaFlag,
+  bruneiFlag,
+  boliviaFlag,
+  caribbeanNetherlandsFlag,
+  brazilFlag,
+  bahamasFlag,
+  bhutanFlag,
+  bouvetIslandFlag,
+  botswanaFlag,
+  belarusFlag,
+  belizeFlag,
+  canadaFlag,
+  cocosIslandsFlag,
+  congoKinshasaFlag,
+  centralAfricanRepublicFlag,
+  congoBrazzavilleFlag,
+  switzerlandFlag,
+  coteDivoireFlag,
+  cookIslandsFlag,
+  chileFlag,
+  cameroonFlag,
+  chinaFlag,
+  colombiaFlag,
+  clippertonIslandFlag,
+  costaRicaFlag,
+  cubaFlag,
+  capeVerdeFlag,
+  curacaoFlag,
+  christmasIslandFlag,
+  cyprusFlag,
+  czechiaFlag,
+  germanyFlag,
+  diegoGarciaFlag,
+  djiboutiFlag,
+  denmarkFlag,
+  dominicaFlag,
+  dominicanrepublicFlag,
+  algeriaFlag,
+  ceutaMelillaFlag,
+  ecuadorFlag,
+  estoniaFlag,
+  egyptFlag,
+  westernSaharaFlag,
+  eritreaFlag,
+  spainFlag,
+  ethiopiaFlag,
+  europeanUnionFlag,
+  finlandFlag,
+  fijiFlag,
+  falklandIslandsFlag,
+  micronesiaFlag,
+  faroeIslandsFlag,
+  franceFlag,
+  gabonFlag,
+  unitedKingdomFlag,
+  grenadaFlag,
+  georgiaFlag,
+  frenchguianaFlag,
+  guernseyFlag,
+  ghanaFlag,
+  gibraltarFlag,
+  greenlandFlag,
+  gambiaFlag,
+  guineaFlag,
+  guadeloupeFlag,
+  equatorialGuineaFlag,
+  greeceFlag,
+  southGeorgiaSouthFlag,
+  guatemalaFlag,
+  guamFlag,
+  guineaBissauFlag,
+  guyanaFlag,
+  hongKongSarChinaFlag,
+  heardMcdonaldislandsFlag,
+  hondurasFlag,
+  croatiaFlag,
+  haitiFlag,
+  hungaryFlag,
+  canaryIslandsFlag,
+  indonesiaFlag,
+  irelandFlag,
+  israelFlag,
+  isleOfManFlag,
+  indiaFlag,
+  britishIndianOceanTerritoryFlag,
+  iraqFlag,
+  iranFlag,
+  icelandFlag,
+  italyFlag,
+  jerseyFlag,
+  jamaicaFlag,
+  jordanFlag,
+  japanFlag,
+  kenyaFlag,
+  kyrgyzstanFlag,
+  cambodiaFlag,
+  kiribatiFlag,
+  comorosFlag,
+  stkittsnevisFlag,
+  northkoreaFlag,
+  southkoreaFlag,
+  kuwaitFlag,
+  caymanislandsFlag,
+  kazakhstanFlag,
+  laosFlag,
+  lebanonFlag,
+  stluciaFlag,
+  liechtensteinFlag,
+  srilankaFlag,
+  liberiaFlag,
+  lesothoFlag,
+  lithuaniaFlag,
+  luxembourgFlag,
+  latviaFlag,
+  libyaFlag,
+  moroccoFlag,
+  monacoFlag,
+  moldovaFlag,
+  montenegroFlag,
+  stMartinFlag,
+  madagascarFlag,
+  marshallIslandsFlag,
+  macedoniaFlag,
+  maliFlag,
+  myanmarFlag,
+  mongoliaFlag,
+  macauSarChinaFlag,
+  northernMarianaIslandsFlag,
+  martiniqueFlag,
+  mauritaniaFlag,
+  montserratFlag,
+  maltaFlag,
+  mauritiusFlag,
+  maldivesFlag,
+  malawiFlag,
+  mexicoFlag,
+  malaysiaFlag,
+  mozambiqueFlag,
+  namibiaFlag,
+  newCaledoniaFlag,
+  nigerFlag,
+  norfolkIslandFlag,
+  nigeriaFlag,
+  nicaraguaFlag,
+  netherlandsFlag,
+  norwayFlag,
+  nepalFlag,
+  nauruFlag,
+  niueFlag,
+  newZealandFlag,
+  omanFlag,
+  panamaFlag,
+  peruFlag,
+  frenchPolynesiaFlag,
+  papuaNewGuineaFlag,
+  philippinesFlag,
+  pakistanFlag,
+  polandFlag,
+  stPierreMiquelonFlag,
+  pitcairnIslandsFlag,
+  puertoRicoFlag,
+  palestinianTerritoriesFlag,
+  portugalFlag,
+  palauFlag,
+  paraguayFlag,
+  qatarFlag,
+  reunionFlag,
+  romaniaFlag,
+  serbiaFlag,
+  russiaFlag,
+  rwandaFlag,
+  saudiArabiaFlag,
+  solomonIslandsFlag,
+  seychellesFlag,
+  sudanFlag,
+  swedenFlag,
+  singaporeFlag,
+  stHelenaFlag,
+  sloveniaFlag,
+  svalbardJanmayenFlag,
+  slovakiaFlag,
+  sierraLeoneFlag,
+  sanMarinoFlag,
+  senegalFlag,
+  somaliaFlag,
+  surinameFlag,
+  southSudanFlag,
+  saoTomePrincipeFlag,
+  elSalvadorFlag,
+  sintMaartenFlag,
+  syriaFlag,
+  swazilandFlag,
+  tristanDaCunhaFlag,
+  turksCaicosislandsFlag,
+  chadFlag,
+  frenchSouthernTerritoriesFlag,
+  togoFlag,
+  thailandFlag,
+  tajikistanFlag,
+  tokelauFlag,
+  timorLesteFlag,
+  turkmenistanFlag,
+  tunisiaFlag,
+  tongaFlag,
+  turkeyFlag,
+  trinidadTobagoFlag,
+  tuvaluFlag,
+  taiwanFlag,
+  tanzaniaFlag,
+  ukraineFlag,
+  ugandaFlag,
+  usOutlyingislandsFlag,
+  unitedNationsFlag,
+  unitedStatesFlag,
+  uruguayFlag,
+  uzbekistanFlag,
+  vaticancityFlag,
+  stVincentGrenadinesFlag,
+  venezuelaFlag,
+  britishVirginislandsFlag,
+  usVirginIslandsFlag,
+  vietnamFlag,
+  vanuatuFlag,
+  wallisFutunaFlag,
+  samoaFlag,
+  kosovoFlag,
+  yemenFlag,
+  mayotteFlag,
+  southAfricaFlag,
+  zambiaFlag,
+  zimbabweFlag,
+  englandFlag,
+  scotlandFlag,
+  walesFlag,
+];

--- a/packages/neon_framework/lib/src/widgets/dialog.dart
+++ b/packages/neon_framework/lib/src/widgets/dialog.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 
 import 'package:built_collection/built_collection.dart';
-import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import 'package:neon_framework/blocs.dart';
 import 'package:neon_framework/models.dart';
 import 'package:neon_framework/src/blocs/accounts.dart';
+import 'package:neon_framework/src/utils/emojis.dart';
 import 'package:neon_framework/src/utils/global_options.dart';
 import 'package:neon_framework/src/utils/relative_time.dart';
 import 'package:neon_framework/src/utils/user_status_clear_at.dart';
@@ -722,35 +722,75 @@ class NeonEmojiPickerDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final localizations = NeonLocalizations.of(context);
+    final groups = [
+      (icon: '🙂', name: localizations.emojisCategorySmileysAndEmotions, emojis: smileysAndEmotionsGroup),
+      (icon: '🙇', name: localizations.emojisCategoryPeople, emojis: peopleGroup),
+      (icon: '🐕', name: localizations.emojisCategoryAnimalsAndNature, emojis: animalsAndNatureGroup),
+      (icon: '🍎', name: localizations.emojisCategoryFoodAndDrink, emojis: foodAndDrinkGroup),
+      (icon: '🚙', name: localizations.emojisCategoryTravelAndPlaces, emojis: travelAndPlacesGroup),
+      (icon: '🏀', name: localizations.emojisCategoryActivitiesAndEvents, emojis: activitiesAndEventsGroup),
+      (icon: '💡', name: localizations.emojisCategoryObjects, emojis: objectsGroup),
+      (icon: '🔣', name: localizations.emojisCategorySymbols, emojis: symbolsGroup),
+      (icon: '🏁', name: localizations.emojisCategoryFlags, emojis: flagsGroup),
+    ];
+
     final constraints = NeonDialogTheme.of(context).constraints;
 
     return NeonDialog(
       content: SizedBox(
         width: constraints.maxWidth,
         height: constraints.maxWidth * 1.5,
-        child: EmojiPicker(
-          config: Config(
-            emojiViewConfig: const EmojiViewConfig(
-              emojiSizeMax: 25,
-              backgroundColor: Colors.transparent,
+        child: DefaultTabController(
+          length: groups.length,
+          child: Scaffold(
+            appBar: TabBar(
+              isScrollable: true,
+              tabAlignment: TabAlignment.center,
+              tabs: [
+                for (final group in groups)
+                  Tooltip(
+                    message: group.name,
+                    child: Tab(
+                      icon: Text(
+                        group.icon,
+                        style: const TextStyle(
+                          fontSize: 20,
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
             ),
-            categoryViewConfig: CategoryViewConfig(
-              backgroundColor: Colors.transparent,
-              indicatorColor: theme.colorScheme.primary,
-              iconColorSelected: theme.colorScheme.primary,
-            ),
-            skinToneConfig: SkinToneConfig(
-              dialogBackgroundColor: theme.dialogBackgroundColor,
-              indicatorColor: theme.colorScheme.primary,
-            ),
-            bottomActionBarConfig: const BottomActionBarConfig(
-              enabled: false,
+            body: TabBarView(
+              children: [
+                for (final group in groups)
+                  SingleChildScrollView(
+                    child: Wrap(
+                      children: [
+                        for (final emoji in group.emojis)
+                          SizedBox.square(
+                            dimension: 40,
+                            child: IconButton(
+                              padding: EdgeInsets.zero,
+                              constraints: const BoxConstraints(),
+                              icon: Center(
+                                child: Text(
+                                  emoji.base,
+                                  style: const TextStyle(
+                                    fontSize: 25,
+                                  ),
+                                ),
+                              ),
+                              onPressed: () => Navigator.of(context).pop(emoji.base),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+              ],
             ),
           ),
-          onEmojiSelected: (category, emoji) {
-            Navigator.of(context).pop(emoji.emoji);
-          },
         ),
       ),
     );

--- a/packages/neon_framework/packages/talk_app/lib/src/widgets/message_input.dart
+++ b/packages/neon_framework/packages/talk_app/lib/src/widgets/message_input.dart
@@ -116,7 +116,7 @@ class _TalkMessageInputState extends State<TalkMessageInput> {
             final textSelection = controller.selection;
 
             controller
-              ..text = text.replaceRange(textSelection.start, textSelection.end, emoji)
+              ..text = !textSelection.isValid ? emoji : text.replaceRange(textSelection.start, textSelection.end, emoji)
               ..selection = textSelection.copyWith(
                 baseOffset: textSelection.start + emoji.length,
                 extentOffset: textSelection.start + emoji.length,

--- a/packages/neon_framework/packages/talk_app/pubspec.yaml
+++ b/packages/neon_framework/packages/talk_app/pubspec.yaml
@@ -44,7 +44,6 @@ dev_dependencies:
       url: https://github.com/nextcloud/neon
       path: packages/neon_lints
   provider: ^6.1.2
-  shared_preferences: ^2.3.3
   url_launcher_platform_interface: ^2.3.2
   vector_graphics_compiler: ^1.1.15
 

--- a/packages/neon_framework/packages/talk_app/test/message_input_test.dart
+++ b/packages/neon_framework/packages/talk_app/test/message_input_test.dart
@@ -18,7 +18,6 @@ import 'package:nextcloud/spreed.dart' as spreed;
 import 'package:nextcloud/user_status.dart' as user_status;
 import 'package:provider/provider.dart';
 import 'package:rxdart/rxdart.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:talk_app/l10n/localizations.dart';
 import 'package:talk_app/src/blocs/room.dart';
 import 'package:talk_app/src/widgets/message.dart';
@@ -127,8 +126,6 @@ void main() {
   });
 
   testWidgets('Emoji button', (tester) async {
-    SharedPreferences.setMockInitialValues({});
-
     await tester.pumpWidgetWithAccessibility(
       TestApp(
         localizationsDelegates: TalkLocalizations.localizationsDelegates,
@@ -154,8 +151,6 @@ void main() {
     await tester.runAsync(() async {
       await tester.tap(find.byIcon(Icons.emoji_emotions_outlined));
     });
-    await tester.pumpAndSettle();
-    await tester.tap(find.byIcon(Icons.tag_faces));
     await tester.pumpAndSettle();
     await tester.tap(find.text('😀'));
     await tester.pumpAndSettle();

--- a/packages/neon_framework/packages/talk_app/test/message_test.dart
+++ b/packages/neon_framework/packages/talk_app/test/message_test.dart
@@ -13,7 +13,6 @@ import 'package:nextcloud/spreed.dart' as spreed;
 import 'package:provider/provider.dart';
 import 'package:provider/single_child_widget.dart';
 import 'package:rxdart/rxdart.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:talk_app/l10n/localizations.dart';
 import 'package:talk_app/l10n/localizations_en.dart';
 import 'package:talk_app/src/blocs/room.dart';
@@ -979,8 +978,6 @@ void main() {
       });
 
       testWidgets('Close', (tester) async {
-        SharedPreferences.setMockInitialValues({});
-
         when(() => room.readOnly).thenReturn(0);
         when(() => room.permissions).thenReturn(spreed.ParticipantPermission.canSendMessageAndShareAndReact.binary);
         when(() => room.actorId).thenReturn('test');
@@ -1019,8 +1016,6 @@ void main() {
 
       group('Add reaction', () {
         testWidgets('Allowed', (tester) async {
-          SharedPreferences.setMockInitialValues({});
-
           await tester.pumpWidgetWithAccessibility(
             wrapWidget(
               providers: [
@@ -1048,8 +1043,6 @@ void main() {
           await tester.runAsync(() async {
             await tester.tap(find.byIcon(Icons.add_reaction_outlined));
             await tester.pumpAndSettle();
-            await tester.tap(find.byIcon(Icons.tag_faces));
-            await tester.pumpAndSettle();
             await tester.tap(find.text('😂'));
             await tester.pumpAndSettle();
             verify(() => roomBloc.addReaction(chatMessage, '😂')).called(1);
@@ -1061,8 +1054,6 @@ void main() {
           await tester.runAsync(() async {
             await tester.tap(find.byIcon(Icons.add_reaction_outlined));
             await tester.pumpAndSettle();
-            await tester.tap(find.byIcon(Icons.tag_faces));
-            await tester.pumpAndSettle();
             await tester.tap(find.text('😂'));
             await tester.pumpAndSettle();
             verify(() => roomBloc.addReaction(chatMessage, '😂')).called(1);
@@ -1070,8 +1061,6 @@ void main() {
         });
 
         testWidgets('Read-only', (tester) async {
-          SharedPreferences.setMockInitialValues({});
-
           when(() => room.readOnly).thenReturn(1);
 
           await tester.pumpWidgetWithAccessibility(
@@ -1107,8 +1096,6 @@ void main() {
         });
 
         testWidgets('No permission', (tester) async {
-          SharedPreferences.setMockInitialValues({});
-
           when(() => room.permissions).thenReturn(0);
 
           await tester.pumpWidgetWithAccessibility(

--- a/packages/neon_framework/packages/talk_app/test/reactions_test.dart
+++ b/packages/neon_framework/packages/talk_app/test/reactions_test.dart
@@ -10,7 +10,6 @@ import 'package:neon_framework/utils.dart';
 import 'package:nextcloud/spreed.dart' as spreed;
 import 'package:provider/provider.dart';
 import 'package:rxdart/rxdart.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:talk_app/l10n/localizations.dart';
 import 'package:talk_app/src/blocs/room.dart';
 import 'package:talk_app/src/widgets/reactions.dart';
@@ -128,8 +127,6 @@ void main() {
   });
 
   testWidgets('Add new reaction', (tester) async {
-    SharedPreferences.setMockInitialValues({});
-
     await tester.pumpWidgetWithAccessibility(
       TestApp(
         localizationsDelegates: TalkLocalizations.localizationsDelegates,
@@ -146,8 +143,6 @@ void main() {
 
     await tester.runAsync(() async {
       await tester.tap(find.byIcon(Icons.add_reaction_outlined), warnIfMissed: false);
-      await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.tag_faces));
       await tester.pumpAndSettle();
       await tester.tap(find.text('😂'));
       await tester.pumpAndSettle();

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -102,6 +102,7 @@ dev_dependencies:
   permission_handler_platform_interface: ^4.2.3
   plugin_platform_interface: ^2.1.8
   shared_preferences: ^2.3.3
+  string_normalizer: ^0.3.1
   url_launcher_platform_interface: ^2.3.2
   vector_graphics_compiler: ^1.1.15
   version: ^3.0.2

--- a/packages/neon_framework/pubspec.yaml
+++ b/packages/neon_framework/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
   cupertino_icons: ^1.0.0 # Do not remove this, is it needed on iOS/macOS. It will not include icons on other platforms because Apple forbids it.
   dynamic_color: ^1.0.0
   dynamite_runtime: ^0.5.0+1
-  emoji_picker_flutter: ^3.0.0
   equatable: ^2.0.0
   file_picker: ^8.0.0+1
   filesize: ^2.0.0
@@ -83,12 +82,14 @@ dev_dependencies:
   bloc_test: ^9.1.7
   build_runner: ^2.4.13
   built_value_generator: ^8.9.2
+  code_builder: ^4.10.1
   cookie_store_conformance_tests:
     git:
       url: https://github.com/nextcloud/neon
       path: packages/cookie_store_conformance_tests
   crypton: ^2.2.1
   custom_lint: ^0.7.0
+  dart_style: ^2.3.7
   flutter_local_notifications_platform_interface: ^8.0.0
   flutter_test:
     sdk: flutter
@@ -101,7 +102,6 @@ dev_dependencies:
   package_info_plus_platform_interface: ^3.0.1
   permission_handler_platform_interface: ^4.2.3
   plugin_platform_interface: ^2.1.8
-  shared_preferences: ^2.3.3
   string_normalizer: ^0.3.1
   url_launcher_platform_interface: ^2.3.2
   vector_graphics_compiler: ^1.1.15

--- a/packages/neon_framework/test/dialog_test.dart
+++ b/packages/neon_framework/test/dialog_test.dart
@@ -11,7 +11,6 @@ import 'package:nextcloud/core.dart' as core;
 import 'package:nextcloud/user_status.dart' as user_status;
 import 'package:nextcloud/utils.dart';
 import 'package:rxdart/rxdart.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:timezone/timezone.dart' as tz;
 
 void main() {
@@ -189,8 +188,6 @@ void main() {
     });
 
     testWidgets('NeonEmojiPickerDialog', (tester) async {
-      SharedPreferences.setMockInitialValues({});
-
       await tester.pumpWidgetWithAccessibility(const TestApp(child: Placeholder()));
       final BuildContext context = tester.element(find.byType(Placeholder));
 
@@ -200,16 +197,15 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byIcon(Icons.tag_faces));
+      // Switch a different category
+      await tester.tap(find.text('🐕'));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text('😀'));
-      expect(await future, '😀');
+      await tester.tap(find.text('🌳'));
+      expect(await future, '🌳');
     });
 
     testWidgets('NeonUserStatusDialog', (tester) async {
-      SharedPreferences.setMockInitialValues({});
-
       final now = tz.TZDateTime.utc(2024, 1, 20);
 
       final status = BehaviorSubject.seeded(
@@ -308,8 +304,6 @@ void main() {
 
       // Set emoji
       await tester.tap(find.byType(IconButton));
-      await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(Icons.tag_faces));
       await tester.pumpAndSettle();
       await tester.tap(find.text('😀'));
       verify(

--- a/tool/generate-assets.sh
+++ b/tool/generate-assets.sh
@@ -85,6 +85,9 @@ done < <(find external/nextcloud-server/{core/img,apps/*/img} -name "*.svg" -not
 (
   cd packages/neon_framework
   precompile_assets
+
+  fvm dart generate_emojis.dart
+  fvm dart fix --apply lib/src/utils/emojis.dart
 )
 
 copy_app_svg dashboard external/nextcloud-server/apps/dashboard


### PR DESCRIPTION
Fixes https://github.com/nextcloud/neon/issues/2499

I thought implementing a custom emoji picker would be hard because all the existing packages suck and are unmaintained, but it turned out it was quite simple in the end.

Because the available emojis are generated from the metadata they are also more complete than what we had before, because the package was manually adding them to a list.

This picker does not support alternates (e.g. skin tones) yet, but it can be added easily.
It also does not save any recently used emojis, but we can add that as well.

Due to having all the metadata available we can now also add shortcode (e.g. `:smile:`) completion for text inputs (e.g. Talk message input) which is pretty neat.

For some reason the Tabbar renders a bit weird on Android and I believe it might be connected to https://github.com/flutter/flutter/issues/119623 as I was seeing that issue as well. On Linux it renders perfectly and the emojis are centered as well :woman_shrugging: