### PR TITLE
fix(nextcloud_test): Use host network for docker containers

### DIFF
--- a/packages/nextcloud/packages/nextcloud_test/lib/src/models/nextcloud_tester.dart
+++ b/packages/nextcloud/packages/nextcloud_test/lib/src/models/nextcloud_tester.dart
@@ -23,14 +23,14 @@ final class NextcloudTester {
   /// The app version tested.
   Version get version => _preset.version;
 
-  /// URL where the target is available from itself.
-  Uri get targetURL {
+  /// URL where the target is available.
+  Uri get url {
     final target = _target;
     if (target == null) {
       throw StateError('The tester has not been initialized');
     }
 
-    return target.targetURL;
+    return target.url;
   }
 
   /// Creates a new [NextcloudClient] for a given [username].

--- a/packages/nextcloud/packages/nextcloud_test/lib/src/test_target/docker_container.dart
+++ b/packages/nextcloud/packages/nextcloud_test/lib/src/test_target/docker_container.dart
@@ -46,11 +46,12 @@ final class DockerContainerFactory extends TestTargetFactory<DockerContainerInst
           'run',
           '--rm',
           '-d',
-          '--add-host',
-          'host.docker.internal:host-gateway',
-          '-p',
-          '$port:80',
+          '--network',
+          'host',
           dockerImageName,
+          'php',
+          '-S',
+          '0.0.0.0:$port',
         ],
       );
       // 125 means the docker run command itself has failed which indicated the port is already used
@@ -110,16 +111,10 @@ final class DockerContainerInstance extends TestTargetInstance {
       );
 
   @override
-  late Uri hostURL = Uri(
+  late Uri url = Uri(
     scheme: 'http',
     host: 'localhost',
     port: port,
-  );
-
-  @override
-  Uri targetURL = Uri(
-    scheme: 'http',
-    host: 'localhost',
   );
 
   @override

--- a/packages/nextcloud/packages/nextcloud_test/lib/src/test_target/local.dart
+++ b/packages/nextcloud/packages/nextcloud_test/lib/src/test_target/local.dart
@@ -90,11 +90,9 @@ final class LocalFactory extends TestTargetFactory<LocalInstance> {
 final class LocalInstance extends TestTargetInstance {
   /// Creates a new test instance for a local server.
   LocalInstance({
-    required Uri url,
+    required this.url,
     required String dir,
-  })  : hostURL = url,
-        targetURL = url,
-        _dir = dir;
+  }) : _dir = dir;
 
   final String _dir;
 
@@ -102,10 +100,7 @@ final class LocalInstance extends TestTargetInstance {
   void destroy() {}
 
   @override
-  final Uri hostURL;
-
-  @override
-  final Uri targetURL;
+  final Uri url;
 
   @override
   Future<String> createAppPassword(String username) async {

--- a/packages/nextcloud/packages/nextcloud_test/lib/src/test_target/test_target.dart
+++ b/packages/nextcloud/packages/nextcloud_test/lib/src/test_target/test_target.dart
@@ -55,11 +55,8 @@ abstract class TestTargetInstance {
   /// Destroys the instance.
   FutureOr<void> destroy();
 
-  /// URL where the target is available from the host side.
-  Uri get hostURL;
-
-  /// URL where the target is available from itself.
-  Uri get targetURL;
+  /// URL where the target is available.
+  Uri get url;
 
   /// Creates an app password for [username] on the instance.
   Future<String> createAppPassword(String username);
@@ -86,7 +83,7 @@ abstract class TestTargetInstance {
     );
 
     return NextcloudClient(
-      hostURL,
+      url,
       loginName: username,
       password: username,
       appPassword: appPassword,

--- a/packages/nextcloud/packages/nextcloud_test_presets/docker/Dockerfile
+++ b/packages/nextcloud/packages/nextcloud_test_presets/docker/Dockerfile
@@ -18,7 +18,6 @@ COPY assets/Recipes /usr/src/nextcloud/data/user2/files/Recipes
 RUN ./occ files:scan --all
 
 ENV PHP_CLI_SERVER_WORKERS=10
-CMD ["php", "-S", "0.0.0.0:80"]
 
 FROM alpine:latest@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099 AS apps
 

--- a/packages/nextcloud/test/api/cookbook/cookbook_test.dart
+++ b/packages/nextcloud/test/api/cookbook/cookbook_test.dart
@@ -99,7 +99,7 @@ void main() {
 
     group('recipes', () {
       test('callImport', () async {
-        final url = cookbook.UrlBuilder()..url = '${tester.targetURL}/static/recipe.html';
+        final url = cookbook.UrlBuilder()..url = '${tester.url}/static/recipe.html';
         final response = await tester.client.cookbook.recipes.$import($body: url.build());
         addTearDown(() async {
           closeFixture();

--- a/packages/nextcloud/test/api/news/news_test.dart
+++ b/packages/nextcloud/test/api/news/news_test.dart
@@ -23,12 +23,12 @@ void main() {
 
     Future<DynamiteResponse<news.ListFeeds, void>> addWikipediaFeed([int? folderID]) async =>
         tester.client.news.feeds.addFeed(
-          url: '${tester.targetURL}/static/wikipedia.xml',
+          url: '${tester.url}/static/wikipedia.xml',
           folderId: folderID,
         );
 
     Future<DynamiteResponse<news.ListFeeds, void>> addNasaFeed() async => tester.client.news.feeds.addFeed(
-          url: '${tester.targetURL}/static/nasa.xml',
+          url: '${tester.url}/static/nasa.xml',
         );
 
     test('Is supported', () async {
@@ -55,7 +55,7 @@ void main() {
         expect(response.body.starredCount, null);
         expect(response.body.newestItemId, isNotNull);
         expect(response.body.feeds, hasLength(1));
-        expect(response.body.feeds[0].url, '${tester.targetURL}/static/wikipedia.xml');
+        expect(response.body.feeds[0].url, '${tester.url}/static/wikipedia.xml');
 
         response = await tester.client.news.feeds.listFeeds();
         expect(response.statusCode, 200);
@@ -64,7 +64,7 @@ void main() {
         expect(response.body.starredCount, 0);
         expect(response.body.newestItemId, isNotNull);
         expect(response.body.feeds, hasLength(1));
-        expect(response.body.feeds[0].url, '${tester.targetURL}/static/wikipedia.xml');
+        expect(response.body.feeds[0].url, '${tester.url}/static/wikipedia.xml');
       });
 
       test('Add feed to folder', () async {
@@ -77,7 +77,7 @@ void main() {
         expect(response.body.newestItemId, isNotNull);
         expect(response.body.feeds, hasLength(1));
         expect(response.body.feeds[0].folderId, isPositive);
-        expect(response.body.feeds[0].url, '${tester.targetURL}/static/wikipedia.xml');
+        expect(response.body.feeds[0].url, '${tester.url}/static/wikipedia.xml');
       });
 
       test('Delete feed', () async {

--- a/tool/dev.sh
+++ b/tool/dev.sh
@@ -15,7 +15,7 @@ echo "Running development instance on http://localhost. To access it in an Andro
 
 tag="$(preset_image_tag "$preset")"
 volume="nextcloud-neon-dev-$(echo "$tag" | cut -d ":" -f 2)"
-container="$(docker run -d --rm -v "$volume":/usr/src/nextcloud -v "$volume":/var/www/html --network=host "$tag")"
+container="$(docker run -d --rm -v "$volume":/usr/src/nextcloud -v "$volume":/var/www/html --network=host "$tag" php -S 0.0.0.0:80)"
 function cleanup() {
     docker kill "$container"
 }


### PR DESCRIPTION
Basically the same as https://github.com/nextcloud/neon/pull/2601.
Also has the benefit that our testing code gets slightly less complicated.

For some reason the tests were still working just fine in CI, but locally the dashboard and weather_status tests were partially failing because the container couldn't connect to the required external services.