### PR TITLE
build: Fix melos hooks

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,6 @@ environment:
 dev_dependencies:
   commitlint_cli: ^0.8.1
   fvm: ^3.2.1
-  melos: ^6.0.0
+  melos: 6.0.0
   custom_lint: ^0.7.0
   coverage: ^1.11.1


### PR DESCRIPTION
For some reason running melos inside a melos hook is currently broken in newer versions. This might be due to contraint differences.