### PR TITLE
test(nextcloud): Test spreed message expiration

### DIFF
--- a/packages/nextcloud/test/api/spreed/spreed_test.dart
+++ b/packages/nextcloud/test/api/spreed/spreed_test.dart
@@ -463,6 +463,34 @@ void main() {
         expect(response.body.ocs.data.parent!.chatMessage!.messageType, spreed.MessageType.commentDeleted);
         expect(response.body.ocs.data.parent!.chatMessage!.systemMessage, '');
       });
+
+      test('Clear history', () async {
+        final room = await createTestRoom();
+
+        final clearHistoryResponse = await tester.client.spreed.chat.clearHistory(
+          token: room.token,
+        );
+        expect(clearHistoryResponse.body.ocs.data.id, isPositive);
+        expect(clearHistoryResponse.body.ocs.data.actorType, spreed.ActorType.users);
+        expect(clearHistoryResponse.body.ocs.data.actorId, 'user1');
+        expect(clearHistoryResponse.body.ocs.data.actorDisplayName, 'User One');
+        expect(clearHistoryResponse.body.ocs.data.message, 'You cleared the history of the conversation');
+        expect(clearHistoryResponse.body.ocs.data.messageType, spreed.MessageType.system);
+        expect(clearHistoryResponse.body.ocs.data.systemMessage, 'history_cleared');
+
+        final receiveMessagesResponse = await tester.client.spreed.chat.receiveMessages(
+          token: room.token,
+          lookIntoFuture: spreed.ChatReceiveMessagesLookIntoFuture.$0,
+        );
+        expect(receiveMessagesResponse.body.ocs.data, hasLength(1));
+        expect(receiveMessagesResponse.body.ocs.data[0].id, isPositive);
+        expect(receiveMessagesResponse.body.ocs.data[0].actorType, spreed.ActorType.users);
+        expect(receiveMessagesResponse.body.ocs.data[0].actorId, 'user1');
+        expect(receiveMessagesResponse.body.ocs.data[0].actorDisplayName, 'User One');
+        expect(receiveMessagesResponse.body.ocs.data[0].message, 'You cleared the history of the conversation');
+        expect(receiveMessagesResponse.body.ocs.data[0].messageType, spreed.MessageType.system);
+        expect(receiveMessagesResponse.body.ocs.data[0].systemMessage, 'history_cleared');
+      });
     });
 
     group('Call', () {

--- a/packages/nextcloud/test/api/spreed/spreed_test.dart
+++ b/packages/nextcloud/test/api/spreed/spreed_test.dart
@@ -168,6 +168,36 @@ void main() {
           });
         });
       });
+
+      test('Message expiration', () async {
+        const expiration = 1;
+
+        final room = await createTestRoom();
+        expect(room.lastMessage.baseMessage, isNotNull);
+        expect(room.lastMessage.builtListNever, isNull);
+        expect(room.lastMessage.chatMessage, isNotNull);
+
+        await tester.client.spreed.room.setMessageExpiration(
+          token: room.token,
+          $body: spreed.RoomSetMessageExpirationRequestApplicationJson(
+            (b) => b.seconds = expiration,
+          ),
+        );
+
+        final clearHistoryResponse = await tester.client.spreed.chat.clearHistory(
+          token: room.token,
+        );
+        expect(clearHistoryResponse.body.ocs.data.expirationTimestamp, isPositive);
+
+        await Future<void>.delayed(const Duration(seconds: expiration));
+
+        final getRoomResponse = await tester.client.spreed.room.getSingleRoom(
+          token: room.token,
+        );
+        expect(getRoomResponse.body.ocs.data.lastMessage.baseMessage, isNull);
+        expect(getRoomResponse.body.ocs.data.lastMessage.builtListNever, isNotNull);
+        expect(getRoomResponse.body.ocs.data.lastMessage.chatMessage, isNull);
+      });
     });
 
     group('Avatar', () {

--- a/packages/nextcloud/test/fixtures/spreed/chat/clear_history.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/chat/clear_history.regexp
@@ -1,0 +1,14 @@
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
+accept: application/json
+authorization: Bearer mock
+content-type: application/json; charset=utf-8
+ocs-apirequest: true
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+DELETE http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
+accept: application/json
+authorization: Bearer mock
+ocs-apirequest: true
+GET http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}\?lookIntoFuture=0&limit=100&lastKnownMessageId=0&lastCommonReadId=0&timeout=30&setReadMarker=1&includeLastKnown=0&noStatusUpdate=0&markNotificationsAsRead=1
+accept: application/json
+authorization: Bearer mock
+ocs-apirequest: true

--- a/packages/nextcloud/test/fixtures/spreed/room/message_expiration.regexp
+++ b/packages/nextcloud/test/fixtures/spreed/room/message_expiration.regexp
@@ -1,0 +1,20 @@
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room
+accept: application/json
+authorization: Bearer mock
+content-type: application/json; charset=utf-8
+ocs-apirequest: true
+\{"roomType":3,"invite":"","roomName":"Test","source":"","objectType":"","objectId":""\}
+POST http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}/message-expiration
+accept: application/json
+authorization: Bearer mock
+content-type: application/json; charset=utf-8
+ocs-apirequest: true
+\{"seconds":1\}
+DELETE http://localhost/ocs/v2\.php/apps/spreed/api/v1/chat/[a-z0-9]{8}
+accept: application/json
+authorization: Bearer mock
+ocs-apirequest: true
+GET http://localhost/ocs/v2\.php/apps/spreed/api/v4/room/[a-z0-9]{8}
+accept: application/json
+authorization: Bearer mock
+ocs-apirequest: true


### PR DESCRIPTION
There are some changes in the `lastMessage` data returned in spreed 21 (https://github.com/nextcloud/neon/pull/2775), so adding a test now to serve as regression testing.