### PR TITLE
fix(neon_framework): Correctly reload after updating account credentials

### DIFF
--- a/packages/neon_framework/lib/src/login/view/login_view.dart
+++ b/packages/neon_framework/lib/src/login/view/login_view.dart
@@ -22,7 +22,9 @@ class LoginView extends StatelessWidget {
     return BlocConsumer<LoginBloc, LoginState>(
       listener: (context, state) {
         if (state is LoginStateDone) {
-          const HomeRoute().go(context);
+          // go() will not work as the user already has to the route with the old account in the stack,
+          // so we need to pushReplacement() the route to have everything reload.
+          const HomeRoute().pushReplacement(context);
         }
       },
       builder: (context, state) {

--- a/packages/neon_framework/test/login/view/login_page_test.dart
+++ b/packages/neon_framework/test/login/view/login_page_test.dart
@@ -57,7 +57,8 @@ void main() {
       );
 
       router = MockGoRouter();
-      when(() => router.go(any())).thenAnswer((_) async {});
+      // ignore: discarded_futures
+      when(() => router.pushReplacement(any())).thenAnswer((_) async => null);
 
       loginBloc = _MockLoginBloc();
       when(() => loginBloc.state).thenReturn(
@@ -92,7 +93,7 @@ void main() {
         );
         await tester.pumpWidgetWithAccessibility(buildSubject());
 
-        verify(() => router.go('/')).called(1);
+        verify(() => router.pushReplacement('/')).called(1);
       },
     );
 


### PR DESCRIPTION
Basically the same fix as I did in https://github.com/nextcloud/neon/pull/2200 with the bug being reintroduced in https://github.com/nextcloud/neon/pull/2407.