### PR TITLE
fix(deps): Downgrade file_picker to 8.1.4 to fix Android build errors

### DIFF
--- a/packages/neon_framework/example/pubspec.lock
+++ b/packages/neon_framework/example/pubspec.lock
@@ -371,13 +371,13 @@ packages:
     source: hosted
     version: "7.0.1"
   file_picker:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: file_picker
-      sha256: "89500471922dd3a89ab0d6e13ab4a2268c25474bff4ca7c628f55c76e0ced1de"
+      sha256: "16dc141db5a2ccc6520ebb6a2eb5945b1b09e95085c021d9f914f8ded7f1465c"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.5"
+    version: "8.1.4"
   file_selector_linux:
     dependency: transitive
     description:

--- a/packages/neon_framework/example/pubspec.yaml
+++ b/packages/neon_framework/example/pubspec.yaml
@@ -48,6 +48,9 @@ dev_dependencies:
       path: packages/neon_lints
   vector_graphics_compiler: any
 
+dependency_overrides:
+  file_picker: 8.1.4
+
 flutter:
   uses-material-design: true
   assets:

--- a/packages/neon_framework/example/pubspec_overrides.yaml
+++ b/packages/neon_framework/example/pubspec_overrides.yaml
@@ -1,4 +1,4 @@
-# melos_managed_dependency_overrides: account_repository,cookie_store,dashboard_app,dynamite_runtime,files_app,interceptor_http_client,neon_framework,neon_http_client,neon_lints,neon_rich_text,news_app,nextcloud,notes_app,notifications_app,notifications_push_repository,sort_box,talk_app
+# melos_managed_dependency_overrides: account_repository,cookie_store,dashboard_app,dynamite_runtime,files_app,interceptor_http_client,neon_framework,neon_http_client,neon_lints,neon_rich_text,news_app,nextcloud,notes_app,notifications_app,notifications_push_repository,sort_box,talk_app,file_picker
 dependency_overrides:
   account_repository:
     path: ../packages/account_repository
@@ -34,3 +34,4 @@ dependency_overrides:
     path: ../packages/sort_box
   talk_app:
     path: ../packages/talk_app
+  file_picker: 8.1.4


### PR DESCRIPTION
It got bumped in https://github.com/nextcloud/neon/pull/2712 which triggered https://github.com/miguelpruivo/flutter_file_picker/issues/1643 so we have to downgrade it for now.