### PR TITLE
build: Depend on flutter in workspace package to fix renovate

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -531,7 +531,7 @@ packages:
     source: hosted
     version: "1.1.1"
   flutter:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,5 +33,9 @@ workspace:
   - packages/nextcloud/packages/nextcloud_test
   - packages/nextcloud/packages/nextcloud_test_presets
 
+dependencies:
+  flutter:
+    sdk: flutter
+
 dev_dependencies:
   melos: 6.0.0


### PR DESCRIPTION
Renovate fails upgrading dependencies in the workspace package because it thinks it's a pure dart package: https://github.com/nextcloud/neon/pull/2181#issuecomment-2829664009
The check for that is not great, but we can simply satisfy it for now: https://github.com/renovatebot/renovate/blob/2818808f28ad18be6ac2644b2bc036b8dd236a23/lib/modules/manager/pub/artifacts.ts#L42