### PR TITLE
fix(nextcloud_test): Handle port already used with retries

### DIFF
--- a/packages/nextcloud/packages/nextcloud_test/lib/src/test_target/docker_container.dart
+++ b/packages/nextcloud/packages/nextcloud_test/lib/src/test_target/docker_container.dart
@@ -38,7 +38,9 @@ final class DockerContainerFactory extends TestTargetFactory<DockerContainerInst
     }
 
     late int port;
-    while (true) {
+
+    // Retry a few times because the random port could already be allocated.
+    for (var i = 0; i < 3; i++) {
       port = _randomPort();
       result = await runExecutableArguments(
         'docker',
@@ -54,8 +56,7 @@ final class DockerContainerFactory extends TestTargetFactory<DockerContainerInst
           '0.0.0.0:$port',
         ],
       );
-      // 125 means the docker run command itself has failed which indicated the port is already used
-      if (result.exitCode != 125) {
+      if (result.exitCode == 0) {
         break;
       }
     }


### PR DESCRIPTION
Forgotten in https://github.com/nextcloud/neon/pull/2769.

On the host network we don't get the 125 status code anymore if the port was already allocated, but just 1. We can't distinguish that from any other failure, so just using retries should do the trick to avoid false positives in case the port is already used.