### PR TITLE
ci: Only publish on demand

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,7 @@
 name: Publish
 
 on:
-  schedule:
-    - cron:  '0 5 * * *'
+  workflow_dispatch:
 
 concurrency:
   group: publish


### PR DESCRIPTION
Currently wasting a lot of CI time and energy for building every day. The F-Droid repo is broken anyway and always needs a manual reset before a new version can be published.