### PR TITLE
ci: Remove renovate PR limit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
     "dependencies"
   ],
   "rangeStrategy": "bump",
+  "prConcurrentLimit": 0,
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true


### PR DESCRIPTION
Sometimes we have a bunch of renovate PRs we can not merge for various reasons, so other PRs like the lockfile maintenance are never created because they would be over the limit.