### PR TITLE
build(example): Update Android compileSdkVersion to 35

### DIFF
--- a/packages/neon_framework/example/android/app/build.gradle
+++ b/packages/neon_framework/example/android/app/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "de.provokateurin.neon"
-    compileSdkVersion = 34
+    compileSdkVersion = 35
 
     compileOptions {
         coreLibraryDesugaringEnabled = true


### PR DESCRIPTION
Fixes
```
Your project is configured to compile against Android SDK 34, but the following plugin(s) require to be compiled against a higher Android SDK version:
- flutter_plugin_android_lifecycle compiles against Android SDK 35
Fix this issue by compiling against the highest Android SDK version (they are backward compatible).
```