### PR TITLE
ci: Correctly name Dart job as current dependencies and not upgraded

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         dependencies:
-          - upgrade
+          - current
           - downgrade
     steps:
       - name: Checkout
@@ -42,7 +42,7 @@ jobs:
         run: ./tool/setup.sh
 
       - name: Check up-to-date pubspec.lock
-        if: ${{ matrix.dependencies == 'upgrade' }}
+        if: ${{ matrix.dependencies == 'current' }}
         run: git --no-pager diff --exit-code
       - name: Downgrade dependencies
         if: ${{ matrix.dependencies == 'downgrade' }}
@@ -72,7 +72,7 @@ jobs:
           fi
 
       - name: Setup Codecov
-        if: ${{ matrix.dependencies == 'upgrade' }}
+        if: ${{ matrix.dependencies == 'current' }}
         run: |
           cd /tmp
           curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
@@ -86,7 +86,7 @@ jobs:
           mkdir /tmp/bin
           mv codecov /tmp/bin
       - name: Upload coverage to Codecov
-        if: ${{ matrix.dependencies == 'upgrade' }}
+        if: ${{ matrix.dependencies == 'current' }}
         run: |
           export PATH="$PATH:/tmp/bin"
           melos exec --file-exists="coverage/lcov.info" --concurrency=1 -- "


### PR DESCRIPTION
We don't upgrade the dependencies, we take the current ones specified in the pubspec.lock.
It's not that relevant right now as it is basically the same as doing an upgrade, because only the example has a pubspec.lock, but with https://github.com/nextcloud/neon/pull/2704 it will be completely wrong.